### PR TITLE
fix(compiler): simplify nested function object names

### DIFF
--- a/src/Compiler/Services/TwoPhaseCompilation/GeneratedFunctionObjectPlanner.cs
+++ b/src/Compiler/Services/TwoPhaseCompilation/GeneratedFunctionObjectPlanner.cs
@@ -22,7 +22,9 @@ internal static class GeneratedFunctionObjectPlanner
             Signature = signature,
             Namespace = string.Empty,
             ModuleName = symbolTable.Root.Name,
-            TypeName = callable.Kind == CallableKind.Arrow
+            TypeName = callable.Kind is CallableKind.Arrow
+                or CallableKind.FunctionDeclaration
+                or CallableKind.FunctionExpression
                 ? GeneratedFunctionObjectNaming.WrapperTypeName
                 : BuildTypeName(callable),
             CanonicalOwnerTypeName = ResolveCanonicalOwnerTypeName(

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -186,7 +186,7 @@
 
 		} // end of class Scope_For_L18C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -206,9 +206,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -219,7 +219,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -230,7 +230,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -243,14 +243,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/parseArgs::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -264,14 +264,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/parseArgs::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -289,9 +289,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -609,7 +609,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CEC314BF_printHelp
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -623,7 +623,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -634,7 +634,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -645,7 +645,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -660,7 +660,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -676,7 +676,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -694,9 +694,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CEC314BF_printHelp
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -803,7 +803,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_67E87462_defaultPinPath
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -823,9 +823,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -836,7 +836,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -847,7 +847,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -860,11 +860,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -878,11 +878,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -900,9 +900,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_67E87462_defaultPinPath
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1048,7 +1048,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1068,9 +1068,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1081,7 +1081,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1092,7 +1092,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1105,14 +1105,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1126,14 +1126,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1151,9 +1151,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1277,7 +1277,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1291,7 +1291,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1302,7 +1302,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1313,7 +1313,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1331,7 +1331,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1350,7 +1350,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1368,9 +1368,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1433,7 +1433,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1453,9 +1453,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1466,7 +1466,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1477,7 +1477,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1490,14 +1490,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1511,14 +1511,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1536,9 +1536,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1652,7 +1652,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_90DD1216_ensureString
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1666,7 +1666,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1677,7 +1677,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1688,7 +1688,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1710,7 +1710,7 @@
 				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0018: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1733,7 +1733,7 @@
 				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0014: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1751,9 +1751,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_90DD1216_ensureString
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1957,7 +1957,7 @@
 
 		} // end of class Scope_ForOf_L106C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1971,7 +1971,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1982,7 +1982,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1993,7 +1993,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2015,7 +2015,7 @@
 				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0018: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2038,7 +2038,7 @@
 				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0014: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2056,9 +2056,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2362,7 +2362,7 @@
 
 		} // end of class Scope_ForOf_L116C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2382,9 +2382,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2395,7 +2395,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2406,7 +2406,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2419,14 +2419,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2440,14 +2440,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2465,9 +2465,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2678,7 +2678,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4A573BF6_validatePin
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2698,9 +2698,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject_FunctionDeclaration_4A573BF6_validatePin::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2711,7 +2711,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2722,7 +2722,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2735,14 +2735,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject_FunctionDeclaration_4A573BF6_validatePin::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2756,14 +2756,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject_FunctionDeclaration_4A573BF6_validatePin::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2781,9 +2781,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4A573BF6_validatePin
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3338,7 +3338,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_62753EAC_loadPin
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3358,9 +3358,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject_FunctionDeclaration_62753EAC_loadPin::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3371,7 +3371,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3382,7 +3382,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3395,14 +3395,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject_FunctionDeclaration_62753EAC_loadPin::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3416,14 +3416,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject_FunctionDeclaration_62753EAC_loadPin::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3441,9 +3441,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_62753EAC_loadPin
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3544,7 +3544,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3564,9 +3564,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3577,7 +3577,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3588,7 +3588,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3601,7 +3601,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -3611,7 +3611,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3625,7 +3625,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -3635,7 +3635,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3653,9 +3653,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3775,7 +3775,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3795,9 +3795,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3808,7 +3808,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3819,7 +3819,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3832,14 +3832,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3853,14 +3853,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3878,9 +3878,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4022,7 +4022,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4042,9 +4042,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4055,7 +4055,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4066,7 +4066,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4079,7 +4079,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -4089,7 +4089,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4103,7 +4103,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -4113,7 +4113,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4131,9 +4131,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4312,7 +4312,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4332,9 +4332,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4345,7 +4345,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4356,7 +4356,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4369,7 +4369,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -4379,7 +4379,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4393,7 +4393,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -4403,7 +4403,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4421,9 +4421,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4867,7 +4867,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4887,9 +4887,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4900,7 +4900,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4911,7 +4911,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4924,14 +4924,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4945,14 +4945,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4970,9 +4970,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5082,7 +5082,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_313C5150_removeDir
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5102,9 +5102,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject_FunctionDeclaration_313C5150_removeDir::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5115,7 +5115,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5126,7 +5126,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5139,14 +5139,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject_FunctionDeclaration_313C5150_removeDir::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5160,14 +5160,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject_FunctionDeclaration_313C5150_removeDir::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5185,9 +5185,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_313C5150_removeDir
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5358,7 +5358,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C8C56586_runGit
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5378,9 +5378,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject_FunctionDeclaration_C8C56586_runGit::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5391,7 +5391,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5402,7 +5402,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5415,7 +5415,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject_FunctionDeclaration_C8C56586_runGit::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -5425,7 +5425,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5439,7 +5439,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject_FunctionDeclaration_C8C56586_runGit::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -5449,7 +5449,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5467,9 +5467,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C8C56586_runGit
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5861,7 +5861,7 @@
 
 		} // end of class Scope_ForOf_L251C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5881,9 +5881,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5894,7 +5894,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5905,7 +5905,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5918,14 +5918,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5939,14 +5939,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5964,9 +5964,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6402,7 +6402,7 @@
 
 		} // end of class Scope_ForOf_L271C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6422,9 +6422,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6435,7 +6435,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6446,7 +6446,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6459,7 +6459,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -6469,7 +6469,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6483,7 +6483,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -6493,7 +6493,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6511,9 +6511,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7356,7 +7356,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -7376,9 +7376,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7389,7 +7389,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7400,7 +7400,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7413,7 +7413,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -7426,7 +7426,7 @@
 				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0020: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
 				IL_0025: ret
-			} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7440,7 +7440,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -7453,7 +7453,7 @@
 				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001c: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7471,9 +7471,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7984,7 +7984,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8004,9 +8004,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8017,7 +8017,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8028,7 +8028,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8041,7 +8041,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -8054,7 +8054,7 @@
 				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0020: call object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
 				IL_0025: ret
-			} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8068,7 +8068,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -8081,7 +8081,7 @@
 				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001c: call object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8099,9 +8099,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8333,7 +8333,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8353,9 +8353,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8366,7 +8366,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8377,7 +8377,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8390,7 +8390,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -8403,7 +8403,7 @@
 				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0020: call object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
 				IL_0025: ret
-			} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8417,7 +8417,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -8430,7 +8430,7 @@
 				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001c: call object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8448,9 +8448,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8698,7 +8698,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DE0B7594_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8718,9 +8718,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject_FunctionDeclaration_DE0B7594_main::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8731,7 +8731,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8742,7 +8742,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8755,11 +8755,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject_FunctionDeclaration_DE0B7594_main::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8773,11 +8773,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject_FunctionDeclaration_DE0B7594_main::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject::_environment0_Compile_Scripts_Test262Bootstrap
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8795,9 +8795,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DE0B7594_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -9159,7 +9159,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262Bootstrap/Scope,
-			[1] class Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject_FunctionDeclaration_DE0B7594_main,
+			[1] class Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject,
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
@@ -9167,29 +9167,29 @@
 			[6] object,
 			[7] object,
 			[8] object[],
-			[9] class Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs,
-			[10] class Modules.Compile_Scripts_Test262Bootstrap/printHelp/FunctionObject_FunctionDeclaration_CEC314BF_printHelp,
-			[11] class Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject_FunctionDeclaration_67E87462_defaultPinPath,
-			[12] class Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd,
-			[13] class Modules.Compile_Scripts_Test262Bootstrap/toPortablePath/FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath,
-			[14] class Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath,
-			[15] class Modules.Compile_Scripts_Test262Bootstrap/ensureString/FunctionObject_FunctionDeclaration_90DD1216_ensureString,
-			[16] class Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray/FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray,
-			[17] class Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp,
-			[18] class Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject_FunctionDeclaration_4A573BF6_validatePin,
-			[19] class Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject_FunctionDeclaration_62753EAC_loadPin,
-			[20] class Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot,
-			[21] class Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel,
-			[22] class Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot,
-			[23] class Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan,
-			[24] class Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir,
-			[25] class Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject_FunctionDeclaration_313C5150_removeDir,
-			[26] class Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject_FunctionDeclaration_C8C56586_runGit,
-			[27] class Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns,
-			[28] class Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot,
-			[29] class Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout,
-			[30] class Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot,
-			[31] class Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot,
+			[9] class Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject,
+			[10] class Modules.Compile_Scripts_Test262Bootstrap/printHelp/FunctionObject,
+			[11] class Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject,
+			[12] class Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject,
+			[13] class Modules.Compile_Scripts_Test262Bootstrap/toPortablePath/FunctionObject,
+			[14] class Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject,
+			[15] class Modules.Compile_Scripts_Test262Bootstrap/ensureString/FunctionObject,
+			[16] class Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray/FunctionObject,
+			[17] class Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject,
+			[18] class Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject,
+			[19] class Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject,
+			[20] class Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject,
+			[21] class Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject,
+			[22] class Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject,
+			[23] class Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject,
+			[24] class Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject,
+			[25] class Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject,
+			[26] class Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject,
+			[27] class Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject,
+			[28] class Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject,
+			[29] class Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject,
+			[30] class Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject,
+			[31] class Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject,
 			[32] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule,
 			[33] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[34] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
@@ -9226,13 +9226,13 @@
 		IL_001c: ldc.i4.0
 		IL_001d: ldelem.ref
 		IL_001e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0023: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0023: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0028: ldc.i4.1
 		IL_0029: conv.r8
 		IL_002a: ldstr "parseArgs"
 		IL_002f: ldc.i4.0
 		IL_0030: ldc.i4.1
-		IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs>(!!0, float64, string, bool, bool)
+		IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0036: stloc.s 9
 		IL_0038: ldloc.0
 		IL_0039: ldloc.s 9
@@ -9244,13 +9244,13 @@
 		IL_0048: ldloc.0
 		IL_0049: stelem.ref
 		IL_004a: stloc.s 8
-		IL_004c: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/printHelp/FunctionObject_FunctionDeclaration_CEC314BF_printHelp::.ctor()
+		IL_004c: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/printHelp/FunctionObject::.ctor()
 		IL_0051: ldc.i4.0
 		IL_0052: conv.r8
 		IL_0053: ldstr "printHelp"
 		IL_0058: ldc.i4.0
 		IL_0059: ldc.i4.1
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/printHelp/FunctionObject_FunctionDeclaration_CEC314BF_printHelp>(!!0, float64, string, bool, bool)
+		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/printHelp/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005f: stloc.s 10
 		IL_0061: ldloc.0
 		IL_0062: ldloc.s 10
@@ -9266,13 +9266,13 @@
 		IL_0077: ldc.i4.0
 		IL_0078: ldelem.ref
 		IL_0079: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_007e: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_007e: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0083: ldc.i4.0
 		IL_0084: conv.r8
 		IL_0085: ldstr "defaultPinPath"
 		IL_008a: ldc.i4.0
 		IL_008b: ldc.i4.1
-		IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject_FunctionDeclaration_67E87462_defaultPinPath>(!!0, float64, string, bool, bool)
+		IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0091: stloc.s 11
 		IL_0093: ldloc.0
 		IL_0094: ldloc.s 11
@@ -9288,13 +9288,13 @@
 		IL_00a9: ldc.i4.0
 		IL_00aa: ldelem.ref
 		IL_00ab: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_00b0: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_00b0: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_00b5: ldc.i4.1
 		IL_00b6: conv.r8
 		IL_00b7: ldstr "resolvePathFromCwd"
 		IL_00bc: ldc.i4.0
 		IL_00bd: ldc.i4.1
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd>(!!0, float64, string, bool, bool)
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c3: stloc.s 12
 		IL_00c5: ldloc.0
 		IL_00c6: ldloc.s 12
@@ -9306,13 +9306,13 @@
 		IL_00d5: ldloc.0
 		IL_00d6: stelem.ref
 		IL_00d7: stloc.s 8
-		IL_00d9: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/toPortablePath/FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::.ctor()
+		IL_00d9: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/toPortablePath/FunctionObject::.ctor()
 		IL_00de: ldc.i4.1
 		IL_00df: conv.r8
 		IL_00e0: ldstr "toPortablePath"
 		IL_00e5: ldc.i4.0
 		IL_00e6: ldc.i4.1
-		IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/toPortablePath/FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath>(!!0, float64, string, bool, bool)
+		IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/toPortablePath/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00ec: stloc.s 13
 		IL_00ee: ldloc.0
 		IL_00ef: ldloc.s 13
@@ -9328,13 +9328,13 @@
 		IL_0104: ldc.i4.0
 		IL_0105: ldelem.ref
 		IL_0106: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_010b: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_010b: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0110: ldc.i4.1
 		IL_0111: conv.r8
 		IL_0112: ldstr "normalizeSpecPath"
 		IL_0117: ldc.i4.0
 		IL_0118: ldc.i4.1
-		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath>(!!0, float64, string, bool, bool)
+		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_011e: stloc.s 14
 		IL_0120: ldloc.0
 		IL_0121: ldloc.s 14
@@ -9346,13 +9346,13 @@
 		IL_0130: ldloc.0
 		IL_0131: stelem.ref
 		IL_0132: stloc.s 8
-		IL_0134: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureString/FunctionObject_FunctionDeclaration_90DD1216_ensureString::.ctor()
+		IL_0134: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureString/FunctionObject::.ctor()
 		IL_0139: ldc.i4.2
 		IL_013a: conv.r8
 		IL_013b: ldstr "ensureString"
 		IL_0140: ldc.i4.0
 		IL_0141: ldc.i4.1
-		IL_0142: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/ensureString/FunctionObject_FunctionDeclaration_90DD1216_ensureString>(!!0, float64, string, bool, bool)
+		IL_0142: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/ensureString/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0147: stloc.s 15
 		IL_0149: ldloc.0
 		IL_014a: ldloc.s 15
@@ -9364,13 +9364,13 @@
 		IL_0159: ldloc.0
 		IL_015a: stelem.ref
 		IL_015b: stloc.s 8
-		IL_015d: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray/FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::.ctor()
+		IL_015d: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray/FunctionObject::.ctor()
 		IL_0162: ldc.i4.2
 		IL_0163: conv.r8
 		IL_0164: ldstr "ensureStringArray"
 		IL_0169: ldc.i4.0
 		IL_016a: ldc.i4.1
-		IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray/FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray>(!!0, float64, string, bool, bool)
+		IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0170: stloc.s 16
 		IL_0172: ldloc.0
 		IL_0173: ldloc.s 16
@@ -9386,13 +9386,13 @@
 		IL_0188: ldc.i4.0
 		IL_0189: ldelem.ref
 		IL_018a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_018f: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_018f: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0194: ldc.i4.1
 		IL_0195: conv.r8
 		IL_0196: ldstr "validateExcludedFromMvp"
 		IL_019b: ldc.i4.0
 		IL_019c: ldc.i4.1
-		IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp>(!!0, float64, string, bool, bool)
+		IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01a2: stloc.s 17
 		IL_01a4: ldloc.0
 		IL_01a5: ldloc.s 17
@@ -9408,13 +9408,13 @@
 		IL_01ba: ldc.i4.0
 		IL_01bb: ldelem.ref
 		IL_01bc: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_01c1: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject_FunctionDeclaration_4A573BF6_validatePin::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_01c1: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_01c6: ldc.i4.1
 		IL_01c7: conv.r8
 		IL_01c8: ldstr "validatePin"
 		IL_01cd: ldc.i4.0
 		IL_01ce: ldc.i4.1
-		IL_01cf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject_FunctionDeclaration_4A573BF6_validatePin>(!!0, float64, string, bool, bool)
+		IL_01cf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01d4: stloc.s 18
 		IL_01d6: ldloc.0
 		IL_01d7: ldloc.s 18
@@ -9430,13 +9430,13 @@
 		IL_01ec: ldc.i4.0
 		IL_01ed: ldelem.ref
 		IL_01ee: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_01f3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject_FunctionDeclaration_62753EAC_loadPin::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_01f3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_01f8: ldc.i4.1
 		IL_01f9: conv.r8
 		IL_01fa: ldstr "loadPin"
 		IL_01ff: ldc.i4.0
 		IL_0200: ldc.i4.1
-		IL_0201: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject_FunctionDeclaration_62753EAC_loadPin>(!!0, float64, string, bool, bool)
+		IL_0201: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0206: stloc.s 19
 		IL_0208: ldloc.0
 		IL_0209: ldloc.s 19
@@ -9452,13 +9452,13 @@
 		IL_021e: ldc.i4.0
 		IL_021f: ldelem.ref
 		IL_0220: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0225: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0225: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_022a: ldc.i4.2
 		IL_022b: conv.r8
 		IL_022c: ldstr "resolveManagedCheckoutRoot"
 		IL_0231: ldc.i4.0
 		IL_0232: ldc.i4.1
-		IL_0233: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot>(!!0, float64, string, bool, bool)
+		IL_0233: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0238: stloc.s 20
 		IL_023a: ldloc.0
 		IL_023b: ldloc.s 20
@@ -9474,13 +9474,13 @@
 		IL_0250: ldc.i4.0
 		IL_0251: ldelem.ref
 		IL_0252: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0257: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0257: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_025c: ldc.i4.1
 		IL_025d: conv.r8
 		IL_025e: ldstr "resolveManagedCheckoutLabel"
 		IL_0263: ldc.i4.0
 		IL_0264: ldc.i4.1
-		IL_0265: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel>(!!0, float64, string, bool, bool)
+		IL_0265: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_026a: stloc.s 21
 		IL_026c: ldloc.0
 		IL_026d: ldloc.s 21
@@ -9496,13 +9496,13 @@
 		IL_0282: ldc.i4.0
 		IL_0283: ldelem.ref
 		IL_0284: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0289: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0289: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_028e: ldc.i4.2
 		IL_028f: conv.r8
 		IL_0290: ldstr "resolveOverrideRoot"
 		IL_0295: ldc.i4.0
 		IL_0296: ldc.i4.1
-		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot>(!!0, float64, string, bool, bool)
+		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_029c: stloc.s 22
 		IL_029e: ldloc.0
 		IL_029f: ldloc.s 22
@@ -9518,13 +9518,13 @@
 		IL_02b4: ldc.i4.0
 		IL_02b5: ldelem.ref
 		IL_02b6: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_02bb: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_02bb: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_02c0: ldc.i4.2
 		IL_02c1: conv.r8
 		IL_02c2: ldstr "describePlan"
 		IL_02c7: ldc.i4.0
 		IL_02c8: ldc.i4.1
-		IL_02c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan>(!!0, float64, string, bool, bool)
+		IL_02c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02ce: stloc.s 23
 		IL_02d0: ldloc.0
 		IL_02d1: ldloc.s 23
@@ -9540,13 +9540,13 @@
 		IL_02e6: ldc.i4.0
 		IL_02e7: ldelem.ref
 		IL_02e8: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_02ed: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_02ed: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_02f2: ldc.i4.1
 		IL_02f3: conv.r8
 		IL_02f4: ldstr "ensureDir"
 		IL_02f9: ldc.i4.0
 		IL_02fa: ldc.i4.1
-		IL_02fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir>(!!0, float64, string, bool, bool)
+		IL_02fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0300: stloc.s 24
 		IL_0302: ldloc.0
 		IL_0303: ldloc.s 24
@@ -9562,13 +9562,13 @@
 		IL_0318: ldc.i4.0
 		IL_0319: ldelem.ref
 		IL_031a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_031f: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject_FunctionDeclaration_313C5150_removeDir::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_031f: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0324: ldc.i4.1
 		IL_0325: conv.r8
 		IL_0326: ldstr "removeDir"
 		IL_032b: ldc.i4.0
 		IL_032c: ldc.i4.1
-		IL_032d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject_FunctionDeclaration_313C5150_removeDir>(!!0, float64, string, bool, bool)
+		IL_032d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0332: stloc.s 25
 		IL_0334: ldloc.0
 		IL_0335: ldloc.s 25
@@ -9584,13 +9584,13 @@
 		IL_034a: ldc.i4.0
 		IL_034b: ldelem.ref
 		IL_034c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0351: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject_FunctionDeclaration_C8C56586_runGit::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0351: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0356: ldc.i4.2
 		IL_0357: conv.r8
 		IL_0358: ldstr "runGit"
 		IL_035d: ldc.i4.0
 		IL_035e: ldc.i4.1
-		IL_035f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject_FunctionDeclaration_C8C56586_runGit>(!!0, float64, string, bool, bool)
+		IL_035f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0364: stloc.s 26
 		IL_0366: ldloc.0
 		IL_0367: ldloc.s 26
@@ -9606,13 +9606,13 @@
 		IL_037c: ldc.i4.0
 		IL_037d: ldelem.ref
 		IL_037e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0383: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0383: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0388: ldc.i4.1
 		IL_0389: conv.r8
 		IL_038a: ldstr "buildSparsePatterns"
 		IL_038f: ldc.i4.0
 		IL_0390: ldc.i4.1
-		IL_0391: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns>(!!0, float64, string, bool, bool)
+		IL_0391: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0396: stloc.s 27
 		IL_0398: ldloc.0
 		IL_0399: ldloc.s 27
@@ -9628,13 +9628,13 @@
 		IL_03ae: ldc.i4.0
 		IL_03af: ldelem.ref
 		IL_03b0: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_03b5: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_03b5: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_03ba: ldc.i4.2
 		IL_03bb: conv.r8
 		IL_03bc: ldstr "validateResolvedRoot"
 		IL_03c1: ldc.i4.0
 		IL_03c2: ldc.i4.1
-		IL_03c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot>(!!0, float64, string, bool, bool)
+		IL_03c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_03c8: stloc.s 28
 		IL_03ca: ldloc.0
 		IL_03cb: ldloc.s 28
@@ -9650,13 +9650,13 @@
 		IL_03e0: ldc.i4.0
 		IL_03e1: ldelem.ref
 		IL_03e2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_03e7: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_03e7: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_03ec: ldc.i4.3
 		IL_03ed: conv.r8
 		IL_03ee: ldstr "ensureManagedCheckout"
 		IL_03f3: ldc.i4.0
 		IL_03f4: ldc.i4.1
-		IL_03f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout>(!!0, float64, string, bool, bool)
+		IL_03f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_03fa: stloc.s 29
 		IL_03fc: ldloc.0
 		IL_03fd: ldloc.s 29
@@ -9672,13 +9672,13 @@
 		IL_0412: ldc.i4.0
 		IL_0413: ldelem.ref
 		IL_0414: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0419: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0419: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_041e: ldc.i4.3
 		IL_041f: conv.r8
 		IL_0420: ldstr "resolveBootstrapRoot"
 		IL_0425: ldc.i4.0
 		IL_0426: ldc.i4.1
-		IL_0427: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot>(!!0, float64, string, bool, bool)
+		IL_0427: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_042c: stloc.s 30
 		IL_042e: ldloc.0
 		IL_042f: ldloc.s 30
@@ -9694,13 +9694,13 @@
 		IL_0444: ldc.i4.0
 		IL_0445: ldelem.ref
 		IL_0446: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_044b: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_044b: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0450: ldc.i4.3
 		IL_0451: conv.r8
 		IL_0452: ldstr "printResolvedRoot"
 		IL_0457: ldc.i4.0
 		IL_0458: ldc.i4.1
-		IL_0459: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot>(!!0, float64, string, bool, bool)
+		IL_0459: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_045e: stloc.s 31
 		IL_0460: ldloc.0
 		IL_0461: ldloc.s 31
@@ -9716,13 +9716,13 @@
 		IL_0476: ldc.i4.0
 		IL_0477: ldelem.ref
 		IL_0478: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_047d: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject_FunctionDeclaration_DE0B7594_main::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_047d: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0482: ldc.i4.0
 		IL_0483: conv.r8
 		IL_0484: ldstr "main"
 		IL_0489: ldc.i4.0
 		IL_048a: ldc.i4.1
-		IL_048b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject_FunctionDeclaration_DE0B7594_main>(!!0, float64, string, bool, bool)
+		IL_048b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0490: stloc.1
 		IL_0491: nop
 		IL_0492: ldarg.1

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8862F24A_quoteString
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Scripts_Test262MetadataParser/quoteString::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Scripts_Test262MetadataParser/quoteString::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8862F24A_quoteString
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -293,7 +293,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -313,9 +313,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject::_environment0_Compile_Scripts_Test262MetadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -326,7 +326,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -337,7 +337,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -350,14 +350,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject::_environment0_Compile_Scripts_Test262MetadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -371,14 +371,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject::_environment0_Compile_Scripts_Test262MetadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -396,9 +396,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -520,7 +520,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -540,9 +540,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject::_environment0_Compile_Scripts_Test262MetadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -553,7 +553,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -564,7 +564,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -577,14 +577,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject::_environment0_Compile_Scripts_Test262MetadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_Test262MetadataParser/formatNegative::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -598,14 +598,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject::_environment0_Compile_Scripts_Test262MetadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_Test262MetadataParser/formatNegative::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -623,9 +623,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -762,7 +762,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -782,9 +782,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject::_environment0_Compile_Scripts_Test262MetadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -795,7 +795,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -806,7 +806,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -819,14 +819,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject::_environment0_Compile_Scripts_Test262MetadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -840,14 +840,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject::_environment0_Compile_Scripts_Test262MetadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -865,9 +865,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1008,7 +1008,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1028,9 +1028,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject::_environment0_Compile_Scripts_Test262MetadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1041,7 +1041,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1052,7 +1052,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1065,7 +1065,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject::_environment0_Compile_Scripts_Test262MetadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -1076,7 +1076,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1090,7 +1090,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject::_environment0_Compile_Scripts_Test262MetadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -1101,7 +1101,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1119,9 +1119,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2844,7 +2844,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262MetadataParser/Scope,
-			[1] class Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult,
+			[1] class Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -2852,10 +2852,10 @@
 			[6] object,
 			[7] object,
 			[8] object[],
-			[9] class Modules.Compile_Scripts_Test262MetadataParser/quoteString/FunctionObject_FunctionDeclaration_8862F24A_quoteString,
-			[10] class Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar,
-			[11] class Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative,
-			[12] class Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue,
+			[9] class Modules.Compile_Scripts_Test262MetadataParser/quoteString/FunctionObject,
+			[10] class Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject,
+			[11] class Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject,
+			[12] class Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject,
 			[13] object,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[15] class [JavaScriptRuntime]JavaScriptRuntime.Console
@@ -2870,13 +2870,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 8
-		IL_0012: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/quoteString/FunctionObject_FunctionDeclaration_8862F24A_quoteString::.ctor()
+		IL_0012: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/quoteString/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "quoteString"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/quoteString/FunctionObject_FunctionDeclaration_8862F24A_quoteString>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/quoteString/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.s 9
 		IL_0027: ldloc.0
 		IL_0028: ldloc.s 9
@@ -2892,13 +2892,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_0044: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
+		IL_0044: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
 		IL_0049: ldc.i4.1
 		IL_004a: conv.r8
 		IL_004b: ldstr "formatScalar"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.s 10
 		IL_0059: ldloc.0
 		IL_005a: ldloc.s 10
@@ -2914,13 +2914,13 @@
 		IL_006f: ldc.i4.0
 		IL_0070: ldelem.ref
 		IL_0071: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_0076: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
+		IL_0076: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
 		IL_007b: ldc.i4.1
 		IL_007c: conv.r8
 		IL_007d: ldstr "formatNegative"
 		IL_0082: ldc.i4.0
 		IL_0083: ldc.i4.1
-		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative>(!!0, float64, string, bool, bool)
+		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0089: stloc.s 11
 		IL_008b: ldloc.0
 		IL_008c: ldloc.s 11
@@ -2936,13 +2936,13 @@
 		IL_00a1: ldc.i4.0
 		IL_00a2: ldelem.ref
 		IL_00a3: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_00a8: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
+		IL_00a8: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
 		IL_00ad: ldc.i4.1
 		IL_00ae: conv.r8
 		IL_00af: ldstr "formatIssue"
 		IL_00b4: ldc.i4.0
 		IL_00b5: ldc.i4.1
-		IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue>(!!0, float64, string, bool, bool)
+		IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00bb: stloc.s 12
 		IL_00bd: ldloc.0
 		IL_00be: ldloc.s 12
@@ -2958,13 +2958,13 @@
 		IL_00d3: ldc.i4.0
 		IL_00d4: ldelem.ref
 		IL_00d5: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_00da: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
+		IL_00da: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
 		IL_00df: ldc.i4.2
 		IL_00e0: conv.r8
 		IL_00e1: ldstr "writeParsedResult"
 		IL_00e6: ldc.i4.0
 		IL_00e7: ldc.i4.1
-		IL_00e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult>(!!0, float64, string, bool, bool)
+		IL_00e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00ed: stloc.1
 		IL_00ee: nop
 		IL_00ef: ldarg.1
@@ -3158,7 +3158,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3172,7 +3172,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3183,7 +3183,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3194,7 +3194,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3212,7 +3212,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.test262_metadataParser/normalizeLineEndings::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3231,7 +3231,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.test262_metadataParser/normalizeLineEndings::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3249,9 +3249,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3373,7 +3373,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C06E48FC_countIndent
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3393,9 +3393,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/countIndent/FunctionObject_FunctionDeclaration_C06E48FC_countIndent::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/countIndent/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3406,7 +3406,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3417,7 +3417,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3430,14 +3430,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/countIndent/FunctionObject_FunctionDeclaration_C06E48FC_countIndent::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/countIndent/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3451,14 +3451,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/countIndent/FunctionObject_FunctionDeclaration_C06E48FC_countIndent::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/countIndent/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3476,9 +3476,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C06E48FC_countIndent
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3641,7 +3641,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6CFFAA1C_unquote
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3661,9 +3661,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/unquote/FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/unquote/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3674,7 +3674,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3685,7 +3685,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3698,14 +3698,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/unquote/FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/unquote/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3719,14 +3719,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/unquote/FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/unquote/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3744,9 +3744,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6CFFAA1C_unquote
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4016,7 +4016,7 @@
 
 		} // end of class Scope_For_L69C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4036,9 +4036,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineList/FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineList/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4049,7 +4049,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4060,7 +4060,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4073,14 +4073,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineList/FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineList/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/parseInlineList::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4094,14 +4094,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineList/FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineList/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/parseInlineList::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4119,9 +4119,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4307,7 +4307,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4327,9 +4327,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineValue/FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineValue/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4340,7 +4340,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4351,7 +4351,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4364,14 +4364,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineValue/FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineValue/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.test262_metadataParser/parseInlineValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4385,14 +4385,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineValue/FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineValue/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.test262_metadataParser/parseInlineValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4410,9 +4410,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4658,7 +4658,7 @@
 
 		} // end of class Scope_For_L92C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4678,9 +4678,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/foldBlockLines/FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/foldBlockLines/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4691,7 +4691,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4702,7 +4702,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4715,7 +4715,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/foldBlockLines/FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/foldBlockLines/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -4723,7 +4723,7 @@
 				IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_0017: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4737,7 +4737,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/foldBlockLines/FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/foldBlockLines/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -4745,7 +4745,7 @@
 				IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_0013: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4763,9 +4763,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5013,7 +5013,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5033,9 +5033,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseBlockScalar/FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseBlockScalar/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5046,7 +5046,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5057,7 +5057,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5070,7 +5070,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseBlockScalar/FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseBlockScalar/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -5087,7 +5087,7 @@
 				IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_002c: call object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64, object)
 				IL_0031: ret
-			} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5101,7 +5101,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseBlockScalar/FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseBlockScalar/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -5118,7 +5118,7 @@
 				IL_0023: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0028: call object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64, object)
 				IL_002d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5136,9 +5136,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5425,7 +5425,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5445,9 +5445,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseIndentedValue/FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseIndentedValue/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5458,7 +5458,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5469,7 +5469,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5482,7 +5482,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseIndentedValue/FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseIndentedValue/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -5496,7 +5496,7 @@
 				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0025: call object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
 				IL_002a: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5510,7 +5510,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseIndentedValue/FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseIndentedValue/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -5524,7 +5524,7 @@
 				IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0021: call object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
 				IL_0026: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5542,9 +5542,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5921,7 +5921,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5941,9 +5941,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5954,7 +5954,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5965,7 +5965,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5978,7 +5978,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -5992,7 +5992,7 @@
 				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0025: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
 				IL_002a: ret
-			} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6006,7 +6006,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -6020,7 +6020,7 @@
 				IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0021: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
 				IL_0026: ret
-			} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6038,9 +6038,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6423,7 +6423,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6443,9 +6443,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6456,7 +6456,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6467,7 +6467,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6480,14 +6480,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.test262_metadataParser/parseTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6501,14 +6501,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.test262_metadataParser/parseTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6526,9 +6526,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6686,7 +6686,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6706,9 +6706,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6719,7 +6719,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6730,7 +6730,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6743,14 +6743,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.test262_metadataParser/extractTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6764,14 +6764,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.test262_metadataParser/extractTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6789,9 +6789,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6949,7 +6949,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5155C561_normalizePath
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -6963,7 +6963,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6974,7 +6974,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6985,7 +6985,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7003,7 +7003,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.test262_metadataParser/normalizePath::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7022,7 +7022,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.test262_metadataParser/normalizePath::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7040,9 +7040,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5155C561_normalizePath
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7142,7 +7142,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_512395F4_getFileName
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -7156,7 +7156,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7167,7 +7167,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7178,7 +7178,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7196,7 +7196,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.test262_metadataParser/getFileName::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7215,7 +7215,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.test262_metadataParser/getFileName::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7233,9 +7233,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_512395F4_getFileName
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7327,7 +7327,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D59C98DE_contains
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -7341,7 +7341,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7352,7 +7352,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7363,7 +7363,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7384,7 +7384,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7406,7 +7406,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7424,9 +7424,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D59C98DE_contains
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7488,7 +7488,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -7502,7 +7502,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7513,7 +7513,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7524,7 +7524,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7553,7 +7553,7 @@
 				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_002b: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
 				IL_0030: ret
-			} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7583,7 +7583,7 @@
 				IL_0022: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0027: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
 				IL_002c: ret
-			} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7601,9 +7601,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7774,7 +7774,7 @@
 
 		} // end of class Scope_For_L267C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_02368D80_toStringArray
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -7794,9 +7794,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toStringArray/FunctionObject_FunctionDeclaration_02368D80_toStringArray::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toStringArray/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7807,7 +7807,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7818,7 +7818,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7831,7 +7831,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toStringArray/FunctionObject_FunctionDeclaration_02368D80_toStringArray::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toStringArray/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -7846,7 +7846,7 @@
 				IL_0025: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_002a: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_002f: ret
-			} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7860,7 +7860,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toStringArray/FunctionObject_FunctionDeclaration_02368D80_toStringArray::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toStringArray/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -7875,7 +7875,7 @@
 				IL_0021: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_002b: ret
-			} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7893,9 +7893,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_02368D80_toStringArray
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8175,7 +8175,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8195,9 +8195,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toNullableString/FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toNullableString/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8208,7 +8208,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8219,7 +8219,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8232,7 +8232,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toNullableString/FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toNullableString/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -8247,7 +8247,7 @@
 				IL_0025: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_002a: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_002f: ret
-			} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8261,7 +8261,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toNullableString/FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toNullableString/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -8276,7 +8276,7 @@
 				IL_0021: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_0026: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_002b: ret
-			} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8294,9 +8294,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8593,7 +8593,7 @@
 
 		} // end of class Scope_For_L312C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8613,9 +8613,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/normalizeNegative/FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/normalizeNegative/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8626,7 +8626,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8637,7 +8637,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8650,7 +8650,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/normalizeNegative/FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/normalizeNegative/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -8661,7 +8661,7 @@
 				IL_0019: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_001e: call object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8675,7 +8675,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/normalizeNegative/FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/normalizeNegative/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -8686,7 +8686,7 @@
 				IL_0015: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_001a: call object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8704,9 +8704,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -9408,7 +9408,7 @@
 
 		} // end of class Scope_For_L364C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -9428,9 +9428,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9441,7 +9441,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9452,7 +9452,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9465,7 +9465,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -9480,7 +9480,7 @@
 				IL_0025: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_002a: call object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
 				IL_002f: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9494,7 +9494,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -9509,7 +9509,7 @@
 				IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0026: call object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
 				IL_002b: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -9527,9 +9527,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -10348,7 +10348,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -10368,9 +10368,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildMvpBlockers/FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildMvpBlockers/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -10381,7 +10381,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -10392,7 +10392,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -10405,7 +10405,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildMvpBlockers/FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildMvpBlockers/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -10418,7 +10418,7 @@
 				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
 				IL_0025: ret
-			} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -10432,7 +10432,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildMvpBlockers/FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildMvpBlockers/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -10445,7 +10445,7 @@
 				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -10463,9 +10463,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -10937,7 +10937,7 @@
 
 		} // end of class Scope_For_L455C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -10957,9 +10957,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Metadata/FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Metadata/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -10970,7 +10970,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -10981,7 +10981,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -10994,7 +10994,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Metadata/FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Metadata/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -11004,7 +11004,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -11018,7 +11018,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Metadata/FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Metadata/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -11028,7 +11028,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -11046,9 +11046,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -11799,7 +11799,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -11819,9 +11819,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262File/FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::_environment0_test262_metadataParser
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262File/FunctionObject::_environment0_test262_metadataParser
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -11832,7 +11832,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -11843,7 +11843,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -11856,14 +11856,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262File/FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262File/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.test262_metadataParser/parseTest262File::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -11877,14 +11877,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262File/FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::_environment0_test262_metadataParser
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262File/FunctionObject::_environment0_test262_metadataParser
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.test262_metadataParser/parseTest262File::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -11902,9 +11902,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -12053,29 +12053,29 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.test262_metadataParser/Scope,
-			[1] class Modules.test262_metadataParser/parseTest262File/FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File,
+			[1] class Modules.test262_metadataParser/parseTest262File/FunctionObject,
 			[2] object[],
-			[3] class Modules.test262_metadataParser/normalizeLineEndings/FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings,
-			[4] class Modules.test262_metadataParser/countIndent/FunctionObject_FunctionDeclaration_C06E48FC_countIndent,
-			[5] class Modules.test262_metadataParser/unquote/FunctionObject_FunctionDeclaration_6CFFAA1C_unquote,
-			[6] class Modules.test262_metadataParser/parseInlineList/FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList,
-			[7] class Modules.test262_metadataParser/parseInlineValue/FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue,
-			[8] class Modules.test262_metadataParser/foldBlockLines/FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines,
-			[9] class Modules.test262_metadataParser/parseBlockScalar/FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar,
-			[10] class Modules.test262_metadataParser/parseIndentedValue/FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue,
-			[11] class Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines,
-			[12] class Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter,
-			[13] class Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter,
-			[14] class Modules.test262_metadataParser/normalizePath/FunctionObject_FunctionDeclaration_5155C561_normalizePath,
-			[15] class Modules.test262_metadataParser/getFileName/FunctionObject_FunctionDeclaration_512395F4_getFileName,
-			[16] class Modules.test262_metadataParser/contains/FunctionObject_FunctionDeclaration_D59C98DE_contains,
-			[17] class Modules.test262_metadataParser/pushIssue/FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue,
-			[18] class Modules.test262_metadataParser/toStringArray/FunctionObject_FunctionDeclaration_02368D80_toStringArray,
-			[19] class Modules.test262_metadataParser/toNullableString/FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString,
-			[20] class Modules.test262_metadataParser/normalizeNegative/FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative,
-			[21] class Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata,
-			[22] class Modules.test262_metadataParser/buildMvpBlockers/FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers,
-			[23] class Modules.test262_metadataParser/parseTest262Metadata/FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata,
+			[3] class Modules.test262_metadataParser/normalizeLineEndings/FunctionObject,
+			[4] class Modules.test262_metadataParser/countIndent/FunctionObject,
+			[5] class Modules.test262_metadataParser/unquote/FunctionObject,
+			[6] class Modules.test262_metadataParser/parseInlineList/FunctionObject,
+			[7] class Modules.test262_metadataParser/parseInlineValue/FunctionObject,
+			[8] class Modules.test262_metadataParser/foldBlockLines/FunctionObject,
+			[9] class Modules.test262_metadataParser/parseBlockScalar/FunctionObject,
+			[10] class Modules.test262_metadataParser/parseIndentedValue/FunctionObject,
+			[11] class Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject,
+			[12] class Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject,
+			[13] class Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject,
+			[14] class Modules.test262_metadataParser/normalizePath/FunctionObject,
+			[15] class Modules.test262_metadataParser/getFileName/FunctionObject,
+			[16] class Modules.test262_metadataParser/contains/FunctionObject,
+			[17] class Modules.test262_metadataParser/pushIssue/FunctionObject,
+			[18] class Modules.test262_metadataParser/toStringArray/FunctionObject,
+			[19] class Modules.test262_metadataParser/toNullableString/FunctionObject,
+			[20] class Modules.test262_metadataParser/normalizeNegative/FunctionObject,
+			[21] class Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject,
+			[22] class Modules.test262_metadataParser/buildMvpBlockers/FunctionObject,
+			[23] class Modules.test262_metadataParser/parseTest262Metadata/FunctionObject,
 			[24] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[25] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[26] object,
@@ -12093,13 +12093,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.test262_metadataParser/normalizeLineEndings/FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::.ctor()
+		IL_0011: newobj instance void Modules.test262_metadataParser/normalizeLineEndings/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "normalizeLineEndings"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/normalizeLineEndings/FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/normalizeLineEndings/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.3
 		IL_0025: ldloc.0
 		IL_0026: ldloc.3
@@ -12115,13 +12115,13 @@
 		IL_0038: ldc.i4.0
 		IL_0039: ldelem.ref
 		IL_003a: castclass Modules.test262_metadataParser/Scope
-		IL_003f: newobj instance void Modules.test262_metadataParser/countIndent/FunctionObject_FunctionDeclaration_C06E48FC_countIndent::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_003f: newobj instance void Modules.test262_metadataParser/countIndent/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0044: ldc.i4.1
 		IL_0045: conv.r8
 		IL_0046: ldstr "countIndent"
 		IL_004b: ldc.i4.0
 		IL_004c: ldc.i4.1
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/countIndent/FunctionObject_FunctionDeclaration_C06E48FC_countIndent>(!!0, float64, string, bool, bool)
+		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/countIndent/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0052: stloc.s 4
 		IL_0054: ldloc.0
 		IL_0055: ldloc.s 4
@@ -12137,13 +12137,13 @@
 		IL_0068: ldc.i4.0
 		IL_0069: ldelem.ref
 		IL_006a: castclass Modules.test262_metadataParser/Scope
-		IL_006f: newobj instance void Modules.test262_metadataParser/unquote/FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_006f: newobj instance void Modules.test262_metadataParser/unquote/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0074: ldc.i4.1
 		IL_0075: conv.r8
 		IL_0076: ldstr "unquote"
 		IL_007b: ldc.i4.0
 		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/unquote/FunctionObject_FunctionDeclaration_6CFFAA1C_unquote>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/unquote/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.s 5
 		IL_0084: ldloc.0
 		IL_0085: ldloc.s 5
@@ -12159,13 +12159,13 @@
 		IL_0098: ldc.i4.0
 		IL_0099: ldelem.ref
 		IL_009a: castclass Modules.test262_metadataParser/Scope
-		IL_009f: newobj instance void Modules.test262_metadataParser/parseInlineList/FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_009f: newobj instance void Modules.test262_metadataParser/parseInlineList/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_00a4: ldc.i4.1
 		IL_00a5: conv.r8
 		IL_00a6: ldstr "parseInlineList"
 		IL_00ab: ldc.i4.0
 		IL_00ac: ldc.i4.1
-		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseInlineList/FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList>(!!0, float64, string, bool, bool)
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseInlineList/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00b2: stloc.s 6
 		IL_00b4: ldloc.0
 		IL_00b5: ldloc.s 6
@@ -12181,13 +12181,13 @@
 		IL_00c8: ldc.i4.0
 		IL_00c9: ldelem.ref
 		IL_00ca: castclass Modules.test262_metadataParser/Scope
-		IL_00cf: newobj instance void Modules.test262_metadataParser/parseInlineValue/FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_00cf: newobj instance void Modules.test262_metadataParser/parseInlineValue/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_00d4: ldc.i4.1
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "parseInlineValue"
 		IL_00db: ldc.i4.0
 		IL_00dc: ldc.i4.1
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseInlineValue/FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseInlineValue/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00e2: stloc.s 7
 		IL_00e4: ldloc.0
 		IL_00e5: ldloc.s 7
@@ -12203,13 +12203,13 @@
 		IL_00f8: ldc.i4.0
 		IL_00f9: ldelem.ref
 		IL_00fa: castclass Modules.test262_metadataParser/Scope
-		IL_00ff: newobj instance void Modules.test262_metadataParser/foldBlockLines/FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_00ff: newobj instance void Modules.test262_metadataParser/foldBlockLines/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0104: ldc.i4.1
 		IL_0105: conv.r8
 		IL_0106: ldstr "foldBlockLines"
 		IL_010b: ldc.i4.0
 		IL_010c: ldc.i4.1
-		IL_010d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/foldBlockLines/FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines>(!!0, float64, string, bool, bool)
+		IL_010d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/foldBlockLines/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0112: stloc.s 8
 		IL_0114: ldloc.0
 		IL_0115: ldloc.s 8
@@ -12225,13 +12225,13 @@
 		IL_0128: ldc.i4.0
 		IL_0129: ldelem.ref
 		IL_012a: castclass Modules.test262_metadataParser/Scope
-		IL_012f: newobj instance void Modules.test262_metadataParser/parseBlockScalar/FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_012f: newobj instance void Modules.test262_metadataParser/parseBlockScalar/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0134: ldc.i4.4
 		IL_0135: conv.r8
 		IL_0136: ldstr "parseBlockScalar"
 		IL_013b: ldc.i4.0
 		IL_013c: ldc.i4.1
-		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseBlockScalar/FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar>(!!0, float64, string, bool, bool)
+		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseBlockScalar/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0142: stloc.s 9
 		IL_0144: ldloc.0
 		IL_0145: ldloc.s 9
@@ -12247,13 +12247,13 @@
 		IL_0158: ldc.i4.0
 		IL_0159: ldelem.ref
 		IL_015a: castclass Modules.test262_metadataParser/Scope
-		IL_015f: newobj instance void Modules.test262_metadataParser/parseIndentedValue/FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_015f: newobj instance void Modules.test262_metadataParser/parseIndentedValue/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0164: ldc.i4.3
 		IL_0165: conv.r8
 		IL_0166: ldstr "parseIndentedValue"
 		IL_016b: ldc.i4.0
 		IL_016c: ldc.i4.1
-		IL_016d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseIndentedValue/FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue>(!!0, float64, string, bool, bool)
+		IL_016d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseIndentedValue/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0172: stloc.s 10
 		IL_0174: ldloc.0
 		IL_0175: ldloc.s 10
@@ -12269,13 +12269,13 @@
 		IL_0188: ldc.i4.0
 		IL_0189: ldelem.ref
 		IL_018a: castclass Modules.test262_metadataParser/Scope
-		IL_018f: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_018f: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0194: ldc.i4.3
 		IL_0195: conv.r8
 		IL_0196: ldstr "parseYamlSubsetLines"
 		IL_019b: ldc.i4.0
 		IL_019c: ldc.i4.1
-		IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines>(!!0, float64, string, bool, bool)
+		IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01a2: stloc.s 11
 		IL_01a4: ldloc.0
 		IL_01a5: ldloc.s 11
@@ -12291,13 +12291,13 @@
 		IL_01b8: ldc.i4.0
 		IL_01b9: ldelem.ref
 		IL_01ba: castclass Modules.test262_metadataParser/Scope
-		IL_01bf: newobj instance void Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_01bf: newobj instance void Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_01c4: ldc.i4.1
 		IL_01c5: conv.r8
 		IL_01c6: ldstr "parseTest262Frontmatter"
 		IL_01cb: ldc.i4.0
 		IL_01cc: ldc.i4.1
-		IL_01cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter>(!!0, float64, string, bool, bool)
+		IL_01cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01d2: stloc.s 12
 		IL_01d4: ldloc.0
 		IL_01d5: ldloc.s 12
@@ -12313,13 +12313,13 @@
 		IL_01e8: ldc.i4.0
 		IL_01e9: ldelem.ref
 		IL_01ea: castclass Modules.test262_metadataParser/Scope
-		IL_01ef: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_01ef: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_01f4: ldc.i4.1
 		IL_01f5: conv.r8
 		IL_01f6: ldstr "extractTest262Frontmatter"
 		IL_01fb: ldc.i4.0
 		IL_01fc: ldc.i4.1
-		IL_01fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter>(!!0, float64, string, bool, bool)
+		IL_01fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0202: stloc.s 13
 		IL_0204: ldloc.0
 		IL_0205: ldloc.s 13
@@ -12331,13 +12331,13 @@
 		IL_0214: ldloc.0
 		IL_0215: stelem.ref
 		IL_0216: stloc.2
-		IL_0217: newobj instance void Modules.test262_metadataParser/normalizePath/FunctionObject_FunctionDeclaration_5155C561_normalizePath::.ctor()
+		IL_0217: newobj instance void Modules.test262_metadataParser/normalizePath/FunctionObject::.ctor()
 		IL_021c: ldc.i4.1
 		IL_021d: conv.r8
 		IL_021e: ldstr "normalizePath"
 		IL_0223: ldc.i4.0
 		IL_0224: ldc.i4.1
-		IL_0225: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/normalizePath/FunctionObject_FunctionDeclaration_5155C561_normalizePath>(!!0, float64, string, bool, bool)
+		IL_0225: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/normalizePath/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_022a: stloc.s 14
 		IL_022c: ldloc.0
 		IL_022d: ldloc.s 14
@@ -12349,13 +12349,13 @@
 		IL_023c: ldloc.0
 		IL_023d: stelem.ref
 		IL_023e: stloc.2
-		IL_023f: newobj instance void Modules.test262_metadataParser/getFileName/FunctionObject_FunctionDeclaration_512395F4_getFileName::.ctor()
+		IL_023f: newobj instance void Modules.test262_metadataParser/getFileName/FunctionObject::.ctor()
 		IL_0244: ldc.i4.1
 		IL_0245: conv.r8
 		IL_0246: ldstr "getFileName"
 		IL_024b: ldc.i4.0
 		IL_024c: ldc.i4.1
-		IL_024d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/getFileName/FunctionObject_FunctionDeclaration_512395F4_getFileName>(!!0, float64, string, bool, bool)
+		IL_024d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/getFileName/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0252: stloc.s 15
 		IL_0254: ldloc.0
 		IL_0255: ldloc.s 15
@@ -12367,13 +12367,13 @@
 		IL_0264: ldloc.0
 		IL_0265: stelem.ref
 		IL_0266: stloc.2
-		IL_0267: newobj instance void Modules.test262_metadataParser/contains/FunctionObject_FunctionDeclaration_D59C98DE_contains::.ctor()
+		IL_0267: newobj instance void Modules.test262_metadataParser/contains/FunctionObject::.ctor()
 		IL_026c: ldc.i4.2
 		IL_026d: conv.r8
 		IL_026e: ldstr "contains"
 		IL_0273: ldc.i4.0
 		IL_0274: ldc.i4.1
-		IL_0275: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/contains/FunctionObject_FunctionDeclaration_D59C98DE_contains>(!!0, float64, string, bool, bool)
+		IL_0275: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/contains/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_027a: stloc.s 16
 		IL_027c: ldloc.0
 		IL_027d: ldloc.s 16
@@ -12385,13 +12385,13 @@
 		IL_028c: ldloc.0
 		IL_028d: stelem.ref
 		IL_028e: stloc.2
-		IL_028f: newobj instance void Modules.test262_metadataParser/pushIssue/FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::.ctor()
+		IL_028f: newobj instance void Modules.test262_metadataParser/pushIssue/FunctionObject::.ctor()
 		IL_0294: ldc.i4.4
 		IL_0295: conv.r8
 		IL_0296: ldstr "pushIssue"
 		IL_029b: ldc.i4.0
 		IL_029c: ldc.i4.1
-		IL_029d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/pushIssue/FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue>(!!0, float64, string, bool, bool)
+		IL_029d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/pushIssue/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02a2: stloc.s 17
 		IL_02a4: ldloc.0
 		IL_02a5: ldloc.s 17
@@ -12407,13 +12407,13 @@
 		IL_02b8: ldc.i4.0
 		IL_02b9: ldelem.ref
 		IL_02ba: castclass Modules.test262_metadataParser/Scope
-		IL_02bf: newobj instance void Modules.test262_metadataParser/toStringArray/FunctionObject_FunctionDeclaration_02368D80_toStringArray::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_02bf: newobj instance void Modules.test262_metadataParser/toStringArray/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_02c4: ldc.i4.3
 		IL_02c5: conv.r8
 		IL_02c6: ldstr "toStringArray"
 		IL_02cb: ldc.i4.0
 		IL_02cc: ldc.i4.1
-		IL_02cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/toStringArray/FunctionObject_FunctionDeclaration_02368D80_toStringArray>(!!0, float64, string, bool, bool)
+		IL_02cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/toStringArray/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02d2: stloc.s 18
 		IL_02d4: ldloc.0
 		IL_02d5: ldloc.s 18
@@ -12429,13 +12429,13 @@
 		IL_02e8: ldc.i4.0
 		IL_02e9: ldelem.ref
 		IL_02ea: castclass Modules.test262_metadataParser/Scope
-		IL_02ef: newobj instance void Modules.test262_metadataParser/toNullableString/FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_02ef: newobj instance void Modules.test262_metadataParser/toNullableString/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_02f4: ldc.i4.3
 		IL_02f5: conv.r8
 		IL_02f6: ldstr "toNullableString"
 		IL_02fb: ldc.i4.0
 		IL_02fc: ldc.i4.1
-		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/toNullableString/FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString>(!!0, float64, string, bool, bool)
+		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/toNullableString/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0302: stloc.s 19
 		IL_0304: ldloc.0
 		IL_0305: ldloc.s 19
@@ -12451,13 +12451,13 @@
 		IL_0318: ldc.i4.0
 		IL_0319: ldelem.ref
 		IL_031a: castclass Modules.test262_metadataParser/Scope
-		IL_031f: newobj instance void Modules.test262_metadataParser/normalizeNegative/FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_031f: newobj instance void Modules.test262_metadataParser/normalizeNegative/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0324: ldc.i4.2
 		IL_0325: conv.r8
 		IL_0326: ldstr "normalizeNegative"
 		IL_032b: ldc.i4.0
 		IL_032c: ldc.i4.1
-		IL_032d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/normalizeNegative/FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative>(!!0, float64, string, bool, bool)
+		IL_032d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/normalizeNegative/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0332: stloc.s 20
 		IL_0334: ldloc.0
 		IL_0335: ldloc.s 20
@@ -12473,13 +12473,13 @@
 		IL_0348: ldc.i4.0
 		IL_0349: ldelem.ref
 		IL_034a: castclass Modules.test262_metadataParser/Scope
-		IL_034f: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_034f: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0354: ldc.i4.3
 		IL_0355: conv.r8
 		IL_0356: ldstr "buildExecutionMetadata"
 		IL_035b: ldc.i4.0
 		IL_035c: ldc.i4.1
-		IL_035d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata>(!!0, float64, string, bool, bool)
+		IL_035d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0362: stloc.s 21
 		IL_0364: ldloc.0
 		IL_0365: ldloc.s 21
@@ -12495,13 +12495,13 @@
 		IL_0378: ldc.i4.0
 		IL_0379: ldelem.ref
 		IL_037a: castclass Modules.test262_metadataParser/Scope
-		IL_037f: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_037f: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0384: ldc.i4.3
 		IL_0385: conv.r8
 		IL_0386: ldstr "buildMvpBlockers"
 		IL_038b: ldc.i4.0
 		IL_038c: ldc.i4.1
-		IL_038d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/buildMvpBlockers/FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers>(!!0, float64, string, bool, bool)
+		IL_038d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/buildMvpBlockers/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0392: stloc.s 22
 		IL_0394: ldloc.0
 		IL_0395: ldloc.s 22
@@ -12517,13 +12517,13 @@
 		IL_03a8: ldc.i4.0
 		IL_03a9: ldelem.ref
 		IL_03aa: castclass Modules.test262_metadataParser/Scope
-		IL_03af: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_03af: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_03b4: ldc.i4.2
 		IL_03b5: conv.r8
 		IL_03b6: ldstr "parseTest262Metadata"
 		IL_03bb: ldc.i4.0
 		IL_03bc: ldc.i4.1
-		IL_03bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseTest262Metadata/FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata>(!!0, float64, string, bool, bool)
+		IL_03bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseTest262Metadata/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_03c2: stloc.s 23
 		IL_03c4: ldloc.0
 		IL_03c5: ldloc.s 23
@@ -12539,13 +12539,13 @@
 		IL_03d8: ldc.i4.0
 		IL_03d9: ldelem.ref
 		IL_03da: castclass Modules.test262_metadataParser/Scope
-		IL_03df: newobj instance void Modules.test262_metadataParser/parseTest262File/FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_03df: newobj instance void Modules.test262_metadataParser/parseTest262File/FunctionObject::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_03e4: ldc.i4.1
 		IL_03e5: conv.r8
 		IL_03e6: ldstr "parseTest262File"
 		IL_03eb: ldc.i4.0
 		IL_03ec: ldc.i4.1
-		IL_03ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseTest262File/FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File>(!!0, float64, string, bool, bool)
+		IL_03ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseTest262File/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_03f2: stloc.1
 		IL_03f3: nop
 		IL_03f4: ldarg.1

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_AsArray_Ternary.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_AsArray_Ternary.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4E5144CC_asArray
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Array_AsArray_Ternary/asArray::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Array_AsArray_Ternary/asArray::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4E5144CC_asArray
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -219,7 +219,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_AsArray_Ternary/Scope,
-			[1] class Modules.Array_AsArray_Ternary/asArray/FunctionObject_FunctionDeclaration_4E5144CC_asArray,
+			[1] class Modules.Array_AsArray_Ternary/asArray/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object[],
@@ -237,13 +237,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void Modules.Array_AsArray_Ternary/asArray/FunctionObject_FunctionDeclaration_4E5144CC_asArray::.ctor()
+		IL_0012: newobj instance void Modules.Array_AsArray_Ternary/asArray/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "asArray"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_AsArray_Ternary/asArray/FunctionObject_FunctionDeclaration_4E5144CC_asArray>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_AsArray_Ternary/asArray/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_CallbackOps_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_CallbackOps_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_637AD77B_L6C11
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_637AD77B_L6C11
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -178,7 +178,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7342AA0E_L9C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -192,7 +192,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -203,7 +203,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -214,7 +214,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -232,7 +232,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Array_CallbackOps_Basic/FunctionExpression_evens::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -251,7 +251,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Array_CallbackOps_Basic/FunctionExpression_evens::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -269,9 +269,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7342AA0E_L9C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -323,7 +323,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_52BEDCC4_L11C21
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -337,7 +337,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -348,7 +348,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -359,7 +359,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -377,7 +377,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -396,7 +396,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -414,9 +414,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_52BEDCC4_L11C21
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -466,7 +466,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1DB110D6_L12C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -480,7 +480,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -491,7 +491,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -502,7 +502,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -523,7 +523,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -545,7 +545,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -563,9 +563,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1DB110D6_L12C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -619,7 +619,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0F06B6BC_L13C27
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -633,7 +633,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -644,7 +644,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -655,7 +655,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -676,7 +676,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -698,7 +698,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -716,9 +716,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_0F06B6BC_L13C27
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -770,7 +770,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FB505DFD_L15C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -784,7 +784,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -795,7 +795,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -806,7 +806,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -824,7 +824,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -843,7 +843,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -861,9 +861,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_FB505DFD_L15C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -932,18 +932,18 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] object[],
-			[5] class Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10/FunctionObject_FunctionExpression_637AD77B_L6C11,
-			[6] class Modules.Array_CallbackOps_Basic/FunctionExpression_evens/FunctionObject_FunctionExpression_7342AA0E_L9C22,
+			[5] class Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10/FunctionObject,
+			[6] class Modules.Array_CallbackOps_Basic/FunctionExpression_evens/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] string,
-			[9] class Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20/FunctionObject_FunctionExpression_52BEDCC4_L11C21,
+			[9] class Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20/FunctionObject,
 			[10] bool,
 			[11] object,
-			[12] class Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21/FunctionObject_FunctionExpression_1DB110D6_L12C22,
+			[12] class Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21/FunctionObject,
 			[13] object,
-			[14] class Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26/FunctionObject_FunctionExpression_0F06B6BC_L13C27,
+			[14] class Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26/FunctionObject,
 			[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[16] class Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30/FunctionObject_FunctionExpression_FB505DFD_L15C31
+			[16] class Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Array_CallbackOps_Basic/Scope::.ctor()
@@ -968,13 +968,13 @@
 		IL_0043: ldloc.0
 		IL_0044: stelem.ref
 		IL_0045: stloc.s 4
-		IL_0047: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10/FunctionObject_FunctionExpression_637AD77B_L6C11::.ctor()
+		IL_0047: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10/FunctionObject::.ctor()
 		IL_004c: ldc.i4.1
 		IL_004d: conv.r8
 		IL_004e: ldstr ""
 		IL_0053: ldc.i4.0
 		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10/FunctionObject_FunctionExpression_637AD77B_L6C11>(!!0, float64, string, bool, bool)
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005a: stloc.s 5
 		IL_005c: ldloc.1
 		IL_005d: ldc.i4.1
@@ -1007,13 +1007,13 @@
 		IL_00b9: ldloc.0
 		IL_00ba: stelem.ref
 		IL_00bb: stloc.s 4
-		IL_00bd: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_evens/FunctionObject_FunctionExpression_7342AA0E_L9C22::.ctor()
+		IL_00bd: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_evens/FunctionObject::.ctor()
 		IL_00c2: ldc.i4.1
 		IL_00c3: conv.r8
 		IL_00c4: ldstr ""
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_evens/FunctionObject_FunctionExpression_7342AA0E_L9C22>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_evens/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 6
 		IL_00d2: ldloc.2
 		IL_00d3: ldc.i4.1
@@ -1042,13 +1042,13 @@
 		IL_010c: ldloc.0
 		IL_010d: stelem.ref
 		IL_010e: stloc.s 4
-		IL_0110: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20/FunctionObject_FunctionExpression_52BEDCC4_L11C21::.ctor()
+		IL_0110: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20/FunctionObject::.ctor()
 		IL_0115: ldc.i4.1
 		IL_0116: conv.r8
 		IL_0117: ldstr ""
 		IL_011c: ldc.i4.0
 		IL_011d: ldc.i4.1
-		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20/FunctionObject_FunctionExpression_52BEDCC4_L11C21>(!!0, float64, string, bool, bool)
+		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0123: stloc.s 9
 		IL_0125: ldloc.2
 		IL_0126: ldc.i4.1
@@ -1075,13 +1075,13 @@
 		IL_015a: ldloc.0
 		IL_015b: stelem.ref
 		IL_015c: stloc.s 4
-		IL_015e: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21/FunctionObject_FunctionExpression_1DB110D6_L12C22::.ctor()
+		IL_015e: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21/FunctionObject::.ctor()
 		IL_0163: ldc.i4.2
 		IL_0164: conv.r8
 		IL_0165: ldstr ""
 		IL_016a: ldc.i4.0
 		IL_016b: ldc.i4.1
-		IL_016c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21/FunctionObject_FunctionExpression_1DB110D6_L12C22>(!!0, float64, string, bool, bool)
+		IL_016c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0171: stloc.s 12
 		IL_0173: ldloc.2
 		IL_0174: ldc.i4.2
@@ -1110,13 +1110,13 @@
 		IL_01b0: ldloc.0
 		IL_01b1: stelem.ref
 		IL_01b2: stloc.s 4
-		IL_01b4: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26/FunctionObject_FunctionExpression_0F06B6BC_L13C27::.ctor()
+		IL_01b4: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26/FunctionObject::.ctor()
 		IL_01b9: ldc.i4.2
 		IL_01ba: conv.r8
 		IL_01bb: ldstr ""
 		IL_01c0: ldc.i4.0
 		IL_01c1: ldc.i4.1
-		IL_01c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26/FunctionObject_FunctionExpression_0F06B6BC_L13C27>(!!0, float64, string, bool, bool)
+		IL_01c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01c7: stloc.s 14
 		IL_01c9: ldloc.2
 		IL_01ca: ldc.i4.1
@@ -1152,13 +1152,13 @@
 		IL_022a: ldloc.0
 		IL_022b: stelem.ref
 		IL_022c: stloc.s 4
-		IL_022e: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30/FunctionObject_FunctionExpression_FB505DFD_L15C31::.ctor()
+		IL_022e: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30/FunctionObject::.ctor()
 		IL_0233: ldc.i4.1
 		IL_0234: conv.r8
 		IL_0235: ldstr ""
 		IL_023a: ldc.i4.0
 		IL_023b: ldc.i4.1
-		IL_023c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30/FunctionObject_FunctionExpression_FB505DFD_L15C31>(!!0, float64, string, bool, bool)
+		IL_023c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0241: stloc.s 16
 		IL_0243: ldloc.s 15
 		IL_0245: ldc.i4.1

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_DenseFastPath_Guards.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_DenseFastPath_Guards.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EA166462_L5C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject_FunctionExpression_EA166462_L5C14::_environment0_Array_DenseFastPath_Guards
+				IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject::_environment0_Array_DenseFastPath_Guards
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject_FunctionExpression_EA166462_L5C14::_environment0_Array_DenseFastPath_Guards
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject::_environment0_Array_DenseFastPath_Guards
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject_FunctionExpression_EA166462_L5C14::_environment0_Array_DenseFastPath_Guards
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject::_environment0_Array_DenseFastPath_Guards
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_EA166462_L5C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -187,7 +187,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4F2CEFAB_L19C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -207,9 +207,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject_FunctionExpression_4F2CEFAB_L19C14::_environment0_Array_DenseFastPath_Guards
+				IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject::_environment0_Array_DenseFastPath_Guards
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -220,7 +220,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -231,7 +231,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -244,11 +244,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject_FunctionExpression_4F2CEFAB_L19C14::_environment0_Array_DenseFastPath_Guards
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject::_environment0_Array_DenseFastPath_Guards
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -262,11 +262,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject_FunctionExpression_4F2CEFAB_L19C14::_environment0_Array_DenseFastPath_Guards
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject::_environment0_Array_DenseFastPath_Guards
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -284,9 +284,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_4F2CEFAB_L19C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -345,7 +345,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3704D58D_L31C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -365,9 +365,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject_FunctionExpression_3704D58D_L31C10::_environment0_Array_DenseFastPath_Guards
+				IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject::_environment0_Array_DenseFastPath_Guards
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -378,7 +378,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -389,7 +389,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -402,14 +402,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject_FunctionExpression_3704D58D_L31C10::_environment0_Array_DenseFastPath_Guards
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject::_environment0_Array_DenseFastPath_Guards
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -423,14 +423,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject_FunctionExpression_3704D58D_L31C10::_environment0_Array_DenseFastPath_Guards
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject::_environment0_Array_DenseFastPath_Guards
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -448,9 +448,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_3704D58D_L31C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -502,7 +502,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2B8CF3A7_L42C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -522,9 +522,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject_FunctionExpression_2B8CF3A7_L42C10::_environment0_Array_DenseFastPath_Guards
+				IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject::_environment0_Array_DenseFastPath_Guards
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -535,7 +535,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -546,7 +546,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -559,14 +559,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject_FunctionExpression_2B8CF3A7_L42C10::_environment0_Array_DenseFastPath_Guards
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject::_environment0_Array_DenseFastPath_Guards
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -580,14 +580,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject_FunctionExpression_2B8CF3A7_L42C10::_environment0_Array_DenseFastPath_Guards
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject::_environment0_Array_DenseFastPath_Guards
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -605,9 +605,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_2B8CF3A7_L42C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -743,18 +743,18 @@
 			[12] object,
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[14] object[],
-			[15] class Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject_FunctionExpression_EA166462_L5C14,
+			[15] class Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[17] object,
 			[18] object,
 			[19] string,
-			[20] class Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject_FunctionExpression_4F2CEFAB_L19C14,
+			[20] class Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject,
 			[21] object,
-			[22] class Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject_FunctionExpression_3704D58D_L31C10,
+			[22] class Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject,
 			[23] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[24] object,
 			[25] bool,
-			[26] class Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject_FunctionExpression_2B8CF3A7_L42C10
+			[26] class Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -784,13 +784,13 @@
 		IL_0048: ldc.i4.0
 		IL_0049: ldelem.ref
 		IL_004a: castclass Modules.Array_DenseFastPath_Guards/Scope
-		IL_004f: newobj instance void Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject_FunctionExpression_EA166462_L5C14::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
+		IL_004f: newobj instance void Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
 		IL_0054: ldc.i4.0
 		IL_0055: conv.r8
 		IL_0056: ldstr ""
 		IL_005b: ldc.i4.0
 		IL_005c: ldc.i4.1
-		IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject_FunctionExpression_EA166462_L5C14>(!!0, float64, string, bool, bool)
+		IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0062: stloc.s 15
 		IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0069: dup
@@ -896,13 +896,13 @@
 		IL_0169: ldc.i4.0
 		IL_016a: ldelem.ref
 		IL_016b: castclass Modules.Array_DenseFastPath_Guards/Scope
-		IL_0170: newobj instance void Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject_FunctionExpression_4F2CEFAB_L19C14::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
+		IL_0170: newobj instance void Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
 		IL_0175: ldc.i4.0
 		IL_0176: conv.r8
 		IL_0177: ldstr ""
 		IL_017c: ldc.i4.0
 		IL_017d: ldc.i4.1
-		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject_FunctionExpression_4F2CEFAB_L19C14>(!!0, float64, string, bool, bool)
+		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0183: stloc.s 20
 		IL_0185: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_018a: dup
@@ -960,13 +960,13 @@
 		IL_0236: ldc.i4.0
 		IL_0237: ldelem.ref
 		IL_0238: castclass Modules.Array_DenseFastPath_Guards/Scope
-		IL_023d: newobj instance void Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject_FunctionExpression_3704D58D_L31C10::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
+		IL_023d: newobj instance void Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
 		IL_0242: ldc.i4.1
 		IL_0243: conv.r8
 		IL_0244: ldstr ""
 		IL_0249: ldc.i4.0
 		IL_024a: ldc.i4.1
-		IL_024b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject_FunctionExpression_3704D58D_L31C10>(!!0, float64, string, bool, bool)
+		IL_024b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0250: stloc.s 22
 		IL_0252: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0257: dup
@@ -1038,13 +1038,13 @@
 		IL_0333: ldc.i4.0
 		IL_0334: ldelem.ref
 		IL_0335: castclass Modules.Array_DenseFastPath_Guards/Scope
-		IL_033a: newobj instance void Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject_FunctionExpression_2B8CF3A7_L42C10::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
+		IL_033a: newobj instance void Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
 		IL_033f: ldc.i4.1
 		IL_0340: conv.r8
 		IL_0341: ldstr ""
 		IL_0346: ldc.i4.0
 		IL_0347: ldc.i4.1
-		IL_0348: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject_FunctionExpression_2B8CF3A7_L42C10>(!!0, float64, string, bool, bool)
+		IL_0348: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_034d: stloc.s 26
 		IL_034f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0354: dup

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Property_Descriptors.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Property_Descriptors.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DD911CFC_L23C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject_FunctionExpression_DD911CFC_L23C10::_environment0_Array_Exotic_Property_Descriptors
+				IL_0008: stfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject::_environment0_Array_Exotic_Property_Descriptors
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject_FunctionExpression_DD911CFC_L23C10::_environment0_Array_Exotic_Property_Descriptors
+				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject::_environment0_Array_Exotic_Property_Descriptors
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject_FunctionExpression_DD911CFC_L23C10::_environment0_Array_Exotic_Property_Descriptors
+				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject::_environment0_Array_Exotic_Property_Descriptors
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_DD911CFC_L23C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -178,7 +178,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5BEC1E07_L24C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -198,9 +198,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject_FunctionExpression_5BEC1E07_L24C10::_environment0_Array_Exotic_Property_Descriptors
+				IL_0008: stfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject::_environment0_Array_Exotic_Property_Descriptors
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -211,7 +211,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -222,7 +222,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -235,14 +235,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject_FunctionExpression_5BEC1E07_L24C10::_environment0_Array_Exotic_Property_Descriptors
+				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject::_environment0_Array_Exotic_Property_Descriptors
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -256,14 +256,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject_FunctionExpression_5BEC1E07_L24C10::_environment0_Array_Exotic_Property_Descriptors
+				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject::_environment0_Array_Exotic_Property_Descriptors
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -281,9 +281,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5BEC1E07_L24C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -347,7 +347,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C8ECECDF_clearArray
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -361,7 +361,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -372,7 +372,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -383,7 +383,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -402,7 +402,7 @@
 				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_0011: call object Modules.Array_Exotic_Property_Descriptors/clearArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -422,7 +422,7 @@
 				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_000d: call object Modules.Array_Exotic_Property_Descriptors/clearArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -440,9 +440,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C8ECECDF_clearArray
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -492,7 +492,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3D5ECCF2_L165C15
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -512,9 +512,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject_FunctionExpression_3D5ECCF2_L165C15::_environment0_Array_Exotic_Property_Descriptors
+				IL_0008: stfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject::_environment0_Array_Exotic_Property_Descriptors
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -525,7 +525,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -536,7 +536,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -549,11 +549,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject_FunctionExpression_3D5ECCF2_L165C15::_environment0_Array_Exotic_Property_Descriptors
+				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject::_environment0_Array_Exotic_Property_Descriptors
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -567,11 +567,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject_FunctionExpression_3D5ECCF2_L165C15::_environment0_Array_Exotic_Property_Descriptors
+				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject::_environment0_Array_Exotic_Property_Descriptors
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -589,9 +589,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_3D5ECCF2_L165C15
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1177,7 +1177,7 @@
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Array_Exotic_Property_Descriptors/Scope,
-			[1] class Modules.Array_Exotic_Property_Descriptors/clearArray/FunctionObject_FunctionDeclaration_C8ECECDF_clearArray,
+			[1] class Modules.Array_Exotic_Property_Descriptors/clearArray/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object,
 			[4] class [System.Runtime]System.Exception,
@@ -1248,8 +1248,8 @@
 			[69] object,
 			[70] object,
 			[71] object,
-			[72] class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject_FunctionExpression_DD911CFC_L23C10,
-			[73] class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject_FunctionExpression_5BEC1E07_L24C10,
+			[72] class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject,
+			[73] class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject,
 			[74] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[75] object,
 			[76] object,
@@ -1257,7 +1257,7 @@
 			[78] string,
 			[79] float64,
 			[80] object,
-			[81] class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject_FunctionExpression_3D5ECCF2_L165C15
+			[81] class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope::.ctor()
@@ -1269,13 +1269,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 64
-		IL_0012: newobj instance void Modules.Array_Exotic_Property_Descriptors/clearArray/FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::.ctor()
+		IL_0012: newobj instance void Modules.Array_Exotic_Property_Descriptors/clearArray/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "clearArray"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/clearArray/FunctionObject_FunctionDeclaration_C8ECECDF_clearArray>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/clearArray/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldc.i4.3
@@ -1457,13 +1457,13 @@
 		IL_022f: ldc.i4.0
 		IL_0230: ldelem.ref
 		IL_0231: castclass Modules.Array_Exotic_Property_Descriptors/Scope
-		IL_0236: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject_FunctionExpression_DD911CFC_L23C10::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
+		IL_0236: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
 		IL_023b: ldc.i4.0
 		IL_023c: conv.r8
 		IL_023d: ldstr ""
 		IL_0242: ldc.i4.0
 		IL_0243: ldc.i4.1
-		IL_0244: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject_FunctionExpression_DD911CFC_L23C10>(!!0, float64, string, bool, bool)
+		IL_0244: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0249: stloc.s 72
 		IL_024b: ldc.i4.1
 		IL_024c: newarr [System.Runtime]System.Object
@@ -1476,13 +1476,13 @@
 		IL_0259: ldc.i4.0
 		IL_025a: ldelem.ref
 		IL_025b: castclass Modules.Array_Exotic_Property_Descriptors/Scope
-		IL_0260: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject_FunctionExpression_5BEC1E07_L24C10::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
+		IL_0260: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
 		IL_0265: ldc.i4.1
 		IL_0266: conv.r8
 		IL_0267: ldstr ""
 		IL_026c: ldc.i4.0
 		IL_026d: ldc.i4.1
-		IL_026e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject_FunctionExpression_5BEC1E07_L24C10>(!!0, float64, string, bool, bool)
+		IL_026e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0273: stloc.s 73
 		IL_0275: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_027a: dup
@@ -2726,13 +2726,13 @@
 		IL_10ec: ldc.i4.0
 		IL_10ed: ldelem.ref
 		IL_10ee: castclass Modules.Array_Exotic_Property_Descriptors/Scope
-		IL_10f3: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject_FunctionExpression_3D5ECCF2_L165C15::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
+		IL_10f3: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
 		IL_10f8: ldc.i4.0
 		IL_10f9: conv.r8
 		IL_10fa: ldstr ""
 		IL_10ff: ldc.i4.0
 		IL_1100: ldc.i4.1
-		IL_1101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject_FunctionExpression_3D5ECCF2_L165C15>(!!0, float64, string, bool, bool)
+		IL_1101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_1106: stloc.s 81
 		IL_1108: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_110d: dup

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Sloppy_Assignment.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Sloppy_Assignment.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_70743D8E_L19C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_Exotic_Sloppy_Assignment/Scope Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14::_environment0_Array_Exotic_Sloppy_Assignment
+				IL_0008: stfld class Modules.Array_Exotic_Sloppy_Assignment/Scope Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject::_environment0_Array_Exotic_Sloppy_Assignment
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -88,7 +88,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -101,11 +101,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_Exotic_Sloppy_Assignment/Scope Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14::_environment0_Array_Exotic_Sloppy_Assignment
+				IL_0001: ldfld class Modules.Array_Exotic_Sloppy_Assignment/Scope Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject::_environment0_Array_Exotic_Sloppy_Assignment
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs::__js_call__(class Modules.Array_Exotic_Sloppy_Assignment/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -119,11 +119,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_Exotic_Sloppy_Assignment/Scope Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14::_environment0_Array_Exotic_Sloppy_Assignment
+				IL_0001: ldfld class Modules.Array_Exotic_Sloppy_Assignment/Scope Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject::_environment0_Array_Exotic_Sloppy_Assignment
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs::__js_call__(class Modules.Array_Exotic_Sloppy_Assignment/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -141,9 +141,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_70743D8E_L19C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -239,7 +239,7 @@
 			[10] object,
 			[11] object,
 			[12] object[],
-			[13] class Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14
+			[13] class Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Array_Exotic_Sloppy_Assignment/Scope::.ctor()
@@ -379,14 +379,14 @@
 		IL_01dc: ldc.i4.0
 		IL_01dd: ldelem.ref
 		IL_01de: castclass Modules.Array_Exotic_Sloppy_Assignment/Scope
-		IL_01e3: newobj instance void Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14::.ctor(class Modules.Array_Exotic_Sloppy_Assignment/Scope)
+		IL_01e3: newobj instance void Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject::.ctor(class Modules.Array_Exotic_Sloppy_Assignment/Scope)
 		IL_01e8: ldc.i4.0
 		IL_01e9: conv.r8
 		IL_01ea: ldstr ""
 		IL_01ef: ldc.i4.0
 		IL_01f0: ldc.i4.0
-		IL_01f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14>(!!0, float64, string, bool, bool)
-		IL_01f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14>(!!0)
+		IL_01f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject>(!!0)
 		IL_01fb: stloc.s 13
 		IL_01fd: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0202: dup

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Find_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Find_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3461D0C8_L5C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Array_Find_Basic/FunctionExpression_found::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Array_Find_Basic/FunctionExpression_found::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_3461D0C8_L5C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -173,7 +173,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E33B8407_L10C27
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -187,7 +187,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -198,7 +198,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -209,7 +209,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -227,7 +227,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Array_Find_Basic/FunctionExpression_notFound::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -246,7 +246,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Array_Find_Basic/FunctionExpression_notFound::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -264,9 +264,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E33B8407_L10C27
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -332,9 +332,9 @@
 			[2] object,
 			[3] object,
 			[4] object[],
-			[5] class Modules.Array_Find_Basic/FunctionExpression_found/FunctionObject_FunctionExpression_3461D0C8_L5C24,
+			[5] class Modules.Array_Find_Basic/FunctionExpression_found/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[7] class Modules.Array_Find_Basic/FunctionExpression_notFound/FunctionObject_FunctionExpression_E33B8407_L10C27
+			[7] class Modules.Array_Find_Basic/FunctionExpression_notFound/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Array_Find_Basic/Scope::.ctor()
@@ -362,13 +362,13 @@
 		IL_0052: ldloc.0
 		IL_0053: stelem.ref
 		IL_0054: stloc.s 4
-		IL_0056: newobj instance void Modules.Array_Find_Basic/FunctionExpression_found/FunctionObject_FunctionExpression_3461D0C8_L5C24::.ctor()
+		IL_0056: newobj instance void Modules.Array_Find_Basic/FunctionExpression_found/FunctionObject::.ctor()
 		IL_005b: ldc.i4.1
 		IL_005c: conv.r8
 		IL_005d: ldstr ""
 		IL_0062: ldc.i4.0
 		IL_0063: ldc.i4.1
-		IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Find_Basic/FunctionExpression_found/FunctionObject_FunctionExpression_3461D0C8_L5C24>(!!0, float64, string, bool, bool)
+		IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Find_Basic/FunctionExpression_found/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0069: stloc.s 5
 		IL_006b: ldloc.1
 		IL_006c: ldc.i4.1
@@ -392,13 +392,13 @@
 		IL_0095: ldloc.0
 		IL_0096: stelem.ref
 		IL_0097: stloc.s 4
-		IL_0099: newobj instance void Modules.Array_Find_Basic/FunctionExpression_notFound/FunctionObject_FunctionExpression_E33B8407_L10C27::.ctor()
+		IL_0099: newobj instance void Modules.Array_Find_Basic/FunctionExpression_notFound/FunctionObject::.ctor()
 		IL_009e: ldc.i4.1
 		IL_009f: conv.r8
 		IL_00a0: ldstr ""
 		IL_00a5: ldc.i4.0
 		IL_00a6: ldc.i4.1
-		IL_00a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Find_Basic/FunctionExpression_notFound/FunctionObject_FunctionExpression_E33B8407_L10C27>(!!0, float64, string, bool, bool)
+		IL_00a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Find_Basic/FunctionExpression_notFound/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00ac: stloc.s 7
 		IL_00ae: ldloc.1
 		IL_00af: ldc.i4.1

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Iterator_Methods.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Iterator_Methods.verified.txt
@@ -55,7 +55,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DBFD1C9F_L44C11
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -77,12 +77,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11::_environment1_FunctionExpression_L41C30
+					IL_0008: stfld class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject::_environment1_FunctionExpression_L41C30
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11::_transitionalScopes
+					IL_000f: stfld object[] Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -93,7 +93,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -104,7 +104,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -117,11 +117,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -135,11 +135,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -157,9 +157,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_DBFD1C9F_L44C11
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -250,7 +250,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_733F3DEF_L41C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -270,9 +270,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_Iterator_Methods/Scope Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject_FunctionExpression_733F3DEF_L41C31::_environment0_Array_Iterator_Methods
+				IL_0008: stfld class Modules.Array_Iterator_Methods/Scope Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject::_environment0_Array_Iterator_Methods
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -283,7 +283,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -294,7 +294,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -307,11 +307,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_Iterator_Methods/Scope Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject_FunctionExpression_733F3DEF_L41C31::_environment0_Array_Iterator_Methods
+				IL_0001: ldfld class Modules.Array_Iterator_Methods/Scope Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject::_environment0_Array_Iterator_Methods
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Array_Iterator_Methods/FunctionExpression_L41C30::__js_call__(class Modules.Array_Iterator_Methods/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -325,11 +325,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_Iterator_Methods/Scope Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject_FunctionExpression_733F3DEF_L41C31::_environment0_Array_Iterator_Methods
+				IL_0001: ldfld class Modules.Array_Iterator_Methods/Scope Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject::_environment0_Array_Iterator_Methods
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Array_Iterator_Methods/FunctionExpression_L41C30::__js_call__(class Modules.Array_Iterator_Methods/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -347,9 +347,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_733F3DEF_L41C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -370,7 +370,7 @@
 			.locals init (
 				[0] class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope,
 				[1] object[],
-				[2] class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11,
+				[2] class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
@@ -396,13 +396,13 @@
 			IL_0023: ldelem.ref
 			IL_0024: castclass Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope
 			IL_0029: ldloc.1
-			IL_002a: newobj instance void Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11::.ctor(class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope, object[])
+			IL_002a: newobj instance void Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject::.ctor(class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope, object[])
 			IL_002f: ldc.i4.0
 			IL_0030: conv.r8
 			IL_0031: ldstr ""
 			IL_0036: ldc.i4.0
 			IL_0037: ldc.i4.1
-			IL_0038: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11>(!!0, float64, string, bool, bool)
+			IL_0038: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_003d: stloc.2
 			IL_003e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0043: dup
@@ -513,7 +513,7 @@
 			[20] bool,
 			[21] object,
 			[22] object[],
-			[23] class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject_FunctionExpression_733F3DEF_L41C31,
+			[23] class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject,
 			[24] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[25] string
 		)
@@ -874,13 +874,13 @@
 		IL_04c6: ldc.i4.0
 		IL_04c7: ldelem.ref
 		IL_04c8: castclass Modules.Array_Iterator_Methods/Scope
-		IL_04cd: newobj instance void Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject_FunctionExpression_733F3DEF_L41C31::.ctor(class Modules.Array_Iterator_Methods/Scope)
+		IL_04cd: newobj instance void Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject::.ctor(class Modules.Array_Iterator_Methods/Scope)
 		IL_04d2: ldc.i4.0
 		IL_04d3: conv.r8
 		IL_04d4: ldstr ""
 		IL_04d9: ldc.i4.0
 		IL_04da: ldc.i4.1
-		IL_04db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject_FunctionExpression_733F3DEF_L41C31>(!!0, float64, string, bool, bool)
+		IL_04db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_04e0: stloc.s 23
 		IL_04e2: ldloc.s 10
 		IL_04e4: ldloc.s 19

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B7CBC545_L4C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Array_Map_Basic/FunctionExpression_lengths::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Array_Map_Basic/FunctionExpression_lengths::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_B7CBC545_L4C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -213,7 +213,7 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] float64,
 			[4] object[],
-			[5] class Modules.Array_Map_Basic/FunctionExpression_lengths/FunctionObject_FunctionExpression_B7CBC545_L4C23,
+			[5] class Modules.Array_Map_Basic/FunctionExpression_lengths/FunctionObject,
 			[6] float64,
 			[7] float64,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -242,13 +242,13 @@
 		IL_0037: ldloc.0
 		IL_0038: stelem.ref
 		IL_0039: stloc.s 4
-		IL_003b: newobj instance void Modules.Array_Map_Basic/FunctionExpression_lengths/FunctionObject_FunctionExpression_B7CBC545_L4C23::.ctor()
+		IL_003b: newobj instance void Modules.Array_Map_Basic/FunctionExpression_lengths/FunctionObject::.ctor()
 		IL_0040: ldc.i4.1
 		IL_0041: conv.r8
 		IL_0042: ldstr ""
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Map_Basic/FunctionExpression_lengths/FunctionObject_FunctionExpression_B7CBC545_L4C23>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Map_Basic/FunctionExpression_lengths/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.s 5
 		IL_0050: ldloc.1
 		IL_0051: ldc.i4.1

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FCCE10B1_inner
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -56,12 +56,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Array_Map_NestedParam/outer/Scope Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner::_environment1_outer
+					IL_0008: stfld class Modules.Array_Map_NestedParam/outer/Scope Modules.Array_Map_NestedParam/outer/inner/FunctionObject::_environment1_outer
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner::_transitionalScopes
+					IL_000f: stfld object[] Modules.Array_Map_NestedParam/outer/inner/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -96,14 +96,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Array_Map_NestedParam/outer/inner/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Array_Map_NestedParam/outer/inner::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -117,14 +117,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Array_Map_NestedParam/outer/inner/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Array_Map_NestedParam/outer/inner::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -142,9 +142,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_FCCE10B1_inner
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -324,7 +324,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AEA8D026_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -344,9 +344,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_Map_NestedParam/Scope Modules.Array_Map_NestedParam/outer/FunctionObject_FunctionDeclaration_AEA8D026_outer::_environment0_Array_Map_NestedParam
+				IL_0008: stfld class Modules.Array_Map_NestedParam/Scope Modules.Array_Map_NestedParam/outer/FunctionObject::_environment0_Array_Map_NestedParam
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -357,7 +357,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -368,7 +368,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -381,14 +381,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_Map_NestedParam/Scope Modules.Array_Map_NestedParam/outer/FunctionObject_FunctionDeclaration_AEA8D026_outer::_environment0_Array_Map_NestedParam
+				IL_0001: ldfld class Modules.Array_Map_NestedParam/Scope Modules.Array_Map_NestedParam/outer/FunctionObject::_environment0_Array_Map_NestedParam
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Array_Map_NestedParam/outer::__js_call__(class Modules.Array_Map_NestedParam/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -402,14 +402,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_Map_NestedParam/Scope Modules.Array_Map_NestedParam/outer/FunctionObject_FunctionDeclaration_AEA8D026_outer::_environment0_Array_Map_NestedParam
+				IL_0001: ldfld class Modules.Array_Map_NestedParam/Scope Modules.Array_Map_NestedParam/outer/FunctionObject::_environment0_Array_Map_NestedParam
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Array_Map_NestedParam/outer::__js_call__(class Modules.Array_Map_NestedParam/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -427,9 +427,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_AEA8D026_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -450,7 +450,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Array_Map_NestedParam/outer/Scope,
-				[1] class Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner,
+				[1] class Modules.Array_Map_NestedParam/outer/inner/FunctionObject,
 				[2] object[],
 				[3] class Modules.Array_Map_NestedParam/outer/ArrowFunction_L9C16/FunctionObject
 			)
@@ -476,13 +476,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.Array_Map_NestedParam/outer/Scope
 			IL_0024: ldloc.2
-			IL_0025: newobj instance void Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner::.ctor(class Modules.Array_Map_NestedParam/outer/Scope, object[])
+			IL_0025: newobj instance void Modules.Array_Map_NestedParam/outer/inner/FunctionObject::.ctor(class Modules.Array_Map_NestedParam/outer/Scope, object[])
 			IL_002a: ldc.i4.1
 			IL_002b: conv.r8
 			IL_002c: ldstr "inner"
 			IL_0031: ldc.i4.0
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Map_NestedParam/outer/inner/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.1
 			IL_0039: nop
 			IL_003a: ldc.i4.1
@@ -607,7 +607,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Map_NestedParam/Scope,
-			[1] class Modules.Array_Map_NestedParam/outer/FunctionObject_FunctionDeclaration_AEA8D026_outer,
+			[1] class Modules.Array_Map_NestedParam/outer/FunctionObject,
 			[2] object,
 			[3] float64,
 			[4] object[],
@@ -631,13 +631,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Array_Map_NestedParam/Scope
-		IL_001b: newobj instance void Modules.Array_Map_NestedParam/outer/FunctionObject_FunctionDeclaration_AEA8D026_outer::.ctor(class Modules.Array_Map_NestedParam/Scope)
+		IL_001b: newobj instance void Modules.Array_Map_NestedParam/outer/FunctionObject::.ctor(class Modules.Array_Map_NestedParam/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "outer"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Map_NestedParam/outer/FunctionObject_FunctionDeclaration_AEA8D026_outer>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Map_NestedParam/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_NonMutatingOps_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_NonMutatingOps_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_49940B4B_L14C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_49940B4B_L14C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -202,7 +202,7 @@
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] string,
 			[9] object[],
-			[10] class Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23/FunctionObject_FunctionExpression_49940B4B_L14C24
+			[10] class Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Array_NonMutatingOps_Basic/Scope::.ctor()
@@ -330,13 +330,13 @@
 		IL_0193: ldloc.0
 		IL_0194: stelem.ref
 		IL_0195: stloc.s 9
-		IL_0197: newobj instance void Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23/FunctionObject_FunctionExpression_49940B4B_L14C24::.ctor()
+		IL_0197: newobj instance void Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23/FunctionObject::.ctor()
 		IL_019c: ldc.i4.2
 		IL_019d: conv.r8
 		IL_019e: ldstr ""
 		IL_01a3: ldc.i4.0
 		IL_01a4: ldc.i4.1
-		IL_01a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23/FunctionObject_FunctionExpression_49940B4B_L14C24>(!!0, float64, string, bool, bool)
+		IL_01a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01aa: stloc.s 10
 		IL_01ac: ldloc.3
 		IL_01ad: ldc.i4.1

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_Call.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_Call.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5A6FB1D8_L8C54
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5A6FB1D8_L8C54
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -183,7 +183,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_47AD9F8D_L11C64
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -197,7 +197,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -208,7 +208,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -219,7 +219,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -240,7 +240,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -262,7 +262,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -280,9 +280,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_47AD9F8D_L11C64
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -353,9 +353,9 @@
 			[3] object,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced/FunctionObject_FunctionExpression_5A6FB1D8_L8C54,
+			[6] class Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[8] class Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight/FunctionObject_FunctionExpression_47AD9F8D_L11C64,
+			[8] class Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight/FunctionObject,
 			[9] float64,
 			[10] object
 		)
@@ -400,13 +400,13 @@
 		IL_0086: ldloc.0
 		IL_0087: stelem.ref
 		IL_0088: stloc.s 5
-		IL_008a: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced/FunctionObject_FunctionExpression_5A6FB1D8_L8C54::.ctor()
+		IL_008a: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced/FunctionObject::.ctor()
 		IL_008f: ldc.i4.2
 		IL_0090: conv.r8
 		IL_0091: ldstr ""
 		IL_0096: ldc.i4.0
 		IL_0097: ldc.i4.1
-		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced/FunctionObject_FunctionExpression_5A6FB1D8_L8C54>(!!0, float64, string, bool, bool)
+		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_009d: stloc.s 6
 		IL_009f: ldloc.s 4
 		IL_00a1: ldstr "call"
@@ -440,13 +440,13 @@
 		IL_00f9: ldloc.0
 		IL_00fa: stelem.ref
 		IL_00fb: stloc.s 5
-		IL_00fd: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight/FunctionObject_FunctionExpression_47AD9F8D_L11C64::.ctor()
+		IL_00fd: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight/FunctionObject::.ctor()
 		IL_0102: ldc.i4.2
 		IL_0103: conv.r8
 		IL_0104: ldstr ""
 		IL_0109: ldc.i4.0
 		IL_010a: ldc.i4.1
-		IL_010b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight/FunctionObject_FunctionExpression_47AD9F8D_L11C64>(!!0, float64, string, bool, bool)
+		IL_010b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0110: stloc.s 8
 		IL_0112: ldloc.s 4
 		IL_0114: ldstr "call"

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_EdgeCases.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_685C2912_L23C46
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject_FunctionExpression_685C2912_L23C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject_FunctionExpression_685C2912_L23C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -97,7 +97,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -111,7 +111,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject_FunctionExpression_685C2912_L23C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -121,7 +121,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -139,9 +139,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_685C2912_L23C46
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -212,7 +212,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E6591AFB_L31C46
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -232,9 +232,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject_FunctionExpression_E6591AFB_L31C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -245,7 +245,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -256,7 +256,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -269,7 +269,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject_FunctionExpression_E6591AFB_L31C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -279,7 +279,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -293,7 +293,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject_FunctionExpression_E6591AFB_L31C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -303,7 +303,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -321,9 +321,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E6591AFB_L31C46
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -394,7 +394,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0644002F_L39C51
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -414,9 +414,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject_FunctionExpression_0644002F_L39C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -427,7 +427,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -438,7 +438,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -451,7 +451,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject_FunctionExpression_0644002F_L39C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -461,7 +461,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -475,7 +475,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject_FunctionExpression_0644002F_L39C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -485,7 +485,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -503,9 +503,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_0644002F_L39C51
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -576,7 +576,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D7F309C8_L47C51
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -596,9 +596,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject_FunctionExpression_D7F309C8_L47C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -609,7 +609,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -620,7 +620,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -633,7 +633,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject_FunctionExpression_D7F309C8_L47C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -643,7 +643,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -657,7 +657,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject_FunctionExpression_D7F309C8_L47C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -667,7 +667,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -685,9 +685,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D7F309C8_L47C51
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -758,7 +758,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C54EE51B_L57C38
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -772,7 +772,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -783,7 +783,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -794,7 +794,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -815,7 +815,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -837,7 +837,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -855,9 +855,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C54EE51B_L57C38
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -911,7 +911,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CB86225F_L66C43
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -925,7 +925,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -936,7 +936,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -947,7 +947,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -968,7 +968,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -990,7 +990,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1008,9 +1008,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_CB86225F_L66C43
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1261,12 +1261,12 @@
 			[22] object,
 			[23] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[24] object[],
-			[25] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject_FunctionExpression_685C2912_L23C46,
-			[26] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject_FunctionExpression_E6591AFB_L31C46,
-			[27] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject_FunctionExpression_0644002F_L39C51,
-			[28] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject_FunctionExpression_D7F309C8_L47C51,
-			[29] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject_FunctionExpression_C54EE51B_L57C38,
-			[30] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject_FunctionExpression_CB86225F_L66C43,
+			[25] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject,
+			[26] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject,
+			[27] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject,
+			[28] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject,
+			[29] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject,
+			[30] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject,
 			[31] float64,
 			[32] object
 		)
@@ -1444,13 +1444,13 @@
 		IL_01e3: ldc.i4.0
 		IL_01e4: ldelem.ref
 		IL_01e5: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_01ea: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject_FunctionExpression_685C2912_L23C46::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
+		IL_01ea: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
 		IL_01ef: ldc.i4.2
 		IL_01f0: conv.r8
 		IL_01f1: ldstr ""
 		IL_01f6: ldc.i4.0
 		IL_01f7: ldc.i4.1
-		IL_01f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject_FunctionExpression_685C2912_L23C46>(!!0, float64, string, bool, bool)
+		IL_01f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01fd: stloc.s 25
 		IL_01ff: ldloc.s 22
 		IL_0201: ldstr "call"
@@ -1500,13 +1500,13 @@
 		IL_028a: ldc.i4.0
 		IL_028b: ldelem.ref
 		IL_028c: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_0291: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject_FunctionExpression_E6591AFB_L31C46::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
+		IL_0291: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
 		IL_0296: ldc.i4.2
 		IL_0297: conv.r8
 		IL_0298: ldstr ""
 		IL_029d: ldc.i4.0
 		IL_029e: ldc.i4.1
-		IL_029f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject_FunctionExpression_E6591AFB_L31C46>(!!0, float64, string, bool, bool)
+		IL_029f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02a4: stloc.s 26
 		IL_02a6: ldloc.s 22
 		IL_02a8: ldstr "call"
@@ -1557,13 +1557,13 @@
 		IL_0336: ldc.i4.0
 		IL_0337: ldelem.ref
 		IL_0338: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_033d: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject_FunctionExpression_0644002F_L39C51::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
+		IL_033d: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
 		IL_0342: ldc.i4.2
 		IL_0343: conv.r8
 		IL_0344: ldstr ""
 		IL_0349: ldc.i4.0
 		IL_034a: ldc.i4.1
-		IL_034b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject_FunctionExpression_0644002F_L39C51>(!!0, float64, string, bool, bool)
+		IL_034b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0350: stloc.s 27
 		IL_0352: ldloc.s 22
 		IL_0354: ldstr "call"
@@ -1613,13 +1613,13 @@
 		IL_03dd: ldc.i4.0
 		IL_03de: ldelem.ref
 		IL_03df: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_03e4: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject_FunctionExpression_D7F309C8_L47C51::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
+		IL_03e4: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
 		IL_03e9: ldc.i4.2
 		IL_03ea: conv.r8
 		IL_03eb: ldstr ""
 		IL_03f0: ldc.i4.0
 		IL_03f1: ldc.i4.1
-		IL_03f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject_FunctionExpression_D7F309C8_L47C51>(!!0, float64, string, bool, bool)
+		IL_03f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_03f7: stloc.s 28
 		IL_03f9: ldloc.s 22
 		IL_03fb: ldstr "call"
@@ -1671,13 +1671,13 @@
 			IL_048b: ldloc.0
 			IL_048c: stelem.ref
 			IL_048d: stloc.s 24
-			IL_048f: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject_FunctionExpression_C54EE51B_L57C38::.ctor()
+			IL_048f: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject::.ctor()
 			IL_0494: ldc.i4.2
 			IL_0495: conv.r8
 			IL_0496: ldstr ""
 			IL_049b: ldc.i4.0
 			IL_049c: ldc.i4.1
-			IL_049d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject_FunctionExpression_C54EE51B_L57C38>(!!0, float64, string, bool, bool)
+			IL_049d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_04a2: stloc.s 29
 			IL_04a4: ldloc.s 22
 			IL_04a6: ldstr "call"
@@ -1752,13 +1752,13 @@
 			IL_055a: ldloc.0
 			IL_055b: stelem.ref
 			IL_055c: stloc.s 24
-			IL_055e: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject_FunctionExpression_CB86225F_L66C43::.ctor()
+			IL_055e: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject::.ctor()
 			IL_0563: ldc.i4.2
 			IL_0564: conv.r8
 			IL_0565: ldstr ""
 			IL_056a: ldc.i4.0
 			IL_056b: ldc.i4.1
-			IL_056c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject_FunctionExpression_CB86225F_L66C43>(!!0, float64, string, bool, bool)
+			IL_056c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0571: stloc.s 30
 			IL_0573: ldloc.s 22
 			IL_0575: ldstr "call"

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Prototype_CustomMethod_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Prototype_CustomMethod_Dispatch.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EB6D1BE0_L3C35
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -105,7 +105,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -124,7 +124,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -142,9 +142,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_EB6D1BE0_L3C35
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -251,7 +251,7 @@
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[2] object,
 			[3] object[],
-			[4] class Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34/FunctionObject_FunctionExpression_EB6D1BE0_L3C35,
+			[4] class Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34/FunctionObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[6] string
 		)
@@ -271,13 +271,13 @@
 		IL_0024: ldloc.0
 		IL_0025: stelem.ref
 		IL_0026: stloc.3
-		IL_0027: newobj instance void Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34/FunctionObject_FunctionExpression_EB6D1BE0_L3C35::.ctor()
+		IL_0027: newobj instance void Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34/FunctionObject::.ctor()
 		IL_002c: ldc.i4.1
 		IL_002d: conv.r8
 		IL_002e: ldstr ""
 		IL_0033: ldc.i4.1
 		IL_0034: ldc.i4.1
-		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34/FunctionObject_FunctionExpression_EB6D1BE0_L3C35>(!!0, float64, string, bool, bool)
+		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_003a: stloc.s 4
 		IL_003c: ldloc.2
 		IL_003d: ldstr "removeGraphNode"

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_SearchOps_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_SearchOps_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_157BCB7F_L8C27
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Array_SearchOps_Basic/FunctionExpression_L8C26::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Array_SearchOps_Basic/FunctionExpression_L8C26::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_157BCB7F_L8C27
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -178,7 +178,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F9B75391_L9C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -192,7 +192,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -203,7 +203,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -214,7 +214,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -232,7 +232,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Array_SearchOps_Basic/FunctionExpression_L9C25::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -251,7 +251,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Array_SearchOps_Basic/FunctionExpression_L9C25::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -269,9 +269,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F9B75391_L9C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -326,7 +326,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0718A511_L10C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -340,7 +340,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -351,7 +351,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -362,7 +362,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -380,7 +380,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Array_SearchOps_Basic/FunctionExpression_L10C30::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -399,7 +399,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Array_SearchOps_Basic/FunctionExpression_L10C30::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -417,9 +417,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_0718A511_L10C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -492,10 +492,10 @@
 			[4] float64,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Array_SearchOps_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_157BCB7F_L8C27,
-			[8] class Modules.Array_SearchOps_Basic/FunctionExpression_L9C25/FunctionObject_FunctionExpression_F9B75391_L9C26,
+			[7] class Modules.Array_SearchOps_Basic/FunctionExpression_L8C26/FunctionObject,
+			[8] class Modules.Array_SearchOps_Basic/FunctionExpression_L9C25/FunctionObject,
 			[9] object,
-			[10] class Modules.Array_SearchOps_Basic/FunctionExpression_L10C30/FunctionObject_FunctionExpression_0718A511_L10C31,
+			[10] class Modules.Array_SearchOps_Basic/FunctionExpression_L10C30/FunctionObject,
 			[11] bool,
 			[12] object
 		)
@@ -565,13 +565,13 @@
 		IL_00c6: ldloc.0
 		IL_00c7: stelem.ref
 		IL_00c8: stloc.s 6
-		IL_00ca: newobj instance void Modules.Array_SearchOps_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_157BCB7F_L8C27::.ctor()
+		IL_00ca: newobj instance void Modules.Array_SearchOps_Basic/FunctionExpression_L8C26/FunctionObject::.ctor()
 		IL_00cf: ldc.i4.1
 		IL_00d0: conv.r8
 		IL_00d1: ldstr ""
 		IL_00d6: ldc.i4.0
 		IL_00d7: ldc.i4.1
-		IL_00d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_SearchOps_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_157BCB7F_L8C27>(!!0, float64, string, bool, bool)
+		IL_00d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_SearchOps_Basic/FunctionExpression_L8C26/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00dd: stloc.s 7
 		IL_00df: ldloc.1
 		IL_00e0: ldc.i4.1
@@ -598,13 +598,13 @@
 		IL_0112: ldloc.0
 		IL_0113: stelem.ref
 		IL_0114: stloc.s 6
-		IL_0116: newobj instance void Modules.Array_SearchOps_Basic/FunctionExpression_L9C25/FunctionObject_FunctionExpression_F9B75391_L9C26::.ctor()
+		IL_0116: newobj instance void Modules.Array_SearchOps_Basic/FunctionExpression_L9C25/FunctionObject::.ctor()
 		IL_011b: ldc.i4.1
 		IL_011c: conv.r8
 		IL_011d: ldstr ""
 		IL_0122: ldc.i4.0
 		IL_0123: ldc.i4.1
-		IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_SearchOps_Basic/FunctionExpression_L9C25/FunctionObject_FunctionExpression_F9B75391_L9C26>(!!0, float64, string, bool, bool)
+		IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_SearchOps_Basic/FunctionExpression_L9C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0129: stloc.s 8
 		IL_012b: ldloc.1
 		IL_012c: ldc.i4.1
@@ -628,13 +628,13 @@
 		IL_0155: ldloc.0
 		IL_0156: stelem.ref
 		IL_0157: stloc.s 6
-		IL_0159: newobj instance void Modules.Array_SearchOps_Basic/FunctionExpression_L10C30/FunctionObject_FunctionExpression_0718A511_L10C31::.ctor()
+		IL_0159: newobj instance void Modules.Array_SearchOps_Basic/FunctionExpression_L10C30/FunctionObject::.ctor()
 		IL_015e: ldc.i4.1
 		IL_015f: conv.r8
 		IL_0160: ldstr ""
 		IL_0165: ldc.i4.0
 		IL_0166: ldc.i4.1
-		IL_0167: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_SearchOps_Basic/FunctionExpression_L10C30/FunctionObject_FunctionExpression_0718A511_L10C31>(!!0, float64, string, bool, bool)
+		IL_0167: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_SearchOps_Basic/FunctionExpression_L10C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_016c: stloc.s 10
 		IL_016e: ldloc.1
 		IL_016f: ldc.i4.1

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_StableLoadReceiver_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_StableLoadReceiver_EvaluationOrder.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3434C852_L7C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14::_environment0_Array_StableLoadReceiver_EvaluationOrder
+				IL_0008: stfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject::_environment0_Array_StableLoadReceiver_EvaluationOrder
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,13 +87,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14::_environment0_Array_StableLoadReceiver_EvaluationOrder
+				IL_0001: ldfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject::_environment0_Array_StableLoadReceiver_EvaluationOrder
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested::__js_call__(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_3434C852_L7C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -165,7 +165,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_52357B65_L16C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -185,9 +185,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8::_environment0_Array_StableLoadReceiver_EvaluationOrder
+				IL_0008: stfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject::_environment0_Array_StableLoadReceiver_EvaluationOrder
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -198,7 +198,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -209,7 +209,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -222,13 +222,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8::_environment0_Array_StableLoadReceiver_EvaluationOrder
+				IL_0001: ldfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject::_environment0_Array_StableLoadReceiver_EvaluationOrder
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7::__js_call__(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_52357B65_L16C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -331,9 +331,9 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object[],
-			[5] class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14,
+			[5] class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject,
 			[6] object,
-			[7] class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8,
+			[7] class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[9] object,
 			[10] object
@@ -369,14 +369,14 @@
 		IL_0051: ldc.i4.0
 		IL_0052: ldelem.ref
 		IL_0053: castclass Modules.Array_StableLoadReceiver_EvaluationOrder/Scope
-		IL_0058: newobj instance void Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14::.ctor(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope)
+		IL_0058: newobj instance void Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject::.ctor(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope)
 		IL_005d: ldc.i4.0
 		IL_005e: conv.r8
 		IL_005f: ldstr ""
 		IL_0064: ldc.i4.0
 		IL_0065: ldc.i4.1
-		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14>(!!0, float64, string, bool, bool)
-		IL_006b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14>(!!0)
+		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_006b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject>(!!0)
 		IL_0070: stloc.s 5
 		IL_0072: ldloc.s 5
 		IL_0074: ldstr "value"
@@ -408,14 +408,14 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Array_StableLoadReceiver_EvaluationOrder/Scope
-		IL_00bd: newobj instance void Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8::.ctor(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope)
+		IL_00bd: newobj instance void Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject::.ctor(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope)
 		IL_00c2: ldc.i4.0
 		IL_00c3: conv.r8
 		IL_00c4: ldstr ""
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8>(!!0, float64, string, bool, bool)
-		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8>(!!0)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject>(!!0)
 		IL_00d5: stloc.s 7
 		IL_00d7: ldloc.3
 		IL_00d8: ldstr "get"

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
@@ -175,7 +175,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_61C7CF9F_createCounter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -195,9 +195,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::_environment0_ArrowFunction_ClosureMutatesOuterVariable
+				IL_0008: stfld class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject::_environment0_ArrowFunction_ClosureMutatesOuterVariable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -208,7 +208,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -219,7 +219,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -232,7 +232,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::_environment0_ArrowFunction_ClosureMutatesOuterVariable
+				IL_0001: ldfld class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject::_environment0_ArrowFunction_ClosureMutatesOuterVariable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -240,7 +240,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -254,7 +254,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::_environment0_ArrowFunction_ClosureMutatesOuterVariable
+				IL_0001: ldfld class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject::_environment0_ArrowFunction_ClosureMutatesOuterVariable
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -262,7 +262,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -280,9 +280,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_61C7CF9F_createCounter
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -392,7 +392,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope,
-			[1] class Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_61C7CF9F_createCounter,
+			[1] class Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -412,13 +412,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope
-		IL_0019: newobj instance void Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::.ctor(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope)
+		IL_0019: newobj instance void Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject::.ctor(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "createCounter"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_61C7CF9F_createCounter>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GeneratedFunctionObjectSurface.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GeneratedFunctionObjectSurface.verified.txt
@@ -184,7 +184,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_83EB34AC_makeArrow
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -198,7 +198,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -209,7 +209,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -220,7 +220,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -235,7 +235,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -251,7 +251,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -269,9 +269,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_83EB34AC_makeArrow
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -394,7 +394,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_GeneratedFunctionObjectSurface/Scope,
-			[1] class Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow/FunctionObject_FunctionDeclaration_83EB34AC_makeArrow,
+			[1] class Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -422,13 +422,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 9
-		IL_0012: newobj instance void Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow/FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::.ctor()
+		IL_0012: newobj instance void Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "makeArrow"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow/FunctionObject_FunctionDeclaration_83EB34AC_makeArrow>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Calls_Module_Function_Before_Await.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Calls_Module_Function_Before_Await.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_638020D9_formatSection
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.Async_Calls_Module_Function_Before_Await/formatSection::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.Async_Calls_Module_Function_Before_Await/formatSection::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_638020D9_formatSection
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -180,7 +180,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C5F6260C_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -202,12 +202,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_Calls_Module_Function_Before_Await/Scope Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject_FunctionDeclaration_C5F6260C_main::_environment0_Async_Calls_Module_Function_Before_Await
+				IL_0008: stfld class Modules.Async_Calls_Module_Function_Before_Await/Scope Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject::_environment0_Async_Calls_Module_Function_Before_Await
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject_FunctionDeclaration_C5F6260C_main::_transitionalScopes
+				IL_000f: stfld object[] Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -218,7 +218,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -229,7 +229,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -242,14 +242,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject_FunctionDeclaration_C5F6260C_main::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_Calls_Module_Function_Before_Await/main::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_C5F6260C_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -292,7 +292,7 @@
 			IL_0020: ldftn object Modules.Async_Calls_Module_Function_Before_Await/main::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject_FunctionDeclaration_C5F6260C_main
+			IL_002c: ldtoken Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -639,9 +639,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_Calls_Module_Function_Before_Await/Scope,
-			[1] class Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject_FunctionDeclaration_C5F6260C_main,
+			[1] class Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject,
 			[2] object[],
-			[3] class Modules.Async_Calls_Module_Function_Before_Await/formatSection/FunctionObject_FunctionDeclaration_638020D9_formatSection,
+			[3] class Modules.Async_Calls_Module_Function_Before_Await/formatSection/FunctionObject,
 			[4] object,
 			[5] class Modules.Async_Calls_Module_Function_Before_Await/ArrowFunction_L13C14/FunctionObject
 		)
@@ -655,13 +655,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Async_Calls_Module_Function_Before_Await/formatSection/FunctionObject_FunctionDeclaration_638020D9_formatSection::.ctor()
+		IL_0011: newobj instance void Modules.Async_Calls_Module_Function_Before_Await/formatSection/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "formatSection"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_Calls_Module_Function_Before_Await/formatSection/FunctionObject_FunctionDeclaration_638020D9_formatSection>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_Calls_Module_Function_Before_Await/formatSection/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.3
 		IL_0025: ldloc.0
 		IL_0026: ldloc.3
@@ -678,14 +678,14 @@
 		IL_0039: ldelem.ref
 		IL_003a: castclass Modules.Async_Calls_Module_Function_Before_Await/Scope
 		IL_003f: ldloc.2
-		IL_0040: newobj instance void Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject_FunctionDeclaration_C5F6260C_main::.ctor(class Modules.Async_Calls_Module_Function_Before_Await/Scope, object[])
+		IL_0040: newobj instance void Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject::.ctor(class Modules.Async_Calls_Module_Function_Before_Await/Scope, object[])
 		IL_0045: ldc.i4.0
 		IL_0046: conv.r8
 		IL_0047: ldstr "main"
 		IL_004c: ldc.i4.0
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject_FunctionDeclaration_C5F6260C_main>(!!0, float64, string, bool, bool)
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject_FunctionDeclaration_C5F6260C_main>(!!0)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject>(!!0)
 		IL_0058: stloc.1
 		IL_0059: nop
 		IL_005a: nop

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_Array.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_Array.verified.txt
@@ -80,7 +80,7 @@
 
 		} // end of class Scope_ForOf_L7C15
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_65EB96EF_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -100,9 +100,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ForAwaitOf_Array/test/FunctionObject_FunctionDeclaration_65EB96EF_test::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_ForAwaitOf_Array/test/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -113,7 +113,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -124,7 +124,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -137,14 +137,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_ForAwaitOf_Array/test/FunctionObject_FunctionDeclaration_65EB96EF_test::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_ForAwaitOf_Array/test/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_ForAwaitOf_Array/test::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_65EB96EF_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -194,7 +194,7 @@
 			IL_0020: ldftn object Modules.Async_ForAwaitOf_Array/test::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_ForAwaitOf_Array/test/FunctionObject_FunctionDeclaration_65EB96EF_test
+			IL_002c: ldtoken Modules.Async_ForAwaitOf_Array/test/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -755,7 +755,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_Array/Scope,
-			[1] class Modules.Async_ForAwaitOf_Array/test/FunctionObject_FunctionDeclaration_65EB96EF_test,
+			[1] class Modules.Async_ForAwaitOf_Array/test/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class Modules.Async_ForAwaitOf_Array/ArrowFunction_L15C13/FunctionObject
@@ -771,14 +771,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.Async_ForAwaitOf_Array/test/FunctionObject_FunctionDeclaration_65EB96EF_test::.ctor(object[])
+		IL_0012: newobj instance void Modules.Async_ForAwaitOf_Array/test/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "test"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_Array/test/FunctionObject_FunctionDeclaration_65EB96EF_test>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_Array/test/FunctionObject_FunctionDeclaration_65EB96EF_test>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_Array/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_Array/test/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
@@ -344,7 +344,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_79857E5C_L5C27
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -364,9 +364,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
+				IL_0008: stfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -377,7 +377,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -388,7 +388,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -401,13 +401,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
+				IL_0001: ldfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable::__js_call__(class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_79857E5C_L5C27
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -607,7 +607,7 @@
 
 		} // end of class Scope_ForOf_L18C15
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2FA20F6D_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -629,12 +629,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject_FunctionDeclaration_2FA20F6D_test::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
+				IL_0008: stfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject_FunctionDeclaration_2FA20F6D_test::_transitionalScopes
+				IL_000f: stfld object[] Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -645,7 +645,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -656,7 +656,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -669,14 +669,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject_FunctionDeclaration_2FA20F6D_test::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_2FA20F6D_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -724,7 +724,7 @@
 			IL_0020: ldftn object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject_FunctionDeclaration_2FA20F6D_test
+			IL_002c: ldtoken Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1259,7 +1259,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope,
-			[1] class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject_FunctionDeclaration_2FA20F6D_test,
+			[1] class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -1280,14 +1280,14 @@
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope
 		IL_0019: ldloc.2
-		IL_001a: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject_FunctionDeclaration_2FA20F6D_test::.ctor(class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope, object[])
+		IL_001a: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject::.ctor(class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope, object[])
 		IL_001f: ldc.i4.0
 		IL_0020: conv.r8
 		IL_0021: ldstr "test"
 		IL_0026: ldc.i4.0
 		IL_0027: ldc.i4.1
-		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject_FunctionDeclaration_2FA20F6D_test>(!!0, float64, string, bool, bool)
-		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject_FunctionDeclaration_2FA20F6D_test>(!!0)
+		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject>(!!0)
 		IL_0032: stloc.1
 		IL_0033: nop
 		IL_0034: ldstr "asyncIterator"
@@ -1308,14 +1308,14 @@
 		IL_0055: ldc.i4.0
 		IL_0056: ldelem.ref
 		IL_0057: castclass Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope
-		IL_005c: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27::.ctor(class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope)
+		IL_005c: newobj instance void Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject::.ctor(class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope)
 		IL_0061: ldc.i4.0
 		IL_0062: conv.r8
 		IL_0063: ldstr ""
 		IL_0068: ldc.i4.0
 		IL_0069: ldc.i4.1
-		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27>(!!0, float64, string, bool, bool)
-		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27>(!!0)
+		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject>(!!0)
 		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_0079: pop
 		IL_007a: ldloc.0

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
@@ -338,7 +338,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_61E3F591_L6C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -358,9 +358,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
+				IL_0008: stfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -371,7 +371,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -382,7 +382,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -395,13 +395,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
+				IL_0001: ldfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable::__js_call__(class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_61E3F591_L6C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -601,7 +601,7 @@
 
 		} // end of class Scope_ForOf_L19C15
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A889D3B4_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -623,12 +623,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject_FunctionDeclaration_A889D3B4_test::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
+				IL_0008: stfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject_FunctionDeclaration_A889D3B4_test::_transitionalScopes
+				IL_000f: stfld object[] Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -639,7 +639,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -650,7 +650,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -663,14 +663,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject_FunctionDeclaration_A889D3B4_test::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_A889D3B4_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -718,7 +718,7 @@
 			IL_0020: ldftn object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject_FunctionDeclaration_A889D3B4_test
+			IL_002c: ldtoken Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1253,7 +1253,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope,
-			[1] class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject_FunctionDeclaration_A889D3B4_test,
+			[1] class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -1274,14 +1274,14 @@
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope
 		IL_0019: ldloc.2
-		IL_001a: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject_FunctionDeclaration_A889D3B4_test::.ctor(class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope, object[])
+		IL_001a: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject::.ctor(class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope, object[])
 		IL_001f: ldc.i4.0
 		IL_0020: conv.r8
 		IL_0021: ldstr "test"
 		IL_0026: ldc.i4.0
 		IL_0027: ldc.i4.1
-		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject_FunctionDeclaration_A889D3B4_test>(!!0, float64, string, bool, bool)
-		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject_FunctionDeclaration_A889D3B4_test>(!!0)
+		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject>(!!0)
 		IL_0032: stloc.1
 		IL_0033: nop
 		IL_0034: ldstr "iterator"
@@ -1302,14 +1302,14 @@
 		IL_0055: ldc.i4.0
 		IL_0056: ldelem.ref
 		IL_0057: castclass Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope
-		IL_005c: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22::.ctor(class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope)
+		IL_005c: newobj instance void Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject::.ctor(class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope)
 		IL_0061: ldc.i4.0
 		IL_0062: conv.r8
 		IL_0063: ldstr ""
 		IL_0068: ldc.i4.0
 		IL_0069: ldc.i4.1
-		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22>(!!0, float64, string, bool, bool)
-		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22>(!!0)
+		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject>(!!0)
 		IL_0074: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_0079: pop
 		IL_007a: ldloc.0

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForOf_AwaitInBody.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForOf_AwaitInBody.verified.txt
@@ -77,7 +77,7 @@
 
 		} // end of class Scope_ForOf_L3C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BBEFEBAA_sum
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -97,9 +97,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ForOf_AwaitInBody/sum/FunctionObject_FunctionDeclaration_BBEFEBAA_sum::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_ForOf_AwaitInBody/sum/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -110,7 +110,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -121,7 +121,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -135,7 +135,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -148,7 +148,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_ForOf_AwaitInBody/sum/FunctionObject_FunctionDeclaration_BBEFEBAA_sum::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_ForOf_AwaitInBody/sum/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -156,9 +156,9 @@
 				IL_0012: call object Modules.Async_ForOf_AwaitInBody/sum::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_BBEFEBAA_sum
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -208,7 +208,7 @@
 			IL_0020: ldftn object Modules.Async_ForOf_AwaitInBody/sum::__js_call__(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_ForOf_AwaitInBody/sum/FunctionObject_FunctionDeclaration_BBEFEBAA_sum
+			IL_002c: ldtoken Modules.Async_ForOf_AwaitInBody/sum/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -611,7 +611,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ForOf_AwaitInBody/Scope,
-			[1] class Modules.Async_ForOf_AwaitInBody/sum/FunctionObject_FunctionDeclaration_BBEFEBAA_sum,
+			[1] class Modules.Async_ForOf_AwaitInBody/sum/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -684,7 +684,7 @@
 		IL_0082: dup
 		IL_0083: ldc.i4.0
 		IL_0084: ldelem.ref
-		IL_0085: castclass Modules.Async_ForOf_AwaitInBody/sum/FunctionObject_FunctionDeclaration_BBEFEBAA_sum
+		IL_0085: castclass Modules.Async_ForOf_AwaitInBody/sum/FunctionObject
 		IL_008a: stloc.1
 		IL_008b: dup
 		IL_008c: ldc.i4.1
@@ -719,14 +719,14 @@
 		IL_00c9: stelem.ref
 		IL_00ca: stloc.2
 		IL_00cb: ldloc.2
-		IL_00cc: newobj instance void Modules.Async_ForOf_AwaitInBody/sum/FunctionObject_FunctionDeclaration_BBEFEBAA_sum::.ctor(object[])
+		IL_00cc: newobj instance void Modules.Async_ForOf_AwaitInBody/sum/FunctionObject::.ctor(object[])
 		IL_00d1: ldc.i4.1
 		IL_00d2: conv.r8
 		IL_00d3: ldstr "sum"
 		IL_00d8: ldc.i4.0
 		IL_00d9: ldc.i4.0
-		IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_ForOf_AwaitInBody/sum/FunctionObject_FunctionDeclaration_BBEFEBAA_sum>(!!0, float64, string, bool, bool)
-		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForOf_AwaitInBody/sum/FunctionObject_FunctionDeclaration_BBEFEBAA_sum>(!!0)
+		IL_00da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_ForOf_AwaitInBody/sum/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ForOf_AwaitInBody/sum/FunctionObject>(!!0)
 		IL_00e4: stloc.1
 		IL_00e5: nop
 		IL_00e6: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_FunctionExpression_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_FunctionExpression_SimpleAwait.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A1C89431_L4C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -57,9 +57,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject_FunctionExpression_A1C89431_L4C19::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -70,7 +70,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -81,7 +81,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -94,14 +94,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject_FunctionExpression_A1C89431_L4C19::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionExpression_A1C89431_L4C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -143,7 +143,7 @@
 			IL_0020: ldftn object Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject_FunctionExpression_A1C89431_L4C19
+			IL_002c: ldtoken Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -418,7 +418,7 @@
 			[0] class Modules.Async_FunctionExpression_SimpleAwait/Scope,
 			[1] object,
 			[2] object[],
-			[3] class Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject_FunctionExpression_A1C89431_L4C19,
+			[3] class Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject,
 			[4] object,
 			[5] class Modules.Async_FunctionExpression_SimpleAwait/ArrowFunction_L11C18/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console
@@ -435,14 +435,14 @@
 		IL_0010: stelem.ref
 		IL_0011: stloc.2
 		IL_0012: ldloc.2
-		IL_0013: newobj instance void Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject_FunctionExpression_A1C89431_L4C19::.ctor(object[])
+		IL_0013: newobj instance void Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject::.ctor(object[])
 		IL_0018: ldc.i4.0
 		IL_0019: conv.r8
 		IL_001a: ldstr ""
 		IL_001f: ldc.i4.0
 		IL_0020: ldc.i4.1
-		IL_0021: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject_FunctionExpression_A1C89431_L4C19>(!!0, float64, string, bool, bool)
-		IL_0026: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject_FunctionExpression_A1C89431_L4C19>(!!0)
+		IL_0021: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0026: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject>(!!0)
 		IL_002b: stloc.3
 		IL_002c: ldloc.3
 		IL_002d: ldstr "asyncFunc"

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_GeneratedFunctionObject_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_GeneratedFunctionObject_Semantics.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5E0E5E41_declared
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -57,9 +57,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_5E0E5E41_declared::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E0E5E41_declared::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -70,7 +70,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E0E5E41_declared::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -81,7 +81,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E0E5E41_declared::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -95,7 +95,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E0E5E41_declared::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -108,7 +108,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_5E0E5E41_declared::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -116,9 +116,9 @@
 				IL_0012: call object Modules.Async_GeneratedFunctionObject_Semantics/declared::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E0E5E41_declared::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_5E0E5E41_declared
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -160,7 +160,7 @@
 			IL_0020: ldftn object Modules.Async_GeneratedFunctionObject_Semantics/declared::__js_call__(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_5E0E5E41_declared
+			IL_002c: ldtoken Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -301,7 +301,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D54A73A4_named
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -321,9 +321,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_D54A73A4_named::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D54A73A4_named::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -334,7 +334,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D54A73A4_named::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -345,7 +345,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D54A73A4_named::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -359,7 +359,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D54A73A4_named::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -372,7 +372,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_D54A73A4_named::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -380,9 +380,9 @@
 				IL_0012: call object Modules.Async_GeneratedFunctionObject_Semantics/named::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionExpression_D54A73A4_named::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionExpression_D54A73A4_named
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -426,7 +426,7 @@
 			IL_0020: ldftn object Modules.Async_GeneratedFunctionObject_Semantics/named::__js_call__(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_D54A73A4_named
+			IL_002c: ldtoken Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -843,7 +843,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_56912F02_makeArrow
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -863,9 +863,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_GeneratedFunctionObject_Semantics/Scope Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject_FunctionDeclaration_56912F02_makeArrow::_environment0_Async_GeneratedFunctionObject_Semantics
+				IL_0008: stfld class Modules.Async_GeneratedFunctionObject_Semantics/Scope Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject::_environment0_Async_GeneratedFunctionObject_Semantics
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_56912F02_makeArrow::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -876,7 +876,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_56912F02_makeArrow::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -887,7 +887,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_56912F02_makeArrow::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -901,7 +901,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_56912F02_makeArrow::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -914,14 +914,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_GeneratedFunctionObject_Semantics/Scope Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject_FunctionDeclaration_56912F02_makeArrow::_environment0_Async_GeneratedFunctionObject_Semantics
+				IL_0001: ldfld class Modules.Async_GeneratedFunctionObject_Semantics/Scope Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject::_environment0_Async_GeneratedFunctionObject_Semantics
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Async_GeneratedFunctionObject_Semantics/makeArrow::__js_call__(class Modules.Async_GeneratedFunctionObject_Semantics/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_56912F02_makeArrow::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -935,14 +935,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_GeneratedFunctionObject_Semantics/Scope Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject_FunctionDeclaration_56912F02_makeArrow::_environment0_Async_GeneratedFunctionObject_Semantics
+				IL_0001: ldfld class Modules.Async_GeneratedFunctionObject_Semantics/Scope Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject::_environment0_Async_GeneratedFunctionObject_Semantics
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Async_GeneratedFunctionObject_Semantics/makeArrow::__js_call__(class Modules.Async_GeneratedFunctionObject_Semantics/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_56912F02_makeArrow::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -960,9 +960,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_56912F02_makeArrow::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_56912F02_makeArrow
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1046,7 +1046,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7B71C845_L20C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -1066,9 +1066,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_7B71C845_L20C10::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7B71C845_L20C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1079,7 +1079,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7B71C845_L20C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1090,7 +1090,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7B71C845_L20C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1104,7 +1104,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_7B71C845_L20C10::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -1117,7 +1117,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_7B71C845_L20C10::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -1125,9 +1125,9 @@
 				IL_0012: call object Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionExpression_7B71C845_L20C10::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionExpression_7B71C845_L20C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1203,7 +1203,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FE2223A9_parameterReject
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -1223,9 +1223,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/parameterReject/FunctionObject_FunctionDeclaration_FE2223A9_parameterReject::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/parameterReject/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE2223A9_parameterReject::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1236,7 +1236,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE2223A9_parameterReject::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1247,7 +1247,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE2223A9_parameterReject::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1261,7 +1261,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE2223A9_parameterReject::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -1274,7 +1274,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/parameterReject/FunctionObject_FunctionDeclaration_FE2223A9_parameterReject::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/parameterReject/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -1282,9 +1282,9 @@
 				IL_0012: call object Modules.Async_GeneratedFunctionObject_Semantics/parameterReject::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE2223A9_parameterReject::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_FE2223A9_parameterReject
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1615,7 +1615,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FE1EFDD7_L60C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -1635,9 +1635,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject_FunctionExpression_FE1EFDD7_L60C34::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FE1EFDD7_L60C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1648,7 +1648,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FE1EFDD7_L60C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1659,7 +1659,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FE1EFDD7_L60C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1673,7 +1673,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_FE1EFDD7_L60C34::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -1686,7 +1686,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject_FunctionExpression_FE1EFDD7_L60C34::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -1694,9 +1694,9 @@
 				IL_0012: call object Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionExpression_FE1EFDD7_L60C34::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionExpression_FE1EFDD7_L60C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2275,7 +2275,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_18A3AD99_rejects
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -2295,9 +2295,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/rejects/FunctionObject_FunctionDeclaration_18A3AD99_rejects::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/rejects/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_18A3AD99_rejects::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2308,7 +2308,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_18A3AD99_rejects::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2319,7 +2319,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_18A3AD99_rejects::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -2333,7 +2333,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_18A3AD99_rejects::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -2346,14 +2346,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/rejects/FunctionObject_FunctionDeclaration_18A3AD99_rejects::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/rejects/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_GeneratedFunctionObject_Semantics/rejects::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_18A3AD99_rejects::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_18A3AD99_rejects
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2538,7 +2538,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F6FA0E16_L125C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 			{
 				// Fields
@@ -2558,9 +2558,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11/FunctionObject_FunctionExpression_F6FA0E16_L125C12::_transitionalScopes
+					IL_0008: stfld object[] Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_F6FA0E16_L125C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -2571,7 +2571,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F6FA0E16_L125C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -2582,7 +2582,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F6FA0E16_L125C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -2596,7 +2596,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_F6FA0E16_L125C12::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -2609,14 +2609,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11/FunctionObject_FunctionExpression_F6FA0E16_L125C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11::__js_call__(object[], object)
 					IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 					IL_0015: ret
-				} // end of method FunctionObject_FunctionExpression_F6FA0E16_L125C12::CallCoreAsync
+				} // end of method FunctionObject::CallCoreAsync
 
-			} // end of class FunctionObject_FunctionExpression_F6FA0E16_L125C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -2660,7 +2660,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2674,7 +2674,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2685,7 +2685,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2696,7 +2696,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -2710,7 +2710,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2725,7 +2725,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Async_GeneratedFunctionObject_Semantics/makeAsync::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2741,7 +2741,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Async_GeneratedFunctionObject_Semantics/makeAsync::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2759,9 +2759,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2779,7 +2779,7 @@
 			.locals init (
 				[0] class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/Scope,
 				[1] object[],
-				[2] class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11/FunctionObject_FunctionExpression_F6FA0E16_L125C12
+				[2] class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/Scope::.ctor()
@@ -2787,14 +2787,14 @@
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.1
 			IL_000c: ldloc.1
-			IL_000d: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11/FunctionObject_FunctionExpression_F6FA0E16_L125C12::.ctor(object[])
+			IL_000d: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11/FunctionObject::.ctor(object[])
 			IL_0012: ldc.i4.0
 			IL_0013: conv.r8
 			IL_0014: ldstr ""
 			IL_0019: ldc.i4.0
 			IL_001a: ldc.i4.0
-			IL_001b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11/FunctionObject_FunctionExpression_F6FA0E16_L125C12>(!!0, float64, string, bool, bool)
-			IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11/FunctionObject_FunctionExpression_F6FA0E16_L125C12>(!!0)
+			IL_001b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionExpression_L125C11/FunctionObject>(!!0)
 			IL_0025: stloc.2
 			IL_0026: ldloc.2
 			IL_0027: ret
@@ -3068,12 +3068,12 @@
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Async_GeneratedFunctionObject_Semantics/Scope,
-			[1] class Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_5E0E5E41_declared,
-			[2] class Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject_FunctionDeclaration_56912F02_makeArrow,
-			[3] class Modules.Async_GeneratedFunctionObject_Semantics/parameterReject/FunctionObject_FunctionDeclaration_FE2223A9_parameterReject,
-			[4] class Modules.Async_GeneratedFunctionObject_Semantics/rejects/FunctionObject_FunctionDeclaration_18A3AD99_rejects,
-			[5] class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync,
-			[6] class Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_D54A73A4_named,
+			[1] class Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject,
+			[2] class Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject,
+			[3] class Modules.Async_GeneratedFunctionObject_Semantics/parameterReject/FunctionObject,
+			[4] class Modules.Async_GeneratedFunctionObject_Semantics/rejects/FunctionObject,
+			[5] class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionObject,
+			[6] class Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject,
 			[7] object,
 			[8] class Modules.Async_GeneratedFunctionObject_Semantics/ObjectLiterals/L19C16_holder,
 			[9] object,
@@ -3107,7 +3107,7 @@
 			[37] object,
 			[38] object,
 			[39] object[],
-			[40] class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_7B71C845_L20C10,
+			[40] class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder/FunctionObject,
 			[41] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[42] string,
 			[43] object,
@@ -3124,7 +3124,7 @@
 			[54] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[55] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[56] class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L59C30/FunctionObject,
-			[57] class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject_FunctionExpression_FE1EFDD7_L60C34,
+			[57] class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject,
 			[58] class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L86C51/FunctionObject,
 			[59] class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L89C61/FunctionObject,
 			[60] class Modules.Async_GeneratedFunctionObject_Semantics/ArrowFunction_L93C12/FunctionObject,
@@ -3143,14 +3143,14 @@
 		IL_0014: stelem.ref
 		IL_0015: stloc.s 39
 		IL_0017: ldloc.s 39
-		IL_0019: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_5E0E5E41_declared::.ctor(object[])
+		IL_0019: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject::.ctor(object[])
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "declared"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.0
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_5E0E5E41_declared>(!!0, float64, string, bool, bool)
-		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_5E0E5E41_declared>(!!0)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/declared/FunctionObject>(!!0)
 		IL_0031: stloc.1
 		IL_0032: ldc.i4.1
 		IL_0033: newarr [System.Runtime]System.Object
@@ -3163,14 +3163,14 @@
 		IL_0040: ldc.i4.0
 		IL_0041: ldelem.ref
 		IL_0042: castclass Modules.Async_GeneratedFunctionObject_Semantics/Scope
-		IL_0047: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject_FunctionDeclaration_56912F02_makeArrow::.ctor(class Modules.Async_GeneratedFunctionObject_Semantics/Scope)
+		IL_0047: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject::.ctor(class Modules.Async_GeneratedFunctionObject_Semantics/Scope)
 		IL_004c: ldc.i4.1
 		IL_004d: conv.r8
 		IL_004e: ldstr "makeArrow"
 		IL_0053: ldc.i4.0
 		IL_0054: ldc.i4.0
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject_FunctionDeclaration_56912F02_makeArrow>(!!0, float64, string, bool, bool)
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject_FunctionDeclaration_56912F02_makeArrow>(!!0)
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_GeneratedFunctionObject_Semantics/makeArrow/FunctionObject>(!!0)
 		IL_005f: stloc.2
 		IL_0060: ldc.i4.1
 		IL_0061: newarr [System.Runtime]System.Object
@@ -3180,14 +3180,14 @@
 		IL_0069: stelem.ref
 		IL_006a: stloc.s 39
 		IL_006c: ldloc.s 39
-		IL_006e: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/parameterReject/FunctionObject_FunctionDeclaration_FE2223A9_parameterReject::.ctor(object[])
+		IL_006e: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/parameterReject/FunctionObject::.ctor(object[])
 		IL_0073: ldc.i4.0
 		IL_0074: conv.r8
 		IL_0075: ldstr "parameterReject"
 		IL_007a: ldc.i4.0
 		IL_007b: ldc.i4.0
-		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/parameterReject/FunctionObject_FunctionDeclaration_FE2223A9_parameterReject>(!!0, float64, string, bool, bool)
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/parameterReject/FunctionObject_FunctionDeclaration_FE2223A9_parameterReject>(!!0)
+		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/parameterReject/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/parameterReject/FunctionObject>(!!0)
 		IL_0086: stloc.3
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -3197,14 +3197,14 @@
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 39
 		IL_0093: ldloc.s 39
-		IL_0095: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/rejects/FunctionObject_FunctionDeclaration_18A3AD99_rejects::.ctor(object[])
+		IL_0095: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/rejects/FunctionObject::.ctor(object[])
 		IL_009a: ldc.i4.0
 		IL_009b: conv.r8
 		IL_009c: ldstr "rejects"
 		IL_00a1: ldc.i4.0
 		IL_00a2: ldc.i4.0
-		IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/rejects/FunctionObject_FunctionDeclaration_18A3AD99_rejects>(!!0, float64, string, bool, bool)
-		IL_00a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/rejects/FunctionObject_FunctionDeclaration_18A3AD99_rejects>(!!0)
+		IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/rejects/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/rejects/FunctionObject>(!!0)
 		IL_00ad: stloc.s 4
 		IL_00af: ldc.i4.1
 		IL_00b0: newarr [System.Runtime]System.Object
@@ -3213,14 +3213,14 @@
 		IL_00b7: ldloc.0
 		IL_00b8: stelem.ref
 		IL_00b9: stloc.s 39
-		IL_00bb: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync::.ctor()
+		IL_00bb: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionObject::.ctor()
 		IL_00c0: ldc.i4.0
 		IL_00c1: conv.r8
 		IL_00c2: ldstr "makeAsync"
 		IL_00c7: ldc.i4.0
 		IL_00c8: ldc.i4.0
-		IL_00c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync>(!!0, float64, string, bool, bool)
-		IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionObject_FunctionDeclaration_B7B5DC63_makeAsync>(!!0)
+		IL_00c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_GeneratedFunctionObject_Semantics/makeAsync/FunctionObject>(!!0)
 		IL_00d3: stloc.s 5
 		IL_00d5: nop
 		IL_00d6: ldc.i4.1
@@ -3231,14 +3231,14 @@
 		IL_00df: stelem.ref
 		IL_00e0: stloc.s 39
 		IL_00e2: ldloc.s 39
-		IL_00e4: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_D54A73A4_named::.ctor(object[])
+		IL_00e4: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject::.ctor(object[])
 		IL_00e9: ldc.i4.1
 		IL_00ea: conv.r8
 		IL_00eb: ldstr "named"
 		IL_00f0: ldc.i4.1
 		IL_00f1: ldc.i4.0
-		IL_00f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_D54A73A4_named>(!!0, float64, string, bool, bool)
-		IL_00f7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_D54A73A4_named>(!!0)
+		IL_00f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00f7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/named/FunctionObject>(!!0)
 		IL_00fc: stloc.s 6
 		IL_00fe: nop
 		IL_00ff: ldloc.0
@@ -3256,14 +3256,14 @@
 		IL_0124: stelem.ref
 		IL_0125: stloc.s 39
 		IL_0127: ldloc.s 39
-		IL_0129: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_7B71C845_L20C10::.ctor(object[])
+		IL_0129: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder/FunctionObject::.ctor(object[])
 		IL_012e: ldc.i4.1
 		IL_012f: conv.r8
 		IL_0130: ldstr ""
 		IL_0135: ldc.i4.0
 		IL_0136: ldc.i4.0
-		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_7B71C845_L20C10>(!!0, float64, string, bool, bool)
-		IL_013c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_7B71C845_L20C10>(!!0)
+		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_013c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_holder/FunctionObject>(!!0)
 		IL_0141: stloc.s 40
 		IL_0143: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/ObjectLiterals/L19C16_holder::.ctor()
 		IL_0148: stloc.s 8
@@ -3562,14 +3562,14 @@
 		IL_047e: stelem.ref
 		IL_047f: stloc.s 39
 		IL_0481: ldloc.s 39
-		IL_0483: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject_FunctionExpression_FE1EFDD7_L60C34::.ctor(object[])
+		IL_0483: newobj instance void Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject::.ctor(object[])
 		IL_0488: ldc.i4.0
 		IL_0489: conv.r8
 		IL_048a: ldstr ""
 		IL_048f: ldc.i4.0
 		IL_0490: ldc.i4.0
-		IL_0491: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject_FunctionExpression_FE1EFDD7_L60C34>(!!0, float64, string, bool, bool)
-		IL_0496: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject_FunctionExpression_FE1EFDD7_L60C34>(!!0)
+		IL_0491: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0496: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_GeneratedFunctionObject_Semantics/FunctionExpression_primitiveParameterReject/FunctionObject>(!!0)
 		IL_049b: stloc.s 57
 		IL_049d: ldloc.s 57
 		IL_049f: ldstr "primitiveParameterReject"

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_HelloWorld.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_08C655B7_helloWorld
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_08C655B7_helloWorld::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_HelloWorld/helloWorld/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_08C655B7_helloWorld::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_HelloWorld/helloWorld/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_HelloWorld/helloWorld::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_08C655B7_helloWorld
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -170,7 +170,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_HelloWorld/Scope,
-			[1] class Modules.Async_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_08C655B7_helloWorld,
+			[1] class Modules.Async_HelloWorld/helloWorld/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -185,14 +185,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.Async_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_08C655B7_helloWorld::.ctor(object[])
+		IL_0012: newobj instance void Modules.Async_HelloWorld/helloWorld/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "helloWorld"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_08C655B7_helloWorld>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_08C655B7_helloWorld>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_HelloWorld/helloWorld/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_HelloWorld/helloWorld/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_PendingPromiseAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_PendingPromiseAwait.verified.txt
@@ -365,7 +365,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E417C379_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -385,9 +385,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_PendingPromiseAwait/test/FunctionObject_FunctionDeclaration_E417C379_test::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_PendingPromiseAwait/test/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E417C379_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -398,7 +398,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E417C379_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -409,7 +409,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E417C379_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -422,14 +422,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_PendingPromiseAwait/test/FunctionObject_FunctionDeclaration_E417C379_test::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_PendingPromiseAwait/test/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_PendingPromiseAwait/test::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_E417C379_test::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_E417C379_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -473,7 +473,7 @@
 			IL_0020: ldftn object Modules.Async_PendingPromiseAwait/test::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_PendingPromiseAwait/test/FunctionObject_FunctionDeclaration_E417C379_test
+			IL_002c: ldtoken Modules.Async_PendingPromiseAwait/test/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -794,7 +794,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_PendingPromiseAwait/Scope,
-			[1] class Modules.Async_PendingPromiseAwait/test/FunctionObject_FunctionDeclaration_E417C379_test,
+			[1] class Modules.Async_PendingPromiseAwait/test/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object,
@@ -811,14 +811,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.Async_PendingPromiseAwait/test/FunctionObject_FunctionDeclaration_E417C379_test::.ctor(object[])
+		IL_0012: newobj instance void Modules.Async_PendingPromiseAwait/test/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "test"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_PendingPromiseAwait/test/FunctionObject_FunctionDeclaration_E417C379_test>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_PendingPromiseAwait/test/FunctionObject_FunctionDeclaration_E417C379_test>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_PendingPromiseAwait/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_PendingPromiseAwait/test/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
@@ -460,7 +460,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1C358AD9_run
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -480,9 +480,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_RealSuspension_SetTimeout/Scope Modules.Async_RealSuspension_SetTimeout/run/FunctionObject_FunctionDeclaration_1C358AD9_run::_environment0_Async_RealSuspension_SetTimeout
+				IL_0008: stfld class Modules.Async_RealSuspension_SetTimeout/Scope Modules.Async_RealSuspension_SetTimeout/run/FunctionObject::_environment0_Async_RealSuspension_SetTimeout
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -493,7 +493,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -504,7 +504,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -517,11 +517,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_RealSuspension_SetTimeout/Scope Modules.Async_RealSuspension_SetTimeout/run/FunctionObject_FunctionDeclaration_1C358AD9_run::_environment0_Async_RealSuspension_SetTimeout
+				IL_0001: ldfld class Modules.Async_RealSuspension_SetTimeout/Scope Modules.Async_RealSuspension_SetTimeout/run/FunctionObject::_environment0_Async_RealSuspension_SetTimeout
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_RealSuspension_SetTimeout/run::__js_call__(class Modules.Async_RealSuspension_SetTimeout/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -535,11 +535,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_RealSuspension_SetTimeout/Scope Modules.Async_RealSuspension_SetTimeout/run/FunctionObject_FunctionDeclaration_1C358AD9_run::_environment0_Async_RealSuspension_SetTimeout
+				IL_0001: ldfld class Modules.Async_RealSuspension_SetTimeout/Scope Modules.Async_RealSuspension_SetTimeout/run/FunctionObject::_environment0_Async_RealSuspension_SetTimeout
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Async_RealSuspension_SetTimeout/run::__js_call__(class Modules.Async_RealSuspension_SetTimeout/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -557,9 +557,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_1C358AD9_run
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -812,7 +812,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_RealSuspension_SetTimeout/Scope,
-			[1] class Modules.Async_RealSuspension_SetTimeout/run/FunctionObject_FunctionDeclaration_1C358AD9_run,
+			[1] class Modules.Async_RealSuspension_SetTimeout/run/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object,
@@ -832,13 +832,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Async_RealSuspension_SetTimeout/Scope
-		IL_0019: newobj instance void Modules.Async_RealSuspension_SetTimeout/run/FunctionObject_FunctionDeclaration_1C358AD9_run::.ctor(class Modules.Async_RealSuspension_SetTimeout/Scope)
+		IL_0019: newobj instance void Modules.Async_RealSuspension_SetTimeout/run/FunctionObject::.ctor(class Modules.Async_RealSuspension_SetTimeout/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "run"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_RealSuspension_SetTimeout/run/FunctionObject_FunctionDeclaration_1C358AD9_run>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_RealSuspension_SetTimeout/run/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ReturnValue.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ReturnValue.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BA1FCA97_getValue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_ReturnValue/getValue/FunctionObject_FunctionDeclaration_BA1FCA97_getValue::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_ReturnValue/getValue/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_ReturnValue/getValue/FunctionObject_FunctionDeclaration_BA1FCA97_getValue::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_ReturnValue/getValue/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_ReturnValue/getValue::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_BA1FCA97_getValue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -280,7 +280,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_ReturnValue/Scope,
-			[1] class Modules.Async_ReturnValue/getValue/FunctionObject_FunctionDeclaration_BA1FCA97_getValue,
+			[1] class Modules.Async_ReturnValue/getValue/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class Modules.Async_ReturnValue/ArrowFunction_L7C17/FunctionObject
@@ -296,14 +296,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.Async_ReturnValue/getValue/FunctionObject_FunctionDeclaration_BA1FCA97_getValue::.ctor(object[])
+		IL_0012: newobj instance void Modules.Async_ReturnValue/getValue/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "getValue"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_ReturnValue/getValue/FunctionObject_FunctionDeclaration_BA1FCA97_getValue>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ReturnValue/getValue/FunctionObject_FunctionDeclaration_BA1FCA97_getValue>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_ReturnValue/getValue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_ReturnValue/getValue/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_SchedulerLocalAcrossAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_SchedulerLocalAcrossAwait.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E9DF5E10_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -57,9 +57,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject_FunctionDeclaration_E9DF5E10_test::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -70,7 +70,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -81,7 +81,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -94,7 +94,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject_FunctionDeclaration_E9DF5E10_test::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -102,9 +102,9 @@
 				IL_0012: call object Modules.Async_SchedulerLocalAcrossAwait/test::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_E9DF5E10_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -149,7 +149,7 @@
 			IL_0020: ldftn object Modules.Async_SchedulerLocalAcrossAwait/test::__js_call__(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject_FunctionDeclaration_E9DF5E10_test
+			IL_002c: ldtoken Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -327,7 +327,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_SchedulerLocalAcrossAwait/Scope,
-			[1] class Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject_FunctionDeclaration_E9DF5E10_test,
+			[1] class Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject,
 			[2] object[]
 		)
 
@@ -341,14 +341,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject_FunctionDeclaration_E9DF5E10_test::.ctor(object[])
+		IL_0012: newobj instance void Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "test"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject_FunctionDeclaration_E9DF5E10_test>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject_FunctionDeclaration_E9DF5E10_test>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_SimpleAwait.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2021CCC7_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -57,9 +57,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_SimpleAwait/test/FunctionObject_FunctionDeclaration_2021CCC7_test::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_SimpleAwait/test/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -70,7 +70,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -81,7 +81,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -94,14 +94,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_SimpleAwait/test/FunctionObject_FunctionDeclaration_2021CCC7_test::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_SimpleAwait/test/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_SimpleAwait/test::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_2021CCC7_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -143,7 +143,7 @@
 			IL_0020: ldftn object Modules.Async_SimpleAwait/test::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_SimpleAwait/test/FunctionObject_FunctionDeclaration_2021CCC7_test
+			IL_002c: ldtoken Modules.Async_SimpleAwait/test/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -417,7 +417,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_SimpleAwait/Scope,
-			[1] class Modules.Async_SimpleAwait/test/FunctionObject_FunctionDeclaration_2021CCC7_test,
+			[1] class Modules.Async_SimpleAwait/test/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class Modules.Async_SimpleAwait/ArrowFunction_L10C13/FunctionObject
@@ -433,14 +433,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.Async_SimpleAwait/test/FunctionObject_FunctionDeclaration_2021CCC7_test::.ctor(object[])
+		IL_0012: newobj instance void Modules.Async_SimpleAwait/test/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "test"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_SimpleAwait/test/FunctionObject_FunctionDeclaration_2021CCC7_test>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_SimpleAwait/test/FunctionObject_FunctionDeclaration_2021CCC7_test>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_SimpleAwait/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_SimpleAwait/test/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_DefaultDestructuringFunctionExport.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_DefaultDestructuringFunctionExport.verified.txt
@@ -58,7 +58,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_60AADF78_pick
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -72,7 +72,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -83,7 +83,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -94,7 +94,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -108,7 +108,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -126,7 +126,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -145,7 +145,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -163,9 +163,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_60AADF78_pick
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -302,7 +302,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/Scope,
-			[1] class Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject_FunctionDeclaration_60AADF78_pick,
+			[1] class Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -375,7 +375,7 @@
 		IL_0082: dup
 		IL_0083: ldc.i4.0
 		IL_0084: ldelem.ref
-		IL_0085: castclass Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject_FunctionDeclaration_60AADF78_pick
+		IL_0085: castclass Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject
 		IL_008a: stloc.1
 		IL_008b: dup
 		IL_008c: ldc.i4.1
@@ -409,14 +409,14 @@
 		IL_00c8: ldloc.0
 		IL_00c9: stelem.ref
 		IL_00ca: stloc.2
-		IL_00cb: newobj instance void Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject_FunctionDeclaration_60AADF78_pick::.ctor()
+		IL_00cb: newobj instance void Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject::.ctor()
 		IL_00d0: ldc.i4.0
 		IL_00d1: conv.r8
 		IL_00d2: ldstr "pick"
 		IL_00d7: ldc.i4.0
 		IL_00d8: ldc.i4.0
-		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject_FunctionDeclaration_60AADF78_pick>(!!0, float64, string, bool, bool)
-		IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject_FunctionDeclaration_60AADF78_pick>(!!0)
+		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject>(!!0)
 		IL_00e3: stloc.1
 		IL_00e4: nop
 		IL_00e5: ldstr "Promise"

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -71,9 +71,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -84,7 +84,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -109,7 +109,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -122,11 +122,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -140,11 +140,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -162,9 +162,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -270,7 +270,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -284,7 +284,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -295,7 +295,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -306,7 +306,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -320,7 +320,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -338,7 +338,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -357,7 +357,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -375,9 +375,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -480,7 +480,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -494,7 +494,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -505,7 +505,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -516,7 +516,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -530,7 +530,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -552,7 +552,7 @@
 				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0018: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get::__js_call__(object, object, string)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -575,7 +575,7 @@
 				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0014: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get::__js_call__(object, object, string)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -593,9 +593,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -653,7 +653,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3D7422AC_L34C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -677,15 +677,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -696,7 +696,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -707,7 +707,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -721,7 +721,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -734,11 +734,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -752,11 +752,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -774,9 +774,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_3D7422AC_L34C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -826,7 +826,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7D62214D_L35C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -850,15 +850,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -869,7 +869,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -880,7 +880,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -894,7 +894,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -907,11 +907,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -925,11 +925,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -947,9 +947,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_7D62214D_L35C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1003,7 +1003,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A05F0817_L45C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -1029,18 +1029,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+						IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::_environment2_FunctionExpression_L44C9
+						IL_0016: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::_environment2_FunctionExpression_L44C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -1051,7 +1051,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -1062,7 +1062,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object ResolveThisArgumentCore (
@@ -1076,7 +1076,7 @@
 						IL_0000: ldarg.1
 						IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::ResolveThisArgumentCore
+					} // end of method FunctionObject::ResolveThisArgumentCore
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1089,11 +1089,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1107,11 +1107,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1129,9 +1129,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_A05F0817_L45C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1196,7 +1196,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1AF19204_L44C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1220,15 +1220,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1239,7 +1239,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1250,7 +1250,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -1264,7 +1264,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1277,14 +1277,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1298,14 +1298,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1323,9 +1323,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_1AF19204_L44C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1347,7 +1347,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87,
+					[4] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -1397,14 +1397,14 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.0
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87>(!!0, float64, string, bool, bool)
-				IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87>(!!0)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject>(!!0)
 				IL_006a: stloc.s 4
 				IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_0071: dup
@@ -1614,7 +1614,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1634,9 +1634,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1647,7 +1647,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1658,7 +1658,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1672,7 +1672,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1685,14 +1685,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1706,14 +1706,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1731,9 +1731,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1773,12 +1773,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87,
-				[21] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94,
+				[20] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject,
+				[21] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10
+				[25] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::.ctor()
@@ -1984,14 +1984,14 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.0
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87>(!!0, float64, string, bool, bool)
-			IL_0236: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87>(!!0)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0236: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject>(!!0)
 			IL_023b: stloc.s 20
 			IL_023d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0242: dup
@@ -2035,14 +2035,14 @@
 			IL_029c: ldelem.ref
 			IL_029d: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope
 			IL_02a2: ldloc.s 19
-			IL_02a4: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, object[])
+			IL_02a4: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, object[])
 			IL_02a9: ldc.i4.0
 			IL_02aa: conv.r8
 			IL_02ab: ldstr ""
 			IL_02b0: ldc.i4.0
 			IL_02b1: ldc.i4.0
-			IL_02b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94>(!!0, float64, string, bool, bool)
-			IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94>(!!0)
+			IL_02b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject>(!!0)
 			IL_02bc: stloc.s 21
 			IL_02be: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02c3: dup
@@ -2212,14 +2212,14 @@
 				IL_0473: ldelem.ref
 				IL_0474: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope
 				IL_0479: ldloc.s 19
-				IL_047b: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, object[])
+				IL_047b: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, object[])
 				IL_0480: ldc.i4.1
 				IL_0481: conv.r8
 				IL_0482: ldstr ""
 				IL_0487: ldc.i4.0
 				IL_0488: ldc.i4.0
-				IL_0489: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10>(!!0, float64, string, bool, bool)
-				IL_048e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10>(!!0)
+				IL_0489: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_048e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject>(!!0)
 				IL_0493: stloc.s 25
 				IL_0495: ldloc.s 25
 				IL_0497: ldc.i4.1
@@ -2330,7 +2330,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2350,9 +2350,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2363,7 +2363,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2374,7 +2374,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -2388,7 +2388,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2401,7 +2401,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2411,7 +2411,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2425,7 +2425,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2435,7 +2435,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2453,9 +2453,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2593,13 +2593,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope,
-			[1] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default,
-			[2] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get,
-			[3] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace,
-			[4] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export,
+			[1] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark,
+			[7] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[9] object
 		)
@@ -2673,22 +2673,22 @@
 		IL_008a: dup
 		IL_008b: ldc.i4.0
 		IL_008c: ldelem.ref
-		IL_008d: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default
+		IL_008d: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject
 		IL_0092: stloc.1
 		IL_0093: dup
 		IL_0094: ldc.i4.1
 		IL_0095: ldelem.ref
-		IL_0096: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get
+		IL_0096: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject
 		IL_009b: stloc.2
 		IL_009c: dup
 		IL_009d: ldc.i4.2
 		IL_009e: ldelem.ref
-		IL_009f: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace
+		IL_009f: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject
 		IL_00a4: stloc.3
 		IL_00a5: dup
 		IL_00a6: ldc.i4.3
 		IL_00a7: ldelem.ref
-		IL_00a8: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export
+		IL_00a8: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject
 		IL_00ad: stloc.s 4
 		IL_00af: dup
 		IL_00b0: ldc.i4.4
@@ -2702,7 +2702,7 @@
 		IL_00be: dup
 		IL_00bf: ldc.i4.6
 		IL_00c0: ldelem.ref
-		IL_00c1: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark
+		IL_00c1: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject
 		IL_00c6: stloc.s 7
 		IL_00c8: dup
 		IL_00c9: ldc.i4.7
@@ -2730,14 +2730,14 @@
 		IL_00f9: ldc.i4.0
 		IL_00fa: ldelem.ref
 		IL_00fb: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope
-		IL_0100: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope)
+		IL_0100: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope)
 		IL_0105: ldc.i4.0
 		IL_0106: conv.r8
 		IL_0107: ldstr "__jroc_esm_mark"
 		IL_010c: ldc.i4.0
 		IL_010d: ldc.i4.0
-		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark>(!!0, float64, string, bool, bool)
-		IL_0113: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark>(!!0)
+		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0113: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject>(!!0)
 		IL_0118: stloc.s 7
 		IL_011a: ldloc.0
 		IL_011b: ldloc.s 7
@@ -2749,14 +2749,14 @@
 		IL_012a: ldloc.0
 		IL_012b: stelem.ref
 		IL_012c: stloc.s 6
-		IL_012e: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::.ctor()
+		IL_012e: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0133: ldc.i4.1
 		IL_0134: conv.r8
 		IL_0135: ldstr "__jroc_esm_default"
 		IL_013a: ldc.i4.0
 		IL_013b: ldc.i4.0
-		IL_013c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default>(!!0, float64, string, bool, bool)
-		IL_0141: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default>(!!0)
+		IL_013c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0141: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject>(!!0)
 		IL_0146: stloc.1
 		IL_0147: ldc.i4.1
 		IL_0148: newarr [System.Runtime]System.Object
@@ -2765,14 +2765,14 @@
 		IL_014f: ldloc.0
 		IL_0150: stelem.ref
 		IL_0151: stloc.s 6
-		IL_0153: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::.ctor()
+		IL_0153: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0158: ldc.i4.2
 		IL_0159: conv.r8
 		IL_015a: ldstr "__jroc_esm_get"
 		IL_015f: ldc.i4.0
 		IL_0160: ldc.i4.0
-		IL_0161: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get>(!!0, float64, string, bool, bool)
-		IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get>(!!0)
+		IL_0161: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject>(!!0)
 		IL_016b: stloc.2
 		IL_016c: ldc.i4.1
 		IL_016d: newarr [System.Runtime]System.Object
@@ -2785,14 +2785,14 @@
 		IL_017a: ldc.i4.0
 		IL_017b: ldelem.ref
 		IL_017c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope
-		IL_0181: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope)
+		IL_0181: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope)
 		IL_0186: ldc.i4.1
 		IL_0187: conv.r8
 		IL_0188: ldstr "__jroc_esm_namespace"
 		IL_018d: ldc.i4.0
 		IL_018e: ldc.i4.0
-		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace>(!!0, float64, string, bool, bool)
-		IL_0194: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace>(!!0)
+		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0194: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject>(!!0)
 		IL_0199: stloc.3
 		IL_019a: ldc.i4.1
 		IL_019b: newarr [System.Runtime]System.Object
@@ -2805,14 +2805,14 @@
 		IL_01a8: ldc.i4.0
 		IL_01a9: ldelem.ref
 		IL_01aa: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope
-		IL_01af: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope)
+		IL_01af: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope)
 		IL_01b4: ldc.i4.2
 		IL_01b5: conv.r8
 		IL_01b6: ldstr "__jroc_esm_export"
 		IL_01bb: ldc.i4.0
 		IL_01bc: ldc.i4.0
-		IL_01bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export>(!!0, float64, string, bool, bool)
-		IL_01c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export>(!!0)
+		IL_01bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject>(!!0)
 		IL_01c7: stloc.s 4
 		IL_01c9: ldc.i4.1
 		IL_01ca: newarr [System.Runtime]System.Object
@@ -2953,7 +2953,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_787D0E6A_L3C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2973,9 +2973,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2986,7 +2986,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2997,7 +2997,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -3011,7 +3011,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3024,11 +3024,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3042,11 +3042,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3064,9 +3064,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_787D0E6A_L3C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3115,7 +3115,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_219C8DFB_run
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -3135,9 +3135,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject_FunctionDeclaration_219C8DFB_run::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3148,7 +3148,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3159,7 +3159,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -3173,7 +3173,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -3186,14 +3186,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject_FunctionDeclaration_219C8DFB_run::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_219C8DFB_run
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3261,7 +3261,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3281,9 +3281,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3294,7 +3294,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3305,7 +3305,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -3319,7 +3319,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3332,11 +3332,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3350,11 +3350,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3372,9 +3372,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3480,7 +3480,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3494,7 +3494,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3505,7 +3505,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3516,7 +3516,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -3530,7 +3530,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3548,7 +3548,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3567,7 +3567,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3585,9 +3585,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3690,7 +3690,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3704,7 +3704,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3715,7 +3715,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3726,7 +3726,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -3740,7 +3740,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3761,7 +3761,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3783,7 +3783,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3801,9 +3801,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3861,7 +3861,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_91DBC25E_L34C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3885,15 +3885,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3904,7 +3904,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3915,7 +3915,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -3929,7 +3929,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3942,11 +3942,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3960,11 +3960,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3982,9 +3982,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_91DBC25E_L34C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4034,7 +4034,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A5C595DB_L35C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4058,15 +4058,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4077,7 +4077,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4088,7 +4088,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -4102,7 +4102,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4115,11 +4115,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4133,11 +4133,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4155,9 +4155,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_A5C595DB_L35C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4211,7 +4211,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_21758CF9_L45C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -4237,18 +4237,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+						IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::_environment2_FunctionExpression_L44C9
+						IL_0016: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::_environment2_FunctionExpression_L44C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -4259,7 +4259,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -4270,7 +4270,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object ResolveThisArgumentCore (
@@ -4284,7 +4284,7 @@
 						IL_0000: ldarg.1
 						IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::ResolveThisArgumentCore
+					} // end of method FunctionObject::ResolveThisArgumentCore
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -4297,11 +4297,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -4315,11 +4315,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -4337,9 +4337,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_21758CF9_L45C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -4404,7 +4404,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6A22A512_L44C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4428,15 +4428,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4447,7 +4447,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4458,7 +4458,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -4472,7 +4472,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4485,14 +4485,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4506,14 +4506,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4531,9 +4531,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_6A22A512_L44C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4555,7 +4555,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87,
+					[4] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -4605,14 +4605,14 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.0
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87>(!!0, float64, string, bool, bool)
-				IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87>(!!0)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject>(!!0)
 				IL_006a: stloc.s 4
 				IL_006c: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_0071: dup
@@ -4822,7 +4822,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4842,9 +4842,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4855,7 +4855,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4866,7 +4866,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -4880,7 +4880,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4893,14 +4893,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4914,14 +4914,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4939,9 +4939,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4981,12 +4981,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87,
-				[21] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94,
+				[20] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject,
+				[21] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10
+				[25] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::.ctor()
@@ -5192,14 +5192,14 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.0
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87>(!!0, float64, string, bool, bool)
-			IL_0236: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87>(!!0)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0236: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject>(!!0)
 			IL_023b: stloc.s 20
 			IL_023d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0242: dup
@@ -5243,14 +5243,14 @@
 			IL_029c: ldelem.ref
 			IL_029d: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope
 			IL_02a2: ldloc.s 19
-			IL_02a4: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, object[])
+			IL_02a4: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, object[])
 			IL_02a9: ldc.i4.0
 			IL_02aa: conv.r8
 			IL_02ab: ldstr ""
 			IL_02b0: ldc.i4.0
 			IL_02b1: ldc.i4.0
-			IL_02b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94>(!!0, float64, string, bool, bool)
-			IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94>(!!0)
+			IL_02b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject>(!!0)
 			IL_02bc: stloc.s 21
 			IL_02be: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02c3: dup
@@ -5420,14 +5420,14 @@
 				IL_0473: ldelem.ref
 				IL_0474: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope
 				IL_0479: ldloc.s 19
-				IL_047b: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, object[])
+				IL_047b: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, object[])
 				IL_0480: ldc.i4.1
 				IL_0481: conv.r8
 				IL_0482: ldstr ""
 				IL_0487: ldc.i4.0
 				IL_0488: ldc.i4.0
-				IL_0489: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10>(!!0, float64, string, bool, bool)
-				IL_048e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10>(!!0)
+				IL_0489: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_048e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject>(!!0)
 				IL_0493: stloc.s 25
 				IL_0495: ldloc.s 25
 				IL_0497: ldc.i4.1
@@ -5538,7 +5538,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5558,9 +5558,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5571,7 +5571,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5582,7 +5582,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -5596,7 +5596,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5609,7 +5609,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -5620,7 +5620,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5634,7 +5634,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -5645,7 +5645,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5663,9 +5663,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5772,14 +5772,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope,
-			[1] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default/FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default,
-			[2] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get/FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get,
-			[3] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace,
-			[4] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export,
+			[1] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject,
 			[5] object[],
-			[6] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject_FunctionDeclaration_219C8DFB_run,
-			[7] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark,
-			[8] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26
+			[6] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject,
+			[7] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject,
+			[8] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope::.ctor()
@@ -5795,14 +5795,14 @@
 		IL_0016: stelem.ref
 		IL_0017: stloc.s 5
 		IL_0019: ldloc.s 5
-		IL_001b: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject_FunctionDeclaration_219C8DFB_run::.ctor(object[])
+		IL_001b: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject::.ctor(object[])
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "run"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.0
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject_FunctionDeclaration_219C8DFB_run>(!!0, float64, string, bool, bool)
-		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject_FunctionDeclaration_219C8DFB_run>(!!0)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject>(!!0)
 		IL_0033: stloc.s 6
 		IL_0035: ldloc.0
 		IL_0036: ldloc.s 6
@@ -5818,14 +5818,14 @@
 		IL_004b: ldc.i4.0
 		IL_004c: ldelem.ref
 		IL_004d: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-		IL_0052: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
+		IL_0052: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
 		IL_0057: ldc.i4.0
 		IL_0058: conv.r8
 		IL_0059: ldstr "__jroc_esm_mark"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.0
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark>(!!0, float64, string, bool, bool)
-		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark>(!!0)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject>(!!0)
 		IL_006a: stloc.s 7
 		IL_006c: ldloc.0
 		IL_006d: ldloc.s 7
@@ -5837,14 +5837,14 @@
 		IL_007c: ldloc.0
 		IL_007d: stelem.ref
 		IL_007e: stloc.s 5
-		IL_0080: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default/FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::.ctor()
+		IL_0080: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0085: ldc.i4.1
 		IL_0086: conv.r8
 		IL_0087: ldstr "__jroc_esm_default"
 		IL_008c: ldc.i4.0
 		IL_008d: ldc.i4.0
-		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default/FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default>(!!0, float64, string, bool, bool)
-		IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default/FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default>(!!0)
+		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default/FunctionObject>(!!0)
 		IL_0098: stloc.1
 		IL_0099: ldc.i4.1
 		IL_009a: newarr [System.Runtime]System.Object
@@ -5853,14 +5853,14 @@
 		IL_00a1: ldloc.0
 		IL_00a2: stelem.ref
 		IL_00a3: stloc.s 5
-		IL_00a5: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get/FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::.ctor()
+		IL_00a5: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get/FunctionObject::.ctor()
 		IL_00aa: ldc.i4.2
 		IL_00ab: conv.r8
 		IL_00ac: ldstr "__jroc_esm_get"
 		IL_00b1: ldc.i4.0
 		IL_00b2: ldc.i4.0
-		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get/FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get>(!!0, float64, string, bool, bool)
-		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get/FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get>(!!0)
+		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get/FunctionObject>(!!0)
 		IL_00bd: stloc.2
 		IL_00be: ldc.i4.1
 		IL_00bf: newarr [System.Runtime]System.Object
@@ -5873,14 +5873,14 @@
 		IL_00cc: ldc.i4.0
 		IL_00cd: ldelem.ref
 		IL_00ce: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-		IL_00d3: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
+		IL_00d3: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
 		IL_00d8: ldc.i4.1
 		IL_00d9: conv.r8
 		IL_00da: ldstr "__jroc_esm_namespace"
 		IL_00df: ldc.i4.0
 		IL_00e0: ldc.i4.0
-		IL_00e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace>(!!0, float64, string, bool, bool)
-		IL_00e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace>(!!0)
+		IL_00e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject>(!!0)
 		IL_00eb: stloc.3
 		IL_00ec: ldc.i4.1
 		IL_00ed: newarr [System.Runtime]System.Object
@@ -5893,14 +5893,14 @@
 		IL_00fa: ldc.i4.0
 		IL_00fb: ldelem.ref
 		IL_00fc: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-		IL_0101: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
+		IL_0101: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
 		IL_0106: ldc.i4.2
 		IL_0107: conv.r8
 		IL_0108: ldstr "__jroc_esm_export"
 		IL_010d: ldc.i4.0
 		IL_010e: ldc.i4.0
-		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export>(!!0, float64, string, bool, bool)
-		IL_0114: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export>(!!0)
+		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0114: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject>(!!0)
 		IL_0119: stloc.s 4
 		IL_011b: ldloc.0
 		IL_011c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
@@ -5918,14 +5918,14 @@
 		IL_0136: ldc.i4.0
 		IL_0137: ldelem.ref
 		IL_0138: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-		IL_013d: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
+		IL_013d: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
 		IL_0142: ldc.i4.0
 		IL_0143: conv.r8
 		IL_0144: ldstr ""
 		IL_0149: ldc.i4.0
 		IL_014a: ldc.i4.0
-		IL_014b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26>(!!0, float64, string, bool, bool)
-		IL_0150: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26>(!!0)
+		IL_014b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0150: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject>(!!0)
 		IL_0155: stloc.s 8
 		IL_0157: ldloc.0
 		IL_0158: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_PendingPromise.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_PendingPromise.verified.txt
@@ -376,7 +376,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E45DA0E2_delay
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -396,9 +396,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Async_TopLevelAwait_PendingPromise/Scope Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay::_environment0_Async_TopLevelAwait_PendingPromise
+				IL_0008: stfld class Modules.Async_TopLevelAwait_PendingPromise/Scope Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject::_environment0_Async_TopLevelAwait_PendingPromise
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -409,7 +409,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -420,7 +420,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -434,7 +434,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -447,14 +447,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_PendingPromise/Scope Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay::_environment0_Async_TopLevelAwait_PendingPromise
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_PendingPromise/Scope Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject::_environment0_Async_TopLevelAwait_PendingPromise
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Async_TopLevelAwait_PendingPromise/delay::__js_call__(class Modules.Async_TopLevelAwait_PendingPromise/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -468,14 +468,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Async_TopLevelAwait_PendingPromise/Scope Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay::_environment0_Async_TopLevelAwait_PendingPromise
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_PendingPromise/Scope Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject::_environment0_Async_TopLevelAwait_PendingPromise
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Async_TopLevelAwait_PendingPromise/delay::__js_call__(class Modules.Async_TopLevelAwait_PendingPromise/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -493,9 +493,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E45DA0E2_delay
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -635,7 +635,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TopLevelAwait_PendingPromise/Scope,
-			[1] class Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay,
+			[1] class Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -708,7 +708,7 @@
 		IL_0082: dup
 		IL_0083: ldc.i4.0
 		IL_0084: ldelem.ref
-		IL_0085: castclass Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay
+		IL_0085: castclass Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject
 		IL_008a: stloc.1
 		IL_008b: dup
 		IL_008c: ldc.i4.1
@@ -745,14 +745,14 @@
 		IL_00c7: ldc.i4.0
 		IL_00c8: ldelem.ref
 		IL_00c9: castclass Modules.Async_TopLevelAwait_PendingPromise/Scope
-		IL_00ce: newobj instance void Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay::.ctor(class Modules.Async_TopLevelAwait_PendingPromise/Scope)
+		IL_00ce: newobj instance void Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject::.ctor(class Modules.Async_TopLevelAwait_PendingPromise/Scope)
 		IL_00d3: ldc.i4.1
 		IL_00d4: conv.r8
 		IL_00d5: ldstr "delay"
 		IL_00da: ldc.i4.0
 		IL_00db: ldc.i4.0
-		IL_00dc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay>(!!0, float64, string, bool, bool)
-		IL_00e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay>(!!0)
+		IL_00dc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject>(!!0)
 		IL_00e6: stloc.1
 		IL_00e7: nop
 		IL_00e8: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatchFinally_AwaitInFinally_OnReject.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatchFinally_AwaitInFinally_OnReject.verified.txt
@@ -99,7 +99,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BA033FBE_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -119,9 +119,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject_FunctionDeclaration_BA033FBE_test::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -132,7 +132,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -143,7 +143,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -156,14 +156,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject_FunctionDeclaration_BA033FBE_test::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_BA033FBE_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -207,7 +207,7 @@
 			IL_0020: ldftn object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject_FunctionDeclaration_BA033FBE_test
+			IL_002c: ldtoken Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -680,7 +680,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/Scope,
-			[1] class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject_FunctionDeclaration_BA033FBE_test,
+			[1] class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/ArrowFunction_L20C13/FunctionObject
@@ -696,14 +696,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject_FunctionDeclaration_BA033FBE_test::.ctor(object[])
+		IL_0012: newobj instance void Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "test"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject_FunctionDeclaration_BA033FBE_test>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject_FunctionDeclaration_BA033FBE_test>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatch_AwaitReject.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatch_AwaitReject.verified.txt
@@ -77,7 +77,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -97,9 +97,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -110,7 +110,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -121,7 +121,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -134,14 +134,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_TryCatch_AwaitReject/testTryCatch::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -184,7 +184,7 @@
 			IL_0020: ldftn object Modules.Async_TryCatch_AwaitReject/testTryCatch::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch
+			IL_002c: ldtoken Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -493,7 +493,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryCatch_AwaitReject/Scope,
-			[1] class Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch,
+			[1] class Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class Modules.Async_TryCatch_AwaitReject/ArrowFunction_L16C21/FunctionObject,
@@ -510,14 +510,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::.ctor(object[])
+		IL_0012: newobj instance void Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "testTryCatch"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_AwaitInFinally_Normal.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_AwaitInFinally_Normal.verified.txt
@@ -80,7 +80,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1C2E403C_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -100,9 +100,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject_FunctionDeclaration_1C2E403C_test::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -113,7 +113,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -124,7 +124,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -137,14 +137,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject_FunctionDeclaration_1C2E403C_test::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_TryFinally_AwaitInFinally_Normal/test::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_1C2E403C_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -188,7 +188,7 @@
 			IL_0020: ldftn object Modules.Async_TryFinally_AwaitInFinally_Normal/test::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject_FunctionDeclaration_1C2E403C_test
+			IL_002c: ldtoken Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -637,7 +637,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryFinally_AwaitInFinally_Normal/Scope,
-			[1] class Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject_FunctionDeclaration_1C2E403C_test,
+			[1] class Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class Modules.Async_TryFinally_AwaitInFinally_Normal/ArrowFunction_L18C13/FunctionObject,
@@ -654,14 +654,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject_FunctionDeclaration_1C2E403C_test::.ctor(object[])
+		IL_0012: newobj instance void Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "test"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject_FunctionDeclaration_1C2E403C_test>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject_FunctionDeclaration_1C2E403C_test>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_FinallyThrowOverridesOriginal.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_FinallyThrowOverridesOriginal.verified.txt
@@ -117,7 +117,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_19E56F41_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -137,9 +137,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject_FunctionDeclaration_19E56F41_test::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -150,7 +150,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -161,7 +161,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -174,14 +174,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject_FunctionDeclaration_19E56F41_test::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_19E56F41_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -226,7 +226,7 @@
 			IL_0020: ldftn object Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject_FunctionDeclaration_19E56F41_test
+			IL_002c: ldtoken Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -640,7 +640,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/Scope,
-			[1] class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject_FunctionDeclaration_19E56F41_test,
+			[1] class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/ArrowFunction_L20C13/FunctionObject
@@ -656,14 +656,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject_FunctionDeclaration_19E56F41_test::.ctor(object[])
+		IL_0012: newobj instance void Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "test"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject_FunctionDeclaration_19E56F41_test>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject_FunctionDeclaration_19E56F41_test>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_PreservesExceptionThroughAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_PreservesExceptionThroughAwait.verified.txt
@@ -120,7 +120,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E25B5249_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -140,9 +140,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject_FunctionDeclaration_E25B5249_test::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -153,7 +153,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -164,7 +164,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -177,14 +177,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject_FunctionDeclaration_E25B5249_test::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_TryFinally_PreservesExceptionThroughAwait/test::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_E25B5249_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -228,7 +228,7 @@
 			IL_0020: ldftn object Modules.Async_TryFinally_PreservesExceptionThroughAwait/test::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject_FunctionDeclaration_E25B5249_test
+			IL_002c: ldtoken Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -686,7 +686,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryFinally_PreservesExceptionThroughAwait/Scope,
-			[1] class Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject_FunctionDeclaration_E25B5249_test,
+			[1] class Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class Modules.Async_TryFinally_PreservesExceptionThroughAwait/ArrowFunction_L22C13/FunctionObject
@@ -702,14 +702,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject_FunctionDeclaration_E25B5249_test::.ctor(object[])
+		IL_0012: newobj instance void Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "test"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject_FunctionDeclaration_E25B5249_test>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject_FunctionDeclaration_E25B5249_test>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_ReturnPreservedThroughAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_ReturnPreservedThroughAwait.verified.txt
@@ -77,7 +77,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CCB1BF9B_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -97,9 +97,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject_FunctionDeclaration_CCB1BF9B_test::_transitionalScopes
+				IL_0008: stfld object[] Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -110,7 +110,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -121,7 +121,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -134,14 +134,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject_FunctionDeclaration_CCB1BF9B_test::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Async_TryFinally_ReturnPreservedThroughAwait/test::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_CCB1BF9B_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -184,7 +184,7 @@
 			IL_0020: ldftn object Modules.Async_TryFinally_ReturnPreservedThroughAwait/test::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject_FunctionDeclaration_CCB1BF9B_test
+			IL_002c: ldtoken Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -590,7 +590,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TryFinally_ReturnPreservedThroughAwait/Scope,
-			[1] class Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject_FunctionDeclaration_CCB1BF9B_test,
+			[1] class Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class Modules.Async_TryFinally_ReturnPreservedThroughAwait/ArrowFunction_L16C13/FunctionObject
@@ -606,14 +606,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject_FunctionDeclaration_CCB1BF9B_test::.ctor(object[])
+		IL_0012: newobj instance void Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "test"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject_FunctionDeclaration_CCB1BF9B_test>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject_FunctionDeclaration_CCB1BF9B_test>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_BasicNext.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_BasicNext.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F18BC1F4_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -57,9 +57,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_BasicNext/g/FunctionObject_FunctionDeclaration_F18BC1F4_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.AsyncGenerator_BasicNext/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -70,7 +70,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -81,7 +81,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -94,15 +94,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.AsyncGenerator_BasicNext/g/FunctionObject_FunctionDeclaration_F18BC1F4_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.AsyncGenerator_BasicNext/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.AsyncGenerator_BasicNext/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F18BC1F4_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -144,7 +144,7 @@
 			IL_0020: ldftn object Modules.AsyncGenerator_BasicNext/g::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.AsyncGenerator_BasicNext/g/FunctionObject_FunctionDeclaration_F18BC1F4_g
+			IL_002c: ldtoken Modules.AsyncGenerator_BasicNext/g/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -926,7 +926,7 @@
 		.locals init (
 			[0] class Modules.AsyncGenerator_BasicNext/Scope,
 			[1] object[],
-			[2] class Modules.AsyncGenerator_BasicNext/g/FunctionObject_FunctionDeclaration_F18BC1F4_g,
+			[2] class Modules.AsyncGenerator_BasicNext/g/FunctionObject,
 			[3] class Modules.AsyncGenerator_BasicNext/ArrowFunction_L9C2/FunctionObject
 		)
 
@@ -940,15 +940,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.1
 		IL_0011: ldloc.1
-		IL_0012: newobj instance void Modules.AsyncGenerator_BasicNext/g/FunctionObject_FunctionDeclaration_F18BC1F4_g::.ctor(object[])
+		IL_0012: newobj instance void Modules.AsyncGenerator_BasicNext/g/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "g"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_BasicNext/g/FunctionObject_FunctionDeclaration_F18BC1F4_g>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_BasicNext/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-		IL_002a: castclass Modules.AsyncGenerator_BasicNext/g/FunctionObject_FunctionDeclaration_F18BC1F4_g
+		IL_002a: castclass Modules.AsyncGenerator_BasicNext/g/FunctionObject
 		IL_002f: stloc.2
 		IL_0030: ldloc.0
 		IL_0031: ldloc.2

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_ForAwaitOf.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_ForAwaitOf.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CEF26CCF_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject_FunctionDeclaration_CEF26CCF_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,15 +87,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject_FunctionDeclaration_CEF26CCF_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.AsyncGenerator_ForAwaitOf/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CEF26CCF_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -136,7 +136,7 @@
 			IL_0020: ldftn object Modules.AsyncGenerator_ForAwaitOf/g::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject_FunctionDeclaration_CEF26CCF_g
+			IL_002c: ldtoken Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1040,7 +1040,7 @@
 		.locals init (
 			[0] class Modules.AsyncGenerator_ForAwaitOf/Scope,
 			[1] object[],
-			[2] class Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject_FunctionDeclaration_CEF26CCF_g,
+			[2] class Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject,
 			[3] class Modules.AsyncGenerator_ForAwaitOf/ArrowFunction_L8C2/FunctionObject
 		)
 
@@ -1054,15 +1054,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.1
 		IL_0011: ldloc.1
-		IL_0012: newobj instance void Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject_FunctionDeclaration_CEF26CCF_g::.ctor(object[])
+		IL_0012: newobj instance void Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "g"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject_FunctionDeclaration_CEF26CCF_g>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-		IL_002a: castclass Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject_FunctionDeclaration_CEF26CCF_g
+		IL_002a: castclass Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject
 		IL_002f: stloc.2
 		IL_0030: ldloc.0
 		IL_0031: ldloc.2

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_GeneratedFunctionObject_Semantics.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_GeneratedFunctionObject_Semantics.verified.txt
@@ -38,7 +38,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EF0FD554_declared
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -58,9 +58,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_EF0FD554_declared::_transitionalScopes
+				IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EF0FD554_declared::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -71,7 +71,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EF0FD554_declared::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -82,7 +82,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EF0FD554_declared::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -96,7 +96,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_EF0FD554_declared::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -109,7 +109,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_EF0FD554_declared::_transitionalScopes
+				IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -118,9 +118,9 @@
 				IL_0017: ldarg.0
 				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EF0FD554_declared::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_EF0FD554_declared
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -165,7 +165,7 @@
 			IL_0020: ldftn object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared::__js_call__(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_EF0FD554_declared
+			IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -535,7 +535,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_643A8051_named
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -555,9 +555,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_643A8051_named::_transitionalScopes
+				IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_643A8051_named::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -568,7 +568,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_643A8051_named::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -579,7 +579,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_643A8051_named::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -593,7 +593,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_643A8051_named::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -606,7 +606,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_643A8051_named::_transitionalScopes
+				IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -615,9 +615,9 @@
 				IL_0017: ldarg.0
 				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionExpression_643A8051_named::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_643A8051_named
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -662,7 +662,7 @@
 			IL_0020: ldftn object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named::__js_call__(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_643A8051_named
+			IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -855,7 +855,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_17E7706B_L12C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -875,9 +875,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject_FunctionExpression_17E7706B_L12C12::_transitionalScopes
+					IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_17E7706B_L12C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -888,7 +888,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_17E7706B_L12C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -899,7 +899,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_17E7706B_L12C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -913,7 +913,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_17E7706B_L12C12::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -926,15 +926,15 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject_FunctionExpression_17E7706B_L12C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11::__js_call__(object[], object)
 					IL_0010: ldarg.0
 					IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 					IL_0016: ret
-				} // end of method FunctionObject_FunctionExpression_17E7706B_L12C12::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_17E7706B_L12C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -975,7 +975,7 @@
 				IL_0020: ldftn object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11::__js_call__(object[], object)
 				IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 				IL_002b: ldarg.0
-				IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject_FunctionExpression_17E7706B_L12C12
+				IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject
 				IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 				IL_0036: ldc.i4.0
 				IL_0037: newarr [System.Runtime]System.Object
@@ -1140,7 +1140,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2E084279_makeGenerator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1154,7 +1154,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E084279_makeGenerator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1165,7 +1165,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E084279_makeGenerator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1176,7 +1176,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E084279_makeGenerator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1190,7 +1190,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E084279_makeGenerator::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1205,7 +1205,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E084279_makeGenerator::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1221,7 +1221,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E084279_makeGenerator::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1239,9 +1239,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E084279_makeGenerator::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2E084279_makeGenerator
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1259,7 +1259,7 @@
 			.locals init (
 				[0] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/Scope,
 				[1] object[],
-				[2] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject_FunctionExpression_17E7706B_L12C12
+				[2] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/Scope::.ctor()
@@ -1267,15 +1267,15 @@
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.1
 			IL_000c: ldloc.1
-			IL_000d: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject_FunctionExpression_17E7706B_L12C12::.ctor(object[])
+			IL_000d: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject::.ctor(object[])
 			IL_0012: ldc.i4.0
 			IL_0013: conv.r8
 			IL_0014: ldstr ""
 			IL_0019: ldc.i4.1
 			IL_001a: ldc.i4.0
-			IL_001b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject_FunctionExpression_17E7706B_L12C12>(!!0, float64, string, bool, bool)
+			IL_001b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-			IL_0025: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject_FunctionExpression_17E7706B_L12C12
+			IL_0025: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L12C11/FunctionObject
 			IL_002a: stloc.2
 			IL_002b: ldloc.2
 			IL_002c: ret
@@ -1313,7 +1313,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A42D114D_L19C15
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1333,9 +1333,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_A42D114D_L19C15::_transitionalScopes
+				IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A42D114D_L19C15::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1346,7 +1346,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A42D114D_L19C15::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1357,7 +1357,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A42D114D_L19C15::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1371,7 +1371,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_A42D114D_L19C15::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1384,7 +1384,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_A42D114D_L19C15::_transitionalScopes
+				IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -1393,9 +1393,9 @@
 				IL_0017: ldarg.0
 				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionExpression_A42D114D_L19C15::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_A42D114D_L19C15
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1440,7 +1440,7 @@
 			IL_0020: ldftn object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object::__js_call__(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_A42D114D_L19C15
+			IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1631,7 +1631,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1653,12 +1653,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator::_environment0_AsyncGenerator_GeneratedFunctionObject_Semantics
+					IL_0008: stfld class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject::_environment0_AsyncGenerator_GeneratedFunctionObject_Semantics
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator::_transitionalScopes
+					IL_000f: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1669,7 +1669,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1680,7 +1680,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -1694,7 +1694,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1707,11 +1707,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator::_transitionalScopes
+					IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1725,11 +1725,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator::_transitionalScopes
+					IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1747,9 +1747,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1854,7 +1854,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_63C8F382_parameterThrows
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1874,9 +1874,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject_FunctionDeclaration_63C8F382_parameterThrows::_transitionalScopes
+					IL_0008: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_63C8F382_parameterThrows::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1887,7 +1887,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_63C8F382_parameterThrows::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1898,7 +1898,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_63C8F382_parameterThrows::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -1912,7 +1912,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionDeclaration_63C8F382_parameterThrows::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1925,7 +1925,7 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject_FunctionDeclaration_63C8F382_parameterThrows::_transitionalScopes
+					IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
@@ -1934,9 +1934,9 @@
 					IL_0017: ldarg.0
 					IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 					IL_001d: ret
-				} // end of method FunctionObject_FunctionDeclaration_63C8F382_parameterThrows::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionDeclaration_63C8F382_parameterThrows
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1979,7 +1979,7 @@
 				IL_0020: ldftn object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows::__js_call__(object[], object, object)
 				IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 				IL_002b: ldarg.0
-				IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject_FunctionDeclaration_63C8F382_parameterThrows
+				IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject
 				IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 				IL_0036: ldc.i4.1
 				IL_0037: newarr [System.Runtime]System.Object
@@ -2260,7 +2260,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_118DECE7_run
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -2282,12 +2282,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject_FunctionDeclaration_118DECE7_run::_environment0_AsyncGenerator_GeneratedFunctionObject_Semantics
+				IL_0008: stfld class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject::_environment0_AsyncGenerator_GeneratedFunctionObject_Semantics
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject_FunctionDeclaration_118DECE7_run::_transitionalScopes
+				IL_000f: stfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_118DECE7_run::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2298,7 +2298,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_118DECE7_run::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2309,7 +2309,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_118DECE7_run::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -2323,7 +2323,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_118DECE7_run::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -2336,14 +2336,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject_FunctionDeclaration_118DECE7_run::_transitionalScopes
+				IL_0001: ldfld object[] Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_118DECE7_run::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_118DECE7_run
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2361,8 +2361,8 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/Scope,
-				[1] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator,
-				[2] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject_FunctionDeclaration_63C8F382_parameterThrows,
+				[1] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject,
+				[2] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject,
 				[3] object,
 				[4] class [System.Runtime]System.Exception,
 				[5] object,
@@ -2416,7 +2416,7 @@
 			IL_0020: ldftn object Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject_FunctionDeclaration_118DECE7_run
+			IL_002c: ldtoken Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -2446,12 +2446,12 @@
 			IL_007b: dup
 			IL_007c: ldc.i4.0
 			IL_007d: ldelem.ref
-			IL_007e: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator
+			IL_007e: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject
 			IL_0083: stloc.1
 			IL_0084: dup
 			IL_0085: ldc.i4.1
 			IL_0086: ldelem.ref
-			IL_0087: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject_FunctionDeclaration_63C8F382_parameterThrows
+			IL_0087: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject
 			IL_008c: stloc.2
 			IL_008d: dup
 			IL_008e: ldc.i4.2
@@ -2619,14 +2619,14 @@
 			IL_01d0: ldelem.ref
 			IL_01d1: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
 			IL_01d6: ldloc.s 19
-			IL_01d8: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator::.ctor(class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope, object[])
+			IL_01d8: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject::.ctor(class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope, object[])
 			IL_01dd: ldc.i4.0
 			IL_01de: conv.r8
 			IL_01df: ldstr "tailCallGenerator"
 			IL_01e4: ldc.i4.0
 			IL_01e5: ldc.i4.0
-			IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator>(!!0, float64, string, bool, bool)
-			IL_01eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject_FunctionDeclaration_E75E3EBF_tailCallGenerator>(!!0)
+			IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_01eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/tailCallGenerator/FunctionObject>(!!0)
 			IL_01f0: stloc.1
 			IL_01f1: ldc.i4.1
 			IL_01f2: newarr [System.Runtime]System.Object
@@ -2638,15 +2638,15 @@
 			IL_01fc: stelem.ref
 			IL_01fd: stloc.s 19
 			IL_01ff: ldloc.s 19
-			IL_0201: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject_FunctionDeclaration_63C8F382_parameterThrows::.ctor(object[])
+			IL_0201: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject::.ctor(object[])
 			IL_0206: ldc.i4.0
 			IL_0207: conv.r8
 			IL_0208: ldstr "parameterThrows"
 			IL_020d: ldc.i4.1
 			IL_020e: ldc.i4.0
-			IL_020f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject_FunctionDeclaration_63C8F382_parameterThrows>(!!0, float64, string, bool, bool)
+			IL_020f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0214: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-			IL_0219: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject_FunctionDeclaration_63C8F382_parameterThrows
+			IL_0219: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/parameterThrows/FunctionObject
 			IL_021e: stloc.2
 			IL_021f: ldarg.0
 			IL_0220: ldc.i4.1
@@ -6094,13 +6094,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope,
-			[1] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject_FunctionDeclaration_118DECE7_run,
+			[1] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject,
 			[2] object[],
-			[3] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_EF0FD554_declared,
-			[4] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject_FunctionDeclaration_2E084279_makeGenerator,
-			[5] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_643A8051_named,
+			[3] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject,
+			[4] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject,
+			[5] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[7] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_A42D114D_L19C15,
+			[7] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject,
 			[8] class [System.Runtime]System.Type,
 			[9] object,
 			[10] class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/AsyncGeneratorClass/FunctionObject_ClassConstructor_AAD039E1_AsyncGeneratorClass,
@@ -6118,15 +6118,15 @@
 		IL_0014: stelem.ref
 		IL_0015: stloc.2
 		IL_0016: ldloc.2
-		IL_0017: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_EF0FD554_declared::.ctor(object[])
+		IL_0017: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject::.ctor(object[])
 		IL_001c: ldc.i4.1
 		IL_001d: conv.r8
 		IL_001e: ldstr "declared"
 		IL_0023: ldc.i4.1
 		IL_0024: ldc.i4.0
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_EF0FD554_declared>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002a: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-		IL_002f: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_EF0FD554_declared
+		IL_002f: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/declared/FunctionObject
 		IL_0034: stloc.3
 		IL_0035: ldloc.0
 		IL_0036: ldloc.3
@@ -6138,14 +6138,14 @@
 		IL_0044: ldloc.0
 		IL_0045: stelem.ref
 		IL_0046: stloc.2
-		IL_0047: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject_FunctionDeclaration_2E084279_makeGenerator::.ctor()
+		IL_0047: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject::.ctor()
 		IL_004c: ldc.i4.0
 		IL_004d: conv.r8
 		IL_004e: ldstr "makeGenerator"
 		IL_0053: ldc.i4.0
 		IL_0054: ldc.i4.0
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject_FunctionDeclaration_2E084279_makeGenerator>(!!0, float64, string, bool, bool)
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject_FunctionDeclaration_2E084279_makeGenerator>(!!0)
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject>(!!0)
 		IL_005f: stloc.s 4
 		IL_0061: ldloc.0
 		IL_0062: ldloc.s 4
@@ -6162,14 +6162,14 @@
 		IL_0076: ldelem.ref
 		IL_0077: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope
 		IL_007c: ldloc.2
-		IL_007d: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject_FunctionDeclaration_118DECE7_run::.ctor(class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope, object[])
+		IL_007d: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject::.ctor(class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/Scope, object[])
 		IL_0082: ldc.i4.0
 		IL_0083: conv.r8
 		IL_0084: ldstr "run"
 		IL_0089: ldc.i4.0
 		IL_008a: ldc.i4.0
-		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject_FunctionDeclaration_118DECE7_run>(!!0, float64, string, bool, bool)
-		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject_FunctionDeclaration_118DECE7_run>(!!0)
+		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/run/FunctionObject>(!!0)
 		IL_0095: stloc.1
 		IL_0096: nop
 		IL_0097: ldc.i4.1
@@ -6180,15 +6180,15 @@
 		IL_00a0: stelem.ref
 		IL_00a1: stloc.2
 		IL_00a2: ldloc.2
-		IL_00a3: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_643A8051_named::.ctor(object[])
+		IL_00a3: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject::.ctor(object[])
 		IL_00a8: ldc.i4.1
 		IL_00a9: conv.r8
 		IL_00aa: ldstr "named"
 		IL_00af: ldc.i4.1
 		IL_00b0: ldc.i4.0
-		IL_00b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_643A8051_named>(!!0, float64, string, bool, bool)
+		IL_00b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00b6: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-		IL_00bb: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_643A8051_named
+		IL_00bb: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/named/FunctionObject
 		IL_00c0: stloc.s 5
 		IL_00c2: ldloc.0
 		IL_00c3: ldloc.s 5
@@ -6209,15 +6209,15 @@
 		IL_00f1: stelem.ref
 		IL_00f2: stloc.2
 		IL_00f3: ldloc.2
-		IL_00f4: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_A42D114D_L19C15::.ctor(object[])
+		IL_00f4: newobj instance void Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject::.ctor(object[])
 		IL_00f9: ldc.i4.1
 		IL_00fa: conv.r8
 		IL_00fb: ldstr ""
 		IL_0100: ldc.i4.1
 		IL_0101: ldc.i4.0
-		IL_0102: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_A42D114D_L19C15>(!!0, float64, string, bool, bool)
+		IL_0102: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0107: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-		IL_010c: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_A42D114D_L19C15
+		IL_010c: castclass Modules.AsyncGenerator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject
 		IL_0111: stloc.s 7
 		IL_0113: ldloc.s 6
 		IL_0115: ldstr "run"

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Return.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Return.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AC260B63_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -90,9 +90,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_Return/g/FunctionObject_FunctionDeclaration_AC260B63_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.AsyncGenerator_Return/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +103,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,7 +114,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -127,15 +127,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.AsyncGenerator_Return/g/FunctionObject_FunctionDeclaration_AC260B63_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.AsyncGenerator_Return/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.AsyncGenerator_Return/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_AC260B63_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -178,7 +178,7 @@
 			IL_0020: ldftn object Modules.AsyncGenerator_Return/g::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.AsyncGenerator_Return/g/FunctionObject_FunctionDeclaration_AC260B63_g
+			IL_002c: ldtoken Modules.AsyncGenerator_Return/g/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1069,7 +1069,7 @@
 		.locals init (
 			[0] class Modules.AsyncGenerator_Return/Scope,
 			[1] object[],
-			[2] class Modules.AsyncGenerator_Return/g/FunctionObject_FunctionDeclaration_AC260B63_g,
+			[2] class Modules.AsyncGenerator_Return/g/FunctionObject,
 			[3] class Modules.AsyncGenerator_Return/ArrowFunction_L14C2/FunctionObject
 		)
 
@@ -1083,15 +1083,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.1
 		IL_0011: ldloc.1
-		IL_0012: newobj instance void Modules.AsyncGenerator_Return/g/FunctionObject_FunctionDeclaration_AC260B63_g::.ctor(object[])
+		IL_0012: newobj instance void Modules.AsyncGenerator_Return/g/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "g"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_Return/g/FunctionObject_FunctionDeclaration_AC260B63_g>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_Return/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-		IL_002a: castclass Modules.AsyncGenerator_Return/g/FunctionObject_FunctionDeclaration_AC260B63_g
+		IL_002a: castclass Modules.AsyncGenerator_Return/g/FunctionObject
 		IL_002f: stloc.2
 		IL_0030: ldloc.0
 		IL_0031: ldloc.2

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
@@ -89,7 +89,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_31CD1283_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -109,9 +109,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_Throw/g/FunctionObject_FunctionDeclaration_31CD1283_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.AsyncGenerator_Throw/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -122,7 +122,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -133,7 +133,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -146,15 +146,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.AsyncGenerator_Throw/g/FunctionObject_FunctionDeclaration_31CD1283_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.AsyncGenerator_Throw/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.AsyncGenerator_Throw/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_31CD1283_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -199,7 +199,7 @@
 			IL_0020: ldftn object Modules.AsyncGenerator_Throw/g::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.AsyncGenerator_Throw/g/FunctionObject_FunctionDeclaration_31CD1283_g
+			IL_002c: ldtoken Modules.AsyncGenerator_Throw/g/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1107,7 +1107,7 @@
 		.locals init (
 			[0] class Modules.AsyncGenerator_Throw/Scope,
 			[1] object[],
-			[2] class Modules.AsyncGenerator_Throw/g/FunctionObject_FunctionDeclaration_31CD1283_g,
+			[2] class Modules.AsyncGenerator_Throw/g/FunctionObject,
 			[3] class Modules.AsyncGenerator_Throw/ArrowFunction_L15C2/FunctionObject
 		)
 
@@ -1121,15 +1121,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.1
 		IL_0011: ldloc.1
-		IL_0012: newobj instance void Modules.AsyncGenerator_Throw/g/FunctionObject_FunctionDeclaration_31CD1283_g::.ctor(object[])
+		IL_0012: newobj instance void Modules.AsyncGenerator_Throw/g/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "g"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_Throw/g/FunctionObject_FunctionDeclaration_31CD1283_g>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_Throw/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-		IL_002a: castclass Modules.AsyncGenerator_Throw/g/FunctionObject_FunctionDeclaration_31CD1283_g
+		IL_002a: castclass Modules.AsyncGenerator_Throw/g/FunctionObject
 		IL_002f: stloc.2
 		IL_0030: ldloc.0
 		IL_0031: ldloc.2

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_TryCatchFinally.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_TryCatchFinally.verified.txt
@@ -96,7 +96,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6BD12A88_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -116,9 +116,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject_FunctionDeclaration_6BD12A88_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -129,7 +129,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -140,7 +140,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -153,15 +153,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject_FunctionDeclaration_6BD12A88_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.AsyncGenerator_TryCatchFinally/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6BD12A88_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -206,7 +206,7 @@
 			IL_0020: ldftn object Modules.AsyncGenerator_TryCatchFinally/g::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject_FunctionDeclaration_6BD12A88_g
+			IL_002c: ldtoken Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1347,7 +1347,7 @@
 		.locals init (
 			[0] class Modules.AsyncGenerator_TryCatchFinally/Scope,
 			[1] object[],
-			[2] class Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject_FunctionDeclaration_6BD12A88_g,
+			[2] class Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject,
 			[3] class Modules.AsyncGenerator_TryCatchFinally/ArrowFunction_L19C2/FunctionObject
 		)
 
@@ -1361,15 +1361,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.1
 		IL_0011: ldloc.1
-		IL_0012: newobj instance void Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject_FunctionDeclaration_6BD12A88_g::.ctor(object[])
+		IL_0012: newobj instance void Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "g"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject_FunctionDeclaration_6BD12A88_g>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-		IL_002a: castclass Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject_FunctionDeclaration_6BD12A88_g
+		IL_002a: castclass Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject
 		IL_002f: stloc.2
 		IL_0030: ldloc.0
 		IL_0031: ldloc.2

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_YieldAwait.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_YieldAwait.verified.txt
@@ -38,7 +38,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_30E5A464_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -58,9 +58,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.AsyncGenerator_YieldAwait/g/FunctionObject_FunctionDeclaration_30E5A464_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.AsyncGenerator_YieldAwait/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -71,7 +71,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -82,7 +82,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -95,15 +95,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.AsyncGenerator_YieldAwait/g/FunctionObject_FunctionDeclaration_30E5A464_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.AsyncGenerator_YieldAwait/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.AsyncGenerator_YieldAwait/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_30E5A464_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -146,7 +146,7 @@
 			IL_0020: ldftn object Modules.AsyncGenerator_YieldAwait/g::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.AsyncGenerator_YieldAwait/g/FunctionObject_FunctionDeclaration_30E5A464_g
+			IL_002c: ldtoken Modules.AsyncGenerator_YieldAwait/g/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1234,7 +1234,7 @@
 		.locals init (
 			[0] class Modules.AsyncGenerator_YieldAwait/Scope,
 			[1] object[],
-			[2] class Modules.AsyncGenerator_YieldAwait/g/FunctionObject_FunctionDeclaration_30E5A464_g,
+			[2] class Modules.AsyncGenerator_YieldAwait/g/FunctionObject,
 			[3] class Modules.AsyncGenerator_YieldAwait/ArrowFunction_L10C2/FunctionObject
 		)
 
@@ -1248,15 +1248,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.1
 		IL_0011: ldloc.1
-		IL_0012: newobj instance void Modules.AsyncGenerator_YieldAwait/g/FunctionObject_FunctionDeclaration_30E5A464_g::.ctor(object[])
+		IL_0012: newobj instance void Modules.AsyncGenerator_YieldAwait/g/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "g"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_YieldAwait/g/FunctionObject_FunctionDeclaration_30E5A464_g>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.AsyncGenerator_YieldAwait/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.AsyncGeneratorFunction::InitializeFunctionObject(object)
-		IL_002a: castclass Modules.AsyncGenerator_YieldAwait/g/FunctionObject_FunctionDeclaration_30E5A464_g
+		IL_002a: castclass Modules.AsyncGenerator_YieldAwait/g/FunctionObject
 		IL_002f: stloc.2
 		IL_0030: ldloc.0
 		IL_0031: ldloc.2

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddObjectObject.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddObjectObject.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BE09096E_add
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.BinaryOperator_AddObjectObject/'add'::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.BinaryOperator_AddObjectObject/'add'::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BE09096E_add
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -202,7 +202,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_AddObjectObject/Scope,
-			[1] class Modules.BinaryOperator_AddObjectObject/'add'/FunctionObject_FunctionDeclaration_BE09096E_add,
+			[1] class Modules.BinaryOperator_AddObjectObject/'add'/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -217,13 +217,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.BinaryOperator_AddObjectObject/'add'/FunctionObject_FunctionDeclaration_BE09096E_add::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_AddObjectObject/'add'/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_AddObjectObject/'add'/FunctionObject_FunctionDeclaration_BE09096E_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_AddObjectObject/'add'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualParameter.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualParameter.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_05C891FE_testParam
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.BinaryOperator_EqualParameter/testParam::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.BinaryOperator_EqualParameter/testParam::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_05C891FE_testParam
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -247,7 +247,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_EqualParameter/Scope,
-			[1] class Modules.BinaryOperator_EqualParameter/testParam/FunctionObject_FunctionDeclaration_05C891FE_testParam,
+			[1] class Modules.BinaryOperator_EqualParameter/testParam/FunctionObject,
 			[2] object[]
 		)
 
@@ -260,13 +260,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.BinaryOperator_EqualParameter/testParam/FunctionObject_FunctionDeclaration_05C891FE_testParam::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_EqualParameter/testParam/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "testParam"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_EqualParameter/testParam/FunctionObject_FunctionDeclaration_05C891FE_testParam>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_EqualParameter/testParam/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_InstanceOf_Basic.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_InstanceOf_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0B57AE94_A
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.BinaryOperator_InstanceOf_Basic/A::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.BinaryOperator_InstanceOf_Basic/A::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0B57AE94_A
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -162,7 +162,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0E57B34D_B
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -176,7 +176,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -187,7 +187,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -198,7 +198,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -213,7 +213,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.BinaryOperator_InstanceOf_Basic/B::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -229,7 +229,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.BinaryOperator_InstanceOf_Basic/B::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -247,9 +247,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0E57B34D_B
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -294,7 +294,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AA105045_Node
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -308,7 +308,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -319,7 +319,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -330,7 +330,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -345,7 +345,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.BinaryOperator_InstanceOf_Basic/Node::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -361,7 +361,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.BinaryOperator_InstanceOf_Basic/Node::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -379,9 +379,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_AA105045_Node
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -448,9 +448,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_InstanceOf_Basic/Scope,
-			[1] class Modules.BinaryOperator_InstanceOf_Basic/A/FunctionObject_FunctionDeclaration_0B57AE94_A,
-			[2] class Modules.BinaryOperator_InstanceOf_Basic/B/FunctionObject_FunctionDeclaration_0E57B34D_B,
-			[3] class Modules.BinaryOperator_InstanceOf_Basic/Node/FunctionObject_FunctionDeclaration_AA105045_Node,
+			[1] class Modules.BinaryOperator_InstanceOf_Basic/A/FunctionObject,
+			[2] class Modules.BinaryOperator_InstanceOf_Basic/B/FunctionObject,
+			[3] class Modules.BinaryOperator_InstanceOf_Basic/Node/FunctionObject,
 			[4] object,
 			[5] object,
 			[6] object[],
@@ -470,13 +470,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void Modules.BinaryOperator_InstanceOf_Basic/A/FunctionObject_FunctionDeclaration_0B57AE94_A::.ctor()
+		IL_0012: newobj instance void Modules.BinaryOperator_InstanceOf_Basic/A/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "A"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_InstanceOf_Basic/A/FunctionObject_FunctionDeclaration_0B57AE94_A>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_InstanceOf_Basic/A/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -485,13 +485,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 6
-		IL_0032: newobj instance void Modules.BinaryOperator_InstanceOf_Basic/B/FunctionObject_FunctionDeclaration_0E57B34D_B::.ctor()
+		IL_0032: newobj instance void Modules.BinaryOperator_InstanceOf_Basic/B/FunctionObject::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "B"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_InstanceOf_Basic/B/FunctionObject_FunctionDeclaration_0E57B34D_B>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_InstanceOf_Basic/B/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -500,13 +500,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 6
-		IL_0052: newobj instance void Modules.BinaryOperator_InstanceOf_Basic/Node/FunctionObject_FunctionDeclaration_AA105045_Node::.ctor()
+		IL_0052: newobj instance void Modules.BinaryOperator_InstanceOf_Basic/Node/FunctionObject::.ctor()
 		IL_0057: ldc.i4.0
 		IL_0058: conv.r8
 		IL_0059: ldstr "Node"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_InstanceOf_Basic/Node/FunctionObject_FunctionDeclaration_AA105045_Node>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_InstanceOf_Basic/Node/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: nop
 		IL_0067: nop

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalAnd_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalAnd_ShortCircuit.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5E9AB76A_inc
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject_FunctionDeclaration_5E9AB76A_inc::_environment0_BinaryOperator_LogicalAnd_ShortCircuit
+				IL_0008: stfld class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject::_environment0_BinaryOperator_LogicalAnd_ShortCircuit
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject_FunctionDeclaration_5E9AB76A_inc::_environment0_BinaryOperator_LogicalAnd_ShortCircuit
+				IL_0001: ldfld class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject::_environment0_BinaryOperator_LogicalAnd_ShortCircuit
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject_FunctionDeclaration_5E9AB76A_inc::_environment0_BinaryOperator_LogicalAnd_ShortCircuit
+				IL_0001: ldfld class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject::_environment0_BinaryOperator_LogicalAnd_ShortCircuit
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5E9AB76A_inc
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -212,7 +212,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope,
-			[1] class Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject_FunctionDeclaration_5E9AB76A_inc,
+			[1] class Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] bool,
@@ -235,13 +235,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope
-		IL_0019: newobj instance void Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject_FunctionDeclaration_5E9AB76A_inc::.ctor(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope)
+		IL_0019: newobj instance void Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject::.ctor(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "inc"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject_FunctionDeclaration_5E9AB76A_inc>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ArrayHasData.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ArrayHasData.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C867B623_arrayHasData
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -105,7 +105,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -124,7 +124,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -142,9 +142,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C867B623_arrayHasData
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -262,7 +262,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalOr_ArrayHasData/Scope,
-			[1] class Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData/FunctionObject_FunctionDeclaration_C867B623_arrayHasData,
+			[1] class Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object,
@@ -278,13 +278,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData/FunctionObject_FunctionDeclaration_C867B623_arrayHasData::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "arrayHasData"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData/FunctionObject_FunctionDeclaration_C867B623_arrayHasData>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ShortCircuit.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7403C23E_inc
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject_FunctionDeclaration_7403C23E_inc::_environment0_BinaryOperator_LogicalOr_ShortCircuit
+				IL_0008: stfld class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject::_environment0_BinaryOperator_LogicalOr_ShortCircuit
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject_FunctionDeclaration_7403C23E_inc::_environment0_BinaryOperator_LogicalOr_ShortCircuit
+				IL_0001: ldfld class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject::_environment0_BinaryOperator_LogicalOr_ShortCircuit
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.BinaryOperator_LogicalOr_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject_FunctionDeclaration_7403C23E_inc::_environment0_BinaryOperator_LogicalOr_ShortCircuit
+				IL_0001: ldfld class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject::_environment0_BinaryOperator_LogicalOr_ShortCircuit
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.BinaryOperator_LogicalOr_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7403C23E_inc
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -212,7 +212,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope,
-			[1] class Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject_FunctionDeclaration_7403C23E_inc,
+			[1] class Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] bool,
@@ -235,13 +235,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope
-		IL_0019: newobj instance void Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject_FunctionDeclaration_7403C23E_inc::.ctor(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope)
+		IL_0019: newobj instance void Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject::.ctor(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "inc"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject_FunctionDeclaration_7403C23E_inc>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_MulObjectObject.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_MulObjectObject.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2F2D5C92_mul
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -89,7 +89,7 @@
 				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001d: call object Modules.BinaryOperator_MulObjectObject/'mul'::__js_call__(object, float64, float64)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -113,7 +113,7 @@
 				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0019: call object Modules.BinaryOperator_MulObjectObject/'mul'::__js_call__(object, float64, float64)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -131,9 +131,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2F2D5C92_mul
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -202,7 +202,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_MulObjectObject/Scope,
-			[1] class Modules.BinaryOperator_MulObjectObject/'mul'/FunctionObject_FunctionDeclaration_2F2D5C92_mul,
+			[1] class Modules.BinaryOperator_MulObjectObject/'mul'/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -217,13 +217,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.BinaryOperator_MulObjectObject/'mul'/FunctionObject_FunctionDeclaration_2F2D5C92_mul::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_MulObjectObject/'mul'/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "mul"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_MulObjectObject/'mul'/FunctionObject_FunctionDeclaration_2F2D5C92_mul>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_MulObjectObject/'mul'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ExplicitNumberAssignment.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ExplicitNumberAssignment.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -223,7 +223,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/Scope,
-			[1] class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement/FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement,
+			[1] class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -238,13 +238,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement/FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "numberAssignmentRefinement"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement/FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ParameterReuseCSE.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ParameterReuseCSE.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -213,7 +213,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/Scope,
-			[1] class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice/FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice,
+			[1] class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -228,13 +228,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice/FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bitwiseParamTwice"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice/FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D44246D3_key
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject_FunctionDeclaration_D44246D3_key::_environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
+				IL_0008: stfld class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject::_environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject_FunctionDeclaration_D44246D3_key::_environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
+				IL_0001: ldfld class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject::_environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key::__js_call__(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject_FunctionDeclaration_D44246D3_key::_environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
+				IL_0001: ldfld class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject::_environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key::__js_call__(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D44246D3_key
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -214,7 +214,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope,
-			[1] class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject_FunctionDeclaration_D44246D3_key,
+			[1] class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -234,13 +234,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope
-		IL_0019: newobj instance void Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject_FunctionDeclaration_D44246D3_key::.ctor(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope)
+		IL_0019: newobj instance void Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject::.ctor(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "key"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject_FunctionDeclaration_D44246D3_key>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_StrictEqualCapturedVariable.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_StrictEqualCapturedVariable.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope_For_L9C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3E7EB29A_process
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -90,9 +90,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject_FunctionDeclaration_3E7EB29A_process::_environment0_BinaryOperator_StrictEqualCapturedVariable
+				IL_0008: stfld class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject::_environment0_BinaryOperator_StrictEqualCapturedVariable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +103,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,7 +114,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -127,14 +127,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject_FunctionDeclaration_3E7EB29A_process::_environment0_BinaryOperator_StrictEqualCapturedVariable
+				IL_0001: ldfld class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject::_environment0_BinaryOperator_StrictEqualCapturedVariable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.BinaryOperator_StrictEqualCapturedVariable/process::__js_call__(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -148,14 +148,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject_FunctionDeclaration_3E7EB29A_process::_environment0_BinaryOperator_StrictEqualCapturedVariable
+				IL_0001: ldfld class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject::_environment0_BinaryOperator_StrictEqualCapturedVariable
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.BinaryOperator_StrictEqualCapturedVariable/process::__js_call__(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -173,9 +173,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3E7EB29A_process
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -462,7 +462,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope,
-			[1] class Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject_FunctionDeclaration_3E7EB29A_process,
+			[1] class Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject,
 			[2] object[],
 			[3] object[],
 			[4] class Modules.BinaryOperator_StrictEqualCapturedVariable/ArrowFunction_L14C9/FunctionObject,
@@ -482,13 +482,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.BinaryOperator_StrictEqualCapturedVariable/Scope
-		IL_0019: newobj instance void Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject_FunctionDeclaration_3E7EB29A_process::.ctor(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope)
+		IL_0019: newobj instance void Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject::.ctor(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "process"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject_FunctionDeclaration_3E7EB29A_process>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedComparisonScheduler.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedComparisonScheduler.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A7653F68_neg
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.BinaryOperator_TypedComparisonScheduler/'neg'::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.BinaryOperator_TypedComparisonScheduler/'neg'::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A7653F68_neg
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -173,7 +173,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F688842E_bitNot
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -187,7 +187,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -198,7 +198,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -209,7 +209,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -228,7 +228,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.BinaryOperator_TypedComparisonScheduler/bitNot::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -248,7 +248,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.BinaryOperator_TypedComparisonScheduler/bitNot::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -266,9 +266,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F688842E_bitNot
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -321,7 +321,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7AC4C157_less
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -335,7 +335,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -346,7 +346,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -357,7 +357,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -378,7 +378,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.BinaryOperator_TypedComparisonScheduler/less::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -400,7 +400,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.BinaryOperator_TypedComparisonScheduler/less::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -418,9 +418,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7AC4C157_less
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -472,7 +472,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1286DABE_compareExpr
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -486,7 +486,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -497,7 +497,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -508,7 +508,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -535,7 +535,7 @@
 				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0029: call object Modules.BinaryOperator_TypedComparisonScheduler/compareExpr::__js_call__(object, float64, float64, float64)
 				IL_002e: ret
-			} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -563,7 +563,7 @@
 				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0025: call object Modules.BinaryOperator_TypedComparisonScheduler/compareExpr::__js_call__(object, float64, float64, float64)
 				IL_002a: ret
-			} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -581,9 +581,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_1286DABE_compareExpr
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -663,7 +663,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6373975E_branch
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -677,7 +677,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -688,7 +688,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -699,7 +699,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -722,7 +722,7 @@
 				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001d: call object Modules.BinaryOperator_TypedComparisonScheduler/branch::__js_call__(object, float64, float64)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -746,7 +746,7 @@
 				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0019: call object Modules.BinaryOperator_TypedComparisonScheduler/branch::__js_call__(object, float64, float64)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -764,9 +764,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6373975E_branch
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -827,7 +827,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F885F27C_boolEq
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -841,7 +841,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -852,7 +852,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -863,7 +863,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -886,7 +886,7 @@
 				IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_001d: call object Modules.BinaryOperator_TypedComparisonScheduler/boolEq::__js_call__(object, float64, string)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -910,7 +910,7 @@
 				IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0019: call object Modules.BinaryOperator_TypedComparisonScheduler/boolEq::__js_call__(object, float64, string)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -928,9 +928,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F885F27C_boolEq
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1002,7 +1002,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_75F894DB_left
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1022,9 +1022,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject_FunctionDeclaration_75F894DB_left::_environment0_BinaryOperator_TypedComparisonScheduler
+				IL_0008: stfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject::_environment0_BinaryOperator_TypedComparisonScheduler
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1035,7 +1035,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1046,7 +1046,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1059,11 +1059,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject_FunctionDeclaration_75F894DB_left::_environment0_BinaryOperator_TypedComparisonScheduler
+				IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject::_environment0_BinaryOperator_TypedComparisonScheduler
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.BinaryOperator_TypedComparisonScheduler/left::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1077,11 +1077,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject_FunctionDeclaration_75F894DB_left::_environment0_BinaryOperator_TypedComparisonScheduler
+				IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject::_environment0_BinaryOperator_TypedComparisonScheduler
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.BinaryOperator_TypedComparisonScheduler/left::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1099,9 +1099,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_75F894DB_left
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1164,7 +1164,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2A86C924_right
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1184,9 +1184,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject_FunctionDeclaration_2A86C924_right::_environment0_BinaryOperator_TypedComparisonScheduler
+				IL_0008: stfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject::_environment0_BinaryOperator_TypedComparisonScheduler
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1197,7 +1197,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1208,7 +1208,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1221,11 +1221,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject_FunctionDeclaration_2A86C924_right::_environment0_BinaryOperator_TypedComparisonScheduler
+				IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject::_environment0_BinaryOperator_TypedComparisonScheduler
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.BinaryOperator_TypedComparisonScheduler/right::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1239,11 +1239,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject_FunctionDeclaration_2A86C924_right::_environment0_BinaryOperator_TypedComparisonScheduler
+				IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject::_environment0_BinaryOperator_TypedComparisonScheduler
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.BinaryOperator_TypedComparisonScheduler/right::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1261,9 +1261,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2A86C924_right
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1400,14 +1400,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_TypedComparisonScheduler/Scope,
-			[1] class Modules.BinaryOperator_TypedComparisonScheduler/'neg'/FunctionObject_FunctionDeclaration_A7653F68_neg,
-			[2] class Modules.BinaryOperator_TypedComparisonScheduler/bitNot/FunctionObject_FunctionDeclaration_F688842E_bitNot,
-			[3] class Modules.BinaryOperator_TypedComparisonScheduler/less/FunctionObject_FunctionDeclaration_7AC4C157_less,
-			[4] class Modules.BinaryOperator_TypedComparisonScheduler/compareExpr/FunctionObject_FunctionDeclaration_1286DABE_compareExpr,
-			[5] class Modules.BinaryOperator_TypedComparisonScheduler/branch/FunctionObject_FunctionDeclaration_6373975E_branch,
-			[6] class Modules.BinaryOperator_TypedComparisonScheduler/boolEq/FunctionObject_FunctionDeclaration_F885F27C_boolEq,
-			[7] class Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject_FunctionDeclaration_75F894DB_left,
-			[8] class Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject_FunctionDeclaration_2A86C924_right,
+			[1] class Modules.BinaryOperator_TypedComparisonScheduler/'neg'/FunctionObject,
+			[2] class Modules.BinaryOperator_TypedComparisonScheduler/bitNot/FunctionObject,
+			[3] class Modules.BinaryOperator_TypedComparisonScheduler/less/FunctionObject,
+			[4] class Modules.BinaryOperator_TypedComparisonScheduler/compareExpr/FunctionObject,
+			[5] class Modules.BinaryOperator_TypedComparisonScheduler/branch/FunctionObject,
+			[6] class Modules.BinaryOperator_TypedComparisonScheduler/boolEq/FunctionObject,
+			[7] class Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject,
+			[8] class Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject,
 			[9] class [System.Runtime]System.Exception,
 			[10] object,
 			[11] object,
@@ -1434,13 +1434,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 14
-		IL_0012: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/'neg'/FunctionObject_FunctionDeclaration_A7653F68_neg::.ctor()
+		IL_0012: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/'neg'/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "neg"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/'neg'/FunctionObject_FunctionDeclaration_A7653F68_neg>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/'neg'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1449,13 +1449,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 14
-		IL_0032: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/bitNot/FunctionObject_FunctionDeclaration_F688842E_bitNot::.ctor()
+		IL_0032: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/bitNot/FunctionObject::.ctor()
 		IL_0037: ldc.i4.1
 		IL_0038: conv.r8
 		IL_0039: ldstr "bitNot"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/bitNot/FunctionObject_FunctionDeclaration_F688842E_bitNot>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/bitNot/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -1464,13 +1464,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 14
-		IL_0052: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/less/FunctionObject_FunctionDeclaration_7AC4C157_less::.ctor()
+		IL_0052: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/less/FunctionObject::.ctor()
 		IL_0057: ldc.i4.2
 		IL_0058: conv.r8
 		IL_0059: ldstr "less"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/less/FunctionObject_FunctionDeclaration_7AC4C157_less>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/less/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -1479,13 +1479,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 14
-		IL_0072: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/compareExpr/FunctionObject_FunctionDeclaration_1286DABE_compareExpr::.ctor()
+		IL_0072: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/compareExpr/FunctionObject::.ctor()
 		IL_0077: ldc.i4.3
 		IL_0078: conv.r8
 		IL_0079: ldstr "compareExpr"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/compareExpr/FunctionObject_FunctionDeclaration_1286DABE_compareExpr>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/compareExpr/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -1494,13 +1494,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 14
-		IL_0093: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/branch/FunctionObject_FunctionDeclaration_6373975E_branch::.ctor()
+		IL_0093: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/branch/FunctionObject::.ctor()
 		IL_0098: ldc.i4.2
 		IL_0099: conv.r8
 		IL_009a: ldstr "branch"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/branch/FunctionObject_FunctionDeclaration_6373975E_branch>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/branch/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1509,13 +1509,13 @@
 		IL_00b0: ldloc.0
 		IL_00b1: stelem.ref
 		IL_00b2: stloc.s 14
-		IL_00b4: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/boolEq/FunctionObject_FunctionDeclaration_F885F27C_boolEq::.ctor()
+		IL_00b4: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/boolEq/FunctionObject::.ctor()
 		IL_00b9: ldc.i4.2
 		IL_00ba: conv.r8
 		IL_00bb: ldstr "boolEq"
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/boolEq/FunctionObject_FunctionDeclaration_F885F27C_boolEq>(!!0, float64, string, bool, bool)
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/boolEq/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c7: stloc.s 6
 		IL_00c9: ldc.i4.1
 		IL_00ca: newarr [System.Runtime]System.Object
@@ -1528,13 +1528,13 @@
 		IL_00d7: ldc.i4.0
 		IL_00d8: ldelem.ref
 		IL_00d9: castclass Modules.BinaryOperator_TypedComparisonScheduler/Scope
-		IL_00de: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject_FunctionDeclaration_75F894DB_left::.ctor(class Modules.BinaryOperator_TypedComparisonScheduler/Scope)
+		IL_00de: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject::.ctor(class Modules.BinaryOperator_TypedComparisonScheduler/Scope)
 		IL_00e3: ldc.i4.0
 		IL_00e4: conv.r8
 		IL_00e5: ldstr "left"
 		IL_00ea: ldc.i4.0
 		IL_00eb: ldc.i4.1
-		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject_FunctionDeclaration_75F894DB_left>(!!0, float64, string, bool, bool)
+		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00f1: stloc.s 7
 		IL_00f3: ldc.i4.1
 		IL_00f4: newarr [System.Runtime]System.Object
@@ -1547,13 +1547,13 @@
 		IL_0101: ldc.i4.0
 		IL_0102: ldelem.ref
 		IL_0103: castclass Modules.BinaryOperator_TypedComparisonScheduler/Scope
-		IL_0108: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject_FunctionDeclaration_2A86C924_right::.ctor(class Modules.BinaryOperator_TypedComparisonScheduler/Scope)
+		IL_0108: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject::.ctor(class Modules.BinaryOperator_TypedComparisonScheduler/Scope)
 		IL_010d: ldc.i4.0
 		IL_010e: conv.r8
 		IL_010f: ldstr "right"
 		IL_0114: ldc.i4.0
 		IL_0115: ldc.i4.1
-		IL_0116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject_FunctionDeclaration_2A86C924_right>(!!0, float64, string, bool, bool)
+		IL_0116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_011b: stloc.s 8
 		IL_011d: nop
 		IL_011e: nop

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.BinaryOperator_TypedNumericScheduler/mulAdd::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.BinaryOperator_TypedNumericScheduler/mulAdd::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -175,7 +175,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F48743DA_addChain
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -189,7 +189,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -200,7 +200,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -211,7 +211,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -242,7 +242,7 @@
 				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0035: call object Modules.BinaryOperator_TypedNumericScheduler/addChain::__js_call__(object, float64, float64, float64, float64)
 				IL_003a: ret
-			} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -274,7 +274,7 @@
 				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0031: call object Modules.BinaryOperator_TypedNumericScheduler/addChain::__js_call__(object, float64, float64, float64, float64)
 				IL_0036: ret
-			} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -292,9 +292,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F48743DA_addChain
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -350,7 +350,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A433882E_tree
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -364,7 +364,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -375,7 +375,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -386,7 +386,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -417,7 +417,7 @@
 				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0035: call object Modules.BinaryOperator_TypedNumericScheduler/tree::__js_call__(object, float64, float64, float64, float64)
 				IL_003a: ret
-			} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -449,7 +449,7 @@
 				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0031: call object Modules.BinaryOperator_TypedNumericScheduler/tree::__js_call__(object, float64, float64, float64, float64)
 				IL_0036: ret
-			} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -467,9 +467,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A433882E_tree
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -525,7 +525,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_73DC7159_subChain
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -539,7 +539,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -550,7 +550,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -561,7 +561,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -588,7 +588,7 @@
 				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0029: call object Modules.BinaryOperator_TypedNumericScheduler/subChain::__js_call__(object, float64, float64, float64)
 				IL_002e: ret
-			} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -616,7 +616,7 @@
 				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0025: call object Modules.BinaryOperator_TypedNumericScheduler/subChain::__js_call__(object, float64, float64, float64)
 				IL_002a: ret
-			} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -634,9 +634,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_73DC7159_subChain
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -689,7 +689,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_14EF6D03_divMod
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -703,7 +703,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -714,7 +714,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -725,7 +725,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -752,7 +752,7 @@
 				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0029: call object Modules.BinaryOperator_TypedNumericScheduler/divMod::__js_call__(object, float64, float64, float64)
 				IL_002e: ret
-			} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -780,7 +780,7 @@
 				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0025: call object Modules.BinaryOperator_TypedNumericScheduler/divMod::__js_call__(object, float64, float64, float64)
 				IL_002a: ret
-			} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -798,9 +798,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_14EF6D03_divMod
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -853,7 +853,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_03A3A6D4_expAdd
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -867,7 +867,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -878,7 +878,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -889,7 +889,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -916,7 +916,7 @@
 				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0029: call object Modules.BinaryOperator_TypedNumericScheduler/expAdd::__js_call__(object, float64, float64, float64)
 				IL_002e: ret
-			} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -944,7 +944,7 @@
 				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0025: call object Modules.BinaryOperator_TypedNumericScheduler/expAdd::__js_call__(object, float64, float64, float64)
 				IL_002a: ret
-			} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -962,9 +962,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_03A3A6D4_expAdd
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1017,7 +1017,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4AA8841F_left
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1037,9 +1037,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject_FunctionDeclaration_4AA8841F_left::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0008: stfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject::_environment0_BinaryOperator_TypedNumericScheduler
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1050,7 +1050,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1061,7 +1061,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1074,11 +1074,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject_FunctionDeclaration_4AA8841F_left::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject::_environment0_BinaryOperator_TypedNumericScheduler
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.BinaryOperator_TypedNumericScheduler/left::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1092,11 +1092,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject_FunctionDeclaration_4AA8841F_left::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject::_environment0_BinaryOperator_TypedNumericScheduler
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.BinaryOperator_TypedNumericScheduler/left::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1114,9 +1114,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4AA8841F_left
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1179,7 +1179,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BF4CE850_right
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1199,9 +1199,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject_FunctionDeclaration_BF4CE850_right::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0008: stfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject::_environment0_BinaryOperator_TypedNumericScheduler
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1212,7 +1212,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1223,7 +1223,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1236,11 +1236,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject_FunctionDeclaration_BF4CE850_right::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject::_environment0_BinaryOperator_TypedNumericScheduler
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.BinaryOperator_TypedNumericScheduler/right::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1254,11 +1254,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject_FunctionDeclaration_BF4CE850_right::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject::_environment0_BinaryOperator_TypedNumericScheduler
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.BinaryOperator_TypedNumericScheduler/right::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1276,9 +1276,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BF4CE850_right
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1341,7 +1341,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D8F5465F_calls
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1361,9 +1361,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject_FunctionDeclaration_D8F5465F_calls::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0008: stfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject::_environment0_BinaryOperator_TypedNumericScheduler
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1374,7 +1374,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1385,7 +1385,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1398,11 +1398,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject_FunctionDeclaration_D8F5465F_calls::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject::_environment0_BinaryOperator_TypedNumericScheduler
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.BinaryOperator_TypedNumericScheduler/calls::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1416,11 +1416,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject_FunctionDeclaration_D8F5465F_calls::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject::_environment0_BinaryOperator_TypedNumericScheduler
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.BinaryOperator_TypedNumericScheduler/calls::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1438,9 +1438,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D8F5465F_calls
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1517,7 +1517,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B3DBBF8F_postfix
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1531,7 +1531,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1542,7 +1542,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1553,7 +1553,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1572,7 +1572,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.BinaryOperator_TypedNumericScheduler/postfix::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1592,7 +1592,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.BinaryOperator_TypedNumericScheduler/postfix::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1610,9 +1610,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B3DBBF8F_postfix
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1718,17 +1718,17 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_TypedNumericScheduler/Scope,
-			[1] class Modules.BinaryOperator_TypedNumericScheduler/mulAdd/FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd,
-			[2] class Modules.BinaryOperator_TypedNumericScheduler/addChain/FunctionObject_FunctionDeclaration_F48743DA_addChain,
-			[3] class Modules.BinaryOperator_TypedNumericScheduler/tree/FunctionObject_FunctionDeclaration_A433882E_tree,
-			[4] class Modules.BinaryOperator_TypedNumericScheduler/subChain/FunctionObject_FunctionDeclaration_73DC7159_subChain,
-			[5] class Modules.BinaryOperator_TypedNumericScheduler/divMod/FunctionObject_FunctionDeclaration_14EF6D03_divMod,
-			[6] class Modules.BinaryOperator_TypedNumericScheduler/expAdd/FunctionObject_FunctionDeclaration_03A3A6D4_expAdd,
-			[7] class Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject_FunctionDeclaration_D8F5465F_calls,
-			[8] class Modules.BinaryOperator_TypedNumericScheduler/postfix/FunctionObject_FunctionDeclaration_B3DBBF8F_postfix,
+			[1] class Modules.BinaryOperator_TypedNumericScheduler/mulAdd/FunctionObject,
+			[2] class Modules.BinaryOperator_TypedNumericScheduler/addChain/FunctionObject,
+			[3] class Modules.BinaryOperator_TypedNumericScheduler/tree/FunctionObject,
+			[4] class Modules.BinaryOperator_TypedNumericScheduler/subChain/FunctionObject,
+			[5] class Modules.BinaryOperator_TypedNumericScheduler/divMod/FunctionObject,
+			[6] class Modules.BinaryOperator_TypedNumericScheduler/expAdd/FunctionObject,
+			[7] class Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject,
+			[8] class Modules.BinaryOperator_TypedNumericScheduler/postfix/FunctionObject,
 			[9] object[],
-			[10] class Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject_FunctionDeclaration_4AA8841F_left,
-			[11] class Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject_FunctionDeclaration_BF4CE850_right,
+			[10] class Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject,
+			[11] class Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject,
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[13] object,
 			[14] object,
@@ -1746,13 +1746,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 9
-		IL_0012: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/mulAdd/FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::.ctor()
+		IL_0012: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/mulAdd/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "mulAdd"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/mulAdd/FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/mulAdd/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1761,13 +1761,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 9
-		IL_0032: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/addChain/FunctionObject_FunctionDeclaration_F48743DA_addChain::.ctor()
+		IL_0032: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/addChain/FunctionObject::.ctor()
 		IL_0037: ldc.i4.4
 		IL_0038: conv.r8
 		IL_0039: ldstr "addChain"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/addChain/FunctionObject_FunctionDeclaration_F48743DA_addChain>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/addChain/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -1776,13 +1776,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 9
-		IL_0052: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/tree/FunctionObject_FunctionDeclaration_A433882E_tree::.ctor()
+		IL_0052: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/tree/FunctionObject::.ctor()
 		IL_0057: ldc.i4.4
 		IL_0058: conv.r8
 		IL_0059: ldstr "tree"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/tree/FunctionObject_FunctionDeclaration_A433882E_tree>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/tree/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -1791,13 +1791,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 9
-		IL_0072: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/subChain/FunctionObject_FunctionDeclaration_73DC7159_subChain::.ctor()
+		IL_0072: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/subChain/FunctionObject::.ctor()
 		IL_0077: ldc.i4.3
 		IL_0078: conv.r8
 		IL_0079: ldstr "subChain"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/subChain/FunctionObject_FunctionDeclaration_73DC7159_subChain>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/subChain/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -1806,13 +1806,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 9
-		IL_0093: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/divMod/FunctionObject_FunctionDeclaration_14EF6D03_divMod::.ctor()
+		IL_0093: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/divMod/FunctionObject::.ctor()
 		IL_0098: ldc.i4.3
 		IL_0099: conv.r8
 		IL_009a: ldstr "divMod"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/divMod/FunctionObject_FunctionDeclaration_14EF6D03_divMod>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/divMod/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1821,13 +1821,13 @@
 		IL_00b0: ldloc.0
 		IL_00b1: stelem.ref
 		IL_00b2: stloc.s 9
-		IL_00b4: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/expAdd/FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::.ctor()
+		IL_00b4: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/expAdd/FunctionObject::.ctor()
 		IL_00b9: ldc.i4.3
 		IL_00ba: conv.r8
 		IL_00bb: ldstr "expAdd"
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/expAdd/FunctionObject_FunctionDeclaration_03A3A6D4_expAdd>(!!0, float64, string, bool, bool)
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/expAdd/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c7: stloc.s 6
 		IL_00c9: ldc.i4.1
 		IL_00ca: newarr [System.Runtime]System.Object
@@ -1840,13 +1840,13 @@
 		IL_00d7: ldc.i4.0
 		IL_00d8: ldelem.ref
 		IL_00d9: castclass Modules.BinaryOperator_TypedNumericScheduler/Scope
-		IL_00de: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject_FunctionDeclaration_4AA8841F_left::.ctor(class Modules.BinaryOperator_TypedNumericScheduler/Scope)
+		IL_00de: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject::.ctor(class Modules.BinaryOperator_TypedNumericScheduler/Scope)
 		IL_00e3: ldc.i4.0
 		IL_00e4: conv.r8
 		IL_00e5: ldstr "left"
 		IL_00ea: ldc.i4.0
 		IL_00eb: ldc.i4.1
-		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject_FunctionDeclaration_4AA8841F_left>(!!0, float64, string, bool, bool)
+		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00f1: stloc.s 10
 		IL_00f3: ldloc.0
 		IL_00f4: ldloc.s 10
@@ -1862,13 +1862,13 @@
 		IL_0109: ldc.i4.0
 		IL_010a: ldelem.ref
 		IL_010b: castclass Modules.BinaryOperator_TypedNumericScheduler/Scope
-		IL_0110: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject_FunctionDeclaration_BF4CE850_right::.ctor(class Modules.BinaryOperator_TypedNumericScheduler/Scope)
+		IL_0110: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject::.ctor(class Modules.BinaryOperator_TypedNumericScheduler/Scope)
 		IL_0115: ldc.i4.0
 		IL_0116: conv.r8
 		IL_0117: ldstr "right"
 		IL_011c: ldc.i4.0
 		IL_011d: ldc.i4.1
-		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject_FunctionDeclaration_BF4CE850_right>(!!0, float64, string, bool, bool)
+		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0123: stloc.s 11
 		IL_0125: ldloc.0
 		IL_0126: ldloc.s 11
@@ -1884,13 +1884,13 @@
 		IL_013b: ldc.i4.0
 		IL_013c: ldelem.ref
 		IL_013d: castclass Modules.BinaryOperator_TypedNumericScheduler/Scope
-		IL_0142: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject_FunctionDeclaration_D8F5465F_calls::.ctor(class Modules.BinaryOperator_TypedNumericScheduler/Scope)
+		IL_0142: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject::.ctor(class Modules.BinaryOperator_TypedNumericScheduler/Scope)
 		IL_0147: ldc.i4.0
 		IL_0148: conv.r8
 		IL_0149: ldstr "calls"
 		IL_014e: ldc.i4.0
 		IL_014f: ldc.i4.1
-		IL_0150: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject_FunctionDeclaration_D8F5465F_calls>(!!0, float64, string, bool, bool)
+		IL_0150: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0155: stloc.s 7
 		IL_0157: ldc.i4.1
 		IL_0158: newarr [System.Runtime]System.Object
@@ -1899,13 +1899,13 @@
 		IL_015f: ldloc.0
 		IL_0160: stelem.ref
 		IL_0161: stloc.s 9
-		IL_0163: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/postfix/FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::.ctor()
+		IL_0163: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/postfix/FunctionObject::.ctor()
 		IL_0168: ldc.i4.1
 		IL_0169: conv.r8
 		IL_016a: ldstr "postfix"
 		IL_016f: ldc.i4.0
 		IL_0170: ldc.i4.1
-		IL_0171: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/postfix/FunctionObject_FunctionDeclaration_B3DBBF8F_postfix>(!!0, float64, string, bool, bool)
+		IL_0171: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/postfix/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0176: stloc.s 8
 		IL_0178: nop
 		IL_0179: nop

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AB9C36BC_add
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_AB9C36BC_add
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -280,7 +280,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/Scope,
-			[1] class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'/FunctionObject_FunctionDeclaration_AB9C36BC_add,
+			[1] class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] string,
@@ -298,13 +298,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'/FunctionObject_FunctionDeclaration_AB9C36BC_add::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'/FunctionObject_FunctionDeclaration_AB9C36BC_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
@@ -11,7 +11,7 @@
 		extends [System.Runtime]System.Object
 	{
 		// Nested Types
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DCE75730_L9C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -31,9 +31,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14::_environment0_Classes_ClassComputedFieldAndMethod_DynamicKey_Log
+				IL_0008: stfld class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject::_environment0_Classes_ClassComputedFieldAndMethod_DynamicKey_Log
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -44,7 +44,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -68,13 +68,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14::_environment0_Classes_ClassComputedFieldAndMethod_DynamicKey_Log
+				IL_0001: ldfld class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject::_environment0_Classes_ClassComputedFieldAndMethod_DynamicKey_Log
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey::__js_call__(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_DCE75730_L9C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -312,14 +312,14 @@
 		IL_003e: ldc.i4.0
 		IL_003f: ldelem.ref
 		IL_0040: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
-		IL_0045: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14::.ctor(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope)
+		IL_0045: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject::.ctor(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope)
 		IL_004a: ldc.i4.0
 		IL_004b: conv.r8
 		IL_004c: ldstr ""
 		IL_0051: ldc.i4.1
 		IL_0052: ldc.i4.1
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14>(!!0, float64, string, bool, bool)
-		IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14>(!!0)
+		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject>(!!0)
 		IL_005d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineClassElementDataProperty(object, object, object)
 		IL_0062: pop
 		IL_0063: ldc.i4.1

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
@@ -184,7 +184,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CC92D50C_testFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -204,9 +204,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_CC92D50C_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
+				IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -217,7 +217,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -228,7 +228,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -241,11 +241,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_CC92D50C_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -259,11 +259,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_CC92D50C_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -281,9 +281,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CC92D50C_testFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -408,7 +408,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope,
-			[1] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_CC92D50C_testFunction,
+			[1] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject,
 			[2] object[]
 		)
 
@@ -425,13 +425,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope
-		IL_0019: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_CC92D50C_testFunction::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_CC92D50C_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -177,7 +177,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9DB40405_testFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -197,9 +197,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9DB40405_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
+				IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -210,7 +210,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -221,7 +221,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -234,11 +234,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9DB40405_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -252,11 +252,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9DB40405_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -274,9 +274,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9DB40405_testFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -396,7 +396,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope,
-			[1] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9DB40405_testFunction,
+			[1] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject,
 			[2] object[]
 		)
 
@@ -413,13 +413,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope
-		IL_0019: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9DB40405_testFunction::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9DB40405_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
@@ -166,7 +166,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EFCEA678_testFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -186,9 +186,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_EFCEA678_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
+				IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -199,7 +199,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -210,7 +210,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -223,11 +223,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_EFCEA678_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -241,11 +241,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_EFCEA678_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -263,9 +263,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_EFCEA678_testFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -387,7 +387,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope,
-			[1] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_EFCEA678_testFunction,
+			[1] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject,
 			[2] object[]
 		)
 
@@ -404,13 +404,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope
-		IL_0019: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_EFCEA678_testFunction::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_EFCEA678_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
@@ -159,7 +159,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9F3BA909_testFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -179,9 +179,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9F3BA909_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
+				IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -192,7 +192,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -203,7 +203,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -216,11 +216,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9F3BA909_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -234,11 +234,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9F3BA909_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject::_environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -256,9 +256,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9F3BA909_testFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -375,7 +375,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope,
-			[1] class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9F3BA909_testFunction,
+			[1] class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject,
 			[2] object[]
 		)
 
@@ -392,13 +392,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope
-		IL_0019: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9F3BA909_testFunction::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9F3BA909_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassLocal_ReassignedClass_FallsBack.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassLocal_ReassignedClass_FallsBack.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B0C5CE34_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -90,9 +90,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test::_environment0_Classes_ClassLocal_ReassignedClass_FallsBack
+				IL_0008: stfld class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject::_environment0_Classes_ClassLocal_ReassignedClass_FallsBack
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +103,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,7 +114,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -128,7 +128,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -141,11 +141,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test::_environment0_Classes_ClassLocal_ReassignedClass_FallsBack
+				IL_0001: ldfld class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject::_environment0_Classes_ClassLocal_ReassignedClass_FallsBack
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test::__js_call__(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -159,11 +159,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test::_environment0_Classes_ClassLocal_ReassignedClass_FallsBack
+				IL_0001: ldfld class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject::_environment0_Classes_ClassLocal_ReassignedClass_FallsBack
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test::__js_call__(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -181,9 +181,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B0C5CE34_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -503,7 +503,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope,
-			[1] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test,
+			[1] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject,
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
 			[4] object,
@@ -523,14 +523,14 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope
-		IL_0019: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test::.ctor(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject::.ctor(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "test"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.0
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test>(!!0, float64, string, bool, bool)
-		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test>(!!0)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject>(!!0)
 		IL_0031: stloc.1
 		IL_0032: ldtoken Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box
 		IL_0037: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -260,7 +260,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -280,9 +280,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
+				IL_0008: stfld class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject::_environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -293,7 +293,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -304,7 +304,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -317,11 +317,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
+				IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject::_environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -335,11 +335,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
+				IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject::_environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -357,9 +357,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -486,7 +486,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope,
-			[1] class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction,
+			[1] class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject,
 			[2] object[]
 		)
 
@@ -503,13 +503,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope
-		IL_0019: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::.ctor(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject::.ctor(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
@@ -246,7 +246,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_77788B24_testFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -266,9 +266,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_77788B24_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariable_Log
+				IL_0008: stfld class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject::_environment0_Classes_ClassMethod_AccessFunctionVariable_Log
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -279,7 +279,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -290,7 +290,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -303,11 +303,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_77788B24_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariable_Log
+				IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject::_environment0_Classes_ClassMethod_AccessFunctionVariable_Log
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -321,11 +321,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_77788B24_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariable_Log
+				IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject::_environment0_Classes_ClassMethod_AccessFunctionVariable_Log
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -343,9 +343,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_77788B24_testFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -469,7 +469,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope,
-			[1] class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_77788B24_testFunction,
+			[1] class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject,
 			[2] object[]
 		)
 
@@ -486,13 +486,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope
-		IL_0019: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_77788B24_testFunction::.ctor(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject::.ctor(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_77788B24_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_GeneratedMethodFunctionObjects.verified.txt
@@ -217,7 +217,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_572C76AF_makeClass
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -231,7 +231,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_572C76AF_makeClass::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -242,7 +242,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_572C76AF_makeClass::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -253,7 +253,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_572C76AF_makeClass::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -268,7 +268,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Classes_GeneratedMethodFunctionObjects/makeClass::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_572C76AF_makeClass::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -284,7 +284,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Classes_GeneratedMethodFunctionObjects/makeClass::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_572C76AF_makeClass::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -302,9 +302,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_572C76AF_makeClass::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_572C76AF_makeClass
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -842,7 +842,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_310CBA8B_makeSecretClass
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -856,7 +856,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_310CBA8B_makeSecretClass::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -867,7 +867,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_310CBA8B_makeSecretClass::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -878,7 +878,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_310CBA8B_makeSecretClass::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -893,7 +893,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_310CBA8B_makeSecretClass::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -909,7 +909,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_310CBA8B_makeSecretClass::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -927,9 +927,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_310CBA8B_makeSecretClass::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_310CBA8B_makeSecretClass
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2277,8 +2277,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_GeneratedMethodFunctionObjects/Scope,
-			[1] class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/FunctionObject_FunctionDeclaration_572C76AF_makeClass,
-			[2] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/FunctionObject_FunctionDeclaration_310CBA8B_makeSecretClass,
+			[1] class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/FunctionObject,
+			[2] class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/FunctionObject,
 			[3] object,
 			[4] object,
 			[5] object,
@@ -2338,13 +2338,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 34
-		IL_0012: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/FunctionObject_FunctionDeclaration_572C76AF_makeClass::.ctor()
+		IL_0012: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeClass/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "makeClass"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/FunctionObject_FunctionDeclaration_572C76AF_makeClass>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeClass/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -2353,13 +2353,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 34
-		IL_0032: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/FunctionObject_FunctionDeclaration_310CBA8B_makeSecretClass::.ctor()
+		IL_0032: newobj instance void Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/FunctionObject::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "makeSecretClass"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/FunctionObject_FunctionDeclaration_310CBA8B_makeSecretClass>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_GeneratedMethodFunctionObjects/makeSecretClass/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: nop
 		IL_0047: ldtoken Modules.Classes_GeneratedMethodFunctionObjects/Base

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
@@ -277,7 +277,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_82BB358F_makeAndRun
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -297,9 +297,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::_environment0_Classes_Inheritance_NestedClassExtendsGlobal
+				IL_0008: stfld class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject::_environment0_Classes_Inheritance_NestedClassExtendsGlobal
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -310,7 +310,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -321,7 +321,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -334,11 +334,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::_environment0_Classes_Inheritance_NestedClassExtendsGlobal
+				IL_0001: ldfld class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject::_environment0_Classes_Inheritance_NestedClassExtendsGlobal
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun::__js_call__(class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -352,11 +352,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::_environment0_Classes_Inheritance_NestedClassExtendsGlobal
+				IL_0001: ldfld class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject::_environment0_Classes_Inheritance_NestedClassExtendsGlobal
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun::__js_call__(class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -374,9 +374,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_82BB358F_makeAndRun
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -754,7 +754,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope,
-			[1] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject_FunctionDeclaration_82BB358F_makeAndRun,
+			[1] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject,
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
 			[4] object,
@@ -774,13 +774,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope
-		IL_0019: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::.ctor(class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope)
+		IL_0019: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject::.ctor(class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "makeAndRun"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject_FunctionDeclaration_82BB358F_makeAndRun>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -491,7 +491,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2161B7CD_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -511,9 +511,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject_FunctionDeclaration_2161B7CD_outer::_environment0_Classes_Inheritance_SuperCapturedScopeVar
+				IL_0008: stfld class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject::_environment0_Classes_Inheritance_SuperCapturedScopeVar
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -524,7 +524,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -535,7 +535,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -548,11 +548,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject_FunctionDeclaration_2161B7CD_outer::_environment0_Classes_Inheritance_SuperCapturedScopeVar
+				IL_0001: ldfld class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject::_environment0_Classes_Inheritance_SuperCapturedScopeVar
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer::__js_call__(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -566,11 +566,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject_FunctionDeclaration_2161B7CD_outer::_environment0_Classes_Inheritance_SuperCapturedScopeVar
+				IL_0001: ldfld class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject::_environment0_Classes_Inheritance_SuperCapturedScopeVar
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer::__js_call__(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -588,9 +588,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2161B7CD_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -833,7 +833,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope,
-			[1] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject_FunctionDeclaration_2161B7CD_outer,
+			[1] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject,
 			[2] object[]
 		)
 
@@ -850,13 +850,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope
-		IL_0019: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject_FunctionDeclaration_2161B7CD_outer::.ctor(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope)
+		IL_0019: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject::.ctor(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject_FunctionDeclaration_2161B7CD_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.CoercionCSE_BoxedDoubleToNumber_NoCse.verified.txt
+++ b/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.CoercionCSE_BoxedDoubleToNumber_NoCse.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6B059E1F_compute
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6B059E1F_compute
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -217,7 +217,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/Scope,
-			[1] class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute/FunctionObject_FunctionDeclaration_6B059E1F_compute,
+			[1] class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object,
@@ -234,13 +234,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute/FunctionObject_FunctionDeclaration_6B059E1F_compute::.ctor()
+		IL_0011: newobj instance void Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "compute"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute/FunctionObject_FunctionDeclaration_6B059E1F_compute>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.NumericInference_ExponentiationLoop_NoBoxing.verified.txt
+++ b/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.NumericInference_ExponentiationLoop_NoBoxing.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B5D0B4A9_arith
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -101,7 +101,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -117,7 +117,7 @@
 				IL_0005: call float64 Modules.NumericInference_ExponentiationLoop_NoBoxing/arith::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -134,7 +134,7 @@
 				IL_0001: call float64 Modules.NumericInference_ExponentiationLoop_NoBoxing/arith::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -152,9 +152,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B5D0B4A9_arith
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -285,7 +285,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.NumericInference_ExponentiationLoop_NoBoxing/Scope,
-			[1] class Modules.NumericInference_ExponentiationLoop_NoBoxing/arith/FunctionObject_FunctionDeclaration_B5D0B4A9_arith,
+			[1] class Modules.NumericInference_ExponentiationLoop_NoBoxing/arith/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] float64,
@@ -301,14 +301,14 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.NumericInference_ExponentiationLoop_NoBoxing/arith/FunctionObject_FunctionDeclaration_B5D0B4A9_arith::.ctor()
+		IL_0011: newobj instance void Modules.NumericInference_ExponentiationLoop_NoBoxing/arith/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "arith"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.0
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.NumericInference_ExponentiationLoop_NoBoxing/arith/FunctionObject_FunctionDeclaration_B5D0B4A9_arith>(!!0, float64, string, bool, bool)
-		IL_0024: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.NumericInference_ExponentiationLoop_NoBoxing/arith/FunctionObject_FunctionDeclaration_B5D0B4A9_arith>(!!0)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.NumericInference_ExponentiationLoop_NoBoxing/arith/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0024: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.NumericInference_ExponentiationLoop_NoBoxing/arith/FunctionObject>(!!0)
 		IL_0029: stloc.1
 		IL_002a: nop
 		IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Function.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Function.verified.txt
@@ -101,7 +101,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8633A077_greet
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -115,7 +115,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -126,7 +126,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -137,7 +137,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -155,7 +155,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.CommonJS_Export_Function_Lib/greet::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -174,7 +174,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.CommonJS_Export_Function_Lib/greet::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -192,9 +192,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8633A077_greet
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -270,7 +270,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_Function_Lib/Scope,
-			[1] class Modules.CommonJS_Export_Function_Lib/greet/FunctionObject_FunctionDeclaration_8633A077_greet,
+			[1] class Modules.CommonJS_Export_Function_Lib/greet/FunctionObject,
 			[2] object[]
 		)
 
@@ -283,13 +283,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.CommonJS_Export_Function_Lib/greet/FunctionObject_FunctionDeclaration_8633A077_greet::.ctor()
+		IL_0011: newobj instance void Modules.CommonJS_Export_Function_Lib/greet/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "greet"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Function_Lib/greet/FunctionObject_FunctionDeclaration_8633A077_greet>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Function_Lib/greet/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
@@ -181,7 +181,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6FDBE108_L9C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -195,7 +195,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -206,7 +206,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -217,7 +217,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -238,7 +238,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -260,7 +260,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -278,9 +278,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_6FDBE108_L9C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -334,7 +334,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_04FF31D5_L12C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -348,7 +348,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -359,7 +359,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -370,7 +370,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -391,7 +391,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -413,7 +413,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -431,9 +431,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_04FF31D5_L12C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -485,7 +485,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6A528E57_L18C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -499,7 +499,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -510,7 +510,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -521,7 +521,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -539,7 +539,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -558,7 +558,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -576,9 +576,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_6A528E57_L18C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -644,10 +644,10 @@
 		.locals init (
 			[0] class Modules.CommonJS_Export_NestedObjects_Lib/Scope,
 			[1] object[],
-			[2] class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_6FDBE108_L9C14,
-			[3] class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18/FunctionObject_FunctionExpression_04FF31D5_L12C19,
+			[2] class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13/FunctionObject,
+			[3] class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[5] class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19/FunctionObject_FunctionExpression_6A528E57_L18C20,
+			[5] class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -661,13 +661,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.1
-		IL_0012: newobj instance void Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_6FDBE108_L9C14::.ctor()
+		IL_0012: newobj instance void Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_6FDBE108_L9C14>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.2
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -676,13 +676,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.1
-		IL_0031: newobj instance void Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18/FunctionObject_FunctionExpression_04FF31D5_L12C19::.ctor()
+		IL_0031: newobj instance void Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18/FunctionObject::.ctor()
 		IL_0036: ldc.i4.2
 		IL_0037: conv.r8
 		IL_0038: ldstr ""
 		IL_003d: ldc.i4.0
 		IL_003e: ldc.i4.1
-		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18/FunctionObject_FunctionExpression_04FF31D5_L12C19>(!!0, float64, string, bool, bool)
+		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0044: stloc.3
 		IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_004a: dup
@@ -701,13 +701,13 @@
 		IL_006c: ldloc.0
 		IL_006d: stelem.ref
 		IL_006e: stloc.1
-		IL_006f: newobj instance void Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19/FunctionObject_FunctionExpression_6A528E57_L18C20::.ctor()
+		IL_006f: newobj instance void Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19/FunctionObject::.ctor()
 		IL_0074: ldc.i4.1
 		IL_0075: conv.r8
 		IL_0076: ldstr ""
 		IL_007b: ldc.i4.0
 		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19/FunctionObject_FunctionExpression_6A528E57_L18C20>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.s 5
 		IL_0084: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0089: dup

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
@@ -133,7 +133,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -153,9 +153,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+				IL_0008: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject::_environment0_CommonJS_Export_ObjectWithClosure_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -166,7 +166,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -177,7 +177,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -190,14 +190,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+				IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject::_environment0_CommonJS_Export_ObjectWithClosure_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor::__js_call__(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -211,14 +211,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+				IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject::_environment0_CommonJS_Export_ObjectWithClosure_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor::__js_call__(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -236,9 +236,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -304,7 +304,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D71C6A35_multiply
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -328,15 +328,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+					IL_0008: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject::_environment0_CommonJS_Export_ObjectWithClosure_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply::_environment1_createCalculator
+					IL_000f: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject::_environment1_createCalculator
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply::_transitionalScopes
+					IL_0016: stfld object[] Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -347,7 +347,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -358,7 +358,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -371,14 +371,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply::_transitionalScopes
+					IL_0001: ldfld object[] Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -392,14 +392,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply::_transitionalScopes
+					IL_0001: ldfld object[] Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -417,9 +417,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_D71C6A35_multiply
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -485,7 +485,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_92111878_createCalculator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -505,9 +505,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject_FunctionDeclaration_92111878_createCalculator::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+				IL_0008: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject::_environment0_CommonJS_Export_ObjectWithClosure_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -518,7 +518,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -529,7 +529,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -542,14 +542,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject_FunctionDeclaration_92111878_createCalculator::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+				IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject::_environment0_CommonJS_Export_ObjectWithClosure_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator::__js_call__(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -563,14 +563,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject_FunctionDeclaration_92111878_createCalculator::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+				IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject::_environment0_CommonJS_Export_ObjectWithClosure_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator::__js_call__(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -588,9 +588,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_92111878_createCalculator
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -611,7 +611,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope,
-				[1] class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply,
+				[1] class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject,
 				[2] object[],
 				[3] object,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
@@ -642,13 +642,13 @@
 			IL_0026: ldelem.ref
 			IL_0027: castclass Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope
 			IL_002c: ldloc.2
-			IL_002d: newobj instance void Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply::.ctor(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope, object[])
+			IL_002d: newobj instance void Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject::.ctor(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope, object[])
 			IL_0032: ldc.i4.1
 			IL_0033: conv.r8
 			IL_0034: ldstr "multiply"
 			IL_0039: ldc.i4.0
 			IL_003a: ldc.i4.1
-			IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply>(!!0, float64, string, bool, bool)
+			IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0040: stloc.1
 			IL_0041: nop
 			IL_0042: ldloc.0
@@ -720,8 +720,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope,
-			[1] class Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor,
-			[2] class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject_FunctionDeclaration_92111878_createCalculator,
+			[1] class Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject,
+			[2] class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
@@ -739,13 +739,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope
-		IL_0019: newobj instance void Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::.ctor(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope)
+		IL_0019: newobj instance void Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject::.ctor(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "multiplyModuleFactor"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: ldc.i4.1
 		IL_002e: newarr [System.Runtime]System.Object
@@ -758,13 +758,13 @@
 		IL_0039: ldc.i4.0
 		IL_003a: ldelem.ref
 		IL_003b: castclass Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope
-		IL_0040: newobj instance void Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject_FunctionDeclaration_92111878_createCalculator::.ctor(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope)
+		IL_0040: newobj instance void Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject::.ctor(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope)
 		IL_0045: ldc.i4.1
 		IL_0046: conv.r8
 		IL_0047: ldstr "createCalculator"
 		IL_004c: ldc.i4.0
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject_FunctionDeclaration_92111878_createCalculator>(!!0, float64, string, bool, bool)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0053: stloc.2
 		IL_0054: nop
 		IL_0055: ldloc.0

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithFunctions.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithFunctions.verified.txt
@@ -130,7 +130,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F4A13FE0_foo
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -144,7 +144,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -155,7 +155,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -166,7 +166,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -181,7 +181,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -197,7 +197,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -215,9 +215,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F4A13FE0_foo
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -262,7 +262,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DA97E8EB_add
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -276,7 +276,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -287,7 +287,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -298,7 +298,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -319,7 +319,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -341,7 +341,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -359,9 +359,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DA97E8EB_add
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -415,7 +415,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F2971258_multiply
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -429,7 +429,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -440,7 +440,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -451,7 +451,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -472,7 +472,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -494,7 +494,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -512,9 +512,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F2971258_multiply
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -589,9 +589,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ObjectWithFunctions_Lib/Scope,
-			[1] class Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo/FunctionObject_FunctionDeclaration_F4A13FE0_foo,
-			[2] class Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'/FunctionObject_FunctionDeclaration_DA97E8EB_add,
-			[3] class Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply/FunctionObject_FunctionDeclaration_F2971258_multiply,
+			[1] class Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo/FunctionObject,
+			[2] class Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'/FunctionObject,
+			[3] class Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply/FunctionObject,
 			[4] object[],
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
@@ -605,13 +605,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo/FunctionObject_FunctionDeclaration_F4A13FE0_foo::.ctor()
+		IL_0012: newobj instance void Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "foo"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo/FunctionObject_FunctionDeclaration_F4A13FE0_foo>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -620,13 +620,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 4
-		IL_0032: newobj instance void Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'/FunctionObject_FunctionDeclaration_DA97E8EB_add::.ctor()
+		IL_0032: newobj instance void Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'/FunctionObject::.ctor()
 		IL_0037: ldc.i4.2
 		IL_0038: conv.r8
 		IL_0039: ldstr "add"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'/FunctionObject_FunctionDeclaration_DA97E8EB_add>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -635,13 +635,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 4
-		IL_0052: newobj instance void Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply/FunctionObject_FunctionDeclaration_F2971258_multiply::.ctor()
+		IL_0052: newobj instance void Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply/FunctionObject::.ctor()
 		IL_0057: ldc.i4.2
 		IL_0058: conv.r8
 		IL_0059: ldstr "multiply"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply/FunctionObject_FunctionDeclaration_F2971258_multiply>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: nop
 		IL_0067: nop

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ChainedAssignment.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ChainedAssignment.verified.txt
@@ -110,7 +110,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E01CF02F_L8C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -124,7 +124,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -135,7 +135,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -146,7 +146,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -164,7 +164,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -183,7 +183,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -201,9 +201,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E01CF02F_L8C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -269,7 +269,7 @@
 		.locals init (
 			[0] class Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/Scope,
 			[1] object[],
-			[2] class Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9/FunctionObject_FunctionExpression_E01CF02F_L8C10,
+			[2] class Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9/FunctionObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object
 		)
@@ -284,13 +284,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.1
-		IL_0012: newobj instance void Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9/FunctionObject_FunctionExpression_E01CF02F_L8C10::.ctor()
+		IL_0012: newobj instance void Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9/FunctionObject_FunctionExpression_E01CF02F_L8C10>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.2
 		IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_002b: dup

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_Function.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_Function.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C0CD2D41_greet
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.CommonJS_Module_Exports_Function/greet::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.CommonJS_Module_Exports_Function/greet::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C0CD2D41_greet
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -199,7 +199,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Module_Exports_Function/Scope,
-			[1] class Modules.CommonJS_Module_Exports_Function/greet/FunctionObject_FunctionDeclaration_C0CD2D41_greet,
+			[1] class Modules.CommonJS_Module_Exports_Function/greet/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -216,13 +216,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.CommonJS_Module_Exports_Function/greet/FunctionObject_FunctionDeclaration_C0CD2D41_greet::.ctor()
+		IL_0011: newobj instance void Modules.CommonJS_Module_Exports_Function/greet/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "greet"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_Function/greet/FunctionObject_FunctionDeclaration_C0CD2D41_greet>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_Function/greet/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
@@ -138,7 +138,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -158,9 +158,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.CommonJS_Require_Basic/Scope Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::_environment0_CommonJS_Require_Basic
+				IL_0008: stfld class Modules.CommonJS_Require_Basic/Scope Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject::_environment0_CommonJS_Require_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -171,7 +171,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -182,7 +182,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -195,11 +195,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Require_Basic/Scope Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::_environment0_CommonJS_Require_Basic
+				IL_0001: ldfld class Modules.CommonJS_Require_Basic/Scope Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject::_environment0_CommonJS_Require_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.CommonJS_Require_Basic/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Basic/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -213,11 +213,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Require_Basic/Scope Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::_environment0_CommonJS_Require_Basic
+				IL_0001: ldfld class Modules.CommonJS_Require_Basic/Scope Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject::_environment0_CommonJS_Require_Basic
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.CommonJS_Require_Basic/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Basic/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -235,9 +235,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -563,7 +563,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Basic/Scope,
-			[1] class Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName,
+			[1] class Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class Modules.CommonJS_Require_Basic/ArrowFunction_L3C9/FunctionObject,
@@ -585,13 +585,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.CommonJS_Require_Basic/Scope
-		IL_0019: newobj instance void Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::.ctor(class Modules.CommonJS_Require_Basic/Scope)
+		IL_0019: newobj instance void Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject::.ctor(class Modules.CommonJS_Require_Basic/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "commonFunctionName"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldc.i4.1
@@ -821,7 +821,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -841,9 +841,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.CommonJS_Require_Dependency/Scope Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::_environment0_CommonJS_Require_Dependency
+				IL_0008: stfld class Modules.CommonJS_Require_Dependency/Scope Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject::_environment0_CommonJS_Require_Dependency
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -854,7 +854,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -865,7 +865,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -878,11 +878,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Require_Dependency/Scope Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::_environment0_CommonJS_Require_Dependency
+				IL_0001: ldfld class Modules.CommonJS_Require_Dependency/Scope Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject::_environment0_CommonJS_Require_Dependency
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.CommonJS_Require_Dependency/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Dependency/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -896,11 +896,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Require_Dependency/Scope Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::_environment0_CommonJS_Require_Dependency
+				IL_0001: ldfld class Modules.CommonJS_Require_Dependency/Scope Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject::_environment0_CommonJS_Require_Dependency
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.CommonJS_Require_Dependency/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Dependency/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -918,9 +918,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1246,7 +1246,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Dependency/Scope,
-			[1] class Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName,
+			[1] class Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class Modules.CommonJS_Require_Dependency/ArrowFunction_L3C9/FunctionObject,
@@ -1267,13 +1267,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.CommonJS_Require_Dependency/Scope
-		IL_0019: newobj instance void Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::.ctor(class Modules.CommonJS_Require_Dependency/Scope)
+		IL_0019: newobj instance void Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject::.ctor(class Modules.CommonJS_Require_Dependency/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "commonFunctionName"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldc.i4.1

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5086E7D4_L6C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject_FunctionExpression_5086E7D4_L6C12::_environment0_CommonJS_Require_Captures_Shadowed_Global_URL
+				IL_0008: stfld class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject::_environment0_CommonJS_Require_Captures_Shadowed_Global_URL
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject_FunctionExpression_5086E7D4_L6C12::_environment0_CommonJS_Require_Captures_Shadowed_Global_URL
+				IL_0001: ldfld class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject::_environment0_CommonJS_Require_Captures_Shadowed_Global_URL
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor::__js_call__(class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject_FunctionExpression_5086E7D4_L6C12::_environment0_CommonJS_Require_Captures_Shadowed_Global_URL
+				IL_0001: ldfld class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject::_environment0_CommonJS_Require_Captures_Shadowed_Global_URL
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor::__js_call__(class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5086E7D4_L6C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -282,7 +282,7 @@
 			[1] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/ObjectLiterals/L5C18_descriptor,
 			[2] object,
 			[3] object[],
-			[4] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject_FunctionExpression_5086E7D4_L6C12,
+			[4] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
 
@@ -307,13 +307,13 @@
 		IL_0026: ldc.i4.0
 		IL_0027: ldelem.ref
 		IL_0028: castclass Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope
-		IL_002d: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject_FunctionExpression_5086E7D4_L6C12::.ctor(class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope)
+		IL_002d: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject::.ctor(class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope)
 		IL_0032: ldc.i4.1
 		IL_0033: conv.r8
 		IL_0034: ldstr ""
 		IL_0039: ldc.i4.0
 		IL_003a: ldc.i4.1
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject_FunctionExpression_5086E7D4_L6C12>(!!0, float64, string, bool, bool)
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0040: stloc.s 4
 		IL_0042: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL/ObjectLiterals/L5C18_descriptor::.ctor()
 		IL_0047: stloc.1
@@ -363,7 +363,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -377,7 +377,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -388,7 +388,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -399,7 +399,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -417,7 +417,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -436,7 +436,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -454,9 +454,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -509,7 +509,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_83E896B1_L7C30
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -523,7 +523,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -534,7 +534,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -545,7 +545,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -563,7 +563,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -582,7 +582,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -600,9 +600,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_83E896B1_L7C30
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -684,10 +684,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/Scope,
-			[1] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL/FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL,
+			[1] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL/FunctionObject,
 			[2] object[],
 			[3] object,
-			[4] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29/FunctionObject_FunctionExpression_83E896B1_L7C30
+			[4] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/Scope::.ctor()
@@ -699,13 +699,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL/FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::.ctor()
+		IL_0011: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "LocalURL"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL/FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -720,13 +720,13 @@
 		IL_003b: ldloc.0
 		IL_003c: stelem.ref
 		IL_003d: stloc.2
-		IL_003e: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29/FunctionObject_FunctionExpression_83E896B1_L7C30::.ctor()
+		IL_003e: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29/FunctionObject::.ctor()
 		IL_0043: ldc.i4.1
 		IL_0044: conv.r8
 		IL_0045: ldstr ""
 		IL_004a: ldc.i4.1
 		IL_004b: ldc.i4.1
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29/FunctionObject_FunctionExpression_83E896B1_L7C30>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0051: stloc.s 4
 		IL_0053: ldloc.3
 		IL_0054: ldstr "resolve"

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_FunctionValueIdentity.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_FunctionValueIdentity.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4F79A024_passthrough
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F79A024_passthrough::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F79A024_passthrough::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F79A024_passthrough::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.CommonJS_Require_FunctionValueIdentity/passthrough::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F79A024_passthrough::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.CommonJS_Require_FunctionValueIdentity/passthrough::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F79A024_passthrough::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F79A024_passthrough::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4F79A024_passthrough
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -169,7 +169,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -189,9 +189,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.CommonJS_Require_FunctionValueIdentity/Scope Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire/FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire::_environment0_CommonJS_Require_FunctionValueIdentity
+				IL_0008: stfld class Modules.CommonJS_Require_FunctionValueIdentity/Scope Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire/FunctionObject::_environment0_CommonJS_Require_FunctionValueIdentity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -202,7 +202,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -213,7 +213,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -226,11 +226,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Require_FunctionValueIdentity/Scope Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire/FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire::_environment0_CommonJS_Require_FunctionValueIdentity
+				IL_0001: ldfld class Modules.CommonJS_Require_FunctionValueIdentity/Scope Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire/FunctionObject::_environment0_CommonJS_Require_FunctionValueIdentity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire::__js_call__(class Modules.CommonJS_Require_FunctionValueIdentity/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -244,11 +244,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Require_FunctionValueIdentity/Scope Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire/FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire::_environment0_CommonJS_Require_FunctionValueIdentity
+				IL_0001: ldfld class Modules.CommonJS_Require_FunctionValueIdentity/Scope Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire/FunctionObject::_environment0_CommonJS_Require_FunctionValueIdentity
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire::__js_call__(class Modules.CommonJS_Require_FunctionValueIdentity/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -266,9 +266,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -403,8 +403,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_FunctionValueIdentity/Scope,
-			[1] class Modules.CommonJS_Require_FunctionValueIdentity/passthrough/FunctionObject_FunctionDeclaration_4F79A024_passthrough,
-			[2] class Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire/FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire,
+			[1] class Modules.CommonJS_Require_FunctionValueIdentity/passthrough/FunctionObject,
+			[2] class Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire/FunctionObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter,
 			[4] object,
 			[5] class Modules.CommonJS_Require_FunctionValueIdentity/ObjectLiterals/L13C16_holder,
@@ -434,13 +434,13 @@
 		IL_001a: ldloc.0
 		IL_001b: stelem.ref
 		IL_001c: stloc.s 8
-		IL_001e: newobj instance void Modules.CommonJS_Require_FunctionValueIdentity/passthrough/FunctionObject_FunctionDeclaration_4F79A024_passthrough::.ctor()
+		IL_001e: newobj instance void Modules.CommonJS_Require_FunctionValueIdentity/passthrough/FunctionObject::.ctor()
 		IL_0023: ldc.i4.1
 		IL_0024: conv.r8
 		IL_0025: ldstr "passthrough"
 		IL_002a: ldc.i4.0
 		IL_002b: ldc.i4.1
-		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_FunctionValueIdentity/passthrough/FunctionObject_FunctionDeclaration_4F79A024_passthrough>(!!0, float64, string, bool, bool)
+		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_FunctionValueIdentity/passthrough/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0031: stloc.1
 		IL_0032: ldc.i4.1
 		IL_0033: newarr [System.Runtime]System.Object
@@ -453,13 +453,13 @@
 		IL_0040: ldc.i4.0
 		IL_0041: ldelem.ref
 		IL_0042: castclass Modules.CommonJS_Require_FunctionValueIdentity/Scope
-		IL_0047: newobj instance void Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire/FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire::.ctor(class Modules.CommonJS_Require_FunctionValueIdentity/Scope)
+		IL_0047: newobj instance void Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire/FunctionObject::.ctor(class Modules.CommonJS_Require_FunctionValueIdentity/Scope)
 		IL_004c: ldc.i4.0
 		IL_004d: conv.r8
 		IL_004e: ldstr "readCapturedRequire"
 		IL_0053: ldc.i4.0
 		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire/FunctionObject_FunctionDeclaration_03646AB7_readCapturedRequire>(!!0, float64, string, bool, bool)
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_FunctionValueIdentity/readCapturedRequire/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005a: stloc.2
 		IL_005b: nop
 		IL_005c: nop
@@ -787,7 +787,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_68E790A0_L6C18
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -807,9 +807,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/Scope Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17/FunctionObject_FunctionExpression_68E790A0_L6C18::_environment0_CommonJS_Require_FunctionValueIdentity_Dependency
+				IL_0008: stfld class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/Scope Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17/FunctionObject::_environment0_CommonJS_Require_FunctionValueIdentity_Dependency
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_68E790A0_L6C18::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -820,7 +820,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_68E790A0_L6C18::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -831,7 +831,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_68E790A0_L6C18::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -844,11 +844,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/Scope Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17/FunctionObject_FunctionExpression_68E790A0_L6C18::_environment0_CommonJS_Require_FunctionValueIdentity_Dependency
+				IL_0001: ldfld class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/Scope Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17/FunctionObject::_environment0_CommonJS_Require_FunctionValueIdentity_Dependency
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17::__js_call__(class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_68E790A0_L6C18::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -862,11 +862,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/Scope Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17/FunctionObject_FunctionExpression_68E790A0_L6C18::_environment0_CommonJS_Require_FunctionValueIdentity_Dependency
+				IL_0001: ldfld class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/Scope Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17/FunctionObject::_environment0_CommonJS_Require_FunctionValueIdentity_Dependency
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17::__js_call__(class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_68E790A0_L6C18::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -884,9 +884,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_68E790A0_L6C18::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_68E790A0_L6C18
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -957,7 +957,7 @@
 			[0] class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.BuiltinDelegateFunctionAdapter,
 			[2] object[],
-			[3] class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17/FunctionObject_FunctionExpression_68E790A0_L6C18,
+			[3] class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -983,13 +983,13 @@
 		IL_002b: ldc.i4.0
 		IL_002c: ldelem.ref
 		IL_002d: castclass Modules.CommonJS_Require_FunctionValueIdentity_Dependency/Scope
-		IL_0032: newobj instance void Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17/FunctionObject_FunctionExpression_68E790A0_L6C18::.ctor(class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/Scope)
+		IL_0032: newobj instance void Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17/FunctionObject::.ctor(class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/Scope)
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr ""
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17/FunctionObject_FunctionExpression_68E790A0_L6C18>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_FunctionValueIdentity_Dependency/FunctionExpression_L6C17/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.3
 		IL_0046: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_004b: dup

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
@@ -202,7 +202,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -222,9 +222,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.b/Scope Modules.b/commonFunctionName/FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::_environment0_b
+				IL_0008: stfld class Modules.b/Scope Modules.b/commonFunctionName/FunctionObject::_environment0_b
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -235,7 +235,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -246,7 +246,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -259,11 +259,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.b/Scope Modules.b/commonFunctionName/FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::_environment0_b
+				IL_0001: ldfld class Modules.b/Scope Modules.b/commonFunctionName/FunctionObject::_environment0_b
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.b/commonFunctionName::__js_call__(class Modules.b/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -277,11 +277,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.b/Scope Modules.b/commonFunctionName/FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::_environment0_b
+				IL_0001: ldfld class Modules.b/Scope Modules.b/commonFunctionName/FunctionObject::_environment0_b
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.b/commonFunctionName::__js_call__(class Modules.b/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -299,9 +299,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -627,7 +627,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.b/Scope,
-			[1] class Modules.b/commonFunctionName/FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName,
+			[1] class Modules.b/commonFunctionName/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class Modules.b/ArrowFunction_L3C9/FunctionObject,
@@ -648,13 +648,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.b/Scope
-		IL_0019: newobj instance void Modules.b/commonFunctionName/FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::.ctor(class Modules.b/Scope)
+		IL_0019: newobj instance void Modules.b/commonFunctionName/FunctionObject::.ctor(class Modules.b/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "commonFunctionName"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.b/commonFunctionName/FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.b/commonFunctionName/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldc.i4.1
@@ -874,7 +874,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -894,9 +894,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.helpers_b/Scope Modules.helpers_b/commonFunctionName/FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::_environment0_helpers_b
+				IL_0008: stfld class Modules.helpers_b/Scope Modules.helpers_b/commonFunctionName/FunctionObject::_environment0_helpers_b
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -907,7 +907,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -918,7 +918,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -931,11 +931,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.helpers_b/Scope Modules.helpers_b/commonFunctionName/FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::_environment0_helpers_b
+				IL_0001: ldfld class Modules.helpers_b/Scope Modules.helpers_b/commonFunctionName/FunctionObject::_environment0_helpers_b
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.helpers_b/commonFunctionName::__js_call__(class Modules.helpers_b/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -949,11 +949,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.helpers_b/Scope Modules.helpers_b/commonFunctionName/FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::_environment0_helpers_b
+				IL_0001: ldfld class Modules.helpers_b/Scope Modules.helpers_b/commonFunctionName/FunctionObject::_environment0_helpers_b
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.helpers_b/commonFunctionName::__js_call__(class Modules.helpers_b/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -971,9 +971,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1299,7 +1299,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.helpers_b/Scope,
-			[1] class Modules.helpers_b/commonFunctionName/FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName,
+			[1] class Modules.helpers_b/commonFunctionName/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class Modules.helpers_b/ArrowFunction_L3C9/FunctionObject,
@@ -1320,13 +1320,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.helpers_b/Scope
-		IL_0019: newobj instance void Modules.helpers_b/commonFunctionName/FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::.ctor(class Modules.helpers_b/Scope)
+		IL_0019: newobj instance void Modules.helpers_b/commonFunctionName/FunctionObject::.ctor(class Modules.helpers_b/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "commonFunctionName"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.helpers_b/commonFunctionName/FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.helpers_b/commonFunctionName/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldc.i4.1

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
@@ -91,7 +91,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_074F556E_loadValue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -111,9 +111,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject_FunctionDeclaration_074F556E_loadValue::_environment0_CommonJS_Require_OptionalChain_InNestedFunction
+				IL_0008: stfld class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject::_environment0_CommonJS_Require_OptionalChain_InNestedFunction
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -124,7 +124,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -135,7 +135,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -148,11 +148,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject_FunctionDeclaration_074F556E_loadValue::_environment0_CommonJS_Require_OptionalChain_InNestedFunction
+				IL_0001: ldfld class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject::_environment0_CommonJS_Require_OptionalChain_InNestedFunction
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue::__js_call__(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -166,11 +166,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject_FunctionDeclaration_074F556E_loadValue::_environment0_CommonJS_Require_OptionalChain_InNestedFunction
+				IL_0001: ldfld class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject::_environment0_CommonJS_Require_OptionalChain_InNestedFunction
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue::__js_call__(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -188,9 +188,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_074F556E_loadValue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -321,7 +321,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope,
-			[1] class Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject_FunctionDeclaration_074F556E_loadValue,
+			[1] class Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -344,13 +344,13 @@
 		IL_001e: ldc.i4.0
 		IL_001f: ldelem.ref
 		IL_0020: castclass Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope
-		IL_0025: newobj instance void Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject_FunctionDeclaration_074F556E_loadValue::.ctor(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope)
+		IL_0025: newobj instance void Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject::.ctor(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope)
 		IL_002a: ldc.i4.0
 		IL_002b: conv.r8
 		IL_002c: ldstr "loadValue"
 		IL_0031: ldc.i4.0
 		IL_0032: ldc.i4.1
-		IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject_FunctionDeclaration_074F556E_loadValue>(!!0, float64, string, bool, bool)
+		IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0038: stloc.1
 		IL_0039: nop
 		IL_003a: nop

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Shadowed_Parameter.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Shadowed_Parameter.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9681A6B4_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.CommonJS_Require_Shadowed_Parameter/test::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.CommonJS_Require_Shadowed_Parameter/test::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9681A6B4_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -315,7 +315,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Shadowed_Parameter/Scope,
-			[1] class Modules.CommonJS_Require_Shadowed_Parameter/test/FunctionObject_FunctionDeclaration_9681A6B4_test,
+			[1] class Modules.CommonJS_Require_Shadowed_Parameter/test/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object[],
@@ -332,13 +332,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.CommonJS_Require_Shadowed_Parameter/test/FunctionObject_FunctionDeclaration_9681A6B4_test::.ctor()
+		IL_0011: newobj instance void Modules.CommonJS_Require_Shadowed_Parameter/test/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "test"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Shadowed_Parameter/test/FunctionObject_FunctionDeclaration_9681A6B4_test>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Shadowed_Parameter/test/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_Conditional_Ternary_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_Conditional_Ternary_ShortCircuit.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CCCFA6D2_bump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject_FunctionDeclaration_CCCFA6D2_bump::_environment0_ControlFlow_Conditional_Ternary_ShortCircuit
+				IL_0008: stfld class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject::_environment0_ControlFlow_Conditional_Ternary_ShortCircuit
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject_FunctionDeclaration_CCCFA6D2_bump::_environment0_ControlFlow_Conditional_Ternary_ShortCircuit
+				IL_0001: ldfld class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject::_environment0_ControlFlow_Conditional_Ternary_ShortCircuit
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject_FunctionDeclaration_CCCFA6D2_bump::_environment0_ControlFlow_Conditional_Ternary_ShortCircuit
+				IL_0001: ldfld class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject::_environment0_ControlFlow_Conditional_Ternary_ShortCircuit
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CCCFA6D2_bump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -212,7 +212,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope,
-			[1] class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject_FunctionDeclaration_CCCFA6D2_bump,
+			[1] class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object[],
@@ -234,13 +234,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope
-		IL_001b: newobj instance void Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject_FunctionDeclaration_CCCFA6D2_bump::.ctor(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope)
+		IL_001b: newobj instance void Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject::.ctor(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "bump"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject_FunctionDeclaration_CCCFA6D2_bump>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: ldloc.0

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_Let_PerIterationBinding.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_Let_PerIterationBinding.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_55CDB75E_L8C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -52,12 +52,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5 Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14::_environment1_ForIn_L7C5
+				IL_0008: stfld class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5 Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject::_environment1_ForIn_L7C5
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14::_transitionalScopes
+				IL_000f: stfld object[] Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -68,7 +68,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -79,7 +79,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -92,11 +92,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14::_transitionalScopes
+				IL_0001: ldfld object[] Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13::__js_call__(object[], object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -110,11 +110,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14::_transitionalScopes
+				IL_0001: ldfld object[] Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject::_transitionalScopes
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13::__js_call__(object[], object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -132,9 +132,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_55CDB75E_L8C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -294,7 +294,7 @@
 			[9] object,
 			[10] bool,
 			[11] object[],
-			[12] class Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14,
+			[12] class Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject,
 			[13] class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -357,13 +357,13 @@
 			IL_00a0: ldelem.ref
 			IL_00a1: castclass Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5
 			IL_00a6: ldloc.s 11
-			IL_00a8: newobj instance void Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14::.ctor(class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5, object[])
+			IL_00a8: newobj instance void Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject::.ctor(class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5, object[])
 			IL_00ad: ldc.i4.0
 			IL_00ae: conv.r8
 			IL_00af: ldstr ""
 			IL_00b4: ldc.i4.0
 			IL_00b5: ldc.i4.1
-			IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14>(!!0, float64, string, bool, bool)
+			IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00bb: stloc.s 12
 			IL_00bd: ldloc.1
 			IL_00be: ldloc.s 12

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_ClosureCallback.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_ClosureCallback.verified.txt
@@ -81,7 +81,7 @@
 
 			} // end of class Scope_ForOf_L5C9
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A72D72D3_inner
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -103,12 +103,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner::_environment1_outer
+					IL_0008: stfld class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject::_environment1_outer
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner::_transitionalScopes
+					IL_000f: stfld object[] Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -119,7 +119,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -130,7 +130,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -143,11 +143,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.ControlFlow_ForOf_ClosureCallback/outer/inner::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -161,11 +161,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.ControlFlow_ForOf_ClosureCallback/outer/inner::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -183,9 +183,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_A72D72D3_inner
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -331,7 +331,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C2A801E0_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -351,9 +351,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ControlFlow_ForOf_ClosureCallback/Scope Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject_FunctionDeclaration_C2A801E0_outer::_environment0_ControlFlow_ForOf_ClosureCallback
+				IL_0008: stfld class Modules.ControlFlow_ForOf_ClosureCallback/Scope Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject::_environment0_ControlFlow_ForOf_ClosureCallback
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -364,7 +364,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -375,7 +375,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -388,14 +388,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ControlFlow_ForOf_ClosureCallback/Scope Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject_FunctionDeclaration_C2A801E0_outer::_environment0_ControlFlow_ForOf_ClosureCallback
+				IL_0001: ldfld class Modules.ControlFlow_ForOf_ClosureCallback/Scope Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject::_environment0_ControlFlow_ForOf_ClosureCallback
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.ControlFlow_ForOf_ClosureCallback/outer::__js_call__(class Modules.ControlFlow_ForOf_ClosureCallback/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -409,14 +409,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ControlFlow_ForOf_ClosureCallback/Scope Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject_FunctionDeclaration_C2A801E0_outer::_environment0_ControlFlow_ForOf_ClosureCallback
+				IL_0001: ldfld class Modules.ControlFlow_ForOf_ClosureCallback/Scope Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject::_environment0_ControlFlow_ForOf_ClosureCallback
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.ControlFlow_ForOf_ClosureCallback/outer::__js_call__(class Modules.ControlFlow_ForOf_ClosureCallback/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -434,9 +434,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C2A801E0_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -458,7 +458,7 @@
 			.locals init (
 				[0] class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope,
 				[1] object[],
-				[2] class Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner
+				[2] class Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope::.ctor()
@@ -482,13 +482,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope
 			IL_0024: ldloc.1
-			IL_0025: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner::.ctor(class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope, object[])
+			IL_0025: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject::.ctor(class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope, object[])
 			IL_002a: ldc.i4.0
 			IL_002b: conv.r8
 			IL_002c: ldstr "inner"
 			IL_0031: ldc.i4.1
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.2
 			IL_0039: ldloc.2
 			IL_003a: ldc.i4.1
@@ -528,7 +528,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_45644ADB_L11C7
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -542,7 +542,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -553,7 +553,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -564,7 +564,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -582,7 +582,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -601,7 +601,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -619,9 +619,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_45644ADB_L11C7
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -695,10 +695,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForOf_ClosureCallback/Scope,
-			[1] class Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject_FunctionDeclaration_C2A801E0_outer,
+			[1] class Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject,
 			[2] object[],
 			[3] object[],
-			[4] class Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject_FunctionExpression_45644ADB_L11C7
+			[4] class Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/Scope::.ctor()
@@ -714,13 +714,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.ControlFlow_ForOf_ClosureCallback/Scope
-		IL_0019: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject_FunctionDeclaration_C2A801E0_outer::.ctor(class Modules.ControlFlow_ForOf_ClosureCallback/Scope)
+		IL_0019: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject::.ctor(class Modules.ControlFlow_ForOf_ClosureCallback/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject_FunctionDeclaration_C2A801E0_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -733,13 +733,13 @@
 		IL_003d: ldloc.0
 		IL_003e: stelem.ref
 		IL_003f: stloc.3
-		IL_0040: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject_FunctionExpression_45644ADB_L11C7::.ctor()
+		IL_0040: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject::.ctor()
 		IL_0045: ldc.i4.1
 		IL_0046: conv.r8
 		IL_0047: ldstr ""
 		IL_004c: ldc.i4.0
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject_FunctionExpression_45644ADB_L11C7>(!!0, float64, string, bool, bool)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0053: stloc.s 4
 		IL_0055: ldloc.1
 		IL_0056: ldloc.2

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_CustomIterable_IteratorProtocol.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_CustomIterable_IteratorProtocol.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D8C5ABFF_L9C13
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -58,15 +58,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+					IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_environment1_FunctionExpression_iterable
+					IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_environment1_FunctionExpression_iterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_transitionalScopes
+					IL_0016: stfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -77,7 +77,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -88,7 +88,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -101,11 +101,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -119,11 +119,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -141,9 +141,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_D8C5ABFF_L9C13
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -271,7 +271,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4C68785C_L15C15
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -295,15 +295,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+					IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15::_environment1_FunctionExpression_iterable
+					IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject::_environment1_FunctionExpression_iterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15::_transitionalScopes
+					IL_0016: stfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -314,7 +314,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -325,7 +325,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -338,11 +338,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -356,11 +356,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -378,9 +378,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_4C68785C_L15C15
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -458,7 +458,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F805EA4E_L6C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -478,9 +478,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject_FunctionExpression_F805EA4E_L6C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -491,7 +491,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -502,7 +502,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -515,11 +515,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject_FunctionExpression_F805EA4E_L6C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -533,11 +533,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject_FunctionExpression_F805EA4E_L6C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -555,9 +555,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F805EA4E_L6C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -578,8 +578,8 @@
 			.locals init (
 				[0] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope,
 				[1] object[],
-				[2] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13,
-				[3] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15,
+				[2] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject,
+				[3] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
@@ -609,13 +609,13 @@
 			IL_0033: ldelem.ref
 			IL_0034: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope
 			IL_0039: ldloc.1
-			IL_003a: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope, object[])
+			IL_003a: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope, object[])
 			IL_003f: ldc.i4.0
 			IL_0040: conv.r8
 			IL_0041: ldstr ""
 			IL_0046: ldc.i4.0
 			IL_0047: ldc.i4.1
-			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13>(!!0, float64, string, bool, bool)
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_004d: stloc.2
 			IL_004e: ldc.i4.2
 			IL_004f: newarr [System.Runtime]System.Object
@@ -637,13 +637,13 @@
 			IL_0067: ldelem.ref
 			IL_0068: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope
 			IL_006d: ldloc.1
-			IL_006e: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope, object[])
+			IL_006e: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope, object[])
 			IL_0073: ldc.i4.0
 			IL_0074: conv.r8
 			IL_0075: ldstr ""
 			IL_007a: ldc.i4.0
 			IL_007b: ldc.i4.1
-			IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15>(!!0, float64, string, bool, bool)
+			IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0081: stloc.3
 			IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0087: dup
@@ -688,7 +688,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_062080D6_L51C13
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -712,15 +712,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+					IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13::_environment1_FunctionExpression_iterableThrow
+					IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject::_environment1_FunctionExpression_iterableThrow
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13::_transitionalScopes
+					IL_0016: stfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -731,7 +731,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -742,7 +742,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -755,11 +755,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -773,11 +773,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -795,9 +795,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_062080D6_L51C13
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -908,7 +908,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4A63F24F_L56C15
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -932,15 +932,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+					IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15::_environment1_FunctionExpression_iterableThrow
+					IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject::_environment1_FunctionExpression_iterableThrow
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15::_transitionalScopes
+					IL_0016: stfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -951,7 +951,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -962,7 +962,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -975,11 +975,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -993,11 +993,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1015,9 +1015,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_4A63F24F_L56C15
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1095,7 +1095,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_815CE0CE_L48C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1115,9 +1115,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_815CE0CE_L48C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1128,7 +1128,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1139,7 +1139,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1152,11 +1152,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_815CE0CE_L48C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1170,11 +1170,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_815CE0CE_L48C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1192,9 +1192,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_815CE0CE_L48C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1215,8 +1215,8 @@
 			.locals init (
 				[0] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope,
 				[1] object[],
-				[2] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13,
-				[3] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15,
+				[2] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject,
+				[3] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
@@ -1246,13 +1246,13 @@
 			IL_0033: ldelem.ref
 			IL_0034: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope
 			IL_0039: ldloc.1
-			IL_003a: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope, object[])
+			IL_003a: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope, object[])
 			IL_003f: ldc.i4.0
 			IL_0040: conv.r8
 			IL_0041: ldstr ""
 			IL_0046: ldc.i4.0
 			IL_0047: ldc.i4.1
-			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13>(!!0, float64, string, bool, bool)
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_004d: stloc.2
 			IL_004e: ldc.i4.2
 			IL_004f: newarr [System.Runtime]System.Object
@@ -1274,13 +1274,13 @@
 			IL_0067: ldelem.ref
 			IL_0068: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope
 			IL_006d: ldloc.1
-			IL_006e: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope, object[])
+			IL_006e: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope, object[])
 			IL_0073: ldc.i4.0
 			IL_0074: conv.r8
 			IL_0075: ldstr ""
 			IL_007a: ldc.i4.0
 			IL_007b: ldc.i4.1
-			IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15>(!!0, float64, string, bool, bool)
+			IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0081: stloc.3
 			IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0087: dup
@@ -1608,11 +1608,11 @@
 			[26] object,
 			[27] object,
 			[28] object[],
-			[29] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject_FunctionExpression_F805EA4E_L6C22,
+			[29] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject,
 			[30] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[31] bool,
 			[32] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[33] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_815CE0CE_L48C22
+			[33] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::.ctor()
@@ -1636,13 +1636,13 @@
 		IL_0035: ldc.i4.0
 		IL_0036: ldelem.ref
 		IL_0037: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
-		IL_003c: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject_FunctionExpression_F805EA4E_L6C22::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope)
+		IL_003c: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope)
 		IL_0041: ldc.i4.0
 		IL_0042: conv.r8
 		IL_0043: ldstr ""
 		IL_0048: ldc.i4.0
 		IL_0049: ldc.i4.1
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject_FunctionExpression_F805EA4E_L6C22>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004f: stloc.s 29
 		IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0056: stloc.s 30
@@ -1942,13 +1942,13 @@
 		IL_030d: ldc.i4.0
 		IL_030e: ldelem.ref
 		IL_030f: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
-		IL_0314: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_815CE0CE_L48C22::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope)
+		IL_0314: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope)
 		IL_0319: ldc.i4.0
 		IL_031a: conv.r8
 		IL_031b: ldstr ""
 		IL_0320: ldc.i4.0
 		IL_0321: ldc.i4.1
-		IL_0322: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_815CE0CE_L48C22>(!!0, float64, string, bool, bool)
+		IL_0322: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0327: stloc.s 33
 		IL_0329: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_032e: stloc.s 30

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_163EAF2D_L6C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -52,12 +52,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5 Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14::_environment1_ForOf_L5C5
+				IL_0008: stfld class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5 Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject::_environment1_ForOf_L5C5
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14::_transitionalScopes
+				IL_000f: stfld object[] Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -68,7 +68,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -79,7 +79,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -92,11 +92,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14::_transitionalScopes
+				IL_0001: ldfld object[] Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13::__js_call__(object[], object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -110,11 +110,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14::_transitionalScopes
+				IL_0001: ldfld object[] Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject::_transitionalScopes
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13::__js_call__(object[], object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -132,9 +132,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_163EAF2D_L6C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -295,7 +295,7 @@
 			[10] object,
 			[11] bool,
 			[12] object[],
-			[13] class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14,
+			[13] class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject,
 			[14] class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5,
 			[15] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -388,13 +388,13 @@
 				IL_00f6: ldelem.ref
 				IL_00f7: castclass Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5
 				IL_00fc: ldloc.s 12
-				IL_00fe: newobj instance void Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14::.ctor(class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5, object[])
+				IL_00fe: newobj instance void Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject::.ctor(class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5, object[])
 				IL_0103: ldc.i4.0
 				IL_0104: conv.r8
 				IL_0105: ldstr ""
 				IL_010a: ldc.i4.0
 				IL_010b: ldc.i4.1
-				IL_010c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14>(!!0, float64, string, bool, bool)
+				IL_010c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0111: stloc.s 13
 				IL_0113: ldloc.1
 				IL_0114: ldloc.s 13

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Let_PerIterationBinding.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Let_PerIterationBinding.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C4DB1299_L6C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -52,12 +52,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5 Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14::_environment1_ForOf_L5C5
+				IL_0008: stfld class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5 Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject::_environment1_ForOf_L5C5
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14::_transitionalScopes
+				IL_000f: stfld object[] Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -68,7 +68,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -79,7 +79,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -92,11 +92,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14::_transitionalScopes
+				IL_0001: ldfld object[] Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13::__js_call__(object[], object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -110,11 +110,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14::_transitionalScopes
+				IL_0001: ldfld object[] Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject::_transitionalScopes
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13::__js_call__(object[], object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -132,9 +132,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C4DB1299_L6C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -295,7 +295,7 @@
 			[10] object,
 			[11] bool,
 			[12] object[],
-			[13] class Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14,
+			[13] class Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject,
 			[14] class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5,
 			[15] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -360,13 +360,13 @@
 				IL_0094: ldelem.ref
 				IL_0095: castclass Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5
 				IL_009a: ldloc.s 12
-				IL_009c: newobj instance void Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14::.ctor(class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5, object[])
+				IL_009c: newobj instance void Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject::.ctor(class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5, object[])
 				IL_00a1: ldc.i4.0
 				IL_00a2: conv.r8
 				IL_00a3: ldstr ""
 				IL_00a8: ldc.i4.0
 				IL_00a9: ldc.i4.1
-				IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14>(!!0, float64, string, bool, bool)
+				IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_00af: stloc.s 13
 				IL_00b1: ldloc.1
 				IL_00b2: ldloc.s 13

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_LabeledStatement_CapturesParentVar.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_LabeledStatement_CapturesParentVar.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DE156F42_L5C27
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -48,7 +48,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -59,7 +59,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -70,7 +70,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -88,7 +88,7 @@
 					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000c: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal::__js_call__(object, object)
 					IL_0011: ret
-				} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -107,7 +107,7 @@
 					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0008: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal::__js_call__(object, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -125,9 +125,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_DE156F42_L5C27
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -208,7 +208,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A6260E1E_nextNode
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -230,12 +230,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode::_environment1_outer
+					IL_0008: stfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject::_environment1_outer
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode::_transitionalScopes
+					IL_000f: stfld object[] Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -246,7 +246,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -257,7 +257,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -270,11 +270,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -288,11 +288,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -310,9 +310,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_A6260E1E_nextNode
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -422,7 +422,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E39E6AE2_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -442,9 +442,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject_FunctionDeclaration_E39E6AE2_outer::_environment0_ControlFlow_LabeledStatement_CapturesParentVar
+				IL_0008: stfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject::_environment0_ControlFlow_LabeledStatement_CapturesParentVar
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -455,7 +455,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -466,7 +466,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -479,11 +479,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject_FunctionDeclaration_E39E6AE2_outer::_environment0_ControlFlow_LabeledStatement_CapturesParentVar
+				IL_0001: ldfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject::_environment0_ControlFlow_LabeledStatement_CapturesParentVar
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer::__js_call__(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -497,11 +497,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject_FunctionDeclaration_E39E6AE2_outer::_environment0_ControlFlow_LabeledStatement_CapturesParentVar
+				IL_0001: ldfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject::_environment0_ControlFlow_LabeledStatement_CapturesParentVar
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer::__js_call__(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -519,9 +519,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E39E6AE2_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -542,9 +542,9 @@
 			.locals init (
 				[0] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope,
 				[1] object[],
-				[2] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal/FunctionObject_FunctionExpression_DE156F42_L5C27,
+				[2] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal/FunctionObject,
 				[3] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/ObjectLiterals/L4C23_NodeTraversal,
-				[4] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode
+				[4] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope::.ctor()
@@ -556,13 +556,13 @@
 			IL_000e: ldarg.0
 			IL_000f: stelem.ref
 			IL_0010: stloc.1
-			IL_0011: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal/FunctionObject_FunctionExpression_DE156F42_L5C27::.ctor()
+			IL_0011: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal/FunctionObject::.ctor()
 			IL_0016: ldc.i4.1
 			IL_0017: conv.r8
 			IL_0018: ldstr ""
 			IL_001d: ldc.i4.0
 			IL_001e: ldc.i4.1
-			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal/FunctionObject_FunctionExpression_DE156F42_L5C27>(!!0, float64, string, bool, bool)
+			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0024: stloc.2
 			IL_0025: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/ObjectLiterals/L4C23_NodeTraversal::.ctor()
 			IL_002a: stloc.3
@@ -588,13 +588,13 @@
 			IL_004a: ldelem.ref
 			IL_004b: castclass Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope
 			IL_0050: ldloc.1
-			IL_0051: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode::.ctor(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope, object[])
+			IL_0051: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject::.ctor(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope, object[])
 			IL_0056: ldc.i4.0
 			IL_0057: conv.r8
 			IL_0058: ldstr "nextNode"
 			IL_005d: ldc.i4.1
 			IL_005e: ldc.i4.1
-			IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode>(!!0, float64, string, bool, bool)
+			IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0064: stloc.s 4
 			IL_0066: ldloc.s 4
 			IL_0068: ret
@@ -703,7 +703,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope,
-			[1] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject_FunctionDeclaration_E39E6AE2_outer,
+			[1] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject,
 			[2] object[],
 			[3] object
 		)
@@ -721,13 +721,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope
-		IL_0019: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject_FunctionDeclaration_E39E6AE2_outer::.ctor(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope)
+		IL_0019: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject::.ctor(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject_FunctionDeclaration_E39E6AE2_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
@@ -167,7 +167,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_09CA7F68_L19C2
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -187,9 +187,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.FinalizationRegistry_Cleanup_Order/Scope Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject_FunctionExpression_09CA7F68_L19C2::_environment0_FinalizationRegistry_Cleanup_Order
+				IL_0008: stfld class Modules.FinalizationRegistry_Cleanup_Order/Scope Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject::_environment0_FinalizationRegistry_Cleanup_Order
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -200,7 +200,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -211,7 +211,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -224,11 +224,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.FinalizationRegistry_Cleanup_Order/Scope Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject_FunctionExpression_09CA7F68_L19C2::_environment0_FinalizationRegistry_Cleanup_Order
+				IL_0001: ldfld class Modules.FinalizationRegistry_Cleanup_Order/Scope Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject::_environment0_FinalizationRegistry_Cleanup_Order
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -242,11 +242,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.FinalizationRegistry_Cleanup_Order/Scope Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject_FunctionExpression_09CA7F68_L19C2::_environment0_FinalizationRegistry_Cleanup_Order
+				IL_0001: ldfld class Modules.FinalizationRegistry_Cleanup_Order/Scope Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject::_environment0_FinalizationRegistry_Cleanup_Order
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -264,9 +264,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_09CA7F68_L19C2
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -784,7 +784,7 @@
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[11] object,
-			[12] class Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject_FunctionExpression_09CA7F68_L19C2,
+			[12] class Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject,
 			[13] class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13/FunctionObject,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
 			[15] class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42/FunctionObject,
@@ -939,13 +939,13 @@
 		IL_017a: ldc.i4.0
 		IL_017b: ldelem.ref
 		IL_017c: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_0181: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject_FunctionExpression_09CA7F68_L19C2::.ctor(class Modules.FinalizationRegistry_Cleanup_Order/Scope)
+		IL_0181: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject::.ctor(class Modules.FinalizationRegistry_Cleanup_Order/Scope)
 		IL_0186: ldc.i4.0
 		IL_0187: conv.r8
 		IL_0188: ldstr ""
 		IL_018d: ldc.i4.0
 		IL_018e: ldc.i4.1
-		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject_FunctionExpression_09CA7F68_L19C2>(!!0, float64, string, bool, bool)
+		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0194: stloc.s 12
 		IL_0196: ldloc.s 12
 		IL_0198: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
@@ -162,7 +162,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DD94D475_L9C2
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -182,9 +182,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.FinalizationRegistry_Unregister_Basic/Scope Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject_FunctionExpression_DD94D475_L9C2::_environment0_FinalizationRegistry_Unregister_Basic
+				IL_0008: stfld class Modules.FinalizationRegistry_Unregister_Basic/Scope Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject::_environment0_FinalizationRegistry_Unregister_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -195,7 +195,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -206,7 +206,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -219,11 +219,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.FinalizationRegistry_Unregister_Basic/Scope Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject_FunctionExpression_DD94D475_L9C2::_environment0_FinalizationRegistry_Unregister_Basic
+				IL_0001: ldfld class Modules.FinalizationRegistry_Unregister_Basic/Scope Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject::_environment0_FinalizationRegistry_Unregister_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1::__js_call__(class Modules.FinalizationRegistry_Unregister_Basic/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -237,11 +237,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.FinalizationRegistry_Unregister_Basic/Scope Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject_FunctionExpression_DD94D475_L9C2::_environment0_FinalizationRegistry_Unregister_Basic
+				IL_0001: ldfld class Modules.FinalizationRegistry_Unregister_Basic/Scope Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject::_environment0_FinalizationRegistry_Unregister_Basic
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1::__js_call__(class Modules.FinalizationRegistry_Unregister_Basic/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -259,9 +259,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_DD94D475_L9C2
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -535,7 +535,7 @@
 			[7] class Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L4C43/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[10] class Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject_FunctionExpression_DD94D475_L9C2,
+			[10] class Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[12] object,
 			[13] class Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14/FunctionObject
@@ -592,13 +592,13 @@
 		IL_0074: ldc.i4.0
 		IL_0075: ldelem.ref
 		IL_0076: castclass Modules.FinalizationRegistry_Unregister_Basic/Scope
-		IL_007b: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject_FunctionExpression_DD94D475_L9C2::.ctor(class Modules.FinalizationRegistry_Unregister_Basic/Scope)
+		IL_007b: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject::.ctor(class Modules.FinalizationRegistry_Unregister_Basic/Scope)
 		IL_0080: ldc.i4.0
 		IL_0081: conv.r8
 		IL_0082: ldstr ""
 		IL_0087: ldc.i4.0
 		IL_0088: ldc.i4.1
-		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject_FunctionExpression_DD94D475_L9C2>(!!0, float64, string, bool, bool)
+		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_008e: stloc.s 10
 		IL_0090: ldloc.s 10
 		IL_0092: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_58D97871_add
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_58D97871_add::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_58D97871_add::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_58D97871_add::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_Apply_Basic/'add'::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_58D97871_add::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_Apply_Basic/'add'::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_58D97871_add::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_58D97871_add::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_58D97871_add
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -202,7 +202,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Apply_Basic/Scope,
-			[1] class Modules.Function_Apply_Basic/'add'/FunctionObject_FunctionDeclaration_58D97871_add,
+			[1] class Modules.Function_Apply_Basic/'add'/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -218,13 +218,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_Apply_Basic/'add'/FunctionObject_FunctionDeclaration_58D97871_add::.ctor()
+		IL_0011: newobj instance void Modules.Function_Apply_Basic/'add'/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Apply_Basic/'add'/FunctionObject_FunctionDeclaration_58D97871_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Apply_Basic/'add'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_NullArgArray_TreatedAsEmpty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_NullArgArray_TreatedAsEmpty.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -51,7 +51,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -62,7 +62,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -73,7 +73,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -107,7 +107,7 @@
 
 				IL_0019: ldloc.0
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -122,7 +122,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -138,7 +138,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -156,9 +156,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -240,7 +240,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Apply_NullArgArray_TreatedAsEmpty/Scope,
-			[1] class Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs/FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs,
+			[1] class Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -255,13 +255,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs/FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::.ctor()
+		IL_0011: newobj instance void Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "countArgs"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs/FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_ThisArg.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_ThisArg.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_992E512E_addBase
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_Apply_ThisArg/addBase::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_Apply_ThisArg/addBase::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_992E512E_addBase
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -201,7 +201,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Apply_ThisArg/Scope,
-			[1] class Modules.Function_Apply_ThisArg/addBase/FunctionObject_FunctionDeclaration_992E512E_addBase,
+			[1] class Modules.Function_Apply_ThisArg/addBase/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -218,13 +218,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_Apply_ThisArg/addBase/FunctionObject_FunctionDeclaration_992E512E_addBase::.ctor()
+		IL_0011: newobj instance void Modules.Function_Apply_ThisArg/addBase/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "addBase"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Apply_ThisArg/addBase/FunctionObject_FunctionDeclaration_992E512E_addBase>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Apply_ThisArg/addBase/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Basics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Basics.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C5119BBF_f
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -51,7 +51,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -62,7 +62,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -73,7 +73,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -113,7 +113,7 @@
 
 				IL_0027: ldloc.0
 				IL_0028: ret
-			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -134,7 +134,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_Arguments_Basics/f::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -156,7 +156,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_Arguments_Basics/f::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -174,9 +174,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C5119BBF_f
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -434,7 +434,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B57FDCE6_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -454,9 +454,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Arguments_Basics/Scope Modules.Function_Arguments_Basics/outer/FunctionObject_FunctionDeclaration_B57FDCE6_outer::_environment0_Function_Arguments_Basics
+				IL_0008: stfld class Modules.Function_Arguments_Basics/Scope Modules.Function_Arguments_Basics/outer/FunctionObject::_environment0_Function_Arguments_Basics
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -467,7 +467,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -478,7 +478,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -519,7 +519,7 @@
 
 				IL_0028: ldloc.0
 				IL_0029: ret
-			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -532,14 +532,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Arguments_Basics/Scope Modules.Function_Arguments_Basics/outer/FunctionObject_FunctionDeclaration_B57FDCE6_outer::_environment0_Function_Arguments_Basics
+				IL_0001: ldfld class Modules.Function_Arguments_Basics/Scope Modules.Function_Arguments_Basics/outer/FunctionObject::_environment0_Function_Arguments_Basics
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Function_Arguments_Basics/outer::__js_call__(class Modules.Function_Arguments_Basics/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -553,14 +553,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Arguments_Basics/Scope Modules.Function_Arguments_Basics/outer/FunctionObject_FunctionDeclaration_B57FDCE6_outer::_environment0_Function_Arguments_Basics
+				IL_0001: ldfld class Modules.Function_Arguments_Basics/Scope Modules.Function_Arguments_Basics/outer/FunctionObject::_environment0_Function_Arguments_Basics
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Function_Arguments_Basics/outer::__js_call__(class Modules.Function_Arguments_Basics/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -578,9 +578,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B57FDCE6_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -697,7 +697,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C98AACFB_inner
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -711,7 +711,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -722,7 +722,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -733,7 +733,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method assembly hidebysig static 
 					object __js_call_with_arguments__ (
@@ -767,7 +767,7 @@
 
 					IL_0019: ldloc.0
 					IL_001a: ret
-				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::__js_call_with_arguments__
+				} // end of method FunctionObject::__js_call_with_arguments__
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -782,7 +782,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.Function_Arguments_Basics/g/inner::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -798,7 +798,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.Function_Arguments_Basics/g/inner::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -816,9 +816,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_C98AACFB_inner
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -891,7 +891,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C4119A2C_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -905,7 +905,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -916,7 +916,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -927,7 +927,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -942,7 +942,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_Arguments_Basics/g::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -958,7 +958,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_Arguments_Basics/g::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -976,9 +976,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C4119A2C_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -995,7 +995,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Arguments_Basics/g/Scope,
-				[1] class Modules.Function_Arguments_Basics/g/inner/FunctionObject_FunctionDeclaration_C98AACFB_inner,
+				[1] class Modules.Function_Arguments_Basics/g/inner/FunctionObject,
 				[2] object[]
 			)
 
@@ -1003,13 +1003,13 @@
 			IL_0005: stloc.0
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.2
-			IL_000c: newobj instance void Modules.Function_Arguments_Basics/g/inner/FunctionObject_FunctionDeclaration_C98AACFB_inner::.ctor()
+			IL_000c: newobj instance void Modules.Function_Arguments_Basics/g/inner/FunctionObject::.ctor()
 			IL_0011: ldc.i4.0
 			IL_0012: conv.r8
 			IL_0013: ldstr "inner"
 			IL_0018: ldc.i4.1
 			IL_0019: ldc.i4.1
-			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/g/inner/FunctionObject_FunctionDeclaration_C98AACFB_inner>(!!0, float64, string, bool, bool)
+			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/g/inner/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_001f: stloc.1
 			IL_0020: nop
 			IL_0021: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -1073,9 +1073,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_Basics/Scope,
-			[1] class Modules.Function_Arguments_Basics/f/FunctionObject_FunctionDeclaration_C5119BBF_f,
-			[2] class Modules.Function_Arguments_Basics/outer/FunctionObject_FunctionDeclaration_B57FDCE6_outer,
-			[3] class Modules.Function_Arguments_Basics/g/FunctionObject_FunctionDeclaration_C4119A2C_g,
+			[1] class Modules.Function_Arguments_Basics/f/FunctionObject,
+			[2] class Modules.Function_Arguments_Basics/outer/FunctionObject,
+			[3] class Modules.Function_Arguments_Basics/g/FunctionObject,
 			[4] object[]
 		)
 
@@ -1088,13 +1088,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void Modules.Function_Arguments_Basics/f/FunctionObject_FunctionDeclaration_C5119BBF_f::.ctor()
+		IL_0012: newobj instance void Modules.Function_Arguments_Basics/f/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "f"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/f/FunctionObject_FunctionDeclaration_C5119BBF_f>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/f/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1107,13 +1107,13 @@
 		IL_0034: ldc.i4.0
 		IL_0035: ldelem.ref
 		IL_0036: castclass Modules.Function_Arguments_Basics/Scope
-		IL_003b: newobj instance void Modules.Function_Arguments_Basics/outer/FunctionObject_FunctionDeclaration_B57FDCE6_outer::.ctor(class Modules.Function_Arguments_Basics/Scope)
+		IL_003b: newobj instance void Modules.Function_Arguments_Basics/outer/FunctionObject::.ctor(class Modules.Function_Arguments_Basics/Scope)
 		IL_0040: ldc.i4.1
 		IL_0041: conv.r8
 		IL_0042: ldstr "outer"
 		IL_0047: ldc.i4.1
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/outer/FunctionObject_FunctionDeclaration_B57FDCE6_outer>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: ldc.i4.1
 		IL_0050: newarr [System.Runtime]System.Object
@@ -1122,13 +1122,13 @@
 		IL_0057: ldloc.0
 		IL_0058: stelem.ref
 		IL_0059: stloc.s 4
-		IL_005b: newobj instance void Modules.Function_Arguments_Basics/g/FunctionObject_FunctionDeclaration_C4119A2C_g::.ctor()
+		IL_005b: newobj instance void Modules.Function_Arguments_Basics/g/FunctionObject::.ctor()
 		IL_0060: ldc.i4.0
 		IL_0061: conv.r8
 		IL_0062: ldstr "g"
 		IL_0067: ldc.i4.0
 		IL_0068: ldc.i4.1
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/g/FunctionObject_FunctionDeclaration_C4119A2C_g>(!!0, float64, string, bool, bool)
+		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006e: stloc.3
 		IL_006f: nop
 		IL_0070: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_CalleeIdentity.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_CalleeIdentity.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D015E2E6_inspect
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -57,9 +57,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject_FunctionDeclaration_D015E2E6_inspect::_environment0_Function_Arguments_CalleeIdentity
+				IL_0008: stfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject::_environment0_Function_Arguments_CalleeIdentity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D015E2E6_inspect::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -70,7 +70,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D015E2E6_inspect::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -81,7 +81,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D015E2E6_inspect::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -95,7 +95,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D015E2E6_inspect::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -133,7 +133,7 @@
 
 				IL_0021: ldloc.0
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_D015E2E6_inspect::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -146,11 +146,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject_FunctionDeclaration_D015E2E6_inspect::_environment0_Function_Arguments_CalleeIdentity
+				IL_0001: ldfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject::_environment0_Function_Arguments_CalleeIdentity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_Arguments_CalleeIdentity/inspect::__js_call__(class Modules.Function_Arguments_CalleeIdentity/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_D015E2E6_inspect::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -164,11 +164,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject_FunctionDeclaration_D015E2E6_inspect::_environment0_Function_Arguments_CalleeIdentity
+				IL_0001: ldfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject::_environment0_Function_Arguments_CalleeIdentity
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_Arguments_CalleeIdentity/inspect::__js_call__(class Modules.Function_Arguments_CalleeIdentity/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_D015E2E6_inspect::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -186,9 +186,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D015E2E6_inspect::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D015E2E6_inspect
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -295,7 +295,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_47BC308D_spreadThis
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -315,9 +315,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject_FunctionDeclaration_47BC308D_spreadThis::_environment0_Function_Arguments_CalleeIdentity
+				IL_0008: stfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject::_environment0_Function_Arguments_CalleeIdentity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_47BC308D_spreadThis::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -328,7 +328,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_47BC308D_spreadThis::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -339,7 +339,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_47BC308D_spreadThis::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -353,7 +353,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_47BC308D_spreadThis::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -391,7 +391,7 @@
 
 				IL_0021: ldloc.0
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_47BC308D_spreadThis::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -404,11 +404,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject_FunctionDeclaration_47BC308D_spreadThis::_environment0_Function_Arguments_CalleeIdentity
+				IL_0001: ldfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject::_environment0_Function_Arguments_CalleeIdentity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_Arguments_CalleeIdentity/spreadThis::__js_call__(class Modules.Function_Arguments_CalleeIdentity/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_47BC308D_spreadThis::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -422,11 +422,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject_FunctionDeclaration_47BC308D_spreadThis::_environment0_Function_Arguments_CalleeIdentity
+				IL_0001: ldfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject::_environment0_Function_Arguments_CalleeIdentity
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_Arguments_CalleeIdentity/spreadThis::__js_call__(class Modules.Function_Arguments_CalleeIdentity/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_47BC308D_spreadThis::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -444,9 +444,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_47BC308D_spreadThis::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_47BC308D_spreadThis
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -527,7 +527,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_30D9BE91_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -547,9 +547,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject_FunctionDeclaration_30D9BE91_outer::_environment0_Function_Arguments_CalleeIdentity
+				IL_0008: stfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject::_environment0_Function_Arguments_CalleeIdentity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_30D9BE91_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -560,7 +560,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_30D9BE91_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -571,7 +571,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_30D9BE91_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -585,7 +585,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_30D9BE91_outer::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -623,7 +623,7 @@
 
 				IL_0021: ldloc.0
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_30D9BE91_outer::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -636,11 +636,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject_FunctionDeclaration_30D9BE91_outer::_environment0_Function_Arguments_CalleeIdentity
+				IL_0001: ldfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject::_environment0_Function_Arguments_CalleeIdentity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_Arguments_CalleeIdentity/outer::__js_call__(class Modules.Function_Arguments_CalleeIdentity/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_30D9BE91_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -654,11 +654,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject_FunctionDeclaration_30D9BE91_outer::_environment0_Function_Arguments_CalleeIdentity
+				IL_0001: ldfld class Modules.Function_Arguments_CalleeIdentity/Scope Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject::_environment0_Function_Arguments_CalleeIdentity
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_Arguments_CalleeIdentity/outer::__js_call__(class Modules.Function_Arguments_CalleeIdentity/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_30D9BE91_outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -676,9 +676,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_30D9BE91_outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_30D9BE91_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -774,7 +774,7 @@
 			IL_00c1: ldarg.0
 			IL_00c2: stelem.ref
 			IL_00c3: ldloc.s 8
-			IL_00c5: call object Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject_FunctionDeclaration_D015E2E6_inspect::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+			IL_00c5: call object Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
 			IL_00ca: pop
 			IL_00cb: ldstr "console"
 			IL_00d0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
@@ -855,10 +855,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_CalleeIdentity/Scope,
-			[1] class Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject_FunctionDeclaration_47BC308D_spreadThis,
+			[1] class Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject,
 			[2] object[],
-			[3] class Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject_FunctionDeclaration_D015E2E6_inspect,
-			[4] class Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject_FunctionDeclaration_30D9BE91_outer,
+			[3] class Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject,
+			[4] class Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject,
 			[5] object,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array
@@ -877,14 +877,14 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Arguments_CalleeIdentity/Scope
-		IL_0019: newobj instance void Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject_FunctionDeclaration_D015E2E6_inspect::.ctor(class Modules.Function_Arguments_CalleeIdentity/Scope)
+		IL_0019: newobj instance void Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject::.ctor(class Modules.Function_Arguments_CalleeIdentity/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "inspect"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.0
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject_FunctionDeclaration_D015E2E6_inspect>(!!0, float64, string, bool, bool)
-		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject_FunctionDeclaration_D015E2E6_inspect>(!!0)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject>(!!0)
 		IL_0031: stloc.3
 		IL_0032: ldloc.0
 		IL_0033: ldloc.3
@@ -900,14 +900,14 @@
 		IL_0045: ldc.i4.0
 		IL_0046: ldelem.ref
 		IL_0047: castclass Modules.Function_Arguments_CalleeIdentity/Scope
-		IL_004c: newobj instance void Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject_FunctionDeclaration_47BC308D_spreadThis::.ctor(class Modules.Function_Arguments_CalleeIdentity/Scope)
+		IL_004c: newobj instance void Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject::.ctor(class Modules.Function_Arguments_CalleeIdentity/Scope)
 		IL_0051: ldc.i4.0
 		IL_0052: conv.r8
 		IL_0053: ldstr "spreadThis"
 		IL_0058: ldc.i4.1
 		IL_0059: ldc.i4.0
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject_FunctionDeclaration_47BC308D_spreadThis>(!!0, float64, string, bool, bool)
-		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject_FunctionDeclaration_47BC308D_spreadThis>(!!0)
+		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject>(!!0)
 		IL_0064: stloc.1
 		IL_0065: ldc.i4.1
 		IL_0066: newarr [System.Runtime]System.Object
@@ -920,14 +920,14 @@
 		IL_0071: ldc.i4.0
 		IL_0072: ldelem.ref
 		IL_0073: castclass Modules.Function_Arguments_CalleeIdentity/Scope
-		IL_0078: newobj instance void Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject_FunctionDeclaration_30D9BE91_outer::.ctor(class Modules.Function_Arguments_CalleeIdentity/Scope)
+		IL_0078: newobj instance void Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject::.ctor(class Modules.Function_Arguments_CalleeIdentity/Scope)
 		IL_007d: ldc.i4.0
 		IL_007e: conv.r8
 		IL_007f: ldstr "outer"
 		IL_0084: ldc.i4.1
 		IL_0085: ldc.i4.0
-		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject_FunctionDeclaration_30D9BE91_outer>(!!0, float64, string, bool, bool)
-		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject_FunctionDeclaration_30D9BE91_outer>(!!0)
+		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject>(!!0)
 		IL_0090: stloc.s 4
 		IL_0092: ldloc.0
 		IL_0093: ldloc.s 4
@@ -955,7 +955,7 @@
 		IL_00c0: ldc.r8 1
 		IL_00c9: box [System.Runtime]System.Double
 		IL_00ce: stelem.ref
-		IL_00cf: call object Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject_FunctionDeclaration_D015E2E6_inspect::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_00cf: call object Modules.Function_Arguments_CalleeIdentity/inspect/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
 		IL_00d4: pop
 		IL_00d5: ldc.i4.0
 		IL_00d6: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
@@ -978,7 +978,7 @@
 		IL_0104: ldloc.0
 		IL_0105: stelem.ref
 		IL_0106: ldloc.2
-		IL_0107: call object Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject_FunctionDeclaration_47BC308D_spreadThis::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_0107: call object Modules.Function_Arguments_CalleeIdentity/spreadThis/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
 		IL_010c: pop
 		IL_010d: ldc.i4.1
 		IL_010e: newarr [System.Runtime]System.Object
@@ -995,7 +995,7 @@
 		IL_0127: ldloc.2
 		IL_0128: ldc.i4.0
 		IL_0129: newarr [System.Runtime]System.Object
-		IL_012e: call object Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject_FunctionDeclaration_30D9BE91_outer::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_012e: call object Modules.Function_Arguments_CalleeIdentity/outer/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
 		IL_0133: pop
 		IL_0134: ret
 	} // end of method Function_Arguments_CalleeIdentity::__js_module_init__

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_ComputedKey_TriggersBinding.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_ComputedKey_TriggersBinding.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_357125B9_f
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -51,7 +51,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -62,7 +62,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -73,7 +73,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -107,7 +107,7 @@
 
 				IL_0019: ldloc.0
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -122,7 +122,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_Arguments_ComputedKey_TriggersBinding/f::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -138,7 +138,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_Arguments_ComputedKey_TriggersBinding/f::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -156,9 +156,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_357125B9_f
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -262,7 +262,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_ComputedKey_TriggersBinding/Scope,
-			[1] class Modules.Function_Arguments_ComputedKey_TriggersBinding/f/FunctionObject_FunctionDeclaration_357125B9_f,
+			[1] class Modules.Function_Arguments_ComputedKey_TriggersBinding/f/FunctionObject,
 			[2] object[]
 		)
 
@@ -275,13 +275,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_Arguments_ComputedKey_TriggersBinding/f/FunctionObject_FunctionDeclaration_357125B9_f::.ctor()
+		IL_0011: newobj instance void Modules.Function_Arguments_ComputedKey_TriggersBinding/f/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "f"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_ComputedKey_TriggersBinding/f/FunctionObject_FunctionDeclaration_357125B9_f>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_ComputedKey_TriggersBinding/f/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Length_Delete.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Length_Delete.verified.txt
@@ -40,7 +40,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F98CF296_L3C17
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -54,7 +54,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -65,7 +65,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -90,7 +90,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -130,7 +130,7 @@
 
 				IL_0027: ldloc.0
 				IL_0028: ret
-			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -151,7 +151,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -173,7 +173,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -191,9 +191,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F98CF296_L3C17
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -356,7 +356,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4B850177_L10C18
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -370,7 +370,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -381,7 +381,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -392,7 +392,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -406,7 +406,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -440,7 +440,7 @@
 
 				IL_0019: ldloc.0
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -455,7 +455,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -471,7 +471,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -489,9 +489,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_4B850177_L10C18
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -561,8 +561,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_Length_Delete/Scope,
-			[1] class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_F98CF296_L3C17,
-			[2] class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'/FunctionObject_FunctionExpression_4B850177_L10C18,
+			[1] class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/FunctionObject,
+			[2] class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'/FunctionObject,
 			[3] object,
 			[4] object[],
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -581,14 +581,14 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.s 4
-		IL_0013: newobj instance void Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_F98CF296_L3C17::.ctor()
+		IL_0013: newobj instance void Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/FunctionObject::.ctor()
 		IL_0018: ldc.i4.2
 		IL_0019: conv.r8
 		IL_001a: ldstr ""
 		IL_001f: ldc.i4.1
 		IL_0020: ldc.i4.0
-		IL_0021: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_F98CF296_L3C17>(!!0, float64, string, bool, bool)
-		IL_0026: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_F98CF296_L3C17>(!!0)
+		IL_0021: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0026: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/FunctionObject>(!!0)
 		IL_002b: stloc.1
 		IL_002c: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0031: stloc.s 4
@@ -607,14 +607,14 @@
 		IL_0060: ldloc.0
 		IL_0061: stelem.ref
 		IL_0062: stloc.s 4
-		IL_0064: newobj instance void Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'/FunctionObject_FunctionExpression_4B850177_L10C18::.ctor()
+		IL_0064: newobj instance void Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'/FunctionObject::.ctor()
 		IL_0069: ldc.i4.0
 		IL_006a: conv.r8
 		IL_006b: ldstr ""
 		IL_0070: ldc.i4.1
 		IL_0071: ldc.i4.0
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'/FunctionObject_FunctionExpression_4B850177_L10C18>(!!0, float64, string, bool, bool)
-		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'/FunctionObject_FunctionExpression_4B850177_L10C18>(!!0)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'/FunctionObject>(!!0)
 		IL_007c: stloc.2
 		IL_007d: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0082: stloc.s 4

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_MappedParameterAliasing.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_MappedParameterAliasing.verified.txt
@@ -40,7 +40,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5F0224F6_L3C17
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -54,7 +54,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -65,7 +65,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -90,7 +90,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -130,7 +130,7 @@
 
 				IL_0027: ldloc.0
 				IL_0028: ret
-			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -151,7 +151,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -173,7 +173,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -191,9 +191,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5F0224F6_L3C17
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -414,7 +414,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_MappedParameterAliasing/Scope,
-			[1] class Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_5F0224F6_L3C17,
+			[1] class Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'/FunctionObject,
 			[2] object[]
 		)
 
@@ -428,14 +428,14 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.2
-		IL_0012: newobj instance void Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_5F0224F6_L3C17::.ctor()
+		IL_0012: newobj instance void Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_5F0224F6_L3C17>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_5F0224F6_L3C17>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0030: stloc.2

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_NoFalsePositive_ObjectLiteralKey.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_NoFalsePositive_ObjectLiteralKey.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_491D1403_f
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject_FunctionDeclaration_491D1403_f::_environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
+				IL_0008: stfld class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject::_environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_491D1403_f::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_491D1403_f::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_491D1403_f::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject_FunctionDeclaration_491D1403_f::_environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
+				IL_0001: ldfld class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject::_environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f::__js_call__(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_491D1403_f::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject_FunctionDeclaration_491D1403_f::_environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
+				IL_0001: ldfld class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject::_environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f::__js_call__(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_491D1403_f::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_491D1403_f::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_491D1403_f
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -278,7 +278,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope,
-			[1] class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject_FunctionDeclaration_491D1403_f,
+			[1] class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject,
 			[2] object[]
 		)
 
@@ -295,13 +295,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope
-		IL_0019: newobj instance void Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject_FunctionDeclaration_491D1403_f::.ctor(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope)
+		IL_0019: newobj instance void Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject::.ctor(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "f"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject_FunctionDeclaration_491D1403_f>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Unmapped_StrictAndComplex.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Unmapped_StrictAndComplex.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F7970187_L3C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -51,7 +51,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -62,7 +62,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -73,7 +73,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -110,7 +110,7 @@
 
 				IL_0020: ldloc.0
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -128,7 +128,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -147,7 +147,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -165,9 +165,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F7970187_L3C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -298,7 +298,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9B0AFD71_L9C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -312,7 +312,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -323,7 +323,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -334,7 +334,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -348,7 +348,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -385,7 +385,7 @@
 
 				IL_0020: ldloc.0
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -403,7 +403,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -422,7 +422,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -440,9 +440,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_9B0AFD71_L9C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -602,8 +602,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_Unmapped_StrictAndComplex/Scope,
-			[1] class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'/FunctionObject_FunctionExpression_F7970187_L3C19,
-			[2] class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'/FunctionObject_FunctionExpression_9B0AFD71_L9C20,
+			[1] class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'/FunctionObject,
+			[2] class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'/FunctionObject,
 			[3] object[]
 		)
 
@@ -617,13 +617,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.3
-		IL_0012: newobj instance void Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'/FunctionObject_FunctionExpression_F7970187_L3C19::.ctor()
+		IL_0012: newobj instance void Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'/FunctionObject_FunctionExpression_F7970187_L3C19>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002b: stloc.3
@@ -640,14 +640,14 @@
 		IL_004a: ldloc.0
 		IL_004b: stelem.ref
 		IL_004c: stloc.3
-		IL_004d: newobj instance void Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'/FunctionObject_FunctionExpression_9B0AFD71_L9C20::.ctor()
+		IL_004d: newobj instance void Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'/FunctionObject::.ctor()
 		IL_0052: ldc.i4.0
 		IL_0053: conv.r8
 		IL_0054: ldstr ""
 		IL_0059: ldc.i4.1
 		IL_005a: ldc.i4.0
-		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'/FunctionObject_FunctionExpression_9B0AFD71_L9C20>(!!0, float64, string, bool, bool)
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'/FunctionObject_FunctionExpression_9B0AFD71_L9C20>(!!0)
+		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'/FunctionObject>(!!0)
 		IL_0065: stloc.2
 		IL_0066: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_006b: stloc.3

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Basic_PartialApplication.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Basic_PartialApplication.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AAB1CA43_sum3
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -90,7 +90,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Function_Bind_Basic_PartialApplication/sum3::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -115,7 +115,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.Function_Bind_Basic_PartialApplication/sum3::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_AAB1CA43_sum3
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -213,7 +213,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_Basic_PartialApplication/Scope,
-			[1] class Modules.Function_Bind_Basic_PartialApplication/sum3/FunctionObject_FunctionDeclaration_AAB1CA43_sum3,
+			[1] class Modules.Function_Bind_Basic_PartialApplication/sum3/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -229,13 +229,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_Bind_Basic_PartialApplication/sum3/FunctionObject_FunctionDeclaration_AAB1CA43_sum3::.ctor()
+		IL_0011: newobj instance void Modules.Function_Bind_Basic_PartialApplication/sum3/FunctionObject::.ctor()
 		IL_0016: ldc.i4.3
 		IL_0017: conv.r8
 		IL_0018: ldstr "sum3"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Bind_Basic_PartialApplication/sum3/FunctionObject_FunctionDeclaration_AAB1CA43_sum3>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Bind_Basic_PartialApplication/sum3/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Construct_NewTargetAndPrototype.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Construct_NewTargetAndPrototype.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D0AE1FAE_C
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject_FunctionDeclaration_D0AE1FAE_C::_environment0_Function_Bind_Construct_NewTargetAndPrototype
+				IL_0008: stfld class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject::_environment0_Function_Bind_Construct_NewTargetAndPrototype
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject_FunctionDeclaration_D0AE1FAE_C::_environment0_Function_Bind_Construct_NewTargetAndPrototype
+				IL_0001: ldfld class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject::_environment0_Function_Bind_Construct_NewTargetAndPrototype
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -97,7 +97,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Function_Bind_Construct_NewTargetAndPrototype/C::__js_call__(class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -111,7 +111,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject_FunctionDeclaration_D0AE1FAE_C::_environment0_Function_Bind_Construct_NewTargetAndPrototype
+				IL_0001: ldfld class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject::_environment0_Function_Bind_Construct_NewTargetAndPrototype
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -121,7 +121,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Function_Bind_Construct_NewTargetAndPrototype/C::__js_call__(class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -139,9 +139,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D0AE1FAE_C
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -269,7 +269,7 @@
 			[1] object,
 			[2] object,
 			[3] object[],
-			[4] class Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject_FunctionDeclaration_D0AE1FAE_C,
+			[4] class Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[6] object,
 			[7] object,
@@ -292,13 +292,13 @@
 		IL_0017: ldc.i4.0
 		IL_0018: ldelem.ref
 		IL_0019: castclass Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope
-		IL_001e: newobj instance void Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject_FunctionDeclaration_D0AE1FAE_C::.ctor(class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope)
+		IL_001e: newobj instance void Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject::.ctor(class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope)
 		IL_0023: ldc.i4.2
 		IL_0024: conv.r8
 		IL_0025: ldstr "C"
 		IL_002a: ldc.i4.1
 		IL_002b: ldc.i4.1
-		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject_FunctionDeclaration_D0AE1FAE_C>(!!0, float64, string, bool, bool)
+		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0031: stloc.s 4
 		IL_0033: ldloc.0
 		IL_0034: ldloc.s 4

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Metadata_LengthNameAndPrototype.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Metadata_LengthNameAndPrototype.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_52CA7D48_target
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -90,7 +90,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Function_Bind_Metadata_LengthNameAndPrototype/target::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -115,7 +115,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.Function_Bind_Metadata_LengthNameAndPrototype/target::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_52CA7D48_target
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -213,7 +213,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_Metadata_LengthNameAndPrototype/Scope,
-			[1] class Modules.Function_Bind_Metadata_LengthNameAndPrototype/target/FunctionObject_FunctionDeclaration_52CA7D48_target,
+			[1] class Modules.Function_Bind_Metadata_LengthNameAndPrototype/target/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -235,13 +235,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void Modules.Function_Bind_Metadata_LengthNameAndPrototype/target/FunctionObject_FunctionDeclaration_52CA7D48_target::.ctor()
+		IL_0012: newobj instance void Modules.Function_Bind_Metadata_LengthNameAndPrototype/target/FunctionObject::.ctor()
 		IL_0017: ldc.i4.3
 		IL_0018: conv.r8
 		IL_0019: ldstr "target"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Bind_Metadata_LengthNameAndPrototype/target/FunctionObject_FunctionDeclaration_52CA7D48_target>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Bind_Metadata_LengthNameAndPrototype/target/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_ThisBinding_IgnoresCallReceiver.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_ThisBinding_IgnoresCallReceiver.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BA5A1879_addBase
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BA5A1879_addBase
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -201,7 +201,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/Scope,
-			[1] class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase/FunctionObject_FunctionDeclaration_BA5A1879_addBase,
+			[1] class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -219,13 +219,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
-		IL_0012: newobj instance void Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase/FunctionObject_FunctionDeclaration_BA5A1879_addBase::.ctor()
+		IL_0012: newobj instance void Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "addBase"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase/FunctionObject_FunctionDeclaration_BA5A1879_addBase>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_BoundFunctionObject_UnifiedTargets.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_BoundFunctionObject_UnifiedTargets.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9F83F158_add
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9F83F158_add::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9F83F158_add::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9F83F158_add::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -90,7 +90,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Function_BoundFunctionObject_UnifiedTargets/'add'::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_9F83F158_add::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -115,7 +115,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.Function_BoundFunctionObject_UnifiedTargets/'add'::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionDeclaration_9F83F158_add::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9F83F158_add::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9F83F158_add
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -204,7 +204,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0C6E34EF_L23C11
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -218,7 +218,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_0C6E34EF_L23C11::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -229,7 +229,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0C6E34EF_L23C11::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -240,7 +240,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0C6E34EF_L23C11::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -258,9 +258,9 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_0C6E34EF_L23C11::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_0C6E34EF_L23C11
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -435,7 +435,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E85FC2F7_L59C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -449,7 +449,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E85FC2F7_L59C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -460,7 +460,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E85FC2F7_L59C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -471,7 +471,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E85FC2F7_L59C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -486,7 +486,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_E85FC2F7_L59C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -502,7 +502,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E85FC2F7_L59C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -520,9 +520,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E85FC2F7_L59C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E85FC2F7_L59C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -759,7 +759,7 @@
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Function_BoundFunctionObject_UnifiedTargets/Scope,
-			[1] class Modules.Function_BoundFunctionObject_UnifiedTargets/'add'/FunctionObject_FunctionDeclaration_9F83F158_add,
+			[1] class Modules.Function_BoundFunctionObject_UnifiedTargets/'add'/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -788,11 +788,11 @@
 			[27] object,
 			[28] bool,
 			[29] object,
-			[30] class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject_FunctionExpression_0C6E34EF_L23C11,
+			[30] class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject,
 			[31] class Modules.Function_BoundFunctionObject_UnifiedTargets/ArrowFunction_L30C15/FunctionObject,
 			[32] class [System.Runtime]System.Type,
 			[33] class Modules.Function_BoundFunctionObject_UnifiedTargets/Box/FunctionObject_ClassConstructor_5F154764_Box,
-			[34] class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject_FunctionExpression_E85FC2F7_L59C14
+			[34] class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/Scope::.ctor()
@@ -804,13 +804,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 16
-		IL_0012: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/'add'/FunctionObject_FunctionDeclaration_9F83F158_add::.ctor()
+		IL_0012: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/'add'/FunctionObject::.ctor()
 		IL_0017: ldc.i4.3
 		IL_0018: conv.r8
 		IL_0019: ldstr "add"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/'add'/FunctionObject_FunctionDeclaration_9F83F158_add>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/'add'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
@@ -1048,14 +1048,14 @@
 		IL_0317: ldloc.0
 		IL_0318: stelem.ref
 		IL_0319: stloc.s 16
-		IL_031b: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject_FunctionExpression_0C6E34EF_L23C11::.ctor()
+		IL_031b: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject::.ctor()
 		IL_0320: ldc.i4.1
 		IL_0321: conv.r8
 		IL_0322: ldstr ""
 		IL_0327: ldc.i4.1
 		IL_0328: ldc.i4.1
-		IL_0329: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject_FunctionExpression_0C6E34EF_L23C11>(!!0, float64, string, bool, bool)
-		IL_032e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject_FunctionExpression_0C6E34EF_L23C11>(!!0)
+		IL_0329: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_032e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_object/FunctionObject>(!!0)
 		IL_0333: stloc.s 30
 		IL_0335: ldloc.s 17
 		IL_0337: ldstr "method"
@@ -1339,13 +1339,13 @@
 		IL_0656: ldloc.0
 		IL_0657: stelem.ref
 		IL_0658: stloc.s 16
-		IL_065a: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject_FunctionExpression_E85FC2F7_L59C14::.ctor()
+		IL_065a: newobj instance void Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject::.ctor()
 		IL_065f: ldc.i4.0
 		IL_0660: conv.r8
 		IL_0661: ldstr ""
 		IL_0666: ldc.i4.0
 		IL_0667: ldc.i4.1
-		IL_0668: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject_FunctionExpression_E85FC2F7_L59C14>(!!0, float64, string, bool, bool)
+		IL_0668: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_BoundFunctionObject_UnifiedTargets/FunctionExpression_L59C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_066d: stloc.s 34
 		IL_066f: ldloc.2
 		IL_0670: ldstr "call"

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity0.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity0.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_166E6F4C_getMessage
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_CallViaVariable_Arity0/getMessage::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_CallViaVariable_Arity0/getMessage::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_166E6F4C_getMessage
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -182,8 +182,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallViaVariable_Arity0/Scope,
-			[1] class Modules.Function_CallViaVariable_Arity0/getMessage/FunctionObject_FunctionDeclaration_166E6F4C_getMessage,
-			[2] class Modules.Function_CallViaVariable_Arity0/getMessage/FunctionObject_FunctionDeclaration_166E6F4C_getMessage,
+			[1] class Modules.Function_CallViaVariable_Arity0/getMessage/FunctionObject,
+			[2] class Modules.Function_CallViaVariable_Arity0/getMessage/FunctionObject,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] object
@@ -198,13 +198,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity0/getMessage/FunctionObject_FunctionDeclaration_166E6F4C_getMessage::.ctor()
+		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity0/getMessage/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "getMessage"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity0/getMessage/FunctionObject_FunctionDeclaration_166E6F4C_getMessage>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity0/getMessage/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity1.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity1.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CC42596D_addPrefix
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_CallViaVariable_Arity1/addPrefix::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_CallViaVariable_Arity1/addPrefix::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CC42596D_addPrefix
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -195,8 +195,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallViaVariable_Arity1/Scope,
-			[1] class Modules.Function_CallViaVariable_Arity1/addPrefix/FunctionObject_FunctionDeclaration_CC42596D_addPrefix,
-			[2] class Modules.Function_CallViaVariable_Arity1/addPrefix/FunctionObject_FunctionDeclaration_CC42596D_addPrefix,
+			[1] class Modules.Function_CallViaVariable_Arity1/addPrefix/FunctionObject,
+			[2] class Modules.Function_CallViaVariable_Arity1/addPrefix/FunctionObject,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] object
@@ -211,13 +211,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity1/addPrefix/FunctionObject_FunctionDeclaration_CC42596D_addPrefix::.ctor()
+		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity1/addPrefix/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "addPrefix"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity1/addPrefix/FunctionObject_FunctionDeclaration_CC42596D_addPrefix>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity1/addPrefix/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity2.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity2.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5E16C7E8_add
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_CallViaVariable_Arity2/'add'::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_CallViaVariable_Arity2/'add'::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5E16C7E8_add
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -202,8 +202,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallViaVariable_Arity2/Scope,
-			[1] class Modules.Function_CallViaVariable_Arity2/'add'/FunctionObject_FunctionDeclaration_5E16C7E8_add,
-			[2] class Modules.Function_CallViaVariable_Arity2/'add'/FunctionObject_FunctionDeclaration_5E16C7E8_add,
+			[1] class Modules.Function_CallViaVariable_Arity2/'add'/FunctionObject,
+			[2] class Modules.Function_CallViaVariable_Arity2/'add'/FunctionObject,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] object
@@ -218,13 +218,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity2/'add'/FunctionObject_FunctionDeclaration_5E16C7E8_add::.ctor()
+		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity2/'add'/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity2/'add'/FunctionObject_FunctionDeclaration_5E16C7E8_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity2/'add'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity3.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity3.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3BEFE3B8_add3
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -90,7 +90,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Function_CallViaVariable_Arity3/add3::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -115,7 +115,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.Function_CallViaVariable_Arity3/add3::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3BEFE3B8_add3
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -213,8 +213,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallViaVariable_Arity3/Scope,
-			[1] class Modules.Function_CallViaVariable_Arity3/add3/FunctionObject_FunctionDeclaration_3BEFE3B8_add3,
-			[2] class Modules.Function_CallViaVariable_Arity3/add3/FunctionObject_FunctionDeclaration_3BEFE3B8_add3,
+			[1] class Modules.Function_CallViaVariable_Arity3/add3/FunctionObject,
+			[2] class Modules.Function_CallViaVariable_Arity3/add3/FunctionObject,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] object
@@ -229,13 +229,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity3/add3/FunctionObject_FunctionDeclaration_3BEFE3B8_add3::.ctor()
+		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity3/add3/FunctionObject::.ctor()
 		IL_0016: ldc.i4.3
 		IL_0017: conv.r8
 		IL_0018: ldstr "add3"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity3/add3/FunctionObject_FunctionDeclaration_3BEFE3B8_add3>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity3/add3/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity4.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity4.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_242B42C2_add4
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -93,7 +93,7 @@
 				IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0021: call object Modules.Function_CallViaVariable_Arity4/add4::__js_call__(object, object, object, object, object)
 				IL_0026: ret
-			} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -121,7 +121,7 @@
 				IL_0018: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001d: call object Modules.Function_CallViaVariable_Arity4/add4::__js_call__(object, object, object, object, object)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -139,9 +139,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_242B42C2_add4
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -224,8 +224,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallViaVariable_Arity4/Scope,
-			[1] class Modules.Function_CallViaVariable_Arity4/add4/FunctionObject_FunctionDeclaration_242B42C2_add4,
-			[2] class Modules.Function_CallViaVariable_Arity4/add4/FunctionObject_FunctionDeclaration_242B42C2_add4,
+			[1] class Modules.Function_CallViaVariable_Arity4/add4/FunctionObject,
+			[2] class Modules.Function_CallViaVariable_Arity4/add4/FunctionObject,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] object
@@ -240,13 +240,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity4/add4/FunctionObject_FunctionDeclaration_242B42C2_add4::.ctor()
+		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity4/add4/FunctionObject::.ctor()
 		IL_0016: ldc.i4.4
 		IL_0017: conv.r8
 		IL_0018: ldstr "add4"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity4/add4/FunctionObject_FunctionDeclaration_242B42C2_add4>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity4/add4/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4E156218_f
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_4E156218_f::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4E156218_f::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4E156218_f::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_Call_Basic/f::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_4E156218_f::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_Call_Basic/f::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_4E156218_f::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4E156218_f::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4E156218_f
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -219,7 +219,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Basic/Scope,
-			[1] class Modules.Function_Call_Basic/f/FunctionObject_FunctionDeclaration_4E156218_f,
+			[1] class Modules.Function_Call_Basic/f/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -235,13 +235,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_Call_Basic/f/FunctionObject_FunctionDeclaration_4E156218_f::.ctor()
+		IL_0011: newobj instance void Modules.Function_Call_Basic/f/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "f"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Basic/f/FunctionObject_FunctionDeclaration_4E156218_f>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Basic/f/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Basic.verified.txt
@@ -77,7 +77,7 @@
 
 		} // end of class Scope_For_L5C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_220DAEBA_dump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -97,9 +97,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Call_Spread_Basic/Scope Modules.Function_Call_Spread_Basic/dump/FunctionObject_FunctionDeclaration_220DAEBA_dump::_environment0_Function_Call_Spread_Basic
+				IL_0008: stfld class Modules.Function_Call_Spread_Basic/Scope Modules.Function_Call_Spread_Basic/dump/FunctionObject::_environment0_Function_Call_Spread_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -110,7 +110,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -121,7 +121,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -159,7 +159,7 @@
 
 				IL_0021: ldloc.0
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -172,11 +172,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Call_Spread_Basic/Scope Modules.Function_Call_Spread_Basic/dump/FunctionObject_FunctionDeclaration_220DAEBA_dump::_environment0_Function_Call_Spread_Basic
+				IL_0001: ldfld class Modules.Function_Call_Spread_Basic/Scope Modules.Function_Call_Spread_Basic/dump/FunctionObject::_environment0_Function_Call_Spread_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_Call_Spread_Basic/dump::__js_call__(class Modules.Function_Call_Spread_Basic/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -190,11 +190,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Call_Spread_Basic/Scope Modules.Function_Call_Spread_Basic/dump/FunctionObject_FunctionDeclaration_220DAEBA_dump::_environment0_Function_Call_Spread_Basic
+				IL_0001: ldfld class Modules.Function_Call_Spread_Basic/Scope Modules.Function_Call_Spread_Basic/dump/FunctionObject::_environment0_Function_Call_Spread_Basic
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_Call_Spread_Basic/dump::__js_call__(class Modules.Function_Call_Spread_Basic/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -212,9 +212,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_220DAEBA_dump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -342,7 +342,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Basic/Scope,
-			[1] class Modules.Function_Call_Spread_Basic/dump/FunctionObject_FunctionDeclaration_220DAEBA_dump,
+			[1] class Modules.Function_Call_Spread_Basic/dump/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -362,13 +362,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Call_Spread_Basic/Scope
-		IL_0019: newobj instance void Modules.Function_Call_Spread_Basic/dump/FunctionObject_FunctionDeclaration_220DAEBA_dump::.ctor(class Modules.Function_Call_Spread_Basic/Scope)
+		IL_0019: newobj instance void Modules.Function_Call_Spread_Basic/dump/FunctionObject::.ctor(class Modules.Function_Call_Spread_Basic/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "dump"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_Basic/dump/FunctionObject_FunctionDeclaration_220DAEBA_dump>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_Basic/dump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_EvaluationOrder.verified.txt
@@ -77,7 +77,7 @@
 
 		} // end of class Scope_For_L5C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DC7F3656_dump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -97,9 +97,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Call_Spread_EvaluationOrder/Scope Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject_FunctionDeclaration_DC7F3656_dump::_environment0_Function_Call_Spread_EvaluationOrder
+				IL_0008: stfld class Modules.Function_Call_Spread_EvaluationOrder/Scope Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject::_environment0_Function_Call_Spread_EvaluationOrder
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -110,7 +110,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -121,7 +121,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -159,7 +159,7 @@
 
 				IL_0021: ldloc.0
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -172,11 +172,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Call_Spread_EvaluationOrder/Scope Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject_FunctionDeclaration_DC7F3656_dump::_environment0_Function_Call_Spread_EvaluationOrder
+				IL_0001: ldfld class Modules.Function_Call_Spread_EvaluationOrder/Scope Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject::_environment0_Function_Call_Spread_EvaluationOrder
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_Call_Spread_EvaluationOrder/dump::__js_call__(class Modules.Function_Call_Spread_EvaluationOrder/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -190,11 +190,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Call_Spread_EvaluationOrder/Scope Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject_FunctionDeclaration_DC7F3656_dump::_environment0_Function_Call_Spread_EvaluationOrder
+				IL_0001: ldfld class Modules.Function_Call_Spread_EvaluationOrder/Scope Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject::_environment0_Function_Call_Spread_EvaluationOrder
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_Call_Spread_EvaluationOrder/dump::__js_call__(class Modules.Function_Call_Spread_EvaluationOrder/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -212,9 +212,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DC7F3656_dump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -323,7 +323,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E6190FBC_arg
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -337,7 +337,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -348,7 +348,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -359,7 +359,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -378,7 +378,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.Function_Call_Spread_EvaluationOrder/arg::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -398,7 +398,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.Function_Call_Spread_EvaluationOrder/arg::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -416,9 +416,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E6190FBC_arg
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -479,7 +479,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5C3E7DAF_spread
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -493,7 +493,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -504,7 +504,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -515,7 +515,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -530,7 +530,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_Call_Spread_EvaluationOrder/spread::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -546,7 +546,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_Call_Spread_EvaluationOrder/spread::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -564,9 +564,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5C3E7DAF_spread
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -650,9 +650,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_EvaluationOrder/Scope,
-			[1] class Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject_FunctionDeclaration_DC7F3656_dump,
-			[2] class Modules.Function_Call_Spread_EvaluationOrder/arg/FunctionObject_FunctionDeclaration_E6190FBC_arg,
-			[3] class Modules.Function_Call_Spread_EvaluationOrder/spread/FunctionObject_FunctionDeclaration_5C3E7DAF_spread,
+			[1] class Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject,
+			[2] class Modules.Function_Call_Spread_EvaluationOrder/arg/FunctionObject,
+			[3] class Modules.Function_Call_Spread_EvaluationOrder/spread/FunctionObject,
 			[4] object[],
 			[5] object[],
 			[6] object,
@@ -672,13 +672,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Function_Call_Spread_EvaluationOrder/Scope
-		IL_001b: newobj instance void Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject_FunctionDeclaration_DC7F3656_dump::.ctor(class Modules.Function_Call_Spread_EvaluationOrder/Scope)
+		IL_001b: newobj instance void Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject::.ctor(class Modules.Function_Call_Spread_EvaluationOrder/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "dump"
 		IL_0027: ldc.i4.1
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject_FunctionDeclaration_DC7F3656_dump>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: ldc.i4.1
 		IL_0030: newarr [System.Runtime]System.Object
@@ -687,13 +687,13 @@
 		IL_0037: ldloc.0
 		IL_0038: stelem.ref
 		IL_0039: stloc.s 4
-		IL_003b: newobj instance void Modules.Function_Call_Spread_EvaluationOrder/arg/FunctionObject_FunctionDeclaration_E6190FBC_arg::.ctor()
+		IL_003b: newobj instance void Modules.Function_Call_Spread_EvaluationOrder/arg/FunctionObject::.ctor()
 		IL_0040: ldc.i4.1
 		IL_0041: conv.r8
 		IL_0042: ldstr "arg"
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_EvaluationOrder/arg/FunctionObject_FunctionDeclaration_E6190FBC_arg>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_EvaluationOrder/arg/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: ldc.i4.1
 		IL_0050: newarr [System.Runtime]System.Object
@@ -702,13 +702,13 @@
 		IL_0057: ldloc.0
 		IL_0058: stelem.ref
 		IL_0059: stloc.s 4
-		IL_005b: newobj instance void Modules.Function_Call_Spread_EvaluationOrder/spread/FunctionObject_FunctionDeclaration_5C3E7DAF_spread::.ctor()
+		IL_005b: newobj instance void Modules.Function_Call_Spread_EvaluationOrder/spread/FunctionObject::.ctor()
 		IL_0060: ldc.i4.0
 		IL_0061: conv.r8
 		IL_0062: ldstr "spread"
 		IL_0067: ldc.i4.0
 		IL_0068: ldc.i4.1
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_EvaluationOrder/spread/FunctionObject_FunctionDeclaration_5C3E7DAF_spread>(!!0, float64, string, bool, bool)
+		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_EvaluationOrder/spread/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006e: stloc.3
 		IL_006f: nop
 		IL_0070: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Middle.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Middle.verified.txt
@@ -77,7 +77,7 @@
 
 		} // end of class Scope_For_L5C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_93D49E1D_dump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -97,9 +97,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Call_Spread_Middle/Scope Modules.Function_Call_Spread_Middle/dump/FunctionObject_FunctionDeclaration_93D49E1D_dump::_environment0_Function_Call_Spread_Middle
+				IL_0008: stfld class Modules.Function_Call_Spread_Middle/Scope Modules.Function_Call_Spread_Middle/dump/FunctionObject::_environment0_Function_Call_Spread_Middle
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -110,7 +110,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -121,7 +121,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -159,7 +159,7 @@
 
 				IL_0021: ldloc.0
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -172,11 +172,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Call_Spread_Middle/Scope Modules.Function_Call_Spread_Middle/dump/FunctionObject_FunctionDeclaration_93D49E1D_dump::_environment0_Function_Call_Spread_Middle
+				IL_0001: ldfld class Modules.Function_Call_Spread_Middle/Scope Modules.Function_Call_Spread_Middle/dump/FunctionObject::_environment0_Function_Call_Spread_Middle
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_Call_Spread_Middle/dump::__js_call__(class Modules.Function_Call_Spread_Middle/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -190,11 +190,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Call_Spread_Middle/Scope Modules.Function_Call_Spread_Middle/dump/FunctionObject_FunctionDeclaration_93D49E1D_dump::_environment0_Function_Call_Spread_Middle
+				IL_0001: ldfld class Modules.Function_Call_Spread_Middle/Scope Modules.Function_Call_Spread_Middle/dump/FunctionObject::_environment0_Function_Call_Spread_Middle
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_Call_Spread_Middle/dump::__js_call__(class Modules.Function_Call_Spread_Middle/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -212,9 +212,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_93D49E1D_dump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -342,7 +342,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Middle/Scope,
-			[1] class Modules.Function_Call_Spread_Middle/dump/FunctionObject_FunctionDeclaration_93D49E1D_dump,
+			[1] class Modules.Function_Call_Spread_Middle/dump/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -362,13 +362,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Call_Spread_Middle/Scope
-		IL_0019: newobj instance void Modules.Function_Call_Spread_Middle/dump/FunctionObject_FunctionDeclaration_93D49E1D_dump::.ctor(class Modules.Function_Call_Spread_Middle/Scope)
+		IL_0019: newobj instance void Modules.Function_Call_Spread_Middle/dump/FunctionObject::.ctor(class Modules.Function_Call_Spread_Middle/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "dump"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_Middle/dump/FunctionObject_FunctionDeclaration_93D49E1D_dump>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_Middle/dump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Multiple.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Multiple.verified.txt
@@ -77,7 +77,7 @@
 
 		} // end of class Scope_For_L5C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_27CD1BFE_dump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -97,9 +97,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Call_Spread_Multiple/Scope Modules.Function_Call_Spread_Multiple/dump/FunctionObject_FunctionDeclaration_27CD1BFE_dump::_environment0_Function_Call_Spread_Multiple
+				IL_0008: stfld class Modules.Function_Call_Spread_Multiple/Scope Modules.Function_Call_Spread_Multiple/dump/FunctionObject::_environment0_Function_Call_Spread_Multiple
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -110,7 +110,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -121,7 +121,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -159,7 +159,7 @@
 
 				IL_0021: ldloc.0
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -172,11 +172,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Call_Spread_Multiple/Scope Modules.Function_Call_Spread_Multiple/dump/FunctionObject_FunctionDeclaration_27CD1BFE_dump::_environment0_Function_Call_Spread_Multiple
+				IL_0001: ldfld class Modules.Function_Call_Spread_Multiple/Scope Modules.Function_Call_Spread_Multiple/dump/FunctionObject::_environment0_Function_Call_Spread_Multiple
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_Call_Spread_Multiple/dump::__js_call__(class Modules.Function_Call_Spread_Multiple/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -190,11 +190,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Call_Spread_Multiple/Scope Modules.Function_Call_Spread_Multiple/dump/FunctionObject_FunctionDeclaration_27CD1BFE_dump::_environment0_Function_Call_Spread_Multiple
+				IL_0001: ldfld class Modules.Function_Call_Spread_Multiple/Scope Modules.Function_Call_Spread_Multiple/dump/FunctionObject::_environment0_Function_Call_Spread_Multiple
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_Call_Spread_Multiple/dump::__js_call__(class Modules.Function_Call_Spread_Multiple/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -212,9 +212,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_27CD1BFE_dump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -342,7 +342,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Multiple/Scope,
-			[1] class Modules.Function_Call_Spread_Multiple/dump/FunctionObject_FunctionDeclaration_27CD1BFE_dump,
+			[1] class Modules.Function_Call_Spread_Multiple/dump/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -362,13 +362,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Call_Spread_Multiple/Scope
-		IL_0019: newobj instance void Modules.Function_Call_Spread_Multiple/dump/FunctionObject_FunctionDeclaration_27CD1BFE_dump::.ctor(class Modules.Function_Call_Spread_Multiple/Scope)
+		IL_0019: newobj instance void Modules.Function_Call_Spread_Multiple/dump/FunctionObject::.ctor(class Modules.Function_Call_Spread_Multiple/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "dump"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_Multiple/dump/FunctionObject_FunctionDeclaration_27CD1BFE_dump>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_Multiple/dump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_StringIterable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_StringIterable.verified.txt
@@ -77,7 +77,7 @@
 
 		} // end of class Scope_For_L5C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ED7BED17_dump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -97,9 +97,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Call_Spread_StringIterable/Scope Modules.Function_Call_Spread_StringIterable/dump/FunctionObject_FunctionDeclaration_ED7BED17_dump::_environment0_Function_Call_Spread_StringIterable
+				IL_0008: stfld class Modules.Function_Call_Spread_StringIterable/Scope Modules.Function_Call_Spread_StringIterable/dump/FunctionObject::_environment0_Function_Call_Spread_StringIterable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -110,7 +110,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -121,7 +121,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -159,7 +159,7 @@
 
 				IL_0021: ldloc.0
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -172,11 +172,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Call_Spread_StringIterable/Scope Modules.Function_Call_Spread_StringIterable/dump/FunctionObject_FunctionDeclaration_ED7BED17_dump::_environment0_Function_Call_Spread_StringIterable
+				IL_0001: ldfld class Modules.Function_Call_Spread_StringIterable/Scope Modules.Function_Call_Spread_StringIterable/dump/FunctionObject::_environment0_Function_Call_Spread_StringIterable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_Call_Spread_StringIterable/dump::__js_call__(class Modules.Function_Call_Spread_StringIterable/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -190,11 +190,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Call_Spread_StringIterable/Scope Modules.Function_Call_Spread_StringIterable/dump/FunctionObject_FunctionDeclaration_ED7BED17_dump::_environment0_Function_Call_Spread_StringIterable
+				IL_0001: ldfld class Modules.Function_Call_Spread_StringIterable/Scope Modules.Function_Call_Spread_StringIterable/dump/FunctionObject::_environment0_Function_Call_Spread_StringIterable
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_Call_Spread_StringIterable/dump::__js_call__(class Modules.Function_Call_Spread_StringIterable/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -212,9 +212,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_ED7BED17_dump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -342,7 +342,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_StringIterable/Scope,
-			[1] class Modules.Function_Call_Spread_StringIterable/dump/FunctionObject_FunctionDeclaration_ED7BED17_dump,
+			[1] class Modules.Function_Call_Spread_StringIterable/dump/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] object[]
@@ -361,13 +361,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Call_Spread_StringIterable/Scope
-		IL_0019: newobj instance void Modules.Function_Call_Spread_StringIterable/dump/FunctionObject_FunctionDeclaration_ED7BED17_dump::.ctor(class Modules.Function_Call_Spread_StringIterable/Scope)
+		IL_0019: newobj instance void Modules.Function_Call_Spread_StringIterable/dump/FunctionObject::.ctor(class Modules.Function_Call_Spread_StringIterable/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "dump"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_StringIterable/dump/FunctionObject_FunctionDeclaration_ED7BED17_dump>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_StringIterable/dump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableArchitecture_InferredSignatureBaseline.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableArchitecture_InferredSignatureBaseline.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C1F8729A_returnNumber
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -82,7 +82,7 @@
 				IL_0005: call float64 Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -99,7 +99,7 @@
 				IL_0001: call float64 Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -117,9 +117,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C1F8729A_returnNumber
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -164,7 +164,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_81A3E649_returnBoolean
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -178,7 +178,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -189,7 +189,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -200,7 +200,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -215,7 +215,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -231,7 +231,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -249,9 +249,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_81A3E649_returnBoolean
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -297,7 +297,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_35A8CC1F_negate
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -311,7 +311,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -322,7 +322,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -333,7 +333,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -352,7 +352,7 @@
 				IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_0011: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate::__js_call__(object, bool)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -372,7 +372,7 @@
 				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_000d: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate::__js_call__(object, bool)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -390,9 +390,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_35A8CC1F_negate
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -446,7 +446,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_743E93DE_returnString
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -460,7 +460,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -471,7 +471,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -482,7 +482,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -497,7 +497,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -513,7 +513,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -531,9 +531,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_743E93DE_returnString
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -578,7 +578,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_192564F0_stringLength
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -592,7 +592,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -603,7 +603,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -614,7 +614,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -633,7 +633,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -653,7 +653,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -671,9 +671,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_192564F0_stringLength
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -722,7 +722,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_960EA86F_identity
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -736,7 +736,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -747,7 +747,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -758,7 +758,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -776,7 +776,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -795,7 +795,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -813,9 +813,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_960EA86F_identity
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -894,12 +894,12 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/Scope,
-			[1] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber/FunctionObject_FunctionDeclaration_C1F8729A_returnNumber,
-			[2] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean/FunctionObject_FunctionDeclaration_81A3E649_returnBoolean,
-			[3] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate/FunctionObject_FunctionDeclaration_35A8CC1F_negate,
-			[4] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString/FunctionObject_FunctionDeclaration_743E93DE_returnString,
-			[5] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength/FunctionObject_FunctionDeclaration_192564F0_stringLength,
-			[6] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity/FunctionObject_FunctionDeclaration_960EA86F_identity,
+			[1] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber/FunctionObject,
+			[2] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean/FunctionObject,
+			[3] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate/FunctionObject,
+			[4] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString/FunctionObject,
+			[5] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength/FunctionObject,
+			[6] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity/FunctionObject,
 			[7] object[],
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[9] object
@@ -914,13 +914,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
-		IL_0012: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber/FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::.ctor()
+		IL_0012: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "returnNumber"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber/FunctionObject_FunctionDeclaration_C1F8729A_returnNumber>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -929,13 +929,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 7
-		IL_0032: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean/FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::.ctor()
+		IL_0032: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean/FunctionObject::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "returnBoolean"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean/FunctionObject_FunctionDeclaration_81A3E649_returnBoolean>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -944,13 +944,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 7
-		IL_0052: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate/FunctionObject_FunctionDeclaration_35A8CC1F_negate::.ctor()
+		IL_0052: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate/FunctionObject::.ctor()
 		IL_0057: ldc.i4.1
 		IL_0058: conv.r8
 		IL_0059: ldstr "negate"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate/FunctionObject_FunctionDeclaration_35A8CC1F_negate>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -959,13 +959,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 7
-		IL_0072: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString/FunctionObject_FunctionDeclaration_743E93DE_returnString::.ctor()
+		IL_0072: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString/FunctionObject::.ctor()
 		IL_0077: ldc.i4.0
 		IL_0078: conv.r8
 		IL_0079: ldstr "returnString"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString/FunctionObject_FunctionDeclaration_743E93DE_returnString>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -974,13 +974,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 7
-		IL_0093: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength/FunctionObject_FunctionDeclaration_192564F0_stringLength::.ctor()
+		IL_0093: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength/FunctionObject::.ctor()
 		IL_0098: ldc.i4.1
 		IL_0099: conv.r8
 		IL_009a: ldstr "stringLength"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength/FunctionObject_FunctionDeclaration_192564F0_stringLength>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -989,13 +989,13 @@
 		IL_00b0: ldloc.0
 		IL_00b1: stelem.ref
 		IL_00b2: stloc.s 7
-		IL_00b4: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity/FunctionObject_FunctionDeclaration_960EA86F_identity::.ctor()
+		IL_00b4: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity/FunctionObject::.ctor()
 		IL_00b9: ldc.i4.1
 		IL_00ba: conv.r8
 		IL_00bb: ldstr "identity"
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity/FunctionObject_FunctionDeclaration_960EA86F_identity>(!!0, float64, string, bool, bool)
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c7: stloc.s 6
 		IL_00c9: nop
 		IL_00ca: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableMaterialization_IdentityAndCaptures.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableMaterialization_IdentityAndCaptures.verified.txt
@@ -441,7 +441,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -461,9 +461,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_CallableMaterialization_IdentityAndCaptures/Scope Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned::_environment0_Function_CallableMaterialization_IdentityAndCaptures
+				IL_0008: stfld class Modules.Function_CallableMaterialization_IdentityAndCaptures/Scope Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject::_environment0_Function_CallableMaterialization_IdentityAndCaptures
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -474,7 +474,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -485,7 +485,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -499,7 +499,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -512,11 +512,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_CallableMaterialization_IdentityAndCaptures/Scope Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned::_environment0_Function_CallableMaterialization_IdentityAndCaptures
+				IL_0001: ldfld class Modules.Function_CallableMaterialization_IdentityAndCaptures/Scope Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject::_environment0_Function_CallableMaterialization_IdentityAndCaptures
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned::__js_call__(class Modules.Function_CallableMaterialization_IdentityAndCaptures/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -530,11 +530,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_CallableMaterialization_IdentityAndCaptures/Scope Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned::_environment0_Function_CallableMaterialization_IdentityAndCaptures
+				IL_0001: ldfld class Modules.Function_CallableMaterialization_IdentityAndCaptures/Scope Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject::_environment0_Function_CallableMaterialization_IdentityAndCaptures
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned::__js_call__(class Modules.Function_CallableMaterialization_IdentityAndCaptures/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -552,9 +552,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -639,7 +639,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -653,7 +653,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -664,7 +664,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -675,7 +675,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -689,7 +689,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -707,7 +707,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_CallableMaterialization_IdentityAndCaptures/invokeUnknown::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -726,7 +726,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_CallableMaterialization_IdentityAndCaptures/invokeUnknown::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -744,9 +744,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1679,8 +1679,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallableMaterialization_IdentityAndCaptures/Scope,
-			[1] class Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned,
-			[2] class Modules.Function_CallableMaterialization_IdentityAndCaptures/invokeUnknown/FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown,
+			[1] class Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject,
+			[2] class Modules.Function_CallableMaterialization_IdentityAndCaptures/invokeUnknown/FunctionObject,
 			[3] object,
 			[4] object,
 			[5] class Modules.Function_CallableMaterialization_IdentityAndCaptures/ObjectLiterals/L13C16_holder,
@@ -1725,14 +1725,14 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Function_CallableMaterialization_IdentityAndCaptures/Scope
-		IL_001b: newobj instance void Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned::.ctor(class Modules.Function_CallableMaterialization_IdentityAndCaptures/Scope)
+		IL_001b: newobj instance void Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject::.ctor(class Modules.Function_CallableMaterialization_IdentityAndCaptures/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "makeReturned"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.0
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned>(!!0, float64, string, bool, bool)
-		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject_FunctionDeclaration_F6D4B3FC_makeReturned>(!!0)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_CallableMaterialization_IdentityAndCaptures/makeReturned/FunctionObject>(!!0)
 		IL_0033: stloc.1
 		IL_0034: ldc.i4.1
 		IL_0035: newarr [System.Runtime]System.Object
@@ -1741,14 +1741,14 @@
 		IL_003c: ldloc.0
 		IL_003d: stelem.ref
 		IL_003e: stloc.s 12
-		IL_0040: newobj instance void Modules.Function_CallableMaterialization_IdentityAndCaptures/invokeUnknown/FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown::.ctor()
+		IL_0040: newobj instance void Modules.Function_CallableMaterialization_IdentityAndCaptures/invokeUnknown/FunctionObject::.ctor()
 		IL_0045: ldc.i4.1
 		IL_0046: conv.r8
 		IL_0047: ldstr "invokeUnknown"
 		IL_004c: ldc.i4.0
 		IL_004d: ldc.i4.0
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableMaterialization_IdentityAndCaptures/invokeUnknown/FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown>(!!0, float64, string, bool, bool)
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_CallableMaterialization_IdentityAndCaptures/invokeUnknown/FunctionObject_FunctionDeclaration_EAD58F19_invokeUnknown>(!!0)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableMaterialization_IdentityAndCaptures/invokeUnknown/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_CallableMaterialization_IdentityAndCaptures/invokeUnknown/FunctionObject>(!!0)
 		IL_0058: stloc.2
 		IL_0059: ldloc.0
 		IL_005a: ldc.r8 0.0

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableReflection_ProxyIntegration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableReflection_ProxyIntegration.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4F6BEF40_target
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F6BEF40_target::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F6BEF40_target::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F6BEF40_target::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_CallableReflection_ProxyIntegration/target::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F6BEF40_target::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_CallableReflection_ProxyIntegration/target::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F6BEF40_target::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F6BEF40_target::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4F6BEF40_target
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -182,7 +182,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B1EFE281_L10C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -202,9 +202,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject_FunctionExpression_B1EFE281_L10C8::_environment0_Function_CallableReflection_ProxyIntegration
+				IL_0008: stfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject::_environment0_Function_CallableReflection_ProxyIntegration
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B1EFE281_L10C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -215,7 +215,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B1EFE281_L10C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -226,7 +226,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B1EFE281_L10C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -239,13 +239,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject_FunctionExpression_B1EFE281_L10C8::_environment0_Function_CallableReflection_ProxyIntegration
+				IL_0001: ldfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject::_environment0_Function_CallableReflection_ProxyIntegration
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7::__js_call__(class Modules.Function_CallableReflection_ProxyIntegration/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_B1EFE281_L10C8::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_B1EFE281_L10C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -294,7 +294,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_47046CC4_L13C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -314,9 +314,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8::_environment0_Function_CallableReflection_ProxyIntegration
+				IL_0008: stfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject::_environment0_Function_CallableReflection_ProxyIntegration
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_47046CC4_L13C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -327,7 +327,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_47046CC4_L13C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -338,7 +338,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_47046CC4_L13C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -351,16 +351,16 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8::_environment0_Function_CallableReflection_ProxyIntegration
+				IL_0001: ldfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject::_environment0_Function_CallableReflection_ProxyIntegration
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7::__js_call__(class Modules.Function_CallableReflection_ProxyIntegration/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_47046CC4_L13C8::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_47046CC4_L13C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -412,7 +412,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5909AFB5_prototypeFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -426,7 +426,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5909AFB5_prototypeFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -437,7 +437,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5909AFB5_prototypeFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -448,7 +448,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5909AFB5_prototypeFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -463,7 +463,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_CallableReflection_ProxyIntegration/prototypeFunction::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_5909AFB5_prototypeFunction::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -479,7 +479,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_CallableReflection_ProxyIntegration/prototypeFunction::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5909AFB5_prototypeFunction::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -497,9 +497,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5909AFB5_prototypeFunction::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5909AFB5_prototypeFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -544,7 +544,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_171A4342_L54C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -564,9 +564,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10::_environment0_Function_CallableReflection_ProxyIntegration
+				IL_0008: stfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject::_environment0_Function_CallableReflection_ProxyIntegration
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_171A4342_L54C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -577,7 +577,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_171A4342_L54C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -588,7 +588,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_171A4342_L54C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -601,7 +601,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10::_environment0_Function_CallableReflection_ProxyIntegration
+				IL_0001: ldfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject::_environment0_Function_CallableReflection_ProxyIntegration
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -614,9 +614,9 @@
 				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0020: call object Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler::__js_call__(class Modules.Function_CallableReflection_ProxyIntegration/Scope, object, object, object, object)
 				IL_0025: ret
-			} // end of method FunctionObject_FunctionExpression_171A4342_L54C10::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_171A4342_L54C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -726,7 +726,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E01112C7_Constructor
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -740,7 +740,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E01112C7_Constructor::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -751,7 +751,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E01112C7_Constructor::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -762,7 +762,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E01112C7_Constructor::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -780,7 +780,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_CallableReflection_ProxyIntegration/Constructor::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_E01112C7_Constructor::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -799,7 +799,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_CallableReflection_ProxyIntegration/Constructor::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E01112C7_Constructor::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -817,9 +817,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E01112C7_Constructor::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E01112C7_Constructor
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -872,7 +872,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7F246675_L80C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -892,9 +892,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14::_environment0_Function_CallableReflection_ProxyIntegration
+				IL_0008: stfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject::_environment0_Function_CallableReflection_ProxyIntegration
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7F246675_L80C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -905,7 +905,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7F246675_L80C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -916,7 +916,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7F246675_L80C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -929,7 +929,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14::_environment0_Function_CallableReflection_ProxyIntegration
+				IL_0001: ldfld class Modules.Function_CallableReflection_ProxyIntegration/Scope Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject::_environment0_Function_CallableReflection_ProxyIntegration
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -942,9 +942,9 @@
 				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0020: call object Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler::__js_call__(class Modules.Function_CallableReflection_ProxyIntegration/Scope, object, object, object, object)
 				IL_0025: ret
-			} // end of method FunctionObject_FunctionExpression_7F246675_L80C14::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_7F246675_L80C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1035,7 +1035,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F84AC1B6_L98C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1049,7 +1049,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_F84AC1B6_L98C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1060,7 +1060,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F84AC1B6_L98C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1071,7 +1071,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F84AC1B6_L98C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1087,9 +1087,9 @@
 				IL_0005: call float64 Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_F84AC1B6_L98C14::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_F84AC1B6_L98C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1134,7 +1134,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A54C4041_L120C17
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1148,7 +1148,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_A54C4041_L120C17::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1159,7 +1159,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A54C4041_L120C17::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1170,7 +1170,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A54C4041_L120C17::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1188,9 +1188,9 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_A54C4041_L120C17::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_A54C4041_L120C17
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1238,7 +1238,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0158934E_L123C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1252,7 +1252,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_0158934E_L123C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1263,7 +1263,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0158934E_L123C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1274,7 +1274,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0158934E_L123C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1292,9 +1292,9 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_0158934E_L123C22::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_0158934E_L123C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1344,7 +1344,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_456E4DC3_L139C53
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1358,7 +1358,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_456E4DC3_L139C53::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1369,7 +1369,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_456E4DC3_L139C53::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1380,7 +1380,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_456E4DC3_L139C53::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1395,9 +1395,9 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_456E4DC3_L139C53::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_456E4DC3_L139C53
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1443,7 +1443,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F90B20CC_L145C63
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1457,7 +1457,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_F90B20CC_L145C63::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1468,7 +1468,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F90B20CC_L145C63::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1479,7 +1479,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F90B20CC_L145C63::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1494,9 +1494,9 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_F90B20CC_L145C63::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_F90B20CC_L145C63
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1733,7 +1733,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallableReflection_ProxyIntegration/Scope,
-			[1] class Modules.Function_CallableReflection_ProxyIntegration/prototypeFunction/FunctionObject_FunctionDeclaration_5909AFB5_prototypeFunction,
+			[1] class Modules.Function_CallableReflection_ProxyIntegration/prototypeFunction/FunctionObject,
 			[2] object,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -1766,12 +1766,12 @@
 			[31] object,
 			[32] object,
 			[33] object[],
-			[34] class Modules.Function_CallableReflection_ProxyIntegration/target/FunctionObject_FunctionDeclaration_4F6BEF40_target,
-			[35] class Modules.Function_CallableReflection_ProxyIntegration/Constructor/FunctionObject_FunctionDeclaration_E01112C7_Constructor,
+			[34] class Modules.Function_CallableReflection_ProxyIntegration/target/FunctionObject,
+			[35] class Modules.Function_CallableReflection_ProxyIntegration/Constructor/FunctionObject,
 			[36] object,
 			[37] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[38] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject_FunctionExpression_B1EFE281_L10C8,
-			[39] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8,
+			[38] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject,
+			[39] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject,
 			[40] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[41] string,
 			[42] object,
@@ -1779,16 +1779,16 @@
 			[44] object,
 			[45] object,
 			[46] object,
-			[47] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10,
-			[48] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14,
+			[47] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject,
+			[48] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject,
 			[49] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
-			[50] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject_FunctionExpression_F84AC1B6_L98C14,
-			[51] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject_FunctionExpression_A54C4041_L120C17,
-			[52] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject_FunctionExpression_0158934E_L123C22,
+			[50] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject,
+			[51] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject,
+			[52] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject,
 			[53] object,
 			[54] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[55] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject_FunctionExpression_456E4DC3_L139C53,
-			[56] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject_FunctionExpression_F90B20CC_L145C63
+			[55] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject,
+			[56] class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -1801,13 +1801,13 @@
 		IL_0013: ldloc.0
 		IL_0014: stelem.ref
 		IL_0015: stloc.s 33
-		IL_0017: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/target/FunctionObject_FunctionDeclaration_4F6BEF40_target::.ctor()
+		IL_0017: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/target/FunctionObject::.ctor()
 		IL_001c: ldc.i4.1
 		IL_001d: conv.r8
 		IL_001e: ldstr "target"
 		IL_0023: ldc.i4.1
 		IL_0024: ldc.i4.1
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/target/FunctionObject_FunctionDeclaration_4F6BEF40_target>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/target/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002a: stloc.s 34
 		IL_002c: ldloc.0
 		IL_002d: ldloc.s 34
@@ -1819,13 +1819,13 @@
 		IL_003c: ldloc.0
 		IL_003d: stelem.ref
 		IL_003e: stloc.s 33
-		IL_0040: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/prototypeFunction/FunctionObject_FunctionDeclaration_5909AFB5_prototypeFunction::.ctor()
+		IL_0040: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/prototypeFunction/FunctionObject::.ctor()
 		IL_0045: ldc.i4.0
 		IL_0046: conv.r8
 		IL_0047: ldstr "prototypeFunction"
 		IL_004c: ldc.i4.0
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/prototypeFunction/FunctionObject_FunctionDeclaration_5909AFB5_prototypeFunction>(!!0, float64, string, bool, bool)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/prototypeFunction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0053: stloc.1
 		IL_0054: ldc.i4.1
 		IL_0055: newarr [System.Runtime]System.Object
@@ -1834,13 +1834,13 @@
 		IL_005c: ldloc.0
 		IL_005d: stelem.ref
 		IL_005e: stloc.s 33
-		IL_0060: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/Constructor/FunctionObject_FunctionDeclaration_E01112C7_Constructor::.ctor()
+		IL_0060: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/Constructor/FunctionObject::.ctor()
 		IL_0065: ldc.i4.1
 		IL_0066: conv.r8
 		IL_0067: ldstr "Constructor"
 		IL_006c: ldc.i4.1
 		IL_006d: ldc.i4.1
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/Constructor/FunctionObject_FunctionDeclaration_E01112C7_Constructor>(!!0, float64, string, bool, bool)
+		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/Constructor/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0073: stloc.s 35
 		IL_0075: ldloc.0
 		IL_0076: ldloc.s 35
@@ -1876,14 +1876,14 @@
 		IL_00cf: ldc.i4.0
 		IL_00d0: ldelem.ref
 		IL_00d1: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_00d6: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject_FunctionExpression_B1EFE281_L10C8::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_00d6: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
 		IL_00db: ldc.i4.0
 		IL_00dc: conv.r8
 		IL_00dd: ldstr ""
 		IL_00e2: ldc.i4.0
 		IL_00e3: ldc.i4.1
-		IL_00e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject_FunctionExpression_B1EFE281_L10C8>(!!0, float64, string, bool, bool)
-		IL_00e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject_FunctionExpression_B1EFE281_L10C8>(!!0)
+		IL_00e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L10C7/FunctionObject>(!!0)
 		IL_00ee: stloc.s 38
 		IL_00f0: ldloc.s 37
 		IL_00f2: ldstr "get"
@@ -1901,14 +1901,14 @@
 		IL_010d: ldc.i4.0
 		IL_010e: ldelem.ref
 		IL_010f: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_0114: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_0114: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
 		IL_0119: ldc.i4.1
 		IL_011a: conv.r8
 		IL_011b: ldstr ""
 		IL_0120: ldc.i4.0
 		IL_0121: ldc.i4.1
-		IL_0122: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8>(!!0, float64, string, bool, bool)
-		IL_0127: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject_FunctionExpression_47046CC4_L13C8>(!!0)
+		IL_0122: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0127: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L13C7/FunctionObject>(!!0)
 		IL_012c: stloc.s 39
 		IL_012e: ldloc.s 37
 		IL_0130: ldstr "set"
@@ -2247,14 +2247,14 @@
 		IL_04e7: ldc.i4.0
 		IL_04e8: ldelem.ref
 		IL_04e9: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_04ee: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_04ee: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
 		IL_04f3: ldc.i4.3
 		IL_04f4: conv.r8
 		IL_04f5: ldstr ""
 		IL_04fa: ldc.i4.1
 		IL_04fb: ldc.i4.1
-		IL_04fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10>(!!0, float64, string, bool, bool)
-		IL_0501: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject_FunctionExpression_171A4342_L54C10>(!!0)
+		IL_04fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0501: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_applyHandler/FunctionObject>(!!0)
 		IL_0506: stloc.s 47
 		IL_0508: ldloc.s 37
 		IL_050a: ldstr "apply"
@@ -2374,14 +2374,14 @@
 		IL_065f: ldc.i4.0
 		IL_0660: ldelem.ref
 		IL_0661: castclass Modules.Function_CallableReflection_ProxyIntegration/Scope
-		IL_0666: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
+		IL_0666: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject::.ctor(class Modules.Function_CallableReflection_ProxyIntegration/Scope)
 		IL_066b: ldc.i4.3
 		IL_066c: conv.r8
 		IL_066d: ldstr ""
 		IL_0672: ldc.i4.0
 		IL_0673: ldc.i4.1
-		IL_0674: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14>(!!0, float64, string, bool, bool)
-		IL_0679: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject_FunctionExpression_7F246675_L80C14>(!!0)
+		IL_0674: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0679: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_constructHandler/FunctionObject>(!!0)
 		IL_067e: stloc.s 48
 		IL_0680: ldloc.s 37
 		IL_0682: ldstr "construct"
@@ -2468,14 +2468,14 @@
 		IL_075b: ldloc.0
 		IL_075c: stelem.ref
 		IL_075d: stloc.s 33
-		IL_075f: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject_FunctionExpression_F84AC1B6_L98C14::.ctor()
+		IL_075f: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject::.ctor()
 		IL_0764: ldc.i4.0
 		IL_0765: conv.r8
 		IL_0766: ldstr ""
 		IL_076b: ldc.i4.0
 		IL_076c: ldc.i4.1
-		IL_076d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject_FunctionExpression_F84AC1B6_L98C14>(!!0, float64, string, bool, bool)
-		IL_0772: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject_FunctionExpression_F84AC1B6_L98C14>(!!0)
+		IL_076d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0772: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_invalidConstructProxy/FunctionObject>(!!0)
 		IL_0777: stloc.s 50
 		IL_0779: ldloc.s 37
 		IL_077b: ldstr "construct"
@@ -2626,14 +2626,14 @@
 		IL_08df: ldloc.0
 		IL_08e0: stelem.ref
 		IL_08e1: stloc.s 33
-		IL_08e3: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject_FunctionExpression_A54C4041_L120C17::.ctor()
+		IL_08e3: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject::.ctor()
 		IL_08e8: ldc.i4.1
 		IL_08e9: conv.r8
 		IL_08ea: ldstr ""
 		IL_08ef: ldc.i4.0
 		IL_08f0: ldc.i4.1
-		IL_08f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject_FunctionExpression_A54C4041_L120C17>(!!0, float64, string, bool, bool)
-		IL_08f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject_FunctionExpression_A54C4041_L120C17>(!!0)
+		IL_08f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_08f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler/FunctionObject>(!!0)
 		IL_08fb: stloc.s 51
 		IL_08fd: ldloc.s 37
 		IL_08ff: ldstr "isExtensible"
@@ -2647,14 +2647,14 @@
 		IL_0914: ldloc.0
 		IL_0915: stelem.ref
 		IL_0916: stloc.s 33
-		IL_0918: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject_FunctionExpression_0158934E_L123C22::.ctor()
+		IL_0918: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject::.ctor()
 		IL_091d: ldc.i4.1
 		IL_091e: conv.r8
 		IL_091f: ldstr ""
 		IL_0924: ldc.i4.0
 		IL_0925: ldc.i4.1
-		IL_0926: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject_FunctionExpression_0158934E_L123C22>(!!0, float64, string, bool, bool)
-		IL_092b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject_FunctionExpression_0158934E_L123C22>(!!0)
+		IL_0926: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_092b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_integrityHandler_L123C21/FunctionObject>(!!0)
 		IL_0930: stloc.s 52
 		IL_0932: ldloc.s 37
 		IL_0934: ldstr "preventExtensions"
@@ -2724,14 +2724,14 @@
 			IL_09d1: ldloc.0
 			IL_09d2: stelem.ref
 			IL_09d3: stloc.s 33
-			IL_09d5: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject_FunctionExpression_456E4DC3_L139C53::.ctor()
+			IL_09d5: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject::.ctor()
 			IL_09da: ldc.i4.0
 			IL_09db: conv.r8
 			IL_09dc: ldstr ""
 			IL_09e1: ldc.i4.0
 			IL_09e2: ldc.i4.1
-			IL_09e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject_FunctionExpression_456E4DC3_L139C53>(!!0, float64, string, bool, bool)
-			IL_09e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject_FunctionExpression_456E4DC3_L139C53>(!!0)
+			IL_09e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_09e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L139C52/FunctionObject>(!!0)
 			IL_09ed: stloc.s 55
 			IL_09ef: ldloc.s 54
 			IL_09f1: ldstr "isExtensible"
@@ -2806,14 +2806,14 @@
 			IL_0a94: ldloc.0
 			IL_0a95: stelem.ref
 			IL_0a96: stloc.s 33
-			IL_0a98: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject_FunctionExpression_F90B20CC_L145C63::.ctor()
+			IL_0a98: newobj instance void Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject::.ctor()
 			IL_0a9d: ldc.i4.0
 			IL_0a9e: conv.r8
 			IL_0a9f: ldstr ""
 			IL_0aa4: ldc.i4.0
 			IL_0aa5: ldc.i4.1
-			IL_0aa6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject_FunctionExpression_F90B20CC_L145C63>(!!0, float64, string, bool, bool)
-			IL_0aab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject_FunctionExpression_F90B20CC_L145C63>(!!0)
+			IL_0aa6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0aab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_CallableReflection_ProxyIntegration/FunctionExpression_L145C62/FunctionObject>(!!0)
 			IL_0ab0: stloc.s 56
 			IL_0ab2: ldloc.s 37
 			IL_0ab4: ldstr "preventExtensions"

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Capture_HasScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Capture_HasScopesParameter.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_76C99FCD_captureOuter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Capture_HasScopesParameter/Scope Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::_environment0_Function_Capture_HasScopesParameter
+				IL_0008: stfld class Modules.Function_Capture_HasScopesParameter/Scope Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject::_environment0_Function_Capture_HasScopesParameter
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Capture_HasScopesParameter/Scope Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::_environment0_Function_Capture_HasScopesParameter
+				IL_0001: ldfld class Modules.Function_Capture_HasScopesParameter/Scope Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject::_environment0_Function_Capture_HasScopesParameter
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_Capture_HasScopesParameter/captureOuter::__js_call__(class Modules.Function_Capture_HasScopesParameter/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Capture_HasScopesParameter/Scope Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::_environment0_Function_Capture_HasScopesParameter
+				IL_0001: ldfld class Modules.Function_Capture_HasScopesParameter/Scope Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject::_environment0_Function_Capture_HasScopesParameter
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_Capture_HasScopesParameter/captureOuter::__js_call__(class Modules.Function_Capture_HasScopesParameter/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_76C99FCD_captureOuter
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -200,7 +200,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Capture_HasScopesParameter/Scope,
-			[1] class Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject_FunctionDeclaration_76C99FCD_captureOuter,
+			[1] class Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -219,13 +219,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Capture_HasScopesParameter/Scope
-		IL_0019: newobj instance void Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::.ctor(class Modules.Function_Capture_HasScopesParameter/Scope)
+		IL_0019: newobj instance void Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject::.ctor(class Modules.Function_Capture_HasScopesParameter/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "captureOuter"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject_FunctionDeclaration_76C99FCD_captureOuter>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_434A5B2B_multiply
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -56,12 +56,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply::_environment1_createCalculator
+					IL_0008: stfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject::_environment1_createCalculator
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply::_transitionalScopes
+					IL_000f: stfld object[] Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -96,14 +96,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -117,14 +117,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -142,9 +142,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_434A5B2B_multiply
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -210,7 +210,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0B167656_createCalculator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -230,9 +230,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject_FunctionDeclaration_0B167656_createCalculator::_environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
+				IL_0008: stfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject::_environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -243,7 +243,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -254,7 +254,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -267,14 +267,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject_FunctionDeclaration_0B167656_createCalculator::_environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
+				IL_0001: ldfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject::_environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -288,14 +288,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject_FunctionDeclaration_0B167656_createCalculator::_environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
+				IL_0001: ldfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject::_environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -313,9 +313,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0B167656_createCalculator
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -336,7 +336,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope,
-				[1] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply,
+				[1] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject,
 				[2] object[],
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
@@ -362,13 +362,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope
 			IL_0024: ldloc.2
-			IL_0025: newobj instance void Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply::.ctor(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope, object[])
+			IL_0025: newobj instance void Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject::.ctor(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope, object[])
 			IL_002a: ldc.i4.1
 			IL_002b: conv.r8
 			IL_002c: ldstr "multiply"
 			IL_0031: ldc.i4.0
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.1
 			IL_0039: nop
 			IL_003a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -426,7 +426,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope,
-			[1] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject_FunctionDeclaration_0B167656_createCalculator,
+			[1] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object[],
@@ -447,13 +447,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope
-		IL_001b: newobj instance void Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject_FunctionDeclaration_0B167656_createCalculator::.ctor(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope)
+		IL_001b: newobj instance void Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject::.ctor(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "createCalculator"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject_FunctionDeclaration_0B167656_createCalculator>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureMutatesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureMutatesOuterVariable.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F0227F52_increment
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -56,12 +56,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment::_environment1_createCounter
+					IL_0008: stfld class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject::_environment1_createCounter
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment::_transitionalScopes
+					IL_000f: stfld object[] Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -96,11 +96,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Function_ClosureMutatesOuterVariable/createCounter/increment::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -114,11 +114,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Function_ClosureMutatesOuterVariable/createCounter/increment::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -136,9 +136,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_F0227F52_increment
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -213,7 +213,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C97C56F8_createCounter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -233,9 +233,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_ClosureMutatesOuterVariable/Scope Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_C97C56F8_createCounter::_environment0_Function_ClosureMutatesOuterVariable
+				IL_0008: stfld class Modules.Function_ClosureMutatesOuterVariable/Scope Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject::_environment0_Function_ClosureMutatesOuterVariable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -246,7 +246,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -257,7 +257,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -270,7 +270,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_ClosureMutatesOuterVariable/Scope Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_C97C56F8_createCounter::_environment0_Function_ClosureMutatesOuterVariable
+				IL_0001: ldfld class Modules.Function_ClosureMutatesOuterVariable/Scope Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject::_environment0_Function_ClosureMutatesOuterVariable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -278,7 +278,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call object Modules.Function_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.Function_ClosureMutatesOuterVariable/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -292,7 +292,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_ClosureMutatesOuterVariable/Scope Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_C97C56F8_createCounter::_environment0_Function_ClosureMutatesOuterVariable
+				IL_0001: ldfld class Modules.Function_ClosureMutatesOuterVariable/Scope Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject::_environment0_Function_ClosureMutatesOuterVariable
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -300,7 +300,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call object Modules.Function_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.Function_ClosureMutatesOuterVariable/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -318,9 +318,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C97C56F8_createCounter
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -341,7 +341,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope,
-				[1] class Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment,
+				[1] class Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject,
 				[2] object[]
 			)
 
@@ -363,13 +363,13 @@
 			IL_0017: ldelem.ref
 			IL_0018: castclass Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope
 			IL_001d: ldloc.2
-			IL_001e: newobj instance void Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment::.ctor(class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope, object[])
+			IL_001e: newobj instance void Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject::.ctor(class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope, object[])
 			IL_0023: ldc.i4.0
 			IL_0024: conv.r8
 			IL_0025: ldstr "increment"
 			IL_002a: ldc.i4.0
 			IL_002b: ldc.i4.1
-			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment>(!!0, float64, string, bool, bool)
+			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0031: stloc.1
 			IL_0032: ldloc.0
 			IL_0033: ldarg.2
@@ -425,7 +425,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ClosureMutatesOuterVariable/Scope,
-			[1] class Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_C97C56F8_createCounter,
+			[1] class Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -445,13 +445,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_ClosureMutatesOuterVariable/Scope
-		IL_0019: newobj instance void Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_C97C56F8_createCounter::.ctor(class Modules.Function_ClosureMutatesOuterVariable/Scope)
+		IL_0019: newobj instance void Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject::.ctor(class Modules.Function_ClosureMutatesOuterVariable/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "createCounter"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_C97C56F8_createCounter>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Closure_CapturedBoolean_AssignAndRead.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Closure_CapturedBoolean_AssignAndRead.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_70247B52_setTrue
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -56,12 +56,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue::_environment1_outer
+					IL_0008: stfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject::_environment1_outer
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue::_transitionalScopes
+					IL_000f: stfld object[] Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -96,11 +96,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -114,11 +114,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -136,9 +136,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_70247B52_setTrue
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -196,7 +196,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2D7D3E81_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -216,9 +216,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject_FunctionDeclaration_2D7D3E81_outer::_environment0_Function_Closure_CapturedBoolean_AssignAndRead
+				IL_0008: stfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject::_environment0_Function_Closure_CapturedBoolean_AssignAndRead
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -229,7 +229,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -240,7 +240,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -253,11 +253,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject_FunctionDeclaration_2D7D3E81_outer::_environment0_Function_Closure_CapturedBoolean_AssignAndRead
+				IL_0001: ldfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject::_environment0_Function_Closure_CapturedBoolean_AssignAndRead
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer::__js_call__(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -271,11 +271,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject_FunctionDeclaration_2D7D3E81_outer::_environment0_Function_Closure_CapturedBoolean_AssignAndRead
+				IL_0001: ldfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject::_environment0_Function_Closure_CapturedBoolean_AssignAndRead
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer::__js_call__(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -293,9 +293,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2D7D3E81_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -315,7 +315,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope,
-				[1] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue,
+				[1] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject,
 				[2] object[],
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[4] object
@@ -339,13 +339,13 @@
 			IL_0017: ldelem.ref
 			IL_0018: castclass Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope
 			IL_001d: ldloc.2
-			IL_001e: newobj instance void Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue::.ctor(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope, object[])
+			IL_001e: newobj instance void Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject::.ctor(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope, object[])
 			IL_0023: ldc.i4.0
 			IL_0024: conv.r8
 			IL_0025: ldstr "setTrue"
 			IL_002a: ldc.i4.0
 			IL_002b: ldc.i4.1
-			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue>(!!0, float64, string, bool, bool)
+			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0031: stloc.1
 			IL_0032: ldloc.0
 			IL_0033: ldc.i4.0
@@ -427,7 +427,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope,
-			[1] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject_FunctionDeclaration_2D7D3E81_outer,
+			[1] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject,
 			[2] object[]
 		)
 
@@ -444,13 +444,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope
-		IL_0019: newobj instance void Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject_FunctionDeclaration_2D7D3E81_outer::.ctor(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope)
+		IL_0019: newobj instance void Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject::.ctor(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject_FunctionDeclaration_2D7D3E81_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CommonArityDynamicDispatch.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CommonArityDynamicDispatch.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0A81B0EC_collect
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -51,7 +51,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A81B0EC_collect::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -62,7 +62,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A81B0EC_collect::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -73,7 +73,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A81B0EC_collect::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -107,7 +107,7 @@
 
 				IL_0019: ldloc.0
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A81B0EC_collect::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -122,7 +122,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_CommonArityDynamicDispatch/collect::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A81B0EC_collect::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -138,7 +138,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_CommonArityDynamicDispatch/collect::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A81B0EC_collect::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -156,9 +156,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A81B0EC_collect::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0A81B0EC_collect
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -271,7 +271,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7ED46722_L29C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -291,9 +291,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_CommonArityDynamicDispatch/Scope Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7/FunctionObject_FunctionExpression_7ED46722_L29C8::_environment0_Function_CommonArityDynamicDispatch
+				IL_0008: stfld class Modules.Function_CommonArityDynamicDispatch/Scope Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7/FunctionObject::_environment0_Function_CommonArityDynamicDispatch
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7ED46722_L29C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -304,7 +304,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7ED46722_L29C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -315,7 +315,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7ED46722_L29C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -328,11 +328,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_CommonArityDynamicDispatch/Scope Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7/FunctionObject_FunctionExpression_7ED46722_L29C8::_environment0_Function_CommonArityDynamicDispatch
+				IL_0001: ldfld class Modules.Function_CommonArityDynamicDispatch/Scope Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7/FunctionObject::_environment0_Function_CommonArityDynamicDispatch
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7::__js_call__(class Modules.Function_CommonArityDynamicDispatch/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_7ED46722_L29C8::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -346,11 +346,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_CommonArityDynamicDispatch/Scope Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7/FunctionObject_FunctionExpression_7ED46722_L29C8::_environment0_Function_CommonArityDynamicDispatch
+				IL_0001: ldfld class Modules.Function_CommonArityDynamicDispatch/Scope Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7/FunctionObject::_environment0_Function_CommonArityDynamicDispatch
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7::__js_call__(class Modules.Function_CommonArityDynamicDispatch/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_7ED46722_L29C8::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -368,9 +368,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7ED46722_L29C8::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7ED46722_L29C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -426,7 +426,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9B2EDA37_Box
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -440,7 +440,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B2EDA37_Box::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -451,7 +451,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B2EDA37_Box::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -462,7 +462,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B2EDA37_Box::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -496,7 +496,7 @@
 
 				IL_0019: ldloc.0
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B2EDA37_Box::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -511,7 +511,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_CommonArityDynamicDispatch/Box::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B2EDA37_Box::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -527,7 +527,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_CommonArityDynamicDispatch/Box::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B2EDA37_Box::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -545,9 +545,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B2EDA37_Box::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9B2EDA37_Box
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -662,12 +662,12 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CommonArityDynamicDispatch/Scope,
-			[1] class Modules.Function_CommonArityDynamicDispatch/collect/FunctionObject_FunctionDeclaration_0A81B0EC_collect,
-			[2] class Modules.Function_CommonArityDynamicDispatch/Box/FunctionObject_FunctionDeclaration_9B2EDA37_Box,
+			[1] class Modules.Function_CommonArityDynamicDispatch/collect/FunctionObject,
+			[2] class Modules.Function_CommonArityDynamicDispatch/Box/FunctionObject,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] object,
-			[6] class Modules.Function_CommonArityDynamicDispatch/Box/FunctionObject_FunctionDeclaration_9B2EDA37_Box,
+			[6] class Modules.Function_CommonArityDynamicDispatch/Box/FunctionObject,
 			[7] object,
 			[8] object,
 			[9] object,
@@ -676,7 +676,7 @@
 			[12] object[],
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[14] object,
-			[15] class Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7/FunctionObject_FunctionExpression_7ED46722_L29C8,
+			[15] class Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7/FunctionObject,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[17] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[18] object[]
@@ -691,13 +691,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 12
-		IL_0012: newobj instance void Modules.Function_CommonArityDynamicDispatch/collect/FunctionObject_FunctionDeclaration_0A81B0EC_collect::.ctor()
+		IL_0012: newobj instance void Modules.Function_CommonArityDynamicDispatch/collect/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "collect"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CommonArityDynamicDispatch/collect/FunctionObject_FunctionDeclaration_0A81B0EC_collect>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CommonArityDynamicDispatch/collect/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -706,13 +706,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 12
-		IL_0032: newobj instance void Modules.Function_CommonArityDynamicDispatch/Box/FunctionObject_FunctionDeclaration_9B2EDA37_Box::.ctor()
+		IL_0032: newobj instance void Modules.Function_CommonArityDynamicDispatch/Box/FunctionObject::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "Box"
 		IL_003e: ldc.i4.1
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CommonArityDynamicDispatch/Box/FunctionObject_FunctionDeclaration_9B2EDA37_Box>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CommonArityDynamicDispatch/Box/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: nop
 		IL_0047: nop
@@ -977,13 +977,13 @@
 		IL_046e: ldc.i4.0
 		IL_046f: ldelem.ref
 		IL_0470: castclass Modules.Function_CommonArityDynamicDispatch/Scope
-		IL_0475: newobj instance void Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7/FunctionObject_FunctionExpression_7ED46722_L29C8::.ctor(class Modules.Function_CommonArityDynamicDispatch/Scope)
+		IL_0475: newobj instance void Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7/FunctionObject::.ctor(class Modules.Function_CommonArityDynamicDispatch/Scope)
 		IL_047a: ldc.i4.0
 		IL_047b: conv.r8
 		IL_047c: ldstr ""
 		IL_0481: ldc.i4.0
 		IL_0482: ldc.i4.1
-		IL_0483: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7/FunctionObject_FunctionExpression_7ED46722_L29C8>(!!0, float64, string, bool, bool)
+		IL_0483: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CommonArityDynamicDispatch/FunctionExpression_L29C7/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0488: stloc.s 15
 		IL_048a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_048f: dup

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_39521C09_Point
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_ConstructedInstance_ObjectSemantics/Point::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_ConstructedInstance_ObjectSemantics/Point::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_39521C09_Point
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -190,7 +190,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7172515D_L8C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -204,7 +204,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -215,7 +215,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -226,7 +226,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -241,7 +241,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -257,7 +257,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -275,9 +275,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7172515D_L8C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -341,7 +341,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_39499524_ReturnObject
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -361,9 +361,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject_FunctionDeclaration_39499524_ReturnObject::_environment0_Function_ConstructedInstance_ObjectSemantics
+				IL_0008: stfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject::_environment0_Function_ConstructedInstance_ObjectSemantics
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -374,7 +374,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -385,7 +385,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -398,11 +398,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject_FunctionDeclaration_39499524_ReturnObject::_environment0_Function_ConstructedInstance_ObjectSemantics
+				IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject::_environment0_Function_ConstructedInstance_ObjectSemantics
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -416,11 +416,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject_FunctionDeclaration_39499524_ReturnObject::_environment0_Function_ConstructedInstance_ObjectSemantics
+				IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject::_environment0_Function_ConstructedInstance_ObjectSemantics
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -438,9 +438,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_39499524_ReturnObject
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -500,7 +500,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -514,7 +514,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -525,7 +525,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -536,7 +536,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -552,7 +552,7 @@
 				IL_0005: call float64 Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -569,7 +569,7 @@
 				IL_0001: call float64 Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -587,9 +587,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -645,7 +645,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9C50FAD2_L48C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -667,12 +667,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12::_environment1_makeConstructor
+					IL_0008: stfld class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject::_environment1_makeConstructor
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12::_transitionalScopes
+					IL_000f: stfld object[] Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -683,7 +683,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -694,7 +694,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -707,14 +707,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -728,14 +728,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -753,9 +753,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_9C50FAD2_L48C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -826,7 +826,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -846,9 +846,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::_environment0_Function_ConstructedInstance_ObjectSemantics
+				IL_0008: stfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject::_environment0_Function_ConstructedInstance_ObjectSemantics
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -859,7 +859,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -870,7 +870,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -883,14 +883,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::_environment0_Function_ConstructedInstance_ObjectSemantics
+				IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject::_environment0_Function_ConstructedInstance_ObjectSemantics
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -904,14 +904,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::_environment0_Function_ConstructedInstance_ObjectSemantics
+				IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject::_environment0_Function_ConstructedInstance_ObjectSemantics
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -929,9 +929,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -953,7 +953,7 @@
 			.locals init (
 				[0] class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope,
 				[1] object[],
-				[2] class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12
+				[2] class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope::.ctor()
@@ -977,13 +977,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope
 			IL_0024: ldloc.1
-			IL_0025: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12::.ctor(class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope, object[])
+			IL_0025: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject::.ctor(class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope, object[])
 			IL_002a: ldc.i4.1
 			IL_002b: conv.r8
 			IL_002c: ldstr ""
 			IL_0031: ldc.i4.1
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.2
 			IL_0039: ldloc.2
 			IL_003a: ret
@@ -1014,7 +1014,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_23475292_L61C18
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1028,7 +1028,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1039,7 +1039,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1050,7 +1050,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1064,7 +1064,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1082,7 +1082,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1101,7 +1101,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1119,9 +1119,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_23475292_L61C18
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1174,7 +1174,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1188,7 +1188,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1199,7 +1199,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1210,7 +1210,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1225,7 +1225,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1241,7 +1241,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1259,9 +1259,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1306,7 +1306,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9DD67922_NullPrototype
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1320,7 +1320,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1331,7 +1331,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1342,7 +1342,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1357,7 +1357,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1373,7 +1373,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1391,9 +1391,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9DD67922_NullPrototype
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1663,24 +1663,24 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ConstructedInstance_ObjectSemantics/Scope,
-			[1] class Modules.Function_ConstructedInstance_ObjectSemantics/Point/FunctionObject_FunctionDeclaration_39521C09_Point,
-			[2] class Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject_FunctionDeclaration_39499524_ReturnObject,
-			[3] class Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive/FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive,
-			[4] class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor,
-			[5] class Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype/FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype,
-			[6] class Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype/FunctionObject_FunctionDeclaration_9DD67922_NullPrototype,
+			[1] class Modules.Function_ConstructedInstance_ObjectSemantics/Point/FunctionObject,
+			[2] class Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject,
+			[3] class Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive/FunctionObject,
+			[4] class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject,
+			[5] class Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype/FunctionObject,
+			[6] class Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype/FunctionObject,
 			[7] object,
 			[8] object,
 			[9] object,
 			[10] object,
 			[11] object,
 			[12] object,
-			[13] class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject_FunctionExpression_23475292_L61C18,
+			[13] class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject,
 			[14] object,
 			[15] object,
 			[16] object[],
 			[17] object,
-			[18] class Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22/FunctionObject_FunctionExpression_7172515D_L8C23,
+			[18] class Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22/FunctionObject,
 			[19] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[20] bool,
 			[21] object,
@@ -1701,13 +1701,13 @@
 		IL_0013: ldloc.0
 		IL_0014: stelem.ref
 		IL_0015: stloc.s 16
-		IL_0017: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/Point/FunctionObject_FunctionDeclaration_39521C09_Point::.ctor()
+		IL_0017: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/Point/FunctionObject::.ctor()
 		IL_001c: ldc.i4.2
 		IL_001d: conv.r8
 		IL_001e: ldstr "Point"
 		IL_0023: ldc.i4.1
 		IL_0024: ldc.i4.1
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/Point/FunctionObject_FunctionDeclaration_39521C09_Point>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/Point/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002a: stloc.1
 		IL_002b: ldc.i4.1
 		IL_002c: newarr [System.Runtime]System.Object
@@ -1720,13 +1720,13 @@
 		IL_0039: ldc.i4.0
 		IL_003a: ldelem.ref
 		IL_003b: castclass Modules.Function_ConstructedInstance_ObjectSemantics/Scope
-		IL_0040: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject_FunctionDeclaration_39499524_ReturnObject::.ctor(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope)
+		IL_0040: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject::.ctor(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope)
 		IL_0045: ldc.i4.0
 		IL_0046: conv.r8
 		IL_0047: ldstr "ReturnObject"
 		IL_004c: ldc.i4.1
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject_FunctionDeclaration_39499524_ReturnObject>(!!0, float64, string, bool, bool)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0053: stloc.2
 		IL_0054: ldc.i4.1
 		IL_0055: newarr [System.Runtime]System.Object
@@ -1735,13 +1735,13 @@
 		IL_005c: ldloc.0
 		IL_005d: stelem.ref
 		IL_005e: stloc.s 16
-		IL_0060: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive/FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::.ctor()
+		IL_0060: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive/FunctionObject::.ctor()
 		IL_0065: ldc.i4.0
 		IL_0066: conv.r8
 		IL_0067: ldstr "ReturnPrimitive"
 		IL_006c: ldc.i4.1
 		IL_006d: ldc.i4.1
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive/FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive>(!!0, float64, string, bool, bool)
+		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0073: stloc.3
 		IL_0074: ldc.i4.1
 		IL_0075: newarr [System.Runtime]System.Object
@@ -1754,13 +1754,13 @@
 		IL_0082: ldc.i4.0
 		IL_0083: ldelem.ref
 		IL_0084: castclass Modules.Function_ConstructedInstance_ObjectSemantics/Scope
-		IL_0089: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::.ctor(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope)
+		IL_0089: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject::.ctor(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope)
 		IL_008e: ldc.i4.1
 		IL_008f: conv.r8
 		IL_0090: ldstr "makeConstructor"
 		IL_0095: ldc.i4.0
 		IL_0096: ldc.i4.1
-		IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor>(!!0, float64, string, bool, bool)
+		IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_009c: stloc.s 4
 		IL_009e: ldc.i4.1
 		IL_009f: newarr [System.Runtime]System.Object
@@ -1769,13 +1769,13 @@
 		IL_00a6: ldloc.0
 		IL_00a7: stelem.ref
 		IL_00a8: stloc.s 16
-		IL_00aa: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype/FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::.ctor()
+		IL_00aa: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype/FunctionObject::.ctor()
 		IL_00af: ldc.i4.0
 		IL_00b0: conv.r8
 		IL_00b1: ldstr "PrimitivePrototype"
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldc.i4.1
-		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype/FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype>(!!0, float64, string, bool, bool)
+		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00bd: stloc.s 5
 		IL_00bf: ldc.i4.1
 		IL_00c0: newarr [System.Runtime]System.Object
@@ -1784,13 +1784,13 @@
 		IL_00c7: ldloc.0
 		IL_00c8: stelem.ref
 		IL_00c9: stloc.s 16
-		IL_00cb: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype/FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::.ctor()
+		IL_00cb: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype/FunctionObject::.ctor()
 		IL_00d0: ldc.i4.0
 		IL_00d1: conv.r8
 		IL_00d2: ldstr "NullPrototype"
 		IL_00d7: ldc.i4.0
 		IL_00d8: ldc.i4.1
-		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype/FunctionObject_FunctionDeclaration_9DD67922_NullPrototype>(!!0, float64, string, bool, bool)
+		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00de: stloc.s 6
 		IL_00e0: nop
 		IL_00e1: nop
@@ -1805,13 +1805,13 @@
 		IL_00f7: ldloc.0
 		IL_00f8: stelem.ref
 		IL_00f9: stloc.s 16
-		IL_00fb: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22/FunctionObject_FunctionExpression_7172515D_L8C23::.ctor()
+		IL_00fb: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22/FunctionObject::.ctor()
 		IL_0100: ldc.i4.0
 		IL_0101: conv.r8
 		IL_0102: ldstr ""
 		IL_0107: ldc.i4.1
 		IL_0108: ldc.i4.1
-		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22/FunctionObject_FunctionExpression_7172515D_L8C23>(!!0, float64, string, bool, bool)
+		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_010e: stloc.s 18
 		IL_0110: ldloc.s 17
 		IL_0112: ldstr "sum"
@@ -2141,14 +2141,14 @@
 		IL_0509: ldloc.0
 		IL_050a: stelem.ref
 		IL_050b: stloc.s 16
-		IL_050d: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject_FunctionExpression_23475292_L61C18::.ctor()
+		IL_050d: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject::.ctor()
 		IL_0512: ldc.i4.1
 		IL_0513: conv.r8
 		IL_0514: ldstr ""
 		IL_0519: ldc.i4.1
 		IL_051a: ldc.i4.0
-		IL_051b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject_FunctionExpression_23475292_L61C18>(!!0, float64, string, bool, bool)
-		IL_0520: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject_FunctionExpression_23475292_L61C18>(!!0)
+		IL_051b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0520: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject>(!!0)
 		IL_0525: stloc.s 13
 		IL_0527: ldloc.s 13
 		IL_0529: dup

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_Call_Length_Name.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_Call_Length_Name.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A064FBB8_L3C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -101,7 +101,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -123,7 +123,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -141,9 +141,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A064FBB8_L3C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -209,7 +209,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_Call_Length_Name/Scope,
-			[1] class Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'/FunctionObject_FunctionExpression_A064FBB8_L3C14,
+			[1] class Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -225,14 +225,14 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.2
-		IL_0012: newobj instance void Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'/FunctionObject_FunctionExpression_A064FBB8_L3C14::.ctor()
+		IL_0012: newobj instance void Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'/FunctionObject_FunctionExpression_A064FBB8_L3C14>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'/FunctionObject_FunctionExpression_A064FBB8_L3C14>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0030: stloc.3

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_GlobalScope_NoClosure.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_GlobalScope_NoClosure.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5C71ED13_L9C16
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -48,7 +48,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -59,7 +59,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -70,7 +70,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -84,7 +84,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -99,7 +99,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -115,7 +115,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -133,9 +133,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_5C71ED13_L9C16
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -200,7 +200,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1B6CABDD_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -220,9 +220,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_Constructor_GlobalScope_NoClosure/Scope Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject_FunctionDeclaration_1B6CABDD_outer::_environment0_Function_Constructor_GlobalScope_NoClosure
+				IL_0008: stfld class Modules.Function_Constructor_GlobalScope_NoClosure/Scope Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject::_environment0_Function_Constructor_GlobalScope_NoClosure
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -233,7 +233,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -244,7 +244,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -257,11 +257,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Constructor_GlobalScope_NoClosure/Scope Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject_FunctionDeclaration_1B6CABDD_outer::_environment0_Function_Constructor_GlobalScope_NoClosure
+				IL_0001: ldfld class Modules.Function_Constructor_GlobalScope_NoClosure/Scope Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject::_environment0_Function_Constructor_GlobalScope_NoClosure
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer::__js_call__(class Modules.Function_Constructor_GlobalScope_NoClosure/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -275,11 +275,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_Constructor_GlobalScope_NoClosure/Scope Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject_FunctionDeclaration_1B6CABDD_outer::_environment0_Function_Constructor_GlobalScope_NoClosure
+				IL_0001: ldfld class Modules.Function_Constructor_GlobalScope_NoClosure/Scope Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject::_environment0_Function_Constructor_GlobalScope_NoClosure
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer::__js_call__(class Modules.Function_Constructor_GlobalScope_NoClosure/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -297,9 +297,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_1B6CABDD_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -320,7 +320,7 @@
 			.locals init (
 				[0] class Modules.Function_Constructor_GlobalScope_NoClosure/outer/Scope,
 				[1] float64,
-				[2] class Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'/FunctionObject_FunctionExpression_5C71ED13_L9C16,
+				[2] class Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'/FunctionObject,
 				[3] object[],
 				[4] object,
 				[5] object
@@ -344,14 +344,14 @@
 			IL_0037: ldarg.0
 			IL_0038: stelem.ref
 			IL_0039: stloc.3
-			IL_003a: newobj instance void Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'/FunctionObject_FunctionExpression_5C71ED13_L9C16::.ctor()
+			IL_003a: newobj instance void Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'/FunctionObject::.ctor()
 			IL_003f: ldc.i4.0
 			IL_0040: conv.r8
 			IL_0041: ldstr ""
 			IL_0046: ldc.i4.0
 			IL_0047: ldc.i4.0
-			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'/FunctionObject_FunctionExpression_5C71ED13_L9C16>(!!0, float64, string, bool, bool)
-			IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'/FunctionObject_FunctionExpression_5C71ED13_L9C16>(!!0)
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'/FunctionObject>(!!0)
 			IL_0052: stloc.2
 			IL_0053: ldstr "console"
 			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
@@ -421,7 +421,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_GlobalScope_NoClosure/Scope,
-			[1] class Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject_FunctionDeclaration_1B6CABDD_outer,
+			[1] class Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject,
 			[2] float64,
 			[3] object[]
 		)
@@ -439,13 +439,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Constructor_GlobalScope_NoClosure/Scope
-		IL_0019: newobj instance void Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject_FunctionDeclaration_1B6CABDD_outer::.ctor(class Modules.Function_Constructor_GlobalScope_NoClosure/Scope)
+		IL_0019: newobj instance void Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject::.ctor(class Modules.Function_Constructor_GlobalScope_NoClosure/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject_FunctionDeclaration_1B6CABDD_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldc.r8 10

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_New_ConstantString_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_New_ConstantString_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_717FBDDC_L3C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -96,7 +96,7 @@
 				IL_0005: call float64 Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -113,7 +113,7 @@
 				IL_0001: call float64 Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -131,9 +131,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_717FBDDC_L3C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -190,7 +190,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_New_ConstantString_Basic/Scope,
-			[1] class Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'/FunctionObject_FunctionExpression_717FBDDC_L3C12,
+			[1] class Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -206,14 +206,14 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.2
-		IL_0012: newobj instance void Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'/FunctionObject_FunctionExpression_717FBDDC_L3C12::.ctor()
+		IL_0012: newobj instance void Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'/FunctionObject_FunctionExpression_717FBDDC_L3C12>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'/FunctionObject_FunctionExpression_717FBDDC_L3C12>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_0030: stloc.3

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterExpression.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterExpression.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_87C4B4A9_calculate
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -112,7 +112,7 @@
 				IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001f: call object Modules.Function_DefaultParameterExpression/calculate::__js_call__(object, float64, object, object)
 				IL_0024: ret
-			} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -138,7 +138,7 @@
 				IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001b: call object Modules.Function_DefaultParameterExpression/calculate::__js_call__(object, float64, object, object)
 				IL_0020: ret
-			} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -156,9 +156,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_87C4B4A9_calculate
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -260,7 +260,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_DefaultParameterExpression/Scope,
-			[1] class Modules.Function_DefaultParameterExpression/calculate/FunctionObject_FunctionDeclaration_87C4B4A9_calculate,
+			[1] class Modules.Function_DefaultParameterExpression/calculate/FunctionObject,
 			[2] object[]
 		)
 
@@ -273,13 +273,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_DefaultParameterExpression/calculate/FunctionObject_FunctionDeclaration_87C4B4A9_calculate::.ctor()
+		IL_0011: newobj instance void Modules.Function_DefaultParameterExpression/calculate/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "calculate"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_DefaultParameterExpression/calculate/FunctionObject_FunctionDeclaration_87C4B4A9_calculate>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_DefaultParameterExpression/calculate/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterValue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterValue.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4C80C787_greet
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -105,7 +105,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_DefaultParameterValue/greet::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -124,7 +124,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_DefaultParameterValue/greet::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -142,9 +142,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4C80C787_greet
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -231,7 +231,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A99DB459_add
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -245,7 +245,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -256,7 +256,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -267,7 +267,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -289,7 +289,7 @@
 				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0018: call object Modules.Function_DefaultParameterValue/'add'::__js_call__(object, float64, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -312,7 +312,7 @@
 				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0014: call object Modules.Function_DefaultParameterValue/'add'::__js_call__(object, float64, object)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -330,9 +330,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A99DB459_add
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -421,7 +421,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4C0D3643_multi
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -435,7 +435,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -446,7 +446,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -457,7 +457,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -481,7 +481,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -506,7 +506,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -524,9 +524,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4C0D3643_multi
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -641,9 +641,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_DefaultParameterValue/Scope,
-			[1] class Modules.Function_DefaultParameterValue/greet/FunctionObject_FunctionDeclaration_4C80C787_greet,
-			[2] class Modules.Function_DefaultParameterValue/'add'/FunctionObject_FunctionDeclaration_A99DB459_add,
-			[3] class Modules.Function_DefaultParameterValue/multi/FunctionObject_FunctionDeclaration_4C0D3643_multi,
+			[1] class Modules.Function_DefaultParameterValue/greet/FunctionObject,
+			[2] class Modules.Function_DefaultParameterValue/'add'/FunctionObject,
+			[3] class Modules.Function_DefaultParameterValue/multi/FunctionObject,
 			[4] object[]
 		)
 
@@ -656,13 +656,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void Modules.Function_DefaultParameterValue/greet/FunctionObject_FunctionDeclaration_4C80C787_greet::.ctor()
+		IL_0012: newobj instance void Modules.Function_DefaultParameterValue/greet/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "greet"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_DefaultParameterValue/greet/FunctionObject_FunctionDeclaration_4C80C787_greet>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_DefaultParameterValue/greet/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -671,13 +671,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 4
-		IL_0032: newobj instance void Modules.Function_DefaultParameterValue/'add'/FunctionObject_FunctionDeclaration_A99DB459_add::.ctor()
+		IL_0032: newobj instance void Modules.Function_DefaultParameterValue/'add'/FunctionObject::.ctor()
 		IL_0037: ldc.i4.1
 		IL_0038: conv.r8
 		IL_0039: ldstr "add"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_DefaultParameterValue/'add'/FunctionObject_FunctionDeclaration_A99DB459_add>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_DefaultParameterValue/'add'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -686,13 +686,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 4
-		IL_0052: newobj instance void Modules.Function_DefaultParameterValue/multi/FunctionObject_FunctionDeclaration_4C0D3643_multi::.ctor()
+		IL_0052: newobj instance void Modules.Function_DefaultParameterValue/multi/FunctionObject::.ctor()
 		IL_0057: ldc.i4.0
 		IL_0058: conv.r8
 		IL_0059: ldstr "multi"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_DefaultParameterValue/multi/FunctionObject_FunctionDeclaration_4C0D3643_multi>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_DefaultParameterValue/multi/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: nop
 		IL_0067: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CBDAF3AF_L9C26
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -56,12 +56,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26::_environment1_makeOffsetMapper
+					IL_0008: stfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject::_environment1_makeOffsetMapper
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26::_transitionalScopes
+					IL_000f: stfld object[] Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -96,14 +96,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -117,14 +117,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -142,9 +142,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_CBDAF3AF_L9C26
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -208,7 +208,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -228,9 +228,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::_environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
+				IL_0008: stfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject::_environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -241,7 +241,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -252,7 +252,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -265,14 +265,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::_environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
+				IL_0001: ldfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject::_environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper::__js_call__(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -286,14 +286,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::_environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
+				IL_0001: ldfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject::_environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper::__js_call__(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -311,9 +311,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -336,7 +336,7 @@
 				[0] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[2] object[],
-				[3] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26,
+				[3] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject,
 				[4] string
 			)
 
@@ -373,13 +373,13 @@
 			IL_0052: ldelem.ref
 			IL_0053: castclass Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope
 			IL_0058: ldloc.2
-			IL_0059: newobj instance void Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26::.ctor(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope, object[])
+			IL_0059: newobj instance void Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject::.ctor(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope, object[])
 			IL_005e: ldc.i4.1
 			IL_005f: conv.r8
 			IL_0060: ldstr ""
 			IL_0065: ldc.i4.0
 			IL_0066: ldc.i4.1
-			IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26>(!!0, float64, string, bool, bool)
+			IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_006c: stloc.3
 			IL_006d: ldloc.1
 			IL_006e: ldc.i4.1
@@ -448,7 +448,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope,
-			[1] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper,
+			[1] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -467,13 +467,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope
-		IL_0019: newobj instance void Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::.ctor(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope)
+		IL_0019: newobj instance void Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject::.ctor(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "makeOffsetMapper"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GeneratedConstruction_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GeneratedConstruction_Semantics.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0A22665E_Receiver
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_GeneratedConstruction_Semantics/Receiver::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_GeneratedConstruction_Semantics/Receiver::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0A22665E_Receiver
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -188,7 +188,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_73B6C30F_Alternate
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -202,7 +202,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -213,7 +213,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -224,7 +224,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -239,7 +239,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_GeneratedConstruction_Semantics/Alternate::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -255,7 +255,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_GeneratedConstruction_Semantics/Alternate::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -273,9 +273,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_73B6C30F_Alternate
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -320,7 +320,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -334,7 +334,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -345,7 +345,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -356,7 +356,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -372,7 +372,7 @@
 				IL_0005: call float64 Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -389,7 +389,7 @@
 				IL_0001: call float64 Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -407,9 +407,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -461,7 +461,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -481,9 +481,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::_environment0_Function_GeneratedConstruction_Semantics
+				IL_0008: stfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject::_environment0_Function_GeneratedConstruction_Semantics
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -494,7 +494,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -505,7 +505,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -518,11 +518,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::_environment0_Function_GeneratedConstruction_Semantics
+				IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject::_environment0_Function_GeneratedConstruction_Semantics
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_GeneratedConstruction_Semantics/ReturnsObject::__js_call__(class Modules.Function_GeneratedConstruction_Semantics/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -536,11 +536,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::_environment0_Function_GeneratedConstruction_Semantics
+				IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject::_environment0_Function_GeneratedConstruction_Semantics
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_GeneratedConstruction_Semantics/ReturnsObject::__js_call__(class Modules.Function_GeneratedConstruction_Semantics/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -558,9 +558,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -619,7 +619,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_60D679A4_BoundTarget
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -633,7 +633,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -644,7 +644,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -655,7 +655,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -673,7 +673,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_GeneratedConstruction_Semantics/BoundTarget::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -692,7 +692,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_GeneratedConstruction_Semantics/BoundTarget::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -710,9 +710,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_60D679A4_BoundTarget
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -875,7 +875,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2A9B4B11_L96C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -889,7 +889,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -900,7 +900,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -911,7 +911,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -926,9 +926,9 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_2A9B4B11_L96C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -973,7 +973,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A05B3306_L69C33
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -993,9 +993,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33::_environment0_Function_GeneratedConstruction_Semantics
+				IL_0008: stfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject::_environment0_Function_GeneratedConstruction_Semantics
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1006,7 +1006,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1017,7 +1017,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1030,11 +1030,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33::_environment0_Function_GeneratedConstruction_Semantics
+				IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject::_environment0_Function_GeneratedConstruction_Semantics
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32::__js_call__(class Modules.Function_GeneratedConstruction_Semantics/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1048,11 +1048,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33::_environment0_Function_GeneratedConstruction_Semantics
+				IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject::_environment0_Function_GeneratedConstruction_Semantics
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32::__js_call__(class Modules.Function_GeneratedConstruction_Semantics/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1070,9 +1070,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A05B3306_L69C33
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1202,7 +1202,7 @@
 			.maxstack 8
 			.locals init (
 				[0] object[],
-				[1] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33
+				[1] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject
 			)
 
 			IL_0000: ldc.i4.1
@@ -1218,13 +1218,13 @@
 			IL_000e: ldc.i4.0
 			IL_000f: ldelem.ref
 			IL_0010: castclass Modules.Function_GeneratedConstruction_Semantics/Scope
-			IL_0015: newobj instance void Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
+			IL_0015: newobj instance void Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
 			IL_001a: ldc.i4.0
 			IL_001b: conv.r8
 			IL_001c: ldstr ""
 			IL_0021: ldc.i4.1
 			IL_0022: ldc.i4.1
-			IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33>(!!0, float64, string, bool, bool)
+			IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0028: stloc.1
 			IL_0029: ldarg.0
 			IL_002a: ldloc.1
@@ -1373,11 +1373,11 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GeneratedConstruction_Semantics/Scope,
-			[1] class Modules.Function_GeneratedConstruction_Semantics/Receiver/FunctionObject_FunctionDeclaration_0A22665E_Receiver,
-			[2] class Modules.Function_GeneratedConstruction_Semantics/Alternate/FunctionObject_FunctionDeclaration_73B6C30F_Alternate,
-			[3] class Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive/FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive,
-			[4] class Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject,
-			[5] class Modules.Function_GeneratedConstruction_Semantics/BoundTarget/FunctionObject_FunctionDeclaration_60D679A4_BoundTarget,
+			[1] class Modules.Function_GeneratedConstruction_Semantics/Receiver/FunctionObject,
+			[2] class Modules.Function_GeneratedConstruction_Semantics/Alternate/FunctionObject,
+			[3] class Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive/FunctionObject,
+			[4] class Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject,
+			[5] class Modules.Function_GeneratedConstruction_Semantics/BoundTarget/FunctionObject,
 			[6] object,
 			[7] object,
 			[8] object,
@@ -1413,9 +1413,9 @@
 			[38] object,
 			[39] class [System.Runtime]System.Type,
 			[40] class Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject,
-			[41] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33,
+			[41] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject,
 			[42] class Modules.Function_GeneratedConstruction_Semantics/ArrowFunction_L95C15/FunctionObject,
-			[43] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_2A9B4B11_L96C24,
+			[43] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject,
 			[44] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
 
@@ -1429,13 +1429,13 @@
 		IL_0013: ldloc.0
 		IL_0014: stelem.ref
 		IL_0015: stloc.s 28
-		IL_0017: newobj instance void Modules.Function_GeneratedConstruction_Semantics/Receiver/FunctionObject_FunctionDeclaration_0A22665E_Receiver::.ctor()
+		IL_0017: newobj instance void Modules.Function_GeneratedConstruction_Semantics/Receiver/FunctionObject::.ctor()
 		IL_001c: ldc.i4.1
 		IL_001d: conv.r8
 		IL_001e: ldstr "Receiver"
 		IL_0023: ldc.i4.1
 		IL_0024: ldc.i4.1
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/Receiver/FunctionObject_FunctionDeclaration_0A22665E_Receiver>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/Receiver/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002a: stloc.1
 		IL_002b: ldc.i4.1
 		IL_002c: newarr [System.Runtime]System.Object
@@ -1444,13 +1444,13 @@
 		IL_0033: ldloc.0
 		IL_0034: stelem.ref
 		IL_0035: stloc.s 28
-		IL_0037: newobj instance void Modules.Function_GeneratedConstruction_Semantics/Alternate/FunctionObject_FunctionDeclaration_73B6C30F_Alternate::.ctor()
+		IL_0037: newobj instance void Modules.Function_GeneratedConstruction_Semantics/Alternate/FunctionObject::.ctor()
 		IL_003c: ldc.i4.0
 		IL_003d: conv.r8
 		IL_003e: ldstr "Alternate"
 		IL_0043: ldc.i4.0
 		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/Alternate/FunctionObject_FunctionDeclaration_73B6C30F_Alternate>(!!0, float64, string, bool, bool)
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/Alternate/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004a: stloc.2
 		IL_004b: ldc.i4.1
 		IL_004c: newarr [System.Runtime]System.Object
@@ -1459,13 +1459,13 @@
 		IL_0053: ldloc.0
 		IL_0054: stelem.ref
 		IL_0055: stloc.s 28
-		IL_0057: newobj instance void Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive/FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::.ctor()
+		IL_0057: newobj instance void Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive/FunctionObject::.ctor()
 		IL_005c: ldc.i4.0
 		IL_005d: conv.r8
 		IL_005e: ldstr "ReturnsPrimitive"
 		IL_0063: ldc.i4.1
 		IL_0064: ldc.i4.1
-		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive/FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive>(!!0, float64, string, bool, bool)
+		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006a: stloc.3
 		IL_006b: ldc.i4.1
 		IL_006c: newarr [System.Runtime]System.Object
@@ -1478,13 +1478,13 @@
 		IL_0079: ldc.i4.0
 		IL_007a: ldelem.ref
 		IL_007b: castclass Modules.Function_GeneratedConstruction_Semantics/Scope
-		IL_0080: newobj instance void Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
+		IL_0080: newobj instance void Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
 		IL_0085: ldc.i4.0
 		IL_0086: conv.r8
 		IL_0087: ldstr "ReturnsObject"
 		IL_008c: ldc.i4.1
 		IL_008d: ldc.i4.1
-		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject>(!!0, float64, string, bool, bool)
+		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0093: stloc.s 4
 		IL_0095: ldc.i4.1
 		IL_0096: newarr [System.Runtime]System.Object
@@ -1493,13 +1493,13 @@
 		IL_009d: ldloc.0
 		IL_009e: stelem.ref
 		IL_009f: stloc.s 28
-		IL_00a1: newobj instance void Modules.Function_GeneratedConstruction_Semantics/BoundTarget/FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::.ctor()
+		IL_00a1: newobj instance void Modules.Function_GeneratedConstruction_Semantics/BoundTarget/FunctionObject::.ctor()
 		IL_00a6: ldc.i4.1
 		IL_00a7: conv.r8
 		IL_00a8: ldstr "BoundTarget"
 		IL_00ad: ldc.i4.1
 		IL_00ae: ldc.i4.1
-		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/BoundTarget/FunctionObject_FunctionDeclaration_60D679A4_BoundTarget>(!!0, float64, string, bool, bool)
+		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/BoundTarget/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00b4: stloc.s 5
 		IL_00b6: nop
 		IL_00b7: nop
@@ -1919,13 +1919,13 @@
 		IL_0512: ldc.i4.0
 		IL_0513: ldelem.ref
 		IL_0514: castclass Modules.Function_GeneratedConstruction_Semantics/Scope
-		IL_0519: newobj instance void Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
+		IL_0519: newobj instance void Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
 		IL_051e: ldc.i4.0
 		IL_051f: conv.r8
 		IL_0520: ldstr ""
 		IL_0525: ldc.i4.1
 		IL_0526: ldc.i4.1
-		IL_0527: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33>(!!0, float64, string, bool, bool)
+		IL_0527: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_052c: stloc.s 41
 		IL_052e: ldloc.s 40
 		IL_0530: ldloc.s 41
@@ -2103,14 +2103,14 @@
 		IL_06ff: ldloc.0
 		IL_0700: stelem.ref
 		IL_0701: stloc.s 28
-		IL_0703: newobj instance void Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_2A9B4B11_L96C24::.ctor()
+		IL_0703: newobj instance void Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject::.ctor()
 		IL_0708: ldc.i4.0
 		IL_0709: conv.r8
 		IL_070a: ldstr ""
 		IL_070f: ldc.i4.0
 		IL_0710: ldc.i4.1
-		IL_0711: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_2A9B4B11_L96C24>(!!0, float64, string, bool, bool)
-		IL_0716: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject_FunctionExpression_2A9B4B11_L96C24>(!!0)
+		IL_0711: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0716: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder/FunctionObject>(!!0)
 		IL_071b: stloc.s 43
 		IL_071d: ldloc.s 37
 		IL_071f: ldstr "method"

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::_environment0_Function_GlobalFunctionCallsGlobalFunction
+				IL_0008: stfld class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject::_environment0_Function_GlobalFunctionCallsGlobalFunction
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::_environment0_Function_GlobalFunctionCallsGlobalFunction
+				IL_0001: ldfld class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject::_environment0_Function_GlobalFunctionCallsGlobalFunction
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy::__js_call__(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::_environment0_Function_GlobalFunctionCallsGlobalFunction
+				IL_0001: ldfld class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject::_environment0_Function_GlobalFunctionCallsGlobalFunction
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy::__js_call__(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -201,7 +201,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ED3CD900_helloWorld
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -215,7 +215,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -226,7 +226,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -237,7 +237,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -252,7 +252,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -268,7 +268,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -286,9 +286,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_ED3CD900_helloWorld
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -367,9 +367,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope,
-			[1] class Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy,
+			[1] class Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject,
 			[2] object[],
-			[3] class Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld/FunctionObject_FunctionDeclaration_ED3CD900_helloWorld,
+			[3] class Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
 
@@ -386,13 +386,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_GlobalFunctionCallsGlobalFunction/Scope
-		IL_0019: newobj instance void Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::.ctor(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope)
+		IL_0019: newobj instance void Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject::.ctor(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "helloWorldProxy"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: ldc.i4.1
 		IL_002e: newarr [System.Runtime]System.Object
@@ -401,13 +401,13 @@
 		IL_0035: ldloc.0
 		IL_0036: stelem.ref
 		IL_0037: stloc.2
-		IL_0038: newobj instance void Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld/FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::.ctor()
+		IL_0038: newobj instance void Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld/FunctionObject::.ctor()
 		IL_003d: ldc.i4.0
 		IL_003e: conv.r8
 		IL_003f: ldstr "helloWorld"
 		IL_0044: ldc.i4.0
 		IL_0045: ldc.i4.1
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld/FunctionObject_FunctionDeclaration_ED3CD900_helloWorld>(!!0, float64, string, bool, bool)
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004b: stloc.3
 		IL_004c: ldloc.0
 		IL_004d: ldloc.3

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::_environment0_Function_GlobalFunctionChangesGlobalVariableValue
+				IL_0008: stfld class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject::_environment0_Function_GlobalFunctionChangesGlobalVariableValue
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::_environment0_Function_GlobalFunctionChangesGlobalVariableValue
+				IL_0001: ldfld class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject::_environment0_Function_GlobalFunctionChangesGlobalVariableValue
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues::__js_call__(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::_environment0_Function_GlobalFunctionChangesGlobalVariableValue
+				IL_0001: ldfld class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject::_environment0_Function_GlobalFunctionChangesGlobalVariableValue
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues::__js_call__(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -279,7 +279,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope,
-			[1] class Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues,
+			[1] class Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object,
@@ -299,13 +299,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope
-		IL_0019: newobj instance void Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::.ctor(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope)
+		IL_0019: newobj instance void Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject::.ctor(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "changeGlobalValues"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionDeclaresAndCallsNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionDeclaresAndCallsNestedFunction.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C398478A_innerFunction
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -48,7 +48,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -59,7 +59,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -70,7 +70,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -85,7 +85,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -101,7 +101,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -119,9 +119,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_C398478A_innerFunction
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -179,7 +179,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_55A149C5_outerFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -193,7 +193,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -204,7 +204,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -215,7 +215,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -230,7 +230,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -246,7 +246,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -264,9 +264,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_55A149C5_outerFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -283,7 +283,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/Scope,
-				[1] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_C398478A_innerFunction,
+				[1] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction/FunctionObject,
 				[2] object,
 				[3] object[],
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.Console
@@ -293,13 +293,13 @@
 			IL_0005: stloc.0
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.3
-			IL_000c: newobj instance void Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_C398478A_innerFunction::.ctor()
+			IL_000c: newobj instance void Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction/FunctionObject::.ctor()
 			IL_0011: ldc.i4.0
 			IL_0012: conv.r8
 			IL_0013: ldstr "innerFunction"
 			IL_0018: ldc.i4.0
 			IL_0019: ldc.i4.1
-			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_C398478A_innerFunction>(!!0, float64, string, bool, bool)
+			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_001f: stloc.1
 			IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 			IL_0025: stloc.s 4
@@ -374,7 +374,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/Scope,
-			[1] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/FunctionObject_FunctionDeclaration_55A149C5_outerFunction,
+			[1] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console
@@ -389,13 +389,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/FunctionObject_FunctionDeclaration_55A149C5_outerFunction::.ctor()
+		IL_0011: newobj instance void Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "outerFunction"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/FunctionObject_FunctionDeclaration_55A149C5_outerFunction>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::_environment0_Function_GlobalFunctionLogsGlobalVariable
+				IL_0008: stfld class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject::_environment0_Function_GlobalFunctionLogsGlobalVariable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::_environment0_Function_GlobalFunctionLogsGlobalVariable
+				IL_0001: ldfld class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject::_environment0_Function_GlobalFunctionLogsGlobalVariable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues::__js_call__(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::_environment0_Function_GlobalFunctionLogsGlobalVariable
+				IL_0001: ldfld class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject::_environment0_Function_GlobalFunctionLogsGlobalVariable
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues::__js_call__(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -227,7 +227,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope,
-			[1] class Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues,
+			[1] class Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject,
 			[2] object[]
 		)
 
@@ -244,13 +244,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_GlobalFunctionLogsGlobalVariable/Scope
-		IL_0019: newobj instance void Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::.ctor(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope)
+		IL_0019: newobj instance void Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject::.ctor(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "logGlobalValues"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -58,15 +58,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+					IL_0008: stfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_environment1_createFunction
+					IL_000f: stfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject::_environment1_createFunction
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_transitionalScopes
+					IL_0016: stfld object[] Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -77,7 +77,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -88,7 +88,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -101,11 +101,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -119,11 +119,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -141,9 +141,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -250,7 +250,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9067EF51_createFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -270,9 +270,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject_FunctionDeclaration_9067EF51_createFunction::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+				IL_0008: stfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -283,7 +283,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -294,7 +294,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -307,14 +307,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject_FunctionDeclaration_9067EF51_createFunction::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+				IL_0001: ldfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction::__js_call__(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -328,14 +328,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject_FunctionDeclaration_9067EF51_createFunction::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+				IL_0001: ldfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction::__js_call__(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -353,9 +353,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9067EF51_createFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -376,7 +376,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope,
-				[1] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction,
+				[1] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject,
 				[2] object[]
 			)
 
@@ -405,13 +405,13 @@
 			IL_0026: ldelem.ref
 			IL_0027: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope
 			IL_002c: ldloc.2
-			IL_002d: newobj instance void Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::.ctor(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope, object[])
+			IL_002d: newobj instance void Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject::.ctor(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope, object[])
 			IL_0032: ldc.i4.0
 			IL_0033: conv.r8
 			IL_0034: ldstr "nestedFunction"
 			IL_0039: ldc.i4.0
 			IL_003a: ldc.i4.1
-			IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction>(!!0, float64, string, bool, bool)
+			IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0040: stloc.1
 			IL_0041: nop
 			IL_0042: ldloc.1
@@ -465,7 +465,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope,
-			[1] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject_FunctionDeclaration_9067EF51_createFunction,
+			[1] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object[],
@@ -485,13 +485,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
-		IL_001b: newobj instance void Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject_FunctionDeclaration_9067EF51_createFunction::.ctor(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope)
+		IL_001b: newobj instance void Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject::.ctor(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "createFunction"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject_FunctionDeclaration_9067EF51_createFunction>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: ldloc.0

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_88106FB6_processArray
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -106,7 +106,7 @@
 				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_0011: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_GlobalFunctionWithArrayIteration/processArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,7 +126,7 @@
 				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_GlobalFunctionWithArrayIteration/processArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -144,9 +144,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_88106FB6_processArray
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -256,7 +256,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithArrayIteration/Scope,
-			[1] class Modules.Function_GlobalFunctionWithArrayIteration/processArray/FunctionObject_FunctionDeclaration_88106FB6_processArray,
+			[1] class Modules.Function_GlobalFunctionWithArrayIteration/processArray/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object,
 			[4] object[],
@@ -273,13 +273,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void Modules.Function_GlobalFunctionWithArrayIteration/processArray/FunctionObject_FunctionDeclaration_88106FB6_processArray::.ctor()
+		IL_0012: newobj instance void Modules.Function_GlobalFunctionWithArrayIteration/processArray/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "processArray"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithArrayIteration/processArray/FunctionObject_FunctionDeclaration_88106FB6_processArray>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithArrayIteration/processArray/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithMultipleParameters.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithMultipleParameters.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E2574271_f1
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.Function_GlobalFunctionWithMultipleParameters/f1::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.Function_GlobalFunctionWithMultipleParameters/f1::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E2574271_f1
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -182,7 +182,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DF573DB8_f2
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -196,7 +196,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -207,7 +207,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -218,7 +218,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -241,7 +241,7 @@
 				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001d: call object Modules.Function_GlobalFunctionWithMultipleParameters/f2::__js_call__(object, float64, float64)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -265,7 +265,7 @@
 				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0019: call object Modules.Function_GlobalFunctionWithMultipleParameters/f2::__js_call__(object, float64, float64)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -283,9 +283,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DF573DB8_f2
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -345,7 +345,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E0573F4B_f3
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -359,7 +359,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -370,7 +370,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -381,7 +381,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -408,7 +408,7 @@
 				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0029: call object Modules.Function_GlobalFunctionWithMultipleParameters/f3::__js_call__(object, float64, float64, float64)
 				IL_002e: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -436,7 +436,7 @@
 				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0025: call object Modules.Function_GlobalFunctionWithMultipleParameters/f3::__js_call__(object, float64, float64, float64)
 				IL_002a: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -454,9 +454,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E0573F4B_f3
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -533,7 +533,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E557472A_f4
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -547,7 +547,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -558,7 +558,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -569,7 +569,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -600,7 +600,7 @@
 				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0035: call object Modules.Function_GlobalFunctionWithMultipleParameters/f4::__js_call__(object, float64, float64, float64, float64)
 				IL_003a: ret
-			} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -632,7 +632,7 @@
 				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0031: call object Modules.Function_GlobalFunctionWithMultipleParameters/f4::__js_call__(object, float64, float64, float64, float64)
 				IL_0036: ret
-			} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -650,9 +650,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E557472A_f4
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -735,7 +735,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E65748BD_f5
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -749,7 +749,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -760,7 +760,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -771,7 +771,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -806,7 +806,7 @@
 				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0041: call object Modules.Function_GlobalFunctionWithMultipleParameters/f5::__js_call__(object, float64, float64, float64, float64, float64)
 				IL_0046: ret
-			} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -842,7 +842,7 @@
 				IL_0038: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_003d: call object Modules.Function_GlobalFunctionWithMultipleParameters/f5::__js_call__(object, float64, float64, float64, float64, float64)
 				IL_0042: ret
-			} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -860,9 +860,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E65748BD_f5
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -951,7 +951,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E3574404_f6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -965,7 +965,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -976,7 +976,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -987,7 +987,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1026,7 +1026,7 @@
 				IL_0048: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_004d: call object Modules.Function_GlobalFunctionWithMultipleParameters/f6::__js_call__(object, float64, float64, float64, float64, float64, float64)
 				IL_0052: ret
-			} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1066,7 +1066,7 @@
 				IL_0044: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0049: call object Modules.Function_GlobalFunctionWithMultipleParameters/f6::__js_call__(object, float64, float64, float64, float64, float64, float64)
 				IL_004e: ret
-			} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1084,9 +1084,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E3574404_f6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1217,12 +1217,12 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithMultipleParameters/Scope,
-			[1] class Modules.Function_GlobalFunctionWithMultipleParameters/f1/FunctionObject_FunctionDeclaration_E2574271_f1,
-			[2] class Modules.Function_GlobalFunctionWithMultipleParameters/f2/FunctionObject_FunctionDeclaration_DF573DB8_f2,
-			[3] class Modules.Function_GlobalFunctionWithMultipleParameters/f3/FunctionObject_FunctionDeclaration_E0573F4B_f3,
-			[4] class Modules.Function_GlobalFunctionWithMultipleParameters/f4/FunctionObject_FunctionDeclaration_E557472A_f4,
-			[5] class Modules.Function_GlobalFunctionWithMultipleParameters/f5/FunctionObject_FunctionDeclaration_E65748BD_f5,
-			[6] class Modules.Function_GlobalFunctionWithMultipleParameters/f6/FunctionObject_FunctionDeclaration_E3574404_f6,
+			[1] class Modules.Function_GlobalFunctionWithMultipleParameters/f1/FunctionObject,
+			[2] class Modules.Function_GlobalFunctionWithMultipleParameters/f2/FunctionObject,
+			[3] class Modules.Function_GlobalFunctionWithMultipleParameters/f3/FunctionObject,
+			[4] class Modules.Function_GlobalFunctionWithMultipleParameters/f4/FunctionObject,
+			[5] class Modules.Function_GlobalFunctionWithMultipleParameters/f5/FunctionObject,
+			[6] class Modules.Function_GlobalFunctionWithMultipleParameters/f6/FunctionObject,
 			[7] object[]
 		)
 
@@ -1235,13 +1235,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
-		IL_0012: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f1/FunctionObject_FunctionDeclaration_E2574271_f1::.ctor()
+		IL_0012: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f1/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "f1"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f1/FunctionObject_FunctionDeclaration_E2574271_f1>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f1/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1250,13 +1250,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 7
-		IL_0032: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f2/FunctionObject_FunctionDeclaration_DF573DB8_f2::.ctor()
+		IL_0032: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f2/FunctionObject::.ctor()
 		IL_0037: ldc.i4.2
 		IL_0038: conv.r8
 		IL_0039: ldstr "f2"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f2/FunctionObject_FunctionDeclaration_DF573DB8_f2>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f2/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -1265,13 +1265,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 7
-		IL_0052: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f3/FunctionObject_FunctionDeclaration_E0573F4B_f3::.ctor()
+		IL_0052: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f3/FunctionObject::.ctor()
 		IL_0057: ldc.i4.3
 		IL_0058: conv.r8
 		IL_0059: ldstr "f3"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f3/FunctionObject_FunctionDeclaration_E0573F4B_f3>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f3/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -1280,13 +1280,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 7
-		IL_0072: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f4/FunctionObject_FunctionDeclaration_E557472A_f4::.ctor()
+		IL_0072: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f4/FunctionObject::.ctor()
 		IL_0077: ldc.i4.4
 		IL_0078: conv.r8
 		IL_0079: ldstr "f4"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f4/FunctionObject_FunctionDeclaration_E557472A_f4>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f4/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -1295,13 +1295,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 7
-		IL_0093: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f5/FunctionObject_FunctionDeclaration_E65748BD_f5::.ctor()
+		IL_0093: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f5/FunctionObject::.ctor()
 		IL_0098: ldc.i4.5
 		IL_0099: conv.r8
 		IL_009a: ldstr "f5"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f5/FunctionObject_FunctionDeclaration_E65748BD_f5>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1310,13 +1310,13 @@
 		IL_00b0: ldloc.0
 		IL_00b1: stelem.ref
 		IL_00b2: stloc.s 7
-		IL_00b4: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f6/FunctionObject_FunctionDeclaration_E3574404_f6::.ctor()
+		IL_00b4: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f6/FunctionObject::.ctor()
 		IL_00b9: ldc.i4.6
 		IL_00ba: conv.r8
 		IL_00bb: ldstr "f6"
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f6/FunctionObject_FunctionDeclaration_E3574404_f6>(!!0, float64, string, bool, bool)
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f6/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c7: stloc.s 6
 		IL_00c9: nop
 		IL_00ca: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D266391D_printMessage
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.Function_GlobalFunctionWithParameter/printMessage::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.Function_GlobalFunctionWithParameter/printMessage::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D266391D_printMessage
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -201,7 +201,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithParameter/Scope,
-			[1] class Modules.Function_GlobalFunctionWithParameter/printMessage/FunctionObject_FunctionDeclaration_D266391D_printMessage,
+			[1] class Modules.Function_GlobalFunctionWithParameter/printMessage/FunctionObject,
 			[2] object[]
 		)
 
@@ -214,13 +214,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_GlobalFunctionWithParameter/printMessage/FunctionObject_FunctionDeclaration_D266391D_printMessage::.ctor()
+		IL_0011: newobj instance void Modules.Function_GlobalFunctionWithParameter/printMessage/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "printMessage"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithParameter/printMessage/FunctionObject_FunctionDeclaration_D266391D_printMessage>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithParameter/printMessage/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_HelloWorld.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9A002B81_helloWorld
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_HelloWorld/helloWorld::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_HelloWorld/helloWorld::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9A002B81_helloWorld
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -191,7 +191,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_HelloWorld/Scope,
-			[1] class Modules.Function_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_9A002B81_helloWorld,
+			[1] class Modules.Function_HelloWorld/helloWorld/FunctionObject,
 			[2] object[]
 		)
 
@@ -204,13 +204,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_9A002B81_helloWorld::.ctor()
+		IL_0011: newobj instance void Modules.Function_HelloWorld/helloWorld/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "helloWorld"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_9A002B81_helloWorld>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_HelloWorld/helloWorld/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Classic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Classic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DC85BFED_L3C2
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_IIFE_Classic/FunctionExpression_L3C1::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_IIFE_Classic/FunctionExpression_L3C1::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_DC85BFED_L3C2
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -184,7 +184,7 @@
 		.locals init (
 			[0] class Modules.Function_IIFE_Classic/Scope,
 			[1] object[],
-			[2] class Modules.Function_IIFE_Classic/FunctionExpression_L3C1/FunctionObject_FunctionExpression_DC85BFED_L3C2
+			[2] class Modules.Function_IIFE_Classic/FunctionExpression_L3C1/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Function_IIFE_Classic/Scope::.ctor()
@@ -197,13 +197,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.1
-		IL_0012: newobj instance void Modules.Function_IIFE_Classic/FunctionExpression_L3C1/FunctionObject_FunctionExpression_DC85BFED_L3C2::.ctor()
+		IL_0012: newobj instance void Modules.Function_IIFE_Classic/FunctionExpression_L3C1/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_IIFE_Classic/FunctionExpression_L3C1/FunctionObject_FunctionExpression_DC85BFED_L3C2>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_IIFE_Classic/FunctionExpression_L3C1/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.2
 		IL_0026: ldloc.2
 		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Recursive.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Recursive.verified.txt
@@ -77,7 +77,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F39F0734_walk
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -91,7 +91,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_F39F0734_walk::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -102,7 +102,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F39F0734_walk::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -113,7 +113,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F39F0734_walk::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -134,7 +134,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_IIFE_Recursive/walk::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_F39F0734_walk::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -156,7 +156,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_IIFE_Recursive/walk::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_F39F0734_walk::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -174,9 +174,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F39F0734_walk::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F39F0734_walk
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -317,7 +317,7 @@
 		.locals init (
 			[0] class Modules.Function_IIFE_Recursive/Scope,
 			[1] object[],
-			[2] class Modules.Function_IIFE_Recursive/walk/FunctionObject_FunctionExpression_F39F0734_walk,
+			[2] class Modules.Function_IIFE_Recursive/walk/FunctionObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -331,13 +331,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.1
-		IL_0012: newobj instance void Modules.Function_IIFE_Recursive/walk/FunctionObject_FunctionExpression_F39F0734_walk::.ctor()
+		IL_0012: newobj instance void Modules.Function_IIFE_Recursive/walk/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "walk"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_IIFE_Recursive/walk/FunctionObject_FunctionExpression_F39F0734_walk>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_IIFE_Recursive/walk/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.2
 		IL_0026: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002b: stloc.1

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Length_Name_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Length_Name_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_74B1D4A4_add3
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -90,7 +90,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Function_Instance_Length_Name_Basic/add3::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -115,7 +115,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.Function_Instance_Length_Name_Basic/add3::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_74B1D4A4_add3
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -213,7 +213,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Instance_Length_Name_Basic/Scope,
-			[1] class Modules.Function_Instance_Length_Name_Basic/add3/FunctionObject_FunctionDeclaration_74B1D4A4_add3,
+			[1] class Modules.Function_Instance_Length_Name_Basic/add3/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object,
@@ -231,13 +231,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_Instance_Length_Name_Basic/add3/FunctionObject_FunctionDeclaration_74B1D4A4_add3::.ctor()
+		IL_0011: newobj instance void Modules.Function_Instance_Length_Name_Basic/add3/FunctionObject::.ctor()
 		IL_0016: ldc.i4.3
 		IL_0017: conv.r8
 		IL_0018: ldstr "add3"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Instance_Length_Name_Basic/add3/FunctionObject_FunctionDeclaration_74B1D4A4_add3>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Instance_Length_Name_Basic/add3/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Length_Name_DescriptorOwnProperties.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Length_Name_DescriptorOwnProperties.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7702B128_namedAdd
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -90,7 +90,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -115,7 +115,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7702B128_namedAdd
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -194,7 +194,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D4A5687D_L18C21
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -208,7 +208,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -219,7 +219,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -230,7 +230,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -244,7 +244,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -265,7 +265,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -287,7 +287,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -305,9 +305,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D4A5687D_L18C21
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -380,10 +380,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/Scope,
-			[1] class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd/FunctionObject_FunctionDeclaration_7702B128_namedAdd,
+			[1] class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd/FunctionObject,
 			[2] object,
 			[3] object,
-			[4] class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'/FunctionObject_FunctionExpression_D4A5687D_L18C21,
+			[4] class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'/FunctionObject,
 			[5] object,
 			[6] object,
 			[7] object[],
@@ -408,13 +408,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
-		IL_0012: newobj instance void Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd/FunctionObject_FunctionDeclaration_7702B128_namedAdd::.ctor()
+		IL_0012: newobj instance void Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd/FunctionObject::.ctor()
 		IL_0017: ldc.i4.3
 		IL_0018: conv.r8
 		IL_0019: ldstr "namedAdd"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd/FunctionObject_FunctionDeclaration_7702B128_namedAdd>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
@@ -663,14 +663,14 @@
 		IL_031a: ldloc.0
 		IL_031b: stelem.ref
 		IL_031c: stloc.s 7
-		IL_031e: newobj instance void Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'/FunctionObject_FunctionExpression_D4A5687D_L18C21::.ctor()
+		IL_031e: newobj instance void Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'/FunctionObject::.ctor()
 		IL_0323: ldc.i4.2
 		IL_0324: conv.r8
 		IL_0325: ldstr ""
 		IL_032a: ldc.i4.0
 		IL_032b: ldc.i4.0
-		IL_032c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'/FunctionObject_FunctionExpression_D4A5687D_L18C21>(!!0, float64, string, bool, bool)
-		IL_0331: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'/FunctionObject_FunctionExpression_D4A5687D_L18C21>(!!0)
+		IL_032c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0331: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'/FunctionObject>(!!0)
 		IL_0336: stloc.s 4
 		IL_0338: ldloc.s 4
 		IL_033a: ldstr "length"

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -82,7 +82,7 @@
 				IL_0005: call float64 Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -99,7 +99,7 @@
 				IL_0001: call float64 Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -117,9 +117,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -185,7 +185,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/Scope,
-			[1] class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34/FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34,
+			[1] class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object,
@@ -202,13 +202,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34/FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::.ctor()
+		IL_0011: newobj instance void Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "DynamicFunction_L12C34"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34/FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IsEven_CompareResultToTrue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IsEven_CompareResultToTrue.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_24CC1E21_isEven
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.Function_IsEven_CompareResultToTrue/isEven::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.Function_IsEven_CompareResultToTrue/isEven::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_24CC1E21_isEven
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -195,7 +195,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_IsEven_CompareResultToTrue/Scope,
-			[1] class Modules.Function_IsEven_CompareResultToTrue/isEven/FunctionObject_FunctionDeclaration_24CC1E21_isEven,
+			[1] class Modules.Function_IsEven_CompareResultToTrue/isEven/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object,
@@ -212,13 +212,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_IsEven_CompareResultToTrue/isEven/FunctionObject_FunctionDeclaration_24CC1E21_isEven::.ctor()
+		IL_0011: newobj instance void Modules.Function_IsEven_CompareResultToTrue/isEven/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "isEven"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_IsEven_CompareResultToTrue/isEven/FunctionObject_FunctionDeclaration_24CC1E21_isEven>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_IsEven_CompareResultToTrue/isEven/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_MaxParameters_16.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_MaxParameters_16.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E2B5C791_f
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -129,7 +129,7 @@
 				IL_0077: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_007c: call object Modules.Function_MaxParameters_16/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
 				IL_0081: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -193,7 +193,7 @@
 				IL_0073: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0078: call object Modules.Function_MaxParameters_16/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
 				IL_007d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -211,9 +211,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E2B5C791_f
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -292,7 +292,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_MaxParameters_16/Scope,
-			[1] class Modules.Function_MaxParameters_16/f/FunctionObject_FunctionDeclaration_E2B5C791_f,
+			[1] class Modules.Function_MaxParameters_16/f/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -307,13 +307,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_MaxParameters_16/f/FunctionObject_FunctionDeclaration_E2B5C791_f::.ctor()
+		IL_0011: newobj instance void Modules.Function_MaxParameters_16/f/FunctionObject::.ctor()
 		IL_0016: ldc.i4.s 16
 		IL_0018: conv.r8
 		IL_0019: ldstr "f"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_MaxParameters_16/f/FunctionObject_FunctionDeclaration_E2B5C791_f>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_MaxParameters_16/f/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_MaxParameters_32_CallViaVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_MaxParameters_32_CallViaVariable.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5DEE3A80_f
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -177,7 +177,7 @@
 				IL_00f7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_00fc: call object Modules.Function_MaxParameters_32_CallViaVariable/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
 				IL_0101: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -289,7 +289,7 @@
 				IL_00f3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_00f8: call object Modules.Function_MaxParameters_32_CallViaVariable/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
 				IL_00fd: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -307,9 +307,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5DEE3A80_f
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -404,8 +404,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_MaxParameters_32_CallViaVariable/Scope,
-			[1] class Modules.Function_MaxParameters_32_CallViaVariable/f/FunctionObject_FunctionDeclaration_5DEE3A80_f,
-			[2] class Modules.Function_MaxParameters_32_CallViaVariable/f/FunctionObject_FunctionDeclaration_5DEE3A80_f,
+			[1] class Modules.Function_MaxParameters_32_CallViaVariable/f/FunctionObject,
+			[2] class Modules.Function_MaxParameters_32_CallViaVariable/f/FunctionObject,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] object
@@ -420,13 +420,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_MaxParameters_32_CallViaVariable/f/FunctionObject_FunctionDeclaration_5DEE3A80_f::.ctor()
+		IL_0011: newobj instance void Modules.Function_MaxParameters_32_CallViaVariable/f/FunctionObject::.ctor()
 		IL_0016: ldc.i4.s 32
 		IL_0018: conv.r8
 		IL_0019: ldstr "f"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_MaxParameters_32_CallViaVariable/f/FunctionObject_FunctionDeclaration_5DEE3A80_f>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_MaxParameters_32_CallViaVariable/f/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -58,15 +58,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_environment0_Function_NestedFunctionAccessesMultipleScopes
+					IL_0008: stfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject::_environment0_Function_NestedFunctionAccessesMultipleScopes
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_environment1_testFunction
+					IL_000f: stfld class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject::_environment1_testFunction
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_transitionalScopes
+					IL_0016: stfld object[] Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -77,7 +77,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -88,7 +88,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -101,11 +101,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -119,11 +119,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -141,9 +141,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -235,7 +235,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B1D31301_testFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -255,9 +255,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject_FunctionDeclaration_B1D31301_testFunction::_environment0_Function_NestedFunctionAccessesMultipleScopes
+				IL_0008: stfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject::_environment0_Function_NestedFunctionAccessesMultipleScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -268,7 +268,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -279,7 +279,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -292,11 +292,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject_FunctionDeclaration_B1D31301_testFunction::_environment0_Function_NestedFunctionAccessesMultipleScopes
+				IL_0001: ldfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject::_environment0_Function_NestedFunctionAccessesMultipleScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction::__js_call__(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -310,11 +310,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject_FunctionDeclaration_B1D31301_testFunction::_environment0_Function_NestedFunctionAccessesMultipleScopes
+				IL_0001: ldfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject::_environment0_Function_NestedFunctionAccessesMultipleScopes
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction::__js_call__(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -332,9 +332,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B1D31301_testFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -354,7 +354,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope,
-				[1] class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction,
+				[1] class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject,
 				[2] object[]
 			)
 
@@ -380,13 +380,13 @@
 			IL_001f: ldelem.ref
 			IL_0020: castclass Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope
 			IL_0025: ldloc.2
-			IL_0026: newobj instance void Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::.ctor(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope, object[])
+			IL_0026: newobj instance void Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject::.ctor(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope, object[])
 			IL_002b: ldc.i4.0
 			IL_002c: conv.r8
 			IL_002d: ldstr "innerFunction"
 			IL_0032: ldc.i4.0
 			IL_0033: ldc.i4.1
-			IL_0034: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction>(!!0, float64, string, bool, bool)
+			IL_0034: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0039: stloc.1
 			IL_003a: ldloc.0
 			IL_003b: ldstr "I am outer"
@@ -452,7 +452,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope,
-			[1] class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject_FunctionDeclaration_B1D31301_testFunction,
+			[1] class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject,
 			[2] object[]
 		)
 
@@ -469,13 +469,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_NestedFunctionAccessesMultipleScopes/Scope
-		IL_0019: newobj instance void Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject_FunctionDeclaration_B1D31301_testFunction::.ctor(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope)
+		IL_0019: newobj instance void Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject::.ctor(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject_FunctionDeclaration_B1D31301_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -56,12 +56,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::_environment1_outerFunction
+					IL_0008: stfld class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject::_environment1_outerFunction
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::_transitionalScopes
+					IL_000f: stfld object[] Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -96,14 +96,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -117,14 +117,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -142,9 +142,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -221,7 +221,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0C23077A_outerFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -241,9 +241,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_NestedFunctionLogsOuterParameter/Scope Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject_FunctionDeclaration_0C23077A_outerFunction::_environment0_Function_NestedFunctionLogsOuterParameter
+				IL_0008: stfld class Modules.Function_NestedFunctionLogsOuterParameter/Scope Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject::_environment0_Function_NestedFunctionLogsOuterParameter
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -254,7 +254,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -265,7 +265,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -278,14 +278,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_NestedFunctionLogsOuterParameter/Scope Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject_FunctionDeclaration_0C23077A_outerFunction::_environment0_Function_NestedFunctionLogsOuterParameter
+				IL_0001: ldfld class Modules.Function_NestedFunctionLogsOuterParameter/Scope Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject::_environment0_Function_NestedFunctionLogsOuterParameter
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction::__js_call__(class Modules.Function_NestedFunctionLogsOuterParameter/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -299,14 +299,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_NestedFunctionLogsOuterParameter/Scope Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject_FunctionDeclaration_0C23077A_outerFunction::_environment0_Function_NestedFunctionLogsOuterParameter
+				IL_0001: ldfld class Modules.Function_NestedFunctionLogsOuterParameter/Scope Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject::_environment0_Function_NestedFunctionLogsOuterParameter
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction::__js_call__(class Modules.Function_NestedFunctionLogsOuterParameter/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -324,9 +324,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0C23077A_outerFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -347,7 +347,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope,
-				[1] class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction,
+				[1] class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject,
 				[2] object[]
 			)
 
@@ -372,13 +372,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope
 			IL_0024: ldloc.2
-			IL_0025: newobj instance void Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::.ctor(class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope, object[])
+			IL_0025: newobj instance void Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject::.ctor(class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope, object[])
 			IL_002a: ldc.i4.1
 			IL_002b: conv.r8
 			IL_002c: ldstr "innerFunction"
 			IL_0031: ldc.i4.0
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.1
 			IL_0039: nop
 			IL_003a: ldloc.1
@@ -430,7 +430,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NestedFunctionLogsOuterParameter/Scope,
-			[1] class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject_FunctionDeclaration_0C23077A_outerFunction,
+			[1] class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject,
 			[2] object,
 			[3] object[]
 		)
@@ -448,13 +448,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_NestedFunctionLogsOuterParameter/Scope
-		IL_0019: newobj instance void Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject_FunctionDeclaration_0C23077A_outerFunction::.ctor(class Modules.Function_NestedFunctionLogsOuterParameter/Scope)
+		IL_0019: newobj instance void Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject::.ctor(class Modules.Function_NestedFunctionLogsOuterParameter/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "outerFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject_FunctionDeclaration_0C23077A_outerFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6D849243_L7C16
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -48,7 +48,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -59,7 +59,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -70,7 +70,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -85,7 +85,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -101,7 +101,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -119,9 +119,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_6D849243_L7C16
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -173,7 +173,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_56210BE4_inner
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -195,12 +195,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner::_environment1_outer
+					IL_0008: stfld class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject::_environment1_outer
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner::_transitionalScopes
+					IL_000f: stfld object[] Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -211,7 +211,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -222,7 +222,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -235,11 +235,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Function_NewExpression_CapturesOuterCtor/outer/inner::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -253,11 +253,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Function_NewExpression_CapturesOuterCtor/outer/inner::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -275,9 +275,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_56210BE4_inner
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -346,7 +346,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_93D08467_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -366,9 +366,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_NewExpression_CapturesOuterCtor/Scope Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject_FunctionDeclaration_93D08467_outer::_environment0_Function_NewExpression_CapturesOuterCtor
+				IL_0008: stfld class Modules.Function_NewExpression_CapturesOuterCtor/Scope Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject::_environment0_Function_NewExpression_CapturesOuterCtor
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -379,7 +379,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -390,7 +390,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -403,11 +403,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_NewExpression_CapturesOuterCtor/Scope Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject_FunctionDeclaration_93D08467_outer::_environment0_Function_NewExpression_CapturesOuterCtor
+				IL_0001: ldfld class Modules.Function_NewExpression_CapturesOuterCtor/Scope Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject::_environment0_Function_NewExpression_CapturesOuterCtor
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_NewExpression_CapturesOuterCtor/outer::__js_call__(class Modules.Function_NewExpression_CapturesOuterCtor/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -421,11 +421,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_NewExpression_CapturesOuterCtor/Scope Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject_FunctionDeclaration_93D08467_outer::_environment0_Function_NewExpression_CapturesOuterCtor
+				IL_0001: ldfld class Modules.Function_NewExpression_CapturesOuterCtor/Scope Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject::_environment0_Function_NewExpression_CapturesOuterCtor
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_NewExpression_CapturesOuterCtor/outer::__js_call__(class Modules.Function_NewExpression_CapturesOuterCtor/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -443,9 +443,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_93D08467_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -465,9 +465,9 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope,
-				[1] class Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner,
+				[1] class Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject,
 				[2] object[],
-				[3] class Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor/FunctionObject_FunctionExpression_6D849243_L7C16,
+				[3] class Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor/FunctionObject,
 				[4] object
 			)
 
@@ -489,13 +489,13 @@
 			IL_0017: ldelem.ref
 			IL_0018: castclass Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope
 			IL_001d: ldloc.2
-			IL_001e: newobj instance void Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner::.ctor(class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope, object[])
+			IL_001e: newobj instance void Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject::.ctor(class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope, object[])
 			IL_0023: ldc.i4.0
 			IL_0024: conv.r8
 			IL_0025: ldstr "inner"
 			IL_002a: ldc.i4.0
 			IL_002b: ldc.i4.1
-			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner>(!!0, float64, string, bool, bool)
+			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0031: stloc.1
 			IL_0032: ldc.i4.1
 			IL_0033: newarr [System.Runtime]System.Object
@@ -504,13 +504,13 @@
 			IL_003a: ldarg.0
 			IL_003b: stelem.ref
 			IL_003c: stloc.2
-			IL_003d: newobj instance void Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor/FunctionObject_FunctionExpression_6D849243_L7C16::.ctor()
+			IL_003d: newobj instance void Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor/FunctionObject::.ctor()
 			IL_0042: ldc.i4.0
 			IL_0043: conv.r8
 			IL_0044: ldstr ""
 			IL_0049: ldc.i4.1
 			IL_004a: ldc.i4.1
-			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor/FunctionObject_FunctionExpression_6D849243_L7C16>(!!0, float64, string, bool, bool)
+			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0050: stloc.3
 			IL_0051: ldloc.3
 			IL_0052: ldstr "Ctor"
@@ -585,7 +585,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NewExpression_CapturesOuterCtor/Scope,
-			[1] class Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject_FunctionDeclaration_93D08467_outer,
+			[1] class Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -604,13 +604,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_NewExpression_CapturesOuterCtor/Scope
-		IL_0019: newobj instance void Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject_FunctionDeclaration_93D08467_outer::.ctor(class Modules.Function_NewExpression_CapturesOuterCtor/Scope)
+		IL_0019: newobj instance void Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject::.ctor(class Modules.Function_NewExpression_CapturesOuterCtor/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject_FunctionDeclaration_93D08467_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_MemberCallee_Compiles.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_MemberCallee_Compiles.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E3E2CDFC_L4C11
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E3E2CDFC_L4C11
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -173,7 +173,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_63DFE404_L11C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -193,9 +193,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_NewExpression_MemberCallee_Compiles/Scope Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject_FunctionExpression_63DFE404_L11C20::_environment0_Function_NewExpression_MemberCallee_Compiles
+				IL_0008: stfld class Modules.Function_NewExpression_MemberCallee_Compiles/Scope Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject::_environment0_Function_NewExpression_MemberCallee_Compiles
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -206,7 +206,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -217,7 +217,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -230,14 +230,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_NewExpression_MemberCallee_Compiles/Scope Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject_FunctionExpression_63DFE404_L11C20::_environment0_Function_NewExpression_MemberCallee_Compiles
+				IL_0001: ldfld class Modules.Function_NewExpression_MemberCallee_Compiles/Scope Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject::_environment0_Function_NewExpression_MemberCallee_Compiles
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow::__js_call__(class Modules.Function_NewExpression_MemberCallee_Compiles/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -251,14 +251,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_NewExpression_MemberCallee_Compiles/Scope Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject_FunctionExpression_63DFE404_L11C20::_environment0_Function_NewExpression_MemberCallee_Compiles
+				IL_0001: ldfld class Modules.Function_NewExpression_MemberCallee_Compiles/Scope Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject::_environment0_Function_NewExpression_MemberCallee_Compiles
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow::__js_call__(class Modules.Function_NewExpression_MemberCallee_Compiles/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -276,9 +276,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_63DFE404_L11C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -425,9 +425,9 @@
 			[0] class Modules.Function_NewExpression_MemberCallee_Compiles/Scope,
 			[1] object,
 			[2] object[],
-			[3] class Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl/FunctionObject_FunctionExpression_E3E2CDFC_L4C11,
+			[3] class Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl/FunctionObject,
 			[4] class Modules.Function_NewExpression_MemberCallee_Compiles/ObjectLiterals/L3C12_impl,
-			[5] class Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject_FunctionExpression_63DFE404_L11C20,
+			[5] class Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[7] object
 		)
@@ -442,13 +442,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.2
-		IL_0012: newobj instance void Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl/FunctionObject_FunctionExpression_E3E2CDFC_L4C11::.ctor()
+		IL_0012: newobj instance void Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl/FunctionObject_FunctionExpression_E3E2CDFC_L4C11>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.3
 		IL_0026: newobj instance void Modules.Function_NewExpression_MemberCallee_Compiles/ObjectLiterals/L3C12_impl::.ctor()
 		IL_002b: stloc.s 4
@@ -469,13 +469,13 @@
 		IL_0049: ldc.i4.0
 		IL_004a: ldelem.ref
 		IL_004b: castclass Modules.Function_NewExpression_MemberCallee_Compiles/Scope
-		IL_0050: newobj instance void Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject_FunctionExpression_63DFE404_L11C20::.ctor(class Modules.Function_NewExpression_MemberCallee_Compiles/Scope)
+		IL_0050: newobj instance void Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject::.ctor(class Modules.Function_NewExpression_MemberCallee_Compiles/Scope)
 		IL_0055: ldc.i4.1
 		IL_0056: conv.r8
 		IL_0057: ldstr ""
 		IL_005c: ldc.i4.0
 		IL_005d: ldc.i4.1
-		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject_FunctionExpression_63DFE404_L11C20>(!!0, float64, string, bool, bool)
+		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0063: stloc.s 5
 		IL_0065: ldloc.s 5
 		IL_0067: ldstr "createWindow"

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_Arrow_Inherits.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_Arrow_Inherits.verified.txt
@@ -190,7 +190,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B41BFF0E_Outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -210,9 +210,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_NewTarget_Arrow_Inherits/Scope Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject_FunctionDeclaration_B41BFF0E_Outer::_environment0_Function_NewTarget_Arrow_Inherits
+				IL_0008: stfld class Modules.Function_NewTarget_Arrow_Inherits/Scope Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject::_environment0_Function_NewTarget_Arrow_Inherits
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -223,7 +223,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -234,7 +234,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -247,11 +247,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_NewTarget_Arrow_Inherits/Scope Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject_FunctionDeclaration_B41BFF0E_Outer::_environment0_Function_NewTarget_Arrow_Inherits
+				IL_0001: ldfld class Modules.Function_NewTarget_Arrow_Inherits/Scope Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject::_environment0_Function_NewTarget_Arrow_Inherits
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_NewTarget_Arrow_Inherits/Outer::__js_call__(class Modules.Function_NewTarget_Arrow_Inherits/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -265,11 +265,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_NewTarget_Arrow_Inherits/Scope Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject_FunctionDeclaration_B41BFF0E_Outer::_environment0_Function_NewTarget_Arrow_Inherits
+				IL_0001: ldfld class Modules.Function_NewTarget_Arrow_Inherits/Scope Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject::_environment0_Function_NewTarget_Arrow_Inherits
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_NewTarget_Arrow_Inherits/Outer::__js_call__(class Modules.Function_NewTarget_Arrow_Inherits/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -287,9 +287,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B41BFF0E_Outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -404,7 +404,7 @@
 		.locals init (
 			[0] class Modules.Function_NewTarget_Arrow_Inherits/Scope,
 			[1] object[],
-			[2] class Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject_FunctionDeclaration_B41BFF0E_Outer,
+			[2] class Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject,
 			[3] object
 		)
 
@@ -421,13 +421,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_NewTarget_Arrow_Inherits/Scope
-		IL_0019: newobj instance void Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject_FunctionDeclaration_B41BFF0E_Outer::.ctor(class Modules.Function_NewTarget_Arrow_Inherits/Scope)
+		IL_0019: newobj instance void Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject::.ctor(class Modules.Function_NewTarget_Arrow_Inherits/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "Outer"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject_FunctionDeclaration_B41BFF0E_Outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.2
 		IL_002d: ldloc.0
 		IL_002e: ldloc.2

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_NewVsCall.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_NewVsCall.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2CD84AA7_C
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_NewTarget_NewVsCall/Scope Modules.Function_NewTarget_NewVsCall/C/FunctionObject_FunctionDeclaration_2CD84AA7_C::_environment0_Function_NewTarget_NewVsCall
+				IL_0008: stfld class Modules.Function_NewTarget_NewVsCall/Scope Modules.Function_NewTarget_NewVsCall/C/FunctionObject::_environment0_Function_NewTarget_NewVsCall
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_NewTarget_NewVsCall/Scope Modules.Function_NewTarget_NewVsCall/C/FunctionObject_FunctionDeclaration_2CD84AA7_C::_environment0_Function_NewTarget_NewVsCall
+				IL_0001: ldfld class Modules.Function_NewTarget_NewVsCall/Scope Modules.Function_NewTarget_NewVsCall/C/FunctionObject::_environment0_Function_NewTarget_NewVsCall
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_NewTarget_NewVsCall/C::__js_call__(class Modules.Function_NewTarget_NewVsCall/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_NewTarget_NewVsCall/Scope Modules.Function_NewTarget_NewVsCall/C/FunctionObject_FunctionDeclaration_2CD84AA7_C::_environment0_Function_NewTarget_NewVsCall
+				IL_0001: ldfld class Modules.Function_NewTarget_NewVsCall/Scope Modules.Function_NewTarget_NewVsCall/C/FunctionObject::_environment0_Function_NewTarget_NewVsCall
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_NewTarget_NewVsCall/C::__js_call__(class Modules.Function_NewTarget_NewVsCall/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2CD84AA7_C
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -245,7 +245,7 @@
 		.locals init (
 			[0] class Modules.Function_NewTarget_NewVsCall/Scope,
 			[1] object[],
-			[2] class Modules.Function_NewTarget_NewVsCall/C/FunctionObject_FunctionDeclaration_2CD84AA7_C,
+			[2] class Modules.Function_NewTarget_NewVsCall/C/FunctionObject,
 			[3] object
 		)
 
@@ -262,13 +262,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_NewTarget_NewVsCall/Scope
-		IL_0019: newobj instance void Modules.Function_NewTarget_NewVsCall/C/FunctionObject_FunctionDeclaration_2CD84AA7_C::.ctor(class Modules.Function_NewTarget_NewVsCall/Scope)
+		IL_0019: newobj instance void Modules.Function_NewTarget_NewVsCall/C/FunctionObject::.ctor(class Modules.Function_NewTarget_NewVsCall/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "C"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewTarget_NewVsCall/C/FunctionObject_FunctionDeclaration_2CD84AA7_C>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewTarget_NewVsCall/C/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.2
 		IL_002d: ldloc.0
 		IL_002e: ldloc.2

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NoCapture_NoScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NoCapture_NoScopesParameter.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_979E7041_add
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_979E7041_add::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_979E7041_add::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_979E7041_add::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -89,7 +89,7 @@
 				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001d: call object Modules.Function_NoCapture_NoScopesParameter/'add'::__js_call__(object, float64, float64)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_979E7041_add::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -113,7 +113,7 @@
 				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0019: call object Modules.Function_NoCapture_NoScopesParameter/'add'::__js_call__(object, float64, float64)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_979E7041_add::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -131,9 +131,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_979E7041_add::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_979E7041_add
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -202,7 +202,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NoCapture_NoScopesParameter/Scope,
-			[1] class Modules.Function_NoCapture_NoScopesParameter/'add'/FunctionObject_FunctionDeclaration_979E7041_add,
+			[1] class Modules.Function_NoCapture_NoScopesParameter/'add'/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -217,13 +217,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_NoCapture_NoScopesParameter/'add'/FunctionObject_FunctionDeclaration_979E7041_add::.ctor()
+		IL_0011: newobj instance void Modules.Function_NoCapture_NoScopesParameter/'add'/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NoCapture_NoScopesParameter/'add'/FunctionObject_FunctionDeclaration_979E7041_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NoCapture_NoScopesParameter/'add'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralMethod_ThisBinding.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralMethod_ThisBinding.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_810AD7A8_L5C13
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_810AD7A8_L5C13
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -196,7 +196,7 @@
 			[0] class Modules.Function_ObjectLiteralMethod_ThisBinding/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[2] object[],
-			[3] class Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj/FunctionObject_FunctionExpression_810AD7A8_L5C13,
+			[3] class Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] object
 		)
@@ -211,13 +211,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.2
-		IL_0012: newobj instance void Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj/FunctionObject_FunctionExpression_810AD7A8_L5C13::.ctor()
+		IL_0012: newobj instance void Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj/FunctionObject_FunctionExpression_810AD7A8_L5C13>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.3
 		IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_002b: dup

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralValueFunction_ForEachCapturesOuter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralValueFunction_ForEachCapturesOuter.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B6BA9BE7_L7C37
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -56,12 +56,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37::_environment1_FunctionExpression_DocumentLike
+					IL_0008: stfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject::_environment1_FunctionExpression_DocumentLike
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37::_transitionalScopes
+					IL_000f: stfld object[] Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -96,14 +96,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -117,14 +117,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -142,9 +142,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_B6BA9BE7_L7C37
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -234,7 +234,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3A7F94BC_L5C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -254,9 +254,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_3A7F94BC_L5C12::_environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
+				IL_0008: stfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject::_environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -267,7 +267,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -278,7 +278,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -291,14 +291,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_3A7F94BC_L5C12::_environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
+				IL_0001: ldfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject::_environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike::__js_call__(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -312,14 +312,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_3A7F94BC_L5C12::_environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
+				IL_0001: ldfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject::_environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike::__js_call__(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -337,9 +337,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_3A7F94BC_L5C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -363,7 +363,7 @@
 				[1] object,
 				[2] bool,
 				[3] object[],
-				[4] class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37
+				[4] class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope::.ctor()
@@ -406,13 +406,13 @@
 			IL_005c: ldelem.ref
 			IL_005d: castclass Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope
 			IL_0062: ldloc.3
-			IL_0063: newobj instance void Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37::.ctor(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope, object[])
+			IL_0063: newobj instance void Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject::.ctor(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope, object[])
 			IL_0068: ldc.i4.1
 			IL_0069: conv.r8
 			IL_006a: ldstr ""
 			IL_006f: ldc.i4.0
 			IL_0070: ldc.i4.1
-			IL_0071: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37>(!!0, float64, string, bool, bool)
+			IL_0071: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0076: stloc.s 4
 			IL_0078: ldloc.1
 			IL_0079: ldstr "forEach"
@@ -449,7 +449,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FDB19B37_L16C15
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -463,7 +463,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -474,7 +474,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -485,7 +485,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -503,7 +503,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -522,7 +522,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -540,9 +540,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_FDB19B37_L16C15
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -672,9 +672,9 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object[],
-			[5] class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_3A7F94BC_L5C12,
+			[5] class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[7] class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator/FunctionObject_FunctionExpression_FDB19B37_L16C15,
+			[7] class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator/FunctionObject,
 			[8] object
 		)
 
@@ -692,13 +692,13 @@
 		IL_0015: ldc.i4.0
 		IL_0016: ldelem.ref
 		IL_0017: castclass Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope
-		IL_001c: newobj instance void Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_3A7F94BC_L5C12::.ctor(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope)
+		IL_001c: newobj instance void Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject::.ctor(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope)
 		IL_0021: ldc.i4.1
 		IL_0022: conv.r8
 		IL_0023: ldstr ""
 		IL_0028: ldc.i4.1
 		IL_0029: ldc.i4.1
-		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_3A7F94BC_L5C12>(!!0, float64, string, bool, bool)
+		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002f: stloc.s 5
 		IL_0031: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0036: dup
@@ -718,13 +718,13 @@
 		IL_005b: ldloc.0
 		IL_005c: stelem.ref
 		IL_005d: stloc.s 4
-		IL_005f: newobj instance void Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator/FunctionObject_FunctionExpression_FDB19B37_L16C15::.ctor()
+		IL_005f: newobj instance void Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator/FunctionObject::.ctor()
 		IL_0064: ldc.i4.1
 		IL_0065: conv.r8
 		IL_0066: ldstr ""
 		IL_006b: ldc.i4.0
 		IL_006c: ldc.i4.1
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator/FunctionObject_FunctionExpression_FDB19B37_L16C15>(!!0, float64, string, bool, bool)
+		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0072: stloc.s 7
 		IL_0074: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0079: dup

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterDestructuring_Object.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterDestructuring_Object.verified.txt
@@ -38,7 +38,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_149977FC_show
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -52,7 +52,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_149977FC_show::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_149977FC_show::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_149977FC_show::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -92,7 +92,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_ParameterDestructuring_Object/show::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_149977FC_show::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -111,7 +111,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_ParameterDestructuring_Object/show::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_149977FC_show::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -129,9 +129,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_149977FC_show::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_149977FC_show
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -241,7 +241,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_984BBA87_config
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -255,7 +255,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -266,7 +266,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -277,7 +277,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -295,7 +295,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_ParameterDestructuring_Object/config::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -314,7 +314,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_ParameterDestructuring_Object/config::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -332,9 +332,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_984BBA87_config
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -500,8 +500,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ParameterDestructuring_Object/Scope,
-			[1] class Modules.Function_ParameterDestructuring_Object/show/FunctionObject_FunctionDeclaration_149977FC_show,
-			[2] class Modules.Function_ParameterDestructuring_Object/config/FunctionObject_FunctionDeclaration_984BBA87_config,
+			[1] class Modules.Function_ParameterDestructuring_Object/show/FunctionObject,
+			[2] class Modules.Function_ParameterDestructuring_Object/config/FunctionObject,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
@@ -515,13 +515,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_ParameterDestructuring_Object/show/FunctionObject_FunctionDeclaration_149977FC_show::.ctor()
+		IL_0011: newobj instance void Modules.Function_ParameterDestructuring_Object/show/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "show"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterDestructuring_Object/show/FunctionObject_FunctionDeclaration_149977FC_show>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterDestructuring_Object/show/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: ldc.i4.1
 		IL_0026: newarr [System.Runtime]System.Object
@@ -530,13 +530,13 @@
 		IL_002d: ldloc.0
 		IL_002e: stelem.ref
 		IL_002f: stloc.3
-		IL_0030: newobj instance void Modules.Function_ParameterDestructuring_Object/config/FunctionObject_FunctionDeclaration_984BBA87_config::.ctor()
+		IL_0030: newobj instance void Modules.Function_ParameterDestructuring_Object/config/FunctionObject::.ctor()
 		IL_0035: ldc.i4.1
 		IL_0036: conv.r8
 		IL_0037: ldstr "config"
 		IL_003c: ldc.i4.0
 		IL_003d: ldc.i4.1
-		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterDestructuring_Object/config/FunctionObject_FunctionDeclaration_984BBA87_config>(!!0, float64, string, bool, bool)
+		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterDestructuring_Object/config/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0043: stloc.2
 		IL_0044: nop
 		IL_0045: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_BinaryArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_BinaryArguments.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_125FB85F_value
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_ParameterTypeInference_BinaryArguments/'value'::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_ParameterTypeInference_BinaryArguments/'value'::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_125FB85F_value
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2088,7 +2088,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/Scope_functionRedeclare,
-				[1] class Modules.Function_ParameterTypeInference_BinaryArguments/'value'/FunctionObject_FunctionDeclaration_125FB85F_value,
+				[1] class Modules.Function_ParameterTypeInference_BinaryArguments/'value'/FunctionObject,
 				[2] object[],
 				[3] float64,
 				[4] object,
@@ -2099,13 +2099,13 @@
 			IL_0005: stloc.0
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.2
-			IL_000c: newobj instance void Modules.Function_ParameterTypeInference_BinaryArguments/'value'/FunctionObject_FunctionDeclaration_125FB85F_value::.ctor()
+			IL_000c: newobj instance void Modules.Function_ParameterTypeInference_BinaryArguments/'value'/FunctionObject::.ctor()
 			IL_0011: ldc.i4.0
 			IL_0012: conv.r8
 			IL_0013: ldstr "value"
 			IL_0018: ldc.i4.0
 			IL_0019: ldc.i4.1
-			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_BinaryArguments/'value'/FunctionObject_FunctionDeclaration_125FB85F_value>(!!0, float64, string, bool, bool)
+			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_BinaryArguments/'value'/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_001f: stloc.1
 			IL_0020: nop
 			IL_0021: ldarg.1

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_DirectRotateArrayArgument.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_DirectRotateArrayArgument.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9877C077_RotateX
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -89,7 +89,7 @@
 				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001d: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -113,7 +113,7 @@
 				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0019: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -131,9 +131,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9877C077_RotateX
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -225,7 +225,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9777BEE4_RotateY
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -239,7 +239,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -250,7 +250,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -261,7 +261,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -284,7 +284,7 @@
 				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001d: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -308,7 +308,7 @@
 				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0019: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -326,9 +326,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9777BEE4_RotateY
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -420,7 +420,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9A77C39D_RotateZ
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -434,7 +434,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -445,7 +445,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -456,7 +456,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -479,7 +479,7 @@
 				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001d: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -503,7 +503,7 @@
 				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0019: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -521,9 +521,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9A77C39D_RotateZ
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -639,9 +639,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/Scope,
-			[1] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX/FunctionObject_FunctionDeclaration_9877C077_RotateX,
-			[2] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY/FunctionObject_FunctionDeclaration_9777BEE4_RotateY,
-			[3] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ/FunctionObject_FunctionDeclaration_9A77C39D_RotateZ,
+			[1] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX/FunctionObject,
+			[2] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY/FunctionObject,
+			[3] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object[],
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -657,13 +657,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
-		IL_0012: newobj instance void Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX/FunctionObject_FunctionDeclaration_9877C077_RotateX::.ctor()
+		IL_0012: newobj instance void Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "RotateX"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX/FunctionObject_FunctionDeclaration_9877C077_RotateX>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -672,13 +672,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 5
-		IL_0032: newobj instance void Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY/FunctionObject_FunctionDeclaration_9777BEE4_RotateY::.ctor()
+		IL_0032: newobj instance void Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY/FunctionObject::.ctor()
 		IL_0037: ldc.i4.2
 		IL_0038: conv.r8
 		IL_0039: ldstr "RotateY"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY/FunctionObject_FunctionDeclaration_9777BEE4_RotateY>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -687,13 +687,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 5
-		IL_0052: newobj instance void Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ/FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::.ctor()
+		IL_0052: newobj instance void Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ/FunctionObject::.ctor()
 		IL_0057: ldc.i4.2
 		IL_0058: conv.r8
 		IL_0059: ldstr "RotateZ"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ/FunctionObject_FunctionDeclaration_9A77C39D_RotateZ>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: nop
 		IL_0067: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_770551A8_add
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_770551A8_add::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_770551A8_add::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_770551A8_add::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_770551A8_add::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_770551A8_add::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_770551A8_add::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_770551A8_add
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -202,7 +202,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/Scope,
-			[1] class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'/FunctionObject_FunctionDeclaration_770551A8_add,
+			[1] class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -217,13 +217,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'/FunctionObject_FunctionDeclaration_770551A8_add::.ctor()
+		IL_0011: newobj instance void Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'/FunctionObject_FunctionDeclaration_770551A8_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_Bind_PropertyExists.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_Bind_PropertyExists.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_30545E80_add
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_30545E80_add::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_30545E80_add::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_30545E80_add::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_Prototype_Bind_PropertyExists/'add'::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_30545E80_add::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_Prototype_Bind_PropertyExists/'add'::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_30545E80_add::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_30545E80_add::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_30545E80_add
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -202,7 +202,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Prototype_Bind_PropertyExists/Scope,
-			[1] class Modules.Function_Prototype_Bind_PropertyExists/'add'/FunctionObject_FunctionDeclaration_30545E80_add,
+			[1] class Modules.Function_Prototype_Bind_PropertyExists/'add'/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -219,13 +219,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_Prototype_Bind_PropertyExists/'add'/FunctionObject_FunctionDeclaration_30545E80_add::.ctor()
+		IL_0011: newobj instance void Modules.Function_Prototype_Bind_PropertyExists/'add'/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Prototype_Bind_PropertyExists/'add'/FunctionObject_FunctionDeclaration_30545E80_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Prototype_Bind_PropertyExists/'add'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ObjectCreate_ObjectPrototype.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ObjectCreate_ObjectPrototype.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -196,7 +196,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B6EC663B_dumpToConsole
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -210,7 +210,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -221,7 +221,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -232,7 +232,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -247,7 +247,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -263,7 +263,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -281,9 +281,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_B6EC663B_dumpToConsole
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -367,11 +367,11 @@
 		.maxstack 12
 		.locals init (
 			[0] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/Scope,
-			[1] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent/FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent,
+			[1] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] object,
-			[5] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole/FunctionObject_FunctionExpression_B6EC663B_dumpToConsole,
+			[5] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -384,13 +384,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent/FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::.ctor()
+		IL_0011: newobj instance void Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "MyEvent"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent/FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -406,13 +406,13 @@
 		IL_0045: ldloc.0
 		IL_0046: stelem.ref
 		IL_0047: stloc.3
-		IL_0048: newobj instance void Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole/FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::.ctor()
+		IL_0048: newobj instance void Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole/FunctionObject::.ctor()
 		IL_004d: ldc.i4.0
 		IL_004e: conv.r8
 		IL_004f: ldstr "dumpToConsole"
 		IL_0054: ldc.i4.1
 		IL_0055: ldc.i4.1
-		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole/FunctionObject_FunctionExpression_B6EC663B_dumpToConsole>(!!0, float64, string, bool, bool)
+		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005b: stloc.s 5
 		IL_005d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0062: dup

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ToString_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ToString_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_98182540_namedFn
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Function_Prototype_ToString_Basic/namedFn::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Function_Prototype_ToString_Basic/namedFn::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_98182540_namedFn
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -202,7 +202,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Prototype_ToString_Basic/Scope,
-			[1] class Modules.Function_Prototype_ToString_Basic/namedFn/FunctionObject_FunctionDeclaration_98182540_namedFn,
+			[1] class Modules.Function_Prototype_ToString_Basic/namedFn/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] object,
@@ -221,13 +221,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_Prototype_ToString_Basic/namedFn/FunctionObject_FunctionDeclaration_98182540_namedFn::.ctor()
+		IL_0011: newobj instance void Modules.Function_Prototype_ToString_Basic/namedFn/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "namedFn"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Prototype_ToString_Basic/namedFn/FunctionObject_FunctionDeclaration_98182540_namedFn>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Prototype_ToString_Basic/namedFn/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Basic.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope_For_L5C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9D72AA57_sum
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -90,9 +90,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_RestParameters_Basic/Scope Modules.Function_RestParameters_Basic/sum/FunctionObject_FunctionDeclaration_9D72AA57_sum::_environment0_Function_RestParameters_Basic
+				IL_0008: stfld class Modules.Function_RestParameters_Basic/Scope Modules.Function_RestParameters_Basic/sum/FunctionObject::_environment0_Function_RestParameters_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +103,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,7 +114,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -152,7 +152,7 @@
 
 				IL_0021: ldloc.0
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -165,11 +165,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_RestParameters_Basic/Scope Modules.Function_RestParameters_Basic/sum/FunctionObject_FunctionDeclaration_9D72AA57_sum::_environment0_Function_RestParameters_Basic
+				IL_0001: ldfld class Modules.Function_RestParameters_Basic/Scope Modules.Function_RestParameters_Basic/sum/FunctionObject::_environment0_Function_RestParameters_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -183,11 +183,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_RestParameters_Basic/Scope Modules.Function_RestParameters_Basic/sum/FunctionObject_FunctionDeclaration_9D72AA57_sum::_environment0_Function_RestParameters_Basic
+				IL_0001: ldfld class Modules.Function_RestParameters_Basic/Scope Modules.Function_RestParameters_Basic/sum/FunctionObject::_environment0_Function_RestParameters_Basic
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -205,9 +205,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9D72AA57_sum
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -322,7 +322,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_Basic/Scope,
-			[1] class Modules.Function_RestParameters_Basic/sum/FunctionObject_FunctionDeclaration_9D72AA57_sum,
+			[1] class Modules.Function_RestParameters_Basic/sum/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -341,13 +341,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_RestParameters_Basic/Scope
-		IL_0019: newobj instance void Modules.Function_RestParameters_Basic/sum/FunctionObject_FunctionDeclaration_9D72AA57_sum::.ctor(class Modules.Function_RestParameters_Basic/Scope)
+		IL_0019: newobj instance void Modules.Function_RestParameters_Basic/sum/FunctionObject::.ctor(class Modules.Function_RestParameters_Basic/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "sum"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_RestParameters_Basic/sum/FunctionObject_FunctionDeclaration_9D72AA57_sum>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_RestParameters_Basic/sum/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Empty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Empty.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_15C1321C_logArgs
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -121,7 +121,7 @@
 
 				IL_0019: ldloc.0
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -136,7 +136,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_RestParameters_Empty/logArgs::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -152,7 +152,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_RestParameters_Empty/logArgs::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -170,9 +170,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_15C1321C_logArgs
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -274,7 +274,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_Empty/Scope,
-			[1] class Modules.Function_RestParameters_Empty/logArgs/FunctionObject_FunctionDeclaration_15C1321C_logArgs,
+			[1] class Modules.Function_RestParameters_Empty/logArgs/FunctionObject,
 			[2] object[]
 		)
 
@@ -287,13 +287,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Function_RestParameters_Empty/logArgs/FunctionObject_FunctionDeclaration_15C1321C_logArgs::.ctor()
+		IL_0011: newobj instance void Modules.Function_RestParameters_Empty/logArgs/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "logArgs"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_RestParameters_Empty/logArgs/FunctionObject_FunctionDeclaration_15C1321C_logArgs>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_RestParameters_Empty/logArgs/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_MultipleNamed.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_MultipleNamed.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope_For_L5C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5CDD99AA_format
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -90,9 +90,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_RestParameters_MultipleNamed/Scope Modules.Function_RestParameters_MultipleNamed/format/FunctionObject_FunctionDeclaration_5CDD99AA_format::_environment0_Function_RestParameters_MultipleNamed
+				IL_0008: stfld class Modules.Function_RestParameters_MultipleNamed/Scope Modules.Function_RestParameters_MultipleNamed/format/FunctionObject::_environment0_Function_RestParameters_MultipleNamed
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +103,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,7 +114,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -158,7 +158,7 @@
 
 				IL_002f: ldloc.0
 				IL_0030: ret
-			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -171,7 +171,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_RestParameters_MultipleNamed/Scope Modules.Function_RestParameters_MultipleNamed/format/FunctionObject_FunctionDeclaration_5CDD99AA_format::_environment0_Function_RestParameters_MultipleNamed
+				IL_0001: ldfld class Modules.Function_RestParameters_MultipleNamed/Scope Modules.Function_RestParameters_MultipleNamed/format/FunctionObject::_environment0_Function_RestParameters_MultipleNamed
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -181,7 +181,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -195,7 +195,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_RestParameters_MultipleNamed/Scope Modules.Function_RestParameters_MultipleNamed/format/FunctionObject_FunctionDeclaration_5CDD99AA_format::_environment0_Function_RestParameters_MultipleNamed
+				IL_0001: ldfld class Modules.Function_RestParameters_MultipleNamed/Scope Modules.Function_RestParameters_MultipleNamed/format/FunctionObject::_environment0_Function_RestParameters_MultipleNamed
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -205,7 +205,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -223,9 +223,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5CDD99AA_format
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -349,7 +349,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_MultipleNamed/Scope,
-			[1] class Modules.Function_RestParameters_MultipleNamed/format/FunctionObject_FunctionDeclaration_5CDD99AA_format,
+			[1] class Modules.Function_RestParameters_MultipleNamed/format/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -368,13 +368,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_RestParameters_MultipleNamed/Scope
-		IL_0019: newobj instance void Modules.Function_RestParameters_MultipleNamed/format/FunctionObject_FunctionDeclaration_5CDD99AA_format::.ctor(class Modules.Function_RestParameters_MultipleNamed/Scope)
+		IL_0019: newobj instance void Modules.Function_RestParameters_MultipleNamed/format/FunctionObject::.ctor(class Modules.Function_RestParameters_MultipleNamed/Scope)
 		IL_001e: ldc.i4.2
 		IL_001f: conv.r8
 		IL_0020: ldstr "format"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_RestParameters_MultipleNamed/format/FunctionObject_FunctionDeclaration_5CDD99AA_format>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_RestParameters_MultipleNamed/format/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_WithNamedParams.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_WithNamedParams.verified.txt
@@ -91,7 +91,7 @@
 
 		} // end of class Scope_For_L5C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3E0DE254_combine
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -111,9 +111,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_RestParameters_WithNamedParams/Scope Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject_FunctionDeclaration_3E0DE254_combine::_environment0_Function_RestParameters_WithNamedParams
+				IL_0008: stfld class Modules.Function_RestParameters_WithNamedParams/Scope Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject::_environment0_Function_RestParameters_WithNamedParams
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -124,7 +124,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -135,7 +135,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -176,7 +176,7 @@
 
 				IL_0028: ldloc.0
 				IL_0029: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -189,14 +189,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_RestParameters_WithNamedParams/Scope Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject_FunctionDeclaration_3E0DE254_combine::_environment0_Function_RestParameters_WithNamedParams
+				IL_0001: ldfld class Modules.Function_RestParameters_WithNamedParams/Scope Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject::_environment0_Function_RestParameters_WithNamedParams
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -210,14 +210,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_RestParameters_WithNamedParams/Scope Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject_FunctionDeclaration_3E0DE254_combine::_environment0_Function_RestParameters_WithNamedParams
+				IL_0001: ldfld class Modules.Function_RestParameters_WithNamedParams/Scope Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject::_environment0_Function_RestParameters_WithNamedParams
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -235,9 +235,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3E0DE254_combine
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -368,7 +368,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_WithNamedParams/Scope,
-			[1] class Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject_FunctionDeclaration_3E0DE254_combine,
+			[1] class Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -387,13 +387,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_RestParameters_WithNamedParams/Scope
-		IL_0019: newobj instance void Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject_FunctionDeclaration_3E0DE254_combine::.ctor(class Modules.Function_RestParameters_WithNamedParams/Scope)
+		IL_0019: newobj instance void Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject::.ctor(class Modules.Function_RestParameters_WithNamedParams/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "combine"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject_FunctionDeclaration_3E0DE254_combine>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_314E1964_multiply
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -56,12 +56,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply::_environment1_createCalculator
+					IL_0008: stfld class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject::_environment1_createCalculator
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply::_transitionalScopes
+					IL_000f: stfld object[] Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -96,14 +96,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Function_ReturnObjectWithClosure/createCalculator/multiply::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -117,14 +117,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Function_ReturnObjectWithClosure/createCalculator/multiply::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -142,9 +142,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_314E1964_multiply
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -210,7 +210,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -230,9 +230,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_ReturnObjectWithClosure/Scope Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::_environment0_Function_ReturnObjectWithClosure
+				IL_0008: stfld class Modules.Function_ReturnObjectWithClosure/Scope Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject::_environment0_Function_ReturnObjectWithClosure
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -243,7 +243,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -254,7 +254,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -267,14 +267,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_ReturnObjectWithClosure/Scope Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::_environment0_Function_ReturnObjectWithClosure
+				IL_0001: ldfld class Modules.Function_ReturnObjectWithClosure/Scope Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject::_environment0_Function_ReturnObjectWithClosure
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -288,14 +288,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_ReturnObjectWithClosure/Scope Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::_environment0_Function_ReturnObjectWithClosure
+				IL_0001: ldfld class Modules.Function_ReturnObjectWithClosure/Scope Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject::_environment0_Function_ReturnObjectWithClosure
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -313,9 +313,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -336,7 +336,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope,
-				[1] class Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply,
+				[1] class Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject,
 				[2] object[],
 				[3] object,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
@@ -363,13 +363,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.Function_ReturnObjectWithClosure/createCalculator/Scope
 			IL_0024: ldloc.2
-			IL_0025: newobj instance void Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply::.ctor(class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope, object[])
+			IL_0025: newobj instance void Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject::.ctor(class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope, object[])
 			IL_002a: ldc.i4.1
 			IL_002b: conv.r8
 			IL_002c: ldstr "multiply"
 			IL_0031: ldc.i4.0
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.1
 			IL_0039: nop
 			IL_003a: ldloc.0
@@ -434,7 +434,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ReturnObjectWithClosure/Scope,
-			[1] class Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator,
+			[1] class Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object[],
@@ -455,13 +455,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Function_ReturnObjectWithClosure/Scope
-		IL_001b: newobj instance void Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::.ctor(class Modules.Function_ReturnObjectWithClosure/Scope)
+		IL_001b: newobj instance void Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject::.ctor(class Modules.Function_ReturnObjectWithClosure/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "createCalculator"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_754F5DB8_returnsFive
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -82,7 +82,7 @@
 				IL_0005: call float64 Modules.Function_ReturnsStaticValueAndLogs/returnsFive::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -99,7 +99,7 @@
 				IL_0001: call float64 Modules.Function_ReturnsStaticValueAndLogs/returnsFive::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -117,9 +117,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_754F5DB8_returnsFive
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -193,7 +193,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ReturnsStaticValueAndLogs/Scope,
-			[1] class Modules.Function_ReturnsStaticValueAndLogs/returnsFive/FunctionObject_FunctionDeclaration_754F5DB8_returnsFive,
+			[1] class Modules.Function_ReturnsStaticValueAndLogs/returnsFive/FunctionObject,
 			[2] float64,
 			[3] object[],
 			[4] object,
@@ -210,13 +210,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Function_ReturnsStaticValueAndLogs/returnsFive/FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::.ctor()
+		IL_0011: newobj instance void Modules.Function_ReturnsStaticValueAndLogs/returnsFive/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "returnsFive"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ReturnsStaticValueAndLogs/returnsFive/FunctionObject_FunctionDeclaration_754F5DB8_returnsFive>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ReturnsStaticValueAndLogs/returnsFive/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6A061CB8_math
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.Function_SchedulerCallResults/math::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.Function_SchedulerCallResults/math::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6A061CB8_math
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -177,7 +177,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B2F496B1_nestedCall
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -191,7 +191,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -202,7 +202,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -213,7 +213,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -232,7 +232,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.Function_SchedulerCallResults/nestedCall::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -252,7 +252,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.Function_SchedulerCallResults/nestedCall::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -270,9 +270,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B2F496B1_nestedCall
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -322,7 +322,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_29CCB5FD_compareCall
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -336,7 +336,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -347,7 +347,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -358,7 +358,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -381,7 +381,7 @@
 				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001d: call object Modules.Function_SchedulerCallResults/compareCall::__js_call__(object, float64, float64)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -405,7 +405,7 @@
 				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0019: call object Modules.Function_SchedulerCallResults/compareCall::__js_call__(object, float64, float64)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -423,9 +423,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_29CCB5FD_compareCall
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -478,7 +478,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6A57C981_argumentCall
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -492,7 +492,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -503,7 +503,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -514,7 +514,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -533,7 +533,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.Function_SchedulerCallResults/argumentCall::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -553,7 +553,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.Function_SchedulerCallResults/argumentCall::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -571,9 +571,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6A57C981_argumentCall
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -635,7 +635,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -649,7 +649,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -660,7 +660,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -671,7 +671,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -698,7 +698,7 @@
 				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0029: call object Modules.Function_SchedulerCallResults/argumentDependency::__js_call__(object, float64, float64, float64)
 				IL_002e: ret
-			} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -726,7 +726,7 @@
 				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0025: call object Modules.Function_SchedulerCallResults/argumentDependency::__js_call__(object, float64, float64, float64)
 				IL_002a: ret
-			} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -744,9 +744,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -813,7 +813,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_35BAD19F_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -833,9 +833,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g::_environment0_Function_SchedulerCallResults
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/g/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -846,7 +846,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -857,7 +857,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -870,11 +870,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/g/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerCallResults/g::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -888,11 +888,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/g/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerCallResults/g::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -910,9 +910,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_35BAD19F_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -975,7 +975,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3ABAD97E_h
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -995,9 +995,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h::_environment0_Function_SchedulerCallResults
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/h/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1008,7 +1008,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1019,7 +1019,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1032,11 +1032,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/h/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerCallResults/h::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1050,11 +1050,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/h/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerCallResults/h::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1072,9 +1072,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3ABAD97E_h
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1137,7 +1137,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_86C347EB_ordered
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1157,9 +1157,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/ordered/FunctionObject_FunctionDeclaration_86C347EB_ordered::_environment0_Function_SchedulerCallResults
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/ordered/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1170,7 +1170,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1181,7 +1181,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1194,11 +1194,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/ordered/FunctionObject_FunctionDeclaration_86C347EB_ordered::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/ordered/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerCallResults/ordered::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1212,11 +1212,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/ordered/FunctionObject_FunctionDeclaration_86C347EB_ordered::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/ordered/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerCallResults/ordered::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1234,9 +1234,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_86C347EB_ordered
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1518,7 +1518,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9A5CC64E_throwing
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1538,9 +1538,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/throwing/FunctionObject_FunctionDeclaration_9A5CC64E_throwing::_environment0_Function_SchedulerCallResults
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/throwing/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1551,7 +1551,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1562,7 +1562,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1575,11 +1575,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/throwing/FunctionObject_FunctionDeclaration_9A5CC64E_throwing::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/throwing/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerCallResults/throwing::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1593,11 +1593,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/throwing/FunctionObject_FunctionDeclaration_9A5CC64E_throwing::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/throwing/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerCallResults/throwing::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1615,9 +1615,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9A5CC64E_throwing
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1774,7 +1774,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E0F2AA72_multiUse
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1794,9 +1794,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/multiUse/FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::_environment0_Function_SchedulerCallResults
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/multiUse/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1807,7 +1807,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1818,7 +1818,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1831,11 +1831,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/multiUse/FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/multiUse/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerCallResults/multiUse::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1849,11 +1849,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/multiUse/FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/multiUse/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerCallResults/multiUse::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1871,9 +1871,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E0F2AA72_multiUse
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1958,7 +1958,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1978,9 +1978,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::_environment0_Function_SchedulerCallResults
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1991,7 +1991,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2002,7 +2002,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2015,11 +2015,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerCallResults/fluentTypedCalls::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2033,11 +2033,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerCallResults/fluentTypedCalls::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2055,9 +2055,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2145,7 +2145,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2165,9 +2165,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::_environment0_Function_SchedulerCallResults
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2178,7 +2178,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2189,7 +2189,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2202,11 +2202,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerCallResults/singleTypedCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2220,11 +2220,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerCallResults/singleTypedCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2242,9 +2242,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2350,7 +2350,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2370,9 +2370,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::_environment0_Function_SchedulerCallResults
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2383,7 +2383,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2394,7 +2394,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2407,11 +2407,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerCallResults/scheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2425,11 +2425,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerCallResults/scheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2447,9 +2447,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2541,7 +2541,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2561,9 +2561,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::_environment0_Function_SchedulerCallResults
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2574,7 +2574,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2585,7 +2585,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2598,11 +2598,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2616,11 +2616,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2638,9 +2638,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2729,7 +2729,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2749,9 +2749,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::_environment0_Function_SchedulerCallResults
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2762,7 +2762,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2773,7 +2773,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2786,11 +2786,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2804,11 +2804,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::_environment0_Function_SchedulerCallResults
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject::_environment0_Function_SchedulerCallResults
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2826,9 +2826,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4162,22 +4162,22 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerCallResults/Scope,
-			[1] class Modules.Function_SchedulerCallResults/math/FunctionObject_FunctionDeclaration_6A061CB8_math,
-			[2] class Modules.Function_SchedulerCallResults/nestedCall/FunctionObject_FunctionDeclaration_B2F496B1_nestedCall,
-			[3] class Modules.Function_SchedulerCallResults/compareCall/FunctionObject_FunctionDeclaration_29CCB5FD_compareCall,
-			[4] class Modules.Function_SchedulerCallResults/argumentCall/FunctionObject_FunctionDeclaration_6A57C981_argumentCall,
-			[5] class Modules.Function_SchedulerCallResults/argumentDependency/FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency,
-			[6] class Modules.Function_SchedulerCallResults/ordered/FunctionObject_FunctionDeclaration_86C347EB_ordered,
-			[7] class Modules.Function_SchedulerCallResults/throwing/FunctionObject_FunctionDeclaration_9A5CC64E_throwing,
-			[8] class Modules.Function_SchedulerCallResults/multiUse/FunctionObject_FunctionDeclaration_E0F2AA72_multiUse,
-			[9] class Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls,
-			[10] class Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall,
-			[11] class Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall,
-			[12] class Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall,
-			[13] class Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult,
+			[1] class Modules.Function_SchedulerCallResults/math/FunctionObject,
+			[2] class Modules.Function_SchedulerCallResults/nestedCall/FunctionObject,
+			[3] class Modules.Function_SchedulerCallResults/compareCall/FunctionObject,
+			[4] class Modules.Function_SchedulerCallResults/argumentCall/FunctionObject,
+			[5] class Modules.Function_SchedulerCallResults/argumentDependency/FunctionObject,
+			[6] class Modules.Function_SchedulerCallResults/ordered/FunctionObject,
+			[7] class Modules.Function_SchedulerCallResults/throwing/FunctionObject,
+			[8] class Modules.Function_SchedulerCallResults/multiUse/FunctionObject,
+			[9] class Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject,
+			[10] class Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject,
+			[11] class Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject,
+			[12] class Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject,
+			[13] class Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject,
 			[14] object[],
-			[15] class Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g,
-			[16] class Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h,
+			[15] class Modules.Function_SchedulerCallResults/g/FunctionObject,
+			[16] class Modules.Function_SchedulerCallResults/h/FunctionObject,
 			[17] class [System.Runtime]System.Type,
 			[18] object,
 			[19] class Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassConstructor_AD25A3C2_Counter,
@@ -4195,13 +4195,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 14
-		IL_0012: newobj instance void Modules.Function_SchedulerCallResults/math/FunctionObject_FunctionDeclaration_6A061CB8_math::.ctor()
+		IL_0012: newobj instance void Modules.Function_SchedulerCallResults/math/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "math"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/math/FunctionObject_FunctionDeclaration_6A061CB8_math>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/math/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -4210,13 +4210,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 14
-		IL_0032: newobj instance void Modules.Function_SchedulerCallResults/nestedCall/FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::.ctor()
+		IL_0032: newobj instance void Modules.Function_SchedulerCallResults/nestedCall/FunctionObject::.ctor()
 		IL_0037: ldc.i4.1
 		IL_0038: conv.r8
 		IL_0039: ldstr "nestedCall"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/nestedCall/FunctionObject_FunctionDeclaration_B2F496B1_nestedCall>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/nestedCall/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -4225,13 +4225,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 14
-		IL_0052: newobj instance void Modules.Function_SchedulerCallResults/compareCall/FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::.ctor()
+		IL_0052: newobj instance void Modules.Function_SchedulerCallResults/compareCall/FunctionObject::.ctor()
 		IL_0057: ldc.i4.2
 		IL_0058: conv.r8
 		IL_0059: ldstr "compareCall"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/compareCall/FunctionObject_FunctionDeclaration_29CCB5FD_compareCall>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/compareCall/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -4240,13 +4240,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 14
-		IL_0072: newobj instance void Modules.Function_SchedulerCallResults/argumentCall/FunctionObject_FunctionDeclaration_6A57C981_argumentCall::.ctor()
+		IL_0072: newobj instance void Modules.Function_SchedulerCallResults/argumentCall/FunctionObject::.ctor()
 		IL_0077: ldc.i4.1
 		IL_0078: conv.r8
 		IL_0079: ldstr "argumentCall"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/argumentCall/FunctionObject_FunctionDeclaration_6A57C981_argumentCall>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/argumentCall/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -4255,13 +4255,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 14
-		IL_0093: newobj instance void Modules.Function_SchedulerCallResults/argumentDependency/FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::.ctor()
+		IL_0093: newobj instance void Modules.Function_SchedulerCallResults/argumentDependency/FunctionObject::.ctor()
 		IL_0098: ldc.i4.3
 		IL_0099: conv.r8
 		IL_009a: ldstr "argumentDependency"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/argumentDependency/FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/argumentDependency/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -4274,13 +4274,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_00bd: newobj instance void Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_00bd: newobj instance void Modules.Function_SchedulerCallResults/g/FunctionObject::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_00c2: ldc.i4.0
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "g"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 15
 		IL_00d2: ldloc.0
 		IL_00d3: ldloc.s 15
@@ -4296,13 +4296,13 @@
 		IL_00e8: ldc.i4.0
 		IL_00e9: ldelem.ref
 		IL_00ea: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_00ef: newobj instance void Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_00ef: newobj instance void Modules.Function_SchedulerCallResults/h/FunctionObject::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_00f4: ldc.i4.0
 		IL_00f5: conv.r8
 		IL_00f6: ldstr "h"
 		IL_00fb: ldc.i4.0
 		IL_00fc: ldc.i4.1
-		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h>(!!0, float64, string, bool, bool)
+		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/h/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0102: stloc.s 16
 		IL_0104: ldloc.0
 		IL_0105: ldloc.s 16
@@ -4318,13 +4318,13 @@
 		IL_011a: ldc.i4.0
 		IL_011b: ldelem.ref
 		IL_011c: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_0121: newobj instance void Modules.Function_SchedulerCallResults/ordered/FunctionObject_FunctionDeclaration_86C347EB_ordered::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_0121: newobj instance void Modules.Function_SchedulerCallResults/ordered/FunctionObject::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_0126: ldc.i4.0
 		IL_0127: conv.r8
 		IL_0128: ldstr "ordered"
 		IL_012d: ldc.i4.0
 		IL_012e: ldc.i4.1
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/ordered/FunctionObject_FunctionDeclaration_86C347EB_ordered>(!!0, float64, string, bool, bool)
+		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/ordered/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0134: stloc.s 6
 		IL_0136: ldc.i4.1
 		IL_0137: newarr [System.Runtime]System.Object
@@ -4337,13 +4337,13 @@
 		IL_0144: ldc.i4.0
 		IL_0145: ldelem.ref
 		IL_0146: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_014b: newobj instance void Modules.Function_SchedulerCallResults/throwing/FunctionObject_FunctionDeclaration_9A5CC64E_throwing::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_014b: newobj instance void Modules.Function_SchedulerCallResults/throwing/FunctionObject::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_0150: ldc.i4.0
 		IL_0151: conv.r8
 		IL_0152: ldstr "throwing"
 		IL_0157: ldc.i4.0
 		IL_0158: ldc.i4.1
-		IL_0159: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/throwing/FunctionObject_FunctionDeclaration_9A5CC64E_throwing>(!!0, float64, string, bool, bool)
+		IL_0159: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/throwing/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_015e: stloc.s 7
 		IL_0160: ldc.i4.1
 		IL_0161: newarr [System.Runtime]System.Object
@@ -4356,13 +4356,13 @@
 		IL_016e: ldc.i4.0
 		IL_016f: ldelem.ref
 		IL_0170: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_0175: newobj instance void Modules.Function_SchedulerCallResults/multiUse/FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_0175: newobj instance void Modules.Function_SchedulerCallResults/multiUse/FunctionObject::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_017a: ldc.i4.0
 		IL_017b: conv.r8
 		IL_017c: ldstr "multiUse"
 		IL_0181: ldc.i4.0
 		IL_0182: ldc.i4.1
-		IL_0183: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/multiUse/FunctionObject_FunctionDeclaration_E0F2AA72_multiUse>(!!0, float64, string, bool, bool)
+		IL_0183: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/multiUse/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0188: stloc.s 8
 		IL_018a: ldc.i4.1
 		IL_018b: newarr [System.Runtime]System.Object
@@ -4375,13 +4375,13 @@
 		IL_0198: ldc.i4.0
 		IL_0199: ldelem.ref
 		IL_019a: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_019f: newobj instance void Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_019f: newobj instance void Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_01a4: ldc.i4.0
 		IL_01a5: conv.r8
 		IL_01a6: ldstr "fluentTypedCalls"
 		IL_01ab: ldc.i4.0
 		IL_01ac: ldc.i4.1
-		IL_01ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls>(!!0, float64, string, bool, bool)
+		IL_01ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01b2: stloc.s 9
 		IL_01b4: ldc.i4.1
 		IL_01b5: newarr [System.Runtime]System.Object
@@ -4394,13 +4394,13 @@
 		IL_01c2: ldc.i4.0
 		IL_01c3: ldelem.ref
 		IL_01c4: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_01c9: newobj instance void Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_01c9: newobj instance void Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_01ce: ldc.i4.0
 		IL_01cf: conv.r8
 		IL_01d0: ldstr "singleTypedCall"
 		IL_01d5: ldc.i4.0
 		IL_01d6: ldc.i4.1
-		IL_01d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall>(!!0, float64, string, bool, bool)
+		IL_01d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01dc: stloc.s 10
 		IL_01de: ldc.i4.1
 		IL_01df: newarr [System.Runtime]System.Object
@@ -4413,13 +4413,13 @@
 		IL_01ec: ldc.i4.0
 		IL_01ed: ldelem.ref
 		IL_01ee: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_01f3: newobj instance void Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_01f3: newobj instance void Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_01f8: ldc.i4.0
 		IL_01f9: conv.r8
 		IL_01fa: ldstr "scheduledInlineCall"
 		IL_01ff: ldc.i4.0
 		IL_0200: ldc.i4.1
-		IL_0201: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall>(!!0, float64, string, bool, bool)
+		IL_0201: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0206: stloc.s 11
 		IL_0208: ldc.i4.1
 		IL_0209: newarr [System.Runtime]System.Object
@@ -4432,13 +4432,13 @@
 		IL_0216: ldc.i4.0
 		IL_0217: ldelem.ref
 		IL_0218: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_021d: newobj instance void Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_021d: newobj instance void Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_0222: ldc.i4.0
 		IL_0223: conv.r8
 		IL_0224: ldstr "deepScheduledInlineCall"
 		IL_0229: ldc.i4.0
 		IL_022a: ldc.i4.1
-		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall>(!!0, float64, string, bool, bool)
+		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0230: stloc.s 12
 		IL_0232: ldc.i4.1
 		IL_0233: newarr [System.Runtime]System.Object
@@ -4451,13 +4451,13 @@
 		IL_0240: ldc.i4.0
 		IL_0241: ldelem.ref
 		IL_0242: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_0247: newobj instance void Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_0247: newobj instance void Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_024c: ldc.i4.0
 		IL_024d: conv.r8
 		IL_024e: ldstr "deepScheduledInlineCallWithCarriedResult"
 		IL_0253: ldc.i4.0
 		IL_0254: ldc.i4.1
-		IL_0255: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult>(!!0, float64, string, bool, bool)
+		IL_0255: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_025a: stloc.s 13
 		IL_025c: nop
 		IL_025d: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_769438BB_concat
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.Function_SchedulerConversionsStableLoads/concat::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.Function_SchedulerConversionsStableLoads/concat::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_769438BB_concat
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -183,7 +183,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F3B41092_stringLength
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -197,7 +197,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -208,7 +208,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -219,7 +219,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -238,7 +238,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.Function_SchedulerConversionsStableLoads/stringLength::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -258,7 +258,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.Function_SchedulerConversionsStableLoads/stringLength::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -276,9 +276,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F3B41092_stringLength
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -329,7 +329,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3006B504_arrayLength
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -343,7 +343,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -354,7 +354,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -365,7 +365,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -384,7 +384,7 @@
 				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_0011: call object Modules.Function_SchedulerConversionsStableLoads/arrayLength::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -404,7 +404,7 @@
 				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_000d: call object Modules.Function_SchedulerConversionsStableLoads/arrayLength::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -422,9 +422,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3006B504_arrayLength
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -474,7 +474,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CF905D20_arrayElement
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -488,7 +488,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -499,7 +499,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -510,7 +510,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -529,7 +529,7 @@
 				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_0011: call object Modules.Function_SchedulerConversionsStableLoads/arrayElement::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -549,7 +549,7 @@
 				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_000d: call object Modules.Function_SchedulerConversionsStableLoads/arrayElement::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -567,9 +567,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CF905D20_arrayElement
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -627,7 +627,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C32D2A2E_typedArray
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -641,7 +641,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -652,7 +652,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -663,7 +663,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -681,7 +681,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_SchedulerConversionsStableLoads/typedArray::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -700,7 +700,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_SchedulerConversionsStableLoads/typedArray::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -718,9 +718,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C32D2A2E_typedArray
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -783,7 +783,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_30928FD8_postfix
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -797,7 +797,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -808,7 +808,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -819,7 +819,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -838,7 +838,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerConversionsStableLoads/postfix::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -858,7 +858,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerConversionsStableLoads/postfix::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -876,9 +876,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_30928FD8_postfix
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -952,7 +952,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C5AABBA4_L29C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -972,9 +972,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerConversionsStableLoads/Scope Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10::_environment0_Function_SchedulerConversionsStableLoads
+				IL_0008: stfld class Modules.Function_SchedulerConversionsStableLoads/Scope Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject::_environment0_Function_SchedulerConversionsStableLoads
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -985,7 +985,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -996,7 +996,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1009,13 +1009,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerConversionsStableLoads/Scope Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10::_environment0_Function_SchedulerConversionsStableLoads
+				IL_0001: ldfld class Modules.Function_SchedulerConversionsStableLoads/Scope Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject::_environment0_Function_SchedulerConversionsStableLoads
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object::__js_call__(class Modules.Function_SchedulerConversionsStableLoads/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_C5AABBA4_L29C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1155,12 +1155,12 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerConversionsStableLoads/Scope,
-			[1] class Modules.Function_SchedulerConversionsStableLoads/concat/FunctionObject_FunctionDeclaration_769438BB_concat,
-			[2] class Modules.Function_SchedulerConversionsStableLoads/stringLength/FunctionObject_FunctionDeclaration_F3B41092_stringLength,
-			[3] class Modules.Function_SchedulerConversionsStableLoads/arrayLength/FunctionObject_FunctionDeclaration_3006B504_arrayLength,
-			[4] class Modules.Function_SchedulerConversionsStableLoads/arrayElement/FunctionObject_FunctionDeclaration_CF905D20_arrayElement,
-			[5] class Modules.Function_SchedulerConversionsStableLoads/typedArray/FunctionObject_FunctionDeclaration_C32D2A2E_typedArray,
-			[6] class Modules.Function_SchedulerConversionsStableLoads/postfix/FunctionObject_FunctionDeclaration_30928FD8_postfix,
+			[1] class Modules.Function_SchedulerConversionsStableLoads/concat/FunctionObject,
+			[2] class Modules.Function_SchedulerConversionsStableLoads/stringLength/FunctionObject,
+			[3] class Modules.Function_SchedulerConversionsStableLoads/arrayLength/FunctionObject,
+			[4] class Modules.Function_SchedulerConversionsStableLoads/arrayElement/FunctionObject,
+			[5] class Modules.Function_SchedulerConversionsStableLoads/typedArray/FunctionObject,
+			[6] class Modules.Function_SchedulerConversionsStableLoads/postfix/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[8] class [System.Runtime]System.Exception,
 			[9] object,
@@ -1169,7 +1169,7 @@
 			[12] object,
 			[13] object[],
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[15] class Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10,
+			[15] class Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject,
 			[16] object,
 			[17] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -1190,13 +1190,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 13
-		IL_0012: newobj instance void Modules.Function_SchedulerConversionsStableLoads/concat/FunctionObject_FunctionDeclaration_769438BB_concat::.ctor()
+		IL_0012: newobj instance void Modules.Function_SchedulerConversionsStableLoads/concat/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "concat"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/concat/FunctionObject_FunctionDeclaration_769438BB_concat>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/concat/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1205,13 +1205,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 13
-		IL_0032: newobj instance void Modules.Function_SchedulerConversionsStableLoads/stringLength/FunctionObject_FunctionDeclaration_F3B41092_stringLength::.ctor()
+		IL_0032: newobj instance void Modules.Function_SchedulerConversionsStableLoads/stringLength/FunctionObject::.ctor()
 		IL_0037: ldc.i4.1
 		IL_0038: conv.r8
 		IL_0039: ldstr "stringLength"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/stringLength/FunctionObject_FunctionDeclaration_F3B41092_stringLength>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/stringLength/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -1220,13 +1220,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 13
-		IL_0052: newobj instance void Modules.Function_SchedulerConversionsStableLoads/arrayLength/FunctionObject_FunctionDeclaration_3006B504_arrayLength::.ctor()
+		IL_0052: newobj instance void Modules.Function_SchedulerConversionsStableLoads/arrayLength/FunctionObject::.ctor()
 		IL_0057: ldc.i4.1
 		IL_0058: conv.r8
 		IL_0059: ldstr "arrayLength"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/arrayLength/FunctionObject_FunctionDeclaration_3006B504_arrayLength>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/arrayLength/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -1235,13 +1235,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 13
-		IL_0072: newobj instance void Modules.Function_SchedulerConversionsStableLoads/arrayElement/FunctionObject_FunctionDeclaration_CF905D20_arrayElement::.ctor()
+		IL_0072: newobj instance void Modules.Function_SchedulerConversionsStableLoads/arrayElement/FunctionObject::.ctor()
 		IL_0077: ldc.i4.1
 		IL_0078: conv.r8
 		IL_0079: ldstr "arrayElement"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/arrayElement/FunctionObject_FunctionDeclaration_CF905D20_arrayElement>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/arrayElement/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -1250,13 +1250,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 13
-		IL_0093: newobj instance void Modules.Function_SchedulerConversionsStableLoads/typedArray/FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::.ctor()
+		IL_0093: newobj instance void Modules.Function_SchedulerConversionsStableLoads/typedArray/FunctionObject::.ctor()
 		IL_0098: ldc.i4.1
 		IL_0099: conv.r8
 		IL_009a: ldstr "typedArray"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/typedArray/FunctionObject_FunctionDeclaration_C32D2A2E_typedArray>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/typedArray/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1265,13 +1265,13 @@
 		IL_00b0: ldloc.0
 		IL_00b1: stelem.ref
 		IL_00b2: stloc.s 13
-		IL_00b4: newobj instance void Modules.Function_SchedulerConversionsStableLoads/postfix/FunctionObject_FunctionDeclaration_30928FD8_postfix::.ctor()
+		IL_00b4: newobj instance void Modules.Function_SchedulerConversionsStableLoads/postfix/FunctionObject::.ctor()
 		IL_00b9: ldc.i4.1
 		IL_00ba: conv.r8
 		IL_00bb: ldstr "postfix"
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/postfix/FunctionObject_FunctionDeclaration_30928FD8_postfix>(!!0, float64, string, bool, bool)
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/postfix/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c7: stloc.s 6
 		IL_00c9: nop
 		IL_00ca: nop
@@ -1297,14 +1297,14 @@
 		IL_00f9: ldc.i4.0
 		IL_00fa: ldelem.ref
 		IL_00fb: castclass Modules.Function_SchedulerConversionsStableLoads/Scope
-		IL_0100: newobj instance void Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10::.ctor(class Modules.Function_SchedulerConversionsStableLoads/Scope)
+		IL_0100: newobj instance void Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject::.ctor(class Modules.Function_SchedulerConversionsStableLoads/Scope)
 		IL_0105: ldc.i4.0
 		IL_0106: conv.r8
 		IL_0107: ldstr ""
 		IL_010c: ldc.i4.0
 		IL_010d: ldc.i4.1
-		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10>(!!0, float64, string, bool, bool)
-		IL_0113: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10>(!!0)
+		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0113: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject>(!!0)
 		IL_0118: stloc.s 15
 		IL_011a: ldloc.s 15
 		IL_011c: ldstr "x"

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerGeneralRegions.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerGeneralRegions.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5F3B77EC_mixed
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -97,7 +97,7 @@
 				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0035: call object Modules.Function_SchedulerGeneralRegions/mixed::__js_call__(object, float64, float64, float64, float64)
 				IL_003a: ret
-			} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -129,7 +129,7 @@
 				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0031: call object Modules.Function_SchedulerGeneralRegions/mixed::__js_call__(object, float64, float64, float64, float64)
 				IL_0036: ret
-			} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -147,9 +147,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5F3B77EC_mixed
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -223,7 +223,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_881E8806_nested
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -243,9 +243,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject_FunctionDeclaration_881E8806_nested::_environment0_Function_SchedulerGeneralRegions
+				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -256,7 +256,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -267,7 +267,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -280,7 +280,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject_FunctionDeclaration_881E8806_nested::_environment0_Function_SchedulerGeneralRegions
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -292,7 +292,7 @@
 				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0023: call object Modules.Function_SchedulerGeneralRegions/'nested'::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64, float64)
 				IL_0028: ret
-			} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -306,7 +306,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject_FunctionDeclaration_881E8806_nested::_environment0_Function_SchedulerGeneralRegions
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -318,7 +318,7 @@
 				IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001f: call object Modules.Function_SchedulerGeneralRegions/'nested'::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64, float64)
 				IL_0024: ret
-			} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -336,9 +336,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_881E8806_nested
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -412,7 +412,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F97EF509_read
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -432,9 +432,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/read/FunctionObject_FunctionDeclaration_F97EF509_read::_environment0_Function_SchedulerGeneralRegions
+				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/read/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -445,7 +445,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -456,7 +456,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -469,11 +469,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/read/FunctionObject_FunctionDeclaration_F97EF509_read::_environment0_Function_SchedulerGeneralRegions
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/read/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerGeneralRegions/read::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -487,11 +487,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/read/FunctionObject_FunctionDeclaration_F97EF509_read::_environment0_Function_SchedulerGeneralRegions
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/read/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerGeneralRegions/read::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -509,9 +509,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F97EF509_read
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -574,7 +574,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C6E365D0_write
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -594,9 +594,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/write/FunctionObject_FunctionDeclaration_C6E365D0_write::_environment0_Function_SchedulerGeneralRegions
+				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/write/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -607,7 +607,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -618,7 +618,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -631,11 +631,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/write/FunctionObject_FunctionDeclaration_C6E365D0_write::_environment0_Function_SchedulerGeneralRegions
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/write/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerGeneralRegions/write::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -649,11 +649,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/write/FunctionObject_FunctionDeclaration_C6E365D0_write::_environment0_Function_SchedulerGeneralRegions
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/write/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerGeneralRegions/write::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -671,9 +671,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C6E365D0_write
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -750,7 +750,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2D7AD0BA_ordered
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -770,9 +770,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::_environment0_Function_SchedulerGeneralRegions
+				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -783,7 +783,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -794,7 +794,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -807,11 +807,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::_environment0_Function_SchedulerGeneralRegions
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerGeneralRegions/ordered::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -825,11 +825,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::_environment0_Function_SchedulerGeneralRegions
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerGeneralRegions/ordered::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -847,9 +847,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2D7AD0BA_ordered
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -963,7 +963,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2BB3E1E3_L39C14
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -985,12 +985,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14::_environment0_Function_SchedulerGeneralRegions
+					IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14::_transitionalScopes
+					IL_000f: stfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1001,7 +1001,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1012,7 +1012,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1025,13 +1025,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_2BB3E1E3_L39C14
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1102,7 +1102,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_17150E04_L43C14
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1124,12 +1124,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::_environment0_Function_SchedulerGeneralRegions
+					IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::_transitionalScopes
+					IL_000f: stfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1140,7 +1140,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1151,7 +1151,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1164,16 +1164,16 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_17150E04_L43C14
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1243,7 +1243,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_61C2125E_getter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1263,9 +1263,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionObject_FunctionDeclaration_61C2125E_getter::_environment0_Function_SchedulerGeneralRegions
+				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1276,7 +1276,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1287,7 +1287,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1300,7 +1300,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionObject_FunctionDeclaration_61C2125E_getter::_environment0_Function_SchedulerGeneralRegions
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -1308,7 +1308,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call object Modules.Function_SchedulerGeneralRegions/getter::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1322,7 +1322,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionObject_FunctionDeclaration_61C2125E_getter::_environment0_Function_SchedulerGeneralRegions
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -1330,7 +1330,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call object Modules.Function_SchedulerGeneralRegions/getter::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1348,9 +1348,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_61C2125E_getter
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1375,7 +1375,7 @@
 				[2] object,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[4] object[],
-				[5] class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14,
+				[5] class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject,
 				[6] object,
 				[7] object,
 				[8] object
@@ -1409,14 +1409,14 @@
 			IL_0037: ldelem.ref
 			IL_0038: castclass Modules.Function_SchedulerGeneralRegions/Scope
 			IL_003d: ldloc.s 4
-			IL_003f: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope, object[])
+			IL_003f: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope, object[])
 			IL_0044: ldc.i4.0
 			IL_0045: conv.r8
 			IL_0046: ldstr ""
 			IL_004b: ldc.i4.1
 			IL_004c: ldc.i4.1
-			IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14>(!!0, float64, string, bool, bool)
-			IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14>(!!0)
+			IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject>(!!0)
 			IL_0057: stloc.s 5
 			IL_0059: ldloc.s 5
 			IL_005b: ldstr "x"
@@ -1448,14 +1448,14 @@
 			IL_0095: ldelem.ref
 			IL_0096: castclass Modules.Function_SchedulerGeneralRegions/Scope
 			IL_009b: ldloc.s 4
-			IL_009d: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope, object[])
+			IL_009d: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope, object[])
 			IL_00a2: ldc.i4.1
 			IL_00a3: conv.r8
 			IL_00a4: ldstr ""
 			IL_00a9: ldc.i4.1
 			IL_00aa: ldc.i4.1
-			IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0, float64, string, bool, bool)
-			IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0)
+			IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject>(!!0)
 			IL_00b5: ldstr "x"
 			IL_00ba: ldstr "set"
 			IL_00bf: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
@@ -1565,7 +1565,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_63E493E1_caught
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1585,9 +1585,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/caught/FunctionObject_FunctionDeclaration_63E493E1_caught::_environment0_Function_SchedulerGeneralRegions
+				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/caught/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1598,7 +1598,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1609,7 +1609,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1622,11 +1622,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/caught/FunctionObject_FunctionDeclaration_63E493E1_caught::_environment0_Function_SchedulerGeneralRegions
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/caught/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerGeneralRegions/caught::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1640,11 +1640,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/caught/FunctionObject_FunctionDeclaration_63E493E1_caught::_environment0_Function_SchedulerGeneralRegions
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/caught/FunctionObject::_environment0_Function_SchedulerGeneralRegions
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerGeneralRegions/caught::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1662,9 +1662,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_63E493E1_caught
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1847,15 +1847,15 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerGeneralRegions/Scope,
-			[1] class Modules.Function_SchedulerGeneralRegions/mixed/FunctionObject_FunctionDeclaration_5F3B77EC_mixed,
-			[2] class Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject_FunctionDeclaration_881E8806_nested,
-			[3] class Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject_FunctionDeclaration_2D7AD0BA_ordered,
-			[4] class Modules.Function_SchedulerGeneralRegions/getter/FunctionObject_FunctionDeclaration_61C2125E_getter,
-			[5] class Modules.Function_SchedulerGeneralRegions/caught/FunctionObject_FunctionDeclaration_63E493E1_caught,
+			[1] class Modules.Function_SchedulerGeneralRegions/mixed/FunctionObject,
+			[2] class Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject,
+			[3] class Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject,
+			[4] class Modules.Function_SchedulerGeneralRegions/getter/FunctionObject,
+			[5] class Modules.Function_SchedulerGeneralRegions/caught/FunctionObject,
 			[6] object,
 			[7] object[],
-			[8] class Modules.Function_SchedulerGeneralRegions/read/FunctionObject_FunctionDeclaration_F97EF509_read,
-			[9] class Modules.Function_SchedulerGeneralRegions/write/FunctionObject_FunctionDeclaration_C6E365D0_write,
+			[8] class Modules.Function_SchedulerGeneralRegions/read/FunctionObject,
+			[9] class Modules.Function_SchedulerGeneralRegions/write/FunctionObject,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[11] object,
 			[12] object
@@ -1870,13 +1870,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
-		IL_0012: newobj instance void Modules.Function_SchedulerGeneralRegions/mixed/FunctionObject_FunctionDeclaration_5F3B77EC_mixed::.ctor()
+		IL_0012: newobj instance void Modules.Function_SchedulerGeneralRegions/mixed/FunctionObject::.ctor()
 		IL_0017: ldc.i4.4
 		IL_0018: conv.r8
 		IL_0019: ldstr "mixed"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/mixed/FunctionObject_FunctionDeclaration_5F3B77EC_mixed>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/mixed/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1889,13 +1889,13 @@
 		IL_0034: ldc.i4.0
 		IL_0035: ldelem.ref
 		IL_0036: castclass Modules.Function_SchedulerGeneralRegions/Scope
-		IL_003b: newobj instance void Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject_FunctionDeclaration_881E8806_nested::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
+		IL_003b: newobj instance void Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
 		IL_0040: ldc.i4.2
 		IL_0041: conv.r8
 		IL_0042: ldstr "nested"
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject_FunctionDeclaration_881E8806_nested>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: ldc.i4.1
 		IL_0050: newarr [System.Runtime]System.Object
@@ -1908,13 +1908,13 @@
 		IL_005d: ldc.i4.0
 		IL_005e: ldelem.ref
 		IL_005f: castclass Modules.Function_SchedulerGeneralRegions/Scope
-		IL_0064: newobj instance void Modules.Function_SchedulerGeneralRegions/read/FunctionObject_FunctionDeclaration_F97EF509_read::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
+		IL_0064: newobj instance void Modules.Function_SchedulerGeneralRegions/read/FunctionObject::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
 		IL_0069: ldc.i4.0
 		IL_006a: conv.r8
 		IL_006b: ldstr "read"
 		IL_0070: ldc.i4.0
 		IL_0071: ldc.i4.1
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/read/FunctionObject_FunctionDeclaration_F97EF509_read>(!!0, float64, string, bool, bool)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/read/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0077: stloc.s 8
 		IL_0079: ldloc.0
 		IL_007a: ldloc.s 8
@@ -1930,13 +1930,13 @@
 		IL_008f: ldc.i4.0
 		IL_0090: ldelem.ref
 		IL_0091: castclass Modules.Function_SchedulerGeneralRegions/Scope
-		IL_0096: newobj instance void Modules.Function_SchedulerGeneralRegions/write/FunctionObject_FunctionDeclaration_C6E365D0_write::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
+		IL_0096: newobj instance void Modules.Function_SchedulerGeneralRegions/write/FunctionObject::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
 		IL_009b: ldc.i4.0
 		IL_009c: conv.r8
 		IL_009d: ldstr "write"
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/write/FunctionObject_FunctionDeclaration_C6E365D0_write>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/write/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a9: stloc.s 9
 		IL_00ab: ldloc.0
 		IL_00ac: ldloc.s 9
@@ -1952,13 +1952,13 @@
 		IL_00c1: ldc.i4.0
 		IL_00c2: ldelem.ref
 		IL_00c3: castclass Modules.Function_SchedulerGeneralRegions/Scope
-		IL_00c8: newobj instance void Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
+		IL_00c8: newobj instance void Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
 		IL_00cd: ldc.i4.0
 		IL_00ce: conv.r8
 		IL_00cf: ldstr "ordered"
 		IL_00d4: ldc.i4.0
 		IL_00d5: ldc.i4.1
-		IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject_FunctionDeclaration_2D7AD0BA_ordered>(!!0, float64, string, bool, bool)
+		IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00db: stloc.3
 		IL_00dc: ldc.i4.1
 		IL_00dd: newarr [System.Runtime]System.Object
@@ -1971,13 +1971,13 @@
 		IL_00ea: ldc.i4.0
 		IL_00eb: ldelem.ref
 		IL_00ec: castclass Modules.Function_SchedulerGeneralRegions/Scope
-		IL_00f1: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionObject_FunctionDeclaration_61C2125E_getter::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
+		IL_00f1: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionObject::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
 		IL_00f6: ldc.i4.1
 		IL_00f7: conv.r8
 		IL_00f8: ldstr "getter"
 		IL_00fd: ldc.i4.0
 		IL_00fe: ldc.i4.1
-		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionObject_FunctionDeclaration_61C2125E_getter>(!!0, float64, string, bool, bool)
+		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0104: stloc.s 4
 		IL_0106: ldc.i4.1
 		IL_0107: newarr [System.Runtime]System.Object
@@ -1990,13 +1990,13 @@
 		IL_0114: ldc.i4.0
 		IL_0115: ldelem.ref
 		IL_0116: castclass Modules.Function_SchedulerGeneralRegions/Scope
-		IL_011b: newobj instance void Modules.Function_SchedulerGeneralRegions/caught/FunctionObject_FunctionDeclaration_63E493E1_caught::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
+		IL_011b: newobj instance void Modules.Function_SchedulerGeneralRegions/caught/FunctionObject::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
 		IL_0120: ldc.i4.0
 		IL_0121: conv.r8
 		IL_0122: ldstr "caught"
 		IL_0127: ldc.i4.0
 		IL_0128: ldc.i4.1
-		IL_0129: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/caught/FunctionObject_FunctionDeclaration_63E493E1_caught>(!!0, float64, string, bool, bool)
+		IL_0129: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/caught/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_012e: stloc.s 5
 		IL_0130: nop
 		IL_0131: nop

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3C021B3C_args
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -89,7 +89,7 @@
 				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001d: call object Modules.Function_SchedulerLiteralArguments/args::__js_call__(object, float64, float64)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -113,7 +113,7 @@
 				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0019: call object Modules.Function_SchedulerLiteralArguments/args::__js_call__(object, float64, float64)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -131,9 +131,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3C021B3C_args
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -197,7 +197,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_82194727_arrayValue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -211,7 +211,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -222,7 +222,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -233,7 +233,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -256,7 +256,7 @@
 				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/arrayValue::__js_call__(object, float64, float64)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -280,7 +280,7 @@
 				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/arrayValue::__js_call__(object, float64, float64)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -298,9 +298,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_82194727_arrayValue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -358,7 +358,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B6660A63_objectValue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -378,9 +378,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject_FunctionDeclaration_B6660A63_objectValue::_environment0_Function_SchedulerLiteralArguments
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -391,7 +391,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -402,7 +402,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -415,7 +415,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject_FunctionDeclaration_B6660A63_objectValue::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -427,7 +427,7 @@
 				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0023: call object Modules.Function_SchedulerLiteralArguments/objectValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
 				IL_0028: ret
-			} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -441,7 +441,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject_FunctionDeclaration_B6660A63_objectValue::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -453,7 +453,7 @@
 				IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001f: call object Modules.Function_SchedulerLiteralArguments/objectValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
 				IL_0024: ret
-			} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -471,9 +471,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B6660A63_objectValue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -535,7 +535,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_93C38E4A_nested
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -555,9 +555,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject_FunctionDeclaration_93C38E4A_nested::_environment0_Function_SchedulerLiteralArguments
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -568,7 +568,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -579,7 +579,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -592,7 +592,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject_FunctionDeclaration_93C38E4A_nested::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -604,7 +604,7 @@
 				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/'nested'::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
 				IL_0028: ret
-			} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -618,7 +618,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject_FunctionDeclaration_93C38E4A_nested::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -630,7 +630,7 @@
 				IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/'nested'::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
 				IL_0024: ret
-			} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -648,9 +648,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_93C38E4A_nested
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -719,7 +719,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3A5A524C_deepArray
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -733,7 +733,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -744,7 +744,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -755,7 +755,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -806,7 +806,7 @@
 				IL_006c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/deepArray::__js_call__(object, float64, float64, float64, float64, float64, float64, float64, float64, float64)
 				IL_0076: ret
-			} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -858,7 +858,7 @@
 				IL_0068: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/deepArray::__js_call__(object, float64, float64, float64, float64, float64, float64, float64, float64, float64)
 				IL_0072: ret
-			} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -876,9 +876,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3A5A524C_deepArray
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -952,7 +952,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_48D60399_f
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -972,9 +972,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/f/FunctionObject_FunctionDeclaration_48D60399_f::_environment0_Function_SchedulerLiteralArguments
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/f/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_48D60399_f::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -985,7 +985,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_48D60399_f::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -996,7 +996,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_48D60399_f::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1009,7 +1009,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/f/FunctionObject_FunctionDeclaration_48D60399_f::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/f/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -1017,7 +1017,7 @@
 				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0017: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_48D60399_f::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1031,7 +1031,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/f/FunctionObject_FunctionDeclaration_48D60399_f::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/f/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -1039,7 +1039,7 @@
 				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0013: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_48D60399_f::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1057,9 +1057,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_48D60399_f::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_48D60399_f
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1122,7 +1122,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1142,9 +1142,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1155,7 +1155,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1166,7 +1166,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1179,11 +1179,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerLiteralArguments/arrayOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1197,11 +1197,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerLiteralArguments/arrayOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1219,9 +1219,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1364,7 +1364,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_46C14D52_objectOrder
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1384,9 +1384,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject_FunctionDeclaration_46C14D52_objectOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1397,7 +1397,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1408,7 +1408,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1421,11 +1421,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject_FunctionDeclaration_46C14D52_objectOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerLiteralArguments/objectOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1439,11 +1439,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject_FunctionDeclaration_46C14D52_objectOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerLiteralArguments/objectOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1461,9 +1461,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_46C14D52_objectOrder
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1592,7 +1592,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_082DF7FE_L42C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1612,9 +1612,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22::_environment0_Function_SchedulerLiteralArguments
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1625,7 +1625,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1636,7 +1636,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1649,13 +1649,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_082DF7FE_L42C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1731,7 +1731,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1751,9 +1751,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1764,7 +1764,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1775,7 +1775,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1788,11 +1788,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerLiteralArguments/spreadOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1806,11 +1806,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerLiteralArguments/spreadOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1828,9 +1828,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1992,7 +1992,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2012,9 +2012,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2025,7 +2025,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2036,7 +2036,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2049,11 +2049,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_SchedulerLiteralArguments/exceptionOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2067,11 +2067,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_SchedulerLiteralArguments/exceptionOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2089,9 +2089,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2231,7 +2231,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DC80D3A4_throwValue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2251,9 +2251,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::_environment0_Function_SchedulerLiteralArguments
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2264,7 +2264,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2275,7 +2275,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2288,7 +2288,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2296,7 +2296,7 @@
 				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0017: call object Modules.Function_SchedulerLiteralArguments/throwValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2310,7 +2310,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::_environment0_Function_SchedulerLiteralArguments
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject::_environment0_Function_SchedulerLiteralArguments
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2318,7 +2318,7 @@
 				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0013: call object Modules.Function_SchedulerLiteralArguments/throwValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2336,9 +2336,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DC80D3A4_throwValue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2457,20 +2457,20 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerLiteralArguments/Scope,
-			[1] class Modules.Function_SchedulerLiteralArguments/args/FunctionObject_FunctionDeclaration_3C021B3C_args,
-			[2] class Modules.Function_SchedulerLiteralArguments/arrayValue/FunctionObject_FunctionDeclaration_82194727_arrayValue,
-			[3] class Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject_FunctionDeclaration_B6660A63_objectValue,
-			[4] class Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject_FunctionDeclaration_93C38E4A_nested,
-			[5] class Modules.Function_SchedulerLiteralArguments/deepArray/FunctionObject_FunctionDeclaration_3A5A524C_deepArray,
-			[6] class Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder,
-			[7] class Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject_FunctionDeclaration_46C14D52_objectOrder,
-			[8] class Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder,
-			[9] class Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder,
+			[1] class Modules.Function_SchedulerLiteralArguments/args/FunctionObject,
+			[2] class Modules.Function_SchedulerLiteralArguments/arrayValue/FunctionObject,
+			[3] class Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject,
+			[4] class Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject,
+			[5] class Modules.Function_SchedulerLiteralArguments/deepArray/FunctionObject,
+			[6] class Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject,
+			[7] class Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject,
+			[8] class Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject,
+			[9] class Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject,
 			[10] object,
 			[11] object,
 			[12] object[],
-			[13] class Modules.Function_SchedulerLiteralArguments/f/FunctionObject_FunctionDeclaration_48D60399_f,
-			[14] class Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue,
+			[13] class Modules.Function_SchedulerLiteralArguments/f/FunctionObject,
+			[14] class Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject,
 			[15] object,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[17] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -2486,13 +2486,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 12
-		IL_0012: newobj instance void Modules.Function_SchedulerLiteralArguments/args/FunctionObject_FunctionDeclaration_3C021B3C_args::.ctor()
+		IL_0012: newobj instance void Modules.Function_SchedulerLiteralArguments/args/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "args"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/args/FunctionObject_FunctionDeclaration_3C021B3C_args>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/args/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -2501,13 +2501,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 12
-		IL_0032: newobj instance void Modules.Function_SchedulerLiteralArguments/arrayValue/FunctionObject_FunctionDeclaration_82194727_arrayValue::.ctor()
+		IL_0032: newobj instance void Modules.Function_SchedulerLiteralArguments/arrayValue/FunctionObject::.ctor()
 		IL_0037: ldc.i4.2
 		IL_0038: conv.r8
 		IL_0039: ldstr "arrayValue"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/arrayValue/FunctionObject_FunctionDeclaration_82194727_arrayValue>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/arrayValue/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -2520,13 +2520,13 @@
 		IL_0054: ldc.i4.0
 		IL_0055: ldelem.ref
 		IL_0056: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_005b: newobj instance void Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject_FunctionDeclaration_B6660A63_objectValue::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_005b: newobj instance void Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_0060: ldc.i4.2
 		IL_0061: conv.r8
 		IL_0062: ldstr "objectValue"
 		IL_0067: ldc.i4.0
 		IL_0068: ldc.i4.1
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject_FunctionDeclaration_B6660A63_objectValue>(!!0, float64, string, bool, bool)
+		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006e: stloc.3
 		IL_006f: ldc.i4.1
 		IL_0070: newarr [System.Runtime]System.Object
@@ -2539,13 +2539,13 @@
 		IL_007d: ldc.i4.0
 		IL_007e: ldelem.ref
 		IL_007f: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_0084: newobj instance void Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject_FunctionDeclaration_93C38E4A_nested::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_0084: newobj instance void Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_0089: ldc.i4.2
 		IL_008a: conv.r8
 		IL_008b: ldstr "nested"
 		IL_0090: ldc.i4.0
 		IL_0091: ldc.i4.1
-		IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject_FunctionDeclaration_93C38E4A_nested>(!!0, float64, string, bool, bool)
+		IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0097: stloc.s 4
 		IL_0099: ldc.i4.1
 		IL_009a: newarr [System.Runtime]System.Object
@@ -2554,13 +2554,13 @@
 		IL_00a1: ldloc.0
 		IL_00a2: stelem.ref
 		IL_00a3: stloc.s 12
-		IL_00a5: newobj instance void Modules.Function_SchedulerLiteralArguments/deepArray/FunctionObject_FunctionDeclaration_3A5A524C_deepArray::.ctor()
+		IL_00a5: newobj instance void Modules.Function_SchedulerLiteralArguments/deepArray/FunctionObject::.ctor()
 		IL_00aa: ldc.i4.s 9
 		IL_00ac: conv.r8
 		IL_00ad: ldstr "deepArray"
 		IL_00b2: ldc.i4.0
 		IL_00b3: ldc.i4.1
-		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/deepArray/FunctionObject_FunctionDeclaration_3A5A524C_deepArray>(!!0, float64, string, bool, bool)
+		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/deepArray/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00b9: stloc.s 5
 		IL_00bb: ldc.i4.1
 		IL_00bc: newarr [System.Runtime]System.Object
@@ -2573,13 +2573,13 @@
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldelem.ref
 		IL_00cb: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_00d0: newobj instance void Modules.Function_SchedulerLiteralArguments/f/FunctionObject_FunctionDeclaration_48D60399_f::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_00d0: newobj instance void Modules.Function_SchedulerLiteralArguments/f/FunctionObject::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_00d5: ldc.i4.1
 		IL_00d6: conv.r8
 		IL_00d7: ldstr "f"
 		IL_00dc: ldc.i4.0
 		IL_00dd: ldc.i4.1
-		IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/f/FunctionObject_FunctionDeclaration_48D60399_f>(!!0, float64, string, bool, bool)
+		IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/f/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00e3: stloc.s 13
 		IL_00e5: ldloc.0
 		IL_00e6: ldloc.s 13
@@ -2595,13 +2595,13 @@
 		IL_00fb: ldc.i4.0
 		IL_00fc: ldelem.ref
 		IL_00fd: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_0102: newobj instance void Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_0102: newobj instance void Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_0107: ldc.i4.0
 		IL_0108: conv.r8
 		IL_0109: ldstr "arrayOrder"
 		IL_010e: ldc.i4.0
 		IL_010f: ldc.i4.1
-		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder>(!!0, float64, string, bool, bool)
+		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0115: stloc.s 6
 		IL_0117: ldc.i4.1
 		IL_0118: newarr [System.Runtime]System.Object
@@ -2614,13 +2614,13 @@
 		IL_0125: ldc.i4.0
 		IL_0126: ldelem.ref
 		IL_0127: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_012c: newobj instance void Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject_FunctionDeclaration_46C14D52_objectOrder::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_012c: newobj instance void Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_0131: ldc.i4.0
 		IL_0132: conv.r8
 		IL_0133: ldstr "objectOrder"
 		IL_0138: ldc.i4.0
 		IL_0139: ldc.i4.1
-		IL_013a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject_FunctionDeclaration_46C14D52_objectOrder>(!!0, float64, string, bool, bool)
+		IL_013a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_013f: stloc.s 7
 		IL_0141: ldc.i4.1
 		IL_0142: newarr [System.Runtime]System.Object
@@ -2633,13 +2633,13 @@
 		IL_014f: ldc.i4.0
 		IL_0150: ldelem.ref
 		IL_0151: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_0156: newobj instance void Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_0156: newobj instance void Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_015b: ldc.i4.0
 		IL_015c: conv.r8
 		IL_015d: ldstr "spreadOrder"
 		IL_0162: ldc.i4.0
 		IL_0163: ldc.i4.1
-		IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder>(!!0, float64, string, bool, bool)
+		IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0169: stloc.s 8
 		IL_016b: ldc.i4.1
 		IL_016c: newarr [System.Runtime]System.Object
@@ -2652,13 +2652,13 @@
 		IL_0179: ldc.i4.0
 		IL_017a: ldelem.ref
 		IL_017b: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_0180: newobj instance void Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_0180: newobj instance void Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_0185: ldc.i4.0
 		IL_0186: conv.r8
 		IL_0187: ldstr "exceptionOrder"
 		IL_018c: ldc.i4.0
 		IL_018d: ldc.i4.1
-		IL_018e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder>(!!0, float64, string, bool, bool)
+		IL_018e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0193: stloc.s 9
 		IL_0195: ldc.i4.1
 		IL_0196: newarr [System.Runtime]System.Object
@@ -2671,13 +2671,13 @@
 		IL_01a3: ldc.i4.0
 		IL_01a4: ldelem.ref
 		IL_01a5: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_01aa: newobj instance void Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_01aa: newobj instance void Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_01af: ldc.i4.1
 		IL_01b0: conv.r8
 		IL_01b1: ldstr "throwValue"
 		IL_01b6: ldc.i4.0
 		IL_01b7: ldc.i4.1
-		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue>(!!0, float64, string, bool, bool)
+		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01bd: stloc.s 14
 		IL_01bf: ldloc.0
 		IL_01c0: ldloc.s 14
@@ -2712,14 +2712,14 @@
 		IL_0200: ldc.i4.0
 		IL_0201: ldelem.ref
 		IL_0202: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_0207: newobj instance void Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_0207: newobj instance void Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_020c: ldc.i4.0
 		IL_020d: conv.r8
 		IL_020e: ldstr ""
 		IL_0213: ldc.i4.0
 		IL_0214: ldc.i4.1
-		IL_0215: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22>(!!0, float64, string, bool, bool)
-		IL_021a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22>(!!0)
+		IL_0215: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_021a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject>(!!0)
 		IL_021f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_0224: pop
 		IL_0225: ldloc.0

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_Direct.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_Direct.verified.txt
@@ -293,7 +293,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B50E971C_L5C21
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -307,7 +307,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_B50E971C_L5C21::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -318,7 +318,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B50E971C_L5C21::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -329,7 +329,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B50E971C_L5C21::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -343,7 +343,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_B50E971C_L5C21::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -361,7 +361,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_StableConstCallable_Direct/FunctionExpression_withDefault::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_B50E971C_L5C21::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -380,7 +380,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_StableConstCallable_Direct/FunctionExpression_withDefault::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B50E971C_L5C21::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -398,9 +398,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B50E971C_L5C21::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_B50E971C_L5C21
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -464,7 +464,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9423069B_namedAdd
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -478,7 +478,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_9423069B_namedAdd::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -489,7 +489,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9423069B_namedAdd::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -500,7 +500,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9423069B_namedAdd::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -514,7 +514,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_9423069B_namedAdd::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -532,7 +532,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_StableConstCallable_Direct/namedAdd::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_9423069B_namedAdd::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -551,7 +551,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_StableConstCallable_Direct/namedAdd::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9423069B_namedAdd::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -569,9 +569,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9423069B_namedAdd::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_9423069B_namedAdd
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -791,7 +791,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1DB493A5_L12C28
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -805,7 +805,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_1DB493A5_L12C28::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -816,7 +816,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1DB493A5_L12C28::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -827,7 +827,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1DB493A5_L12C28::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -841,7 +841,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_1DB493A5_L12C28::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -878,7 +878,7 @@
 
 				IL_0020: ldloc.0
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionExpression_1DB493A5_L12C28::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -896,7 +896,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_StableConstCallable_Direct/FunctionExpression_expressionWithRest::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_1DB493A5_L12C28::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -915,7 +915,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_StableConstCallable_Direct/FunctionExpression_expressionWithRest::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1DB493A5_L12C28::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -933,9 +933,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1DB493A5_L12C28::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1DB493A5_L12C28
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1005,7 +1005,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_020A28AA_L15C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1019,7 +1019,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_020A28AA_L15C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1030,7 +1030,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_020A28AA_L15C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1041,7 +1041,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_020A28AA_L15C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1055,7 +1055,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_020A28AA_L15C24::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1070,7 +1070,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_StableConstCallable_Direct/FunctionExpression_readsNewTarget::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_020A28AA_L15C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1086,7 +1086,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_StableConstCallable_Direct/FunctionExpression_readsNewTarget::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_020A28AA_L15C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1104,9 +1104,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_020A28AA_L15C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_020A28AA_L15C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1325,7 +1325,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4E669083_readsOwnThis
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -1339,7 +1339,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionDeclaration_4E669083_readsOwnThis::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1350,7 +1350,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_4E669083_readsOwnThis::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1361,7 +1361,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_4E669083_readsOwnThis::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -1375,7 +1375,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionDeclaration_4E669083_readsOwnThis::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1390,7 +1390,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.Function_StableConstCallable_Direct/ArrowFunction_L20C32/readsOwnThis::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionDeclaration_4E669083_readsOwnThis::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1406,7 +1406,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.Function_StableConstCallable_Direct/ArrowFunction_L20C32/readsOwnThis::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionDeclaration_4E669083_readsOwnThis::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1424,9 +1424,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_4E669083_readsOwnThis::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_4E669083_readsOwnThis
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1553,7 +1553,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_StableConstCallable_Direct/ArrowFunction_L20C32/Scope,
-				[1] class Modules.Function_StableConstCallable_Direct/ArrowFunction_L20C32/readsOwnThis/FunctionObject_FunctionDeclaration_4E669083_readsOwnThis,
+				[1] class Modules.Function_StableConstCallable_Direct/ArrowFunction_L20C32/readsOwnThis/FunctionObject,
 				[2] object[],
 				[3] string
 			)
@@ -1562,14 +1562,14 @@
 			IL_0005: stloc.0
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.2
-			IL_000c: newobj instance void Modules.Function_StableConstCallable_Direct/ArrowFunction_L20C32/readsOwnThis/FunctionObject_FunctionDeclaration_4E669083_readsOwnThis::.ctor()
+			IL_000c: newobj instance void Modules.Function_StableConstCallable_Direct/ArrowFunction_L20C32/readsOwnThis/FunctionObject::.ctor()
 			IL_0011: ldc.i4.0
 			IL_0012: conv.r8
 			IL_0013: ldstr "readsOwnThis"
 			IL_0018: ldc.i4.1
 			IL_0019: ldc.i4.0
-			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Direct/ArrowFunction_L20C32/readsOwnThis/FunctionObject_FunctionDeclaration_4E669083_readsOwnThis>(!!0, float64, string, bool, bool)
-			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Direct/ArrowFunction_L20C32/readsOwnThis/FunctionObject_FunctionDeclaration_4E669083_readsOwnThis>(!!0)
+			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Direct/ArrowFunction_L20C32/readsOwnThis/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Direct/ArrowFunction_L20C32/readsOwnThis/FunctionObject>(!!0)
 			IL_0024: stloc.1
 			IL_0025: nop
 			IL_0026: ldloc.1
@@ -1797,7 +1797,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8E3F84B5_L28C29
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1811,7 +1811,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8E3F84B5_L28C29::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1822,7 +1822,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8E3F84B5_L28C29::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1833,7 +1833,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8E3F84B5_L28C29::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1847,7 +1847,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8E3F84B5_L28C29::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1862,7 +1862,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_8E3F84B5_L28C29::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1878,7 +1878,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_StableConstCallable_Direct/FunctionExpression_nestedOrdinaryClass::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8E3F84B5_L28C29::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1896,9 +1896,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8E3F84B5_L28C29::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_8E3F84B5_L28C29
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2017,7 +2017,7 @@
 		.locals init (
 			[0] class Modules.Function_StableConstCallable_Direct/Scope,
 			[1] object,
-			[2] class Modules.Function_StableConstCallable_Direct/namedAdd/FunctionObject_FunctionExpression_9423069B_namedAdd,
+			[2] class Modules.Function_StableConstCallable_Direct/namedAdd/FunctionObject,
 			[3] object,
 			[4] object[],
 			[5] class Modules.Function_StableConstCallable_Direct/ArrowFunction_L3C16/FunctionObject,
@@ -2067,14 +2067,14 @@
 		IL_0043: ldloc.0
 		IL_0044: stelem.ref
 		IL_0045: stloc.s 4
-		IL_0047: newobj instance void Modules.Function_StableConstCallable_Direct/namedAdd/FunctionObject_FunctionExpression_9423069B_namedAdd::.ctor()
+		IL_0047: newobj instance void Modules.Function_StableConstCallable_Direct/namedAdd/FunctionObject::.ctor()
 		IL_004c: ldc.i4.1
 		IL_004d: conv.r8
 		IL_004e: ldstr "namedAdd"
 		IL_0053: ldc.i4.1
 		IL_0054: ldc.i4.0
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Direct/namedAdd/FunctionObject_FunctionExpression_9423069B_namedAdd>(!!0, float64, string, bool, bool)
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Direct/namedAdd/FunctionObject_FunctionExpression_9423069B_namedAdd>(!!0)
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Direct/namedAdd/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Direct/namedAdd/FunctionObject>(!!0)
 		IL_005f: stloc.2
 		IL_0060: nop
 		IL_0061: nop
@@ -2175,7 +2175,7 @@
 		IL_0166: ldc.r8 3
 		IL_016f: box [System.Runtime]System.Double
 		IL_0174: stelem.ref
-		IL_0175: call object Modules.Function_StableConstCallable_Direct/FunctionExpression_expressionWithRest/FunctionObject_FunctionExpression_1DB493A5_L12C28::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_0175: call object Modules.Function_StableConstCallable_Direct/FunctionExpression_expressionWithRest/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
 		IL_017a: stloc.s 13
 		IL_017c: ldnull
 		IL_017d: call object Modules.Function_StableConstCallable_Direct/FunctionExpression_readsNewTarget::__js_call__(object)

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_Fallbacks.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_Fallbacks.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8D4F3F93_L3C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8D4F3F93_L3C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8D4F3F93_L3C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8D4F3F93_L3C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8D4F3F93_L3C22::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -95,7 +95,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_ordinaryThis::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_8D4F3F93_L3C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -111,7 +111,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_ordinaryThis::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8D4F3F93_L3C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -129,9 +129,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8D4F3F93_L3C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_8D4F3F93_L3C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -184,7 +184,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AE4F2BB5_L7C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -198,7 +198,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_AE4F2BB5_L7C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -209,7 +209,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AE4F2BB5_L7C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -220,7 +220,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AE4F2BB5_L7C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -235,7 +235,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_strictThis::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_AE4F2BB5_L7C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -251,7 +251,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_strictThis::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_AE4F2BB5_L7C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -269,9 +269,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AE4F2BB5_L7C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_AE4F2BB5_L7C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -335,7 +335,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_79C15758_L12C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -349,7 +349,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_79C15758_L12C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -360,7 +360,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_79C15758_L12C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -371,7 +371,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_79C15758_L12C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -385,7 +385,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_79C15758_L12C23::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -422,7 +422,7 @@
 
 				IL_0020: ldloc.0
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionExpression_79C15758_L12C23::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -440,7 +440,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_withArguments::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_79C15758_L12C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -459,7 +459,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_withArguments::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_79C15758_L12C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -477,9 +477,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_79C15758_L12C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_79C15758_L12C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -870,7 +870,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_16282285_L19C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -890,9 +890,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression/FunctionObject_FunctionExpression_16282285_L19C25::_transitionalScopes
+				IL_0008: stfld object[] Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_16282285_L19C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -903,7 +903,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_16282285_L19C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -914,7 +914,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_16282285_L19C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -928,7 +928,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_16282285_L19C25::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -941,7 +941,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression/FunctionObject_FunctionExpression_16282285_L19C25::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -949,9 +949,9 @@
 				IL_0012: call object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionExpression_16282285_L19C25::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionExpression_16282285_L19C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1006,7 +1006,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C3DBE7DB_L22C29
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1026,9 +1026,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject_FunctionExpression_C3DBE7DB_L22C29::_transitionalScopes
+				IL_0008: stfld object[] Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C3DBE7DB_L22C29::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1039,7 +1039,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C3DBE7DB_L22C29::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1050,7 +1050,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C3DBE7DB_L22C29::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1064,7 +1064,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_C3DBE7DB_L22C29::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1077,15 +1077,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject_FunctionExpression_C3DBE7DB_L22C29::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionExpression_C3DBE7DB_L22C29::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_C3DBE7DB_L22C29
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1125,7 +1125,7 @@
 			IL_001f: ldftn object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject_FunctionExpression_C3DBE7DB_L22C29
+			IL_002b: ldtoken Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -1356,7 +1356,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_70B327F2_L28C11
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1370,7 +1370,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_70B327F2_L28C11::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1381,7 +1381,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_70B327F2_L28C11::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1392,7 +1392,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_70B327F2_L28C11::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1406,7 +1406,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_70B327F2_L28C11::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1421,7 +1421,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_receiver::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_70B327F2_L28C11::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1437,7 +1437,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_receiver::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_70B327F2_L28C11::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1455,9 +1455,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_70B327F2_L28C11::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_70B327F2_L28C11
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1670,7 +1670,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1690,9 +1690,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::_environment0_Function_StableConstCallable_Fallbacks
+				IL_0008: stfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject::_environment0_Function_StableConstCallable_Fallbacks
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1703,7 +1703,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1714,7 +1714,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1728,7 +1728,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -1769,7 +1769,7 @@
 
 				IL_0028: ldloc.0
 				IL_0029: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1782,14 +1782,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::_environment0_Function_StableConstCallable_Fallbacks
+				IL_0001: ldfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject::_environment0_Function_StableConstCallable_Fallbacks
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments::__js_call__(class Modules.Function_StableConstCallable_Fallbacks/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1803,14 +1803,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::_environment0_Function_StableConstCallable_Fallbacks
+				IL_0001: ldfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject::_environment0_Function_StableConstCallable_Fallbacks
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments::__js_call__(class Modules.Function_StableConstCallable_Fallbacks/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1828,9 +1828,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2098,7 +2098,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2118,9 +2118,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget::_environment0_Function_StableConstCallable_Fallbacks
+				IL_0008: stfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject::_environment0_Function_StableConstCallable_Fallbacks
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2131,7 +2131,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2142,7 +2142,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -2156,7 +2156,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2169,11 +2169,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget::_environment0_Function_StableConstCallable_Fallbacks
+				IL_0001: ldfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject::_environment0_Function_StableConstCallable_Fallbacks
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget::__js_call__(class Modules.Function_StableConstCallable_Fallbacks/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2187,11 +2187,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget::_environment0_Function_StableConstCallable_Fallbacks
+				IL_0001: ldfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject::_environment0_Function_StableConstCallable_Fallbacks
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget::__js_call__(class Modules.Function_StableConstCallable_Fallbacks/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2209,9 +2209,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2435,7 +2435,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0669F3FF_L44C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2449,7 +2449,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_0669F3FF_L44C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2460,7 +2460,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0669F3FF_L44C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2471,7 +2471,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0669F3FF_L44C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -2485,7 +2485,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_0669F3FF_L44C25::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2500,7 +2500,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_nestedArrowThis::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_0669F3FF_L44C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2516,7 +2516,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_nestedArrowThis::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_0669F3FF_L44C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2534,9 +2534,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0669F3FF_L44C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_0669F3FF_L44C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2617,7 +2617,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AC3524CC_recurse
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2631,7 +2631,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_AC3524CC_recurse::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2642,7 +2642,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AC3524CC_recurse::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2653,7 +2653,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AC3524CC_recurse::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -2667,7 +2667,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_AC3524CC_recurse::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2685,7 +2685,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Function_StableConstCallable_Fallbacks/recurse::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_AC3524CC_recurse::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2704,7 +2704,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Function_StableConstCallable_Fallbacks/recurse::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AC3524CC_recurse::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2722,9 +2722,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AC3524CC_recurse::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_AC3524CC_recurse
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2818,7 +2818,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_22C5D573_ownIdentity
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2838,9 +2838,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject_FunctionExpression_22C5D573_ownIdentity::_environment0_Function_StableConstCallable_Fallbacks
+				IL_0008: stfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject::_environment0_Function_StableConstCallable_Fallbacks
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_22C5D573_ownIdentity::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2851,7 +2851,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_22C5D573_ownIdentity::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2862,7 +2862,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_22C5D573_ownIdentity::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -2876,7 +2876,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_22C5D573_ownIdentity::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2889,11 +2889,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject_FunctionExpression_22C5D573_ownIdentity::_environment0_Function_StableConstCallable_Fallbacks
+				IL_0001: ldfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject::_environment0_Function_StableConstCallable_Fallbacks
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_StableConstCallable_Fallbacks/ownIdentity::__js_call__(class Modules.Function_StableConstCallable_Fallbacks/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_22C5D573_ownIdentity::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2907,11 +2907,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject_FunctionExpression_22C5D573_ownIdentity::_environment0_Function_StableConstCallable_Fallbacks
+				IL_0001: ldfld class Modules.Function_StableConstCallable_Fallbacks/Scope Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject::_environment0_Function_StableConstCallable_Fallbacks
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_StableConstCallable_Fallbacks/ownIdentity::__js_call__(class Modules.Function_StableConstCallable_Fallbacks/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_22C5D573_ownIdentity::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2929,9 +2929,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_22C5D573_ownIdentity::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_22C5D573_ownIdentity
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3768,7 +3768,7 @@
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Function_StableConstCallable_Fallbacks/Scope,
-			[1] class Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments,
+			[1] class Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -3778,20 +3778,20 @@
 			[8] object,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[10] object,
-			[11] class Modules.Function_StableConstCallable_Fallbacks/recurse/FunctionObject_FunctionExpression_AC3524CC_recurse,
+			[11] class Modules.Function_StableConstCallable_Fallbacks/recurse/FunctionObject,
 			[12] object,
 			[13] object[],
-			[14] class Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget,
-			[15] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_ordinaryThis/FunctionObject_FunctionExpression_8D4F3F93_L3C22,
-			[16] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_strictThis/FunctionObject_FunctionExpression_AE4F2BB5_L7C20,
-			[17] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_withArguments/FunctionObject_FunctionExpression_79C15758_L12C23,
+			[14] class Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject,
+			[15] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_ordinaryThis/FunctionObject,
+			[16] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_strictThis/FunctionObject,
+			[17] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_withArguments/FunctionObject,
 			[18] class Modules.Function_StableConstCallable_Fallbacks/ArrowFunction_L16C22/FunctionObject,
 			[19] class Modules.Function_StableConstCallable_Fallbacks/ArrowFunction_L18C20/FunctionObject,
-			[20] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression/FunctionObject_FunctionExpression_16282285_L19C25,
-			[21] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject_FunctionExpression_C3DBE7DB_L22C29,
-			[22] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_receiver/FunctionObject_FunctionExpression_70B327F2_L28C11,
-			[23] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_nestedArrowThis/FunctionObject_FunctionExpression_0669F3FF_L44C25,
-			[24] class Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject_FunctionExpression_22C5D573_ownIdentity,
+			[20] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression/FunctionObject,
+			[21] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject,
+			[22] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_receiver/FunctionObject,
+			[23] class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_nestedArrowThis/FunctionObject,
+			[24] class Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject,
 			[25] class [System.Runtime]System.Type,
 			[26] object,
 			[27] class Modules.Function_StableConstCallable_Fallbacks/StableConstBase/FunctionObject_ClassConstructor_FF86048C_StableConstBase,
@@ -3825,14 +3825,14 @@
 		IL_0032: ldc.i4.0
 		IL_0033: ldelem.ref
 		IL_0034: castclass Modules.Function_StableConstCallable_Fallbacks/Scope
-		IL_0039: newobj instance void Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::.ctor(class Modules.Function_StableConstCallable_Fallbacks/Scope)
+		IL_0039: newobj instance void Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject::.ctor(class Modules.Function_StableConstCallable_Fallbacks/Scope)
 		IL_003e: ldc.i4.1
 		IL_003f: conv.r8
 		IL_0040: ldstr "readLexicalArguments"
 		IL_0045: ldc.i4.1
 		IL_0046: ldc.i4.0
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments>(!!0, float64, string, bool, bool)
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments>(!!0)
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject>(!!0)
 		IL_0051: stloc.1
 		IL_0052: ldc.i4.1
 		IL_0053: newarr [System.Runtime]System.Object
@@ -3845,14 +3845,14 @@
 		IL_0060: ldc.i4.0
 		IL_0061: ldelem.ref
 		IL_0062: castclass Modules.Function_StableConstCallable_Fallbacks/Scope
-		IL_0067: newobj instance void Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget::.ctor(class Modules.Function_StableConstCallable_Fallbacks/Scope)
+		IL_0067: newobj instance void Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject::.ctor(class Modules.Function_StableConstCallable_Fallbacks/Scope)
 		IL_006c: ldc.i4.0
 		IL_006d: conv.r8
 		IL_006e: ldstr "ReadNewTarget"
 		IL_0073: ldc.i4.1
 		IL_0074: ldc.i4.0
-		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget>(!!0, float64, string, bool, bool)
-		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject_FunctionDeclaration_8B5E937A_ReadNewTarget>(!!0)
+		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/ReadNewTarget/FunctionObject>(!!0)
 		IL_007f: stloc.s 14
 		IL_0081: ldloc.0
 		IL_0082: ldloc.s 14
@@ -3871,14 +3871,14 @@
 		IL_00ac: ldloc.0
 		IL_00ad: stelem.ref
 		IL_00ae: stloc.s 13
-		IL_00b0: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_ordinaryThis/FunctionObject_FunctionExpression_8D4F3F93_L3C22::.ctor()
+		IL_00b0: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_ordinaryThis/FunctionObject::.ctor()
 		IL_00b5: ldc.i4.0
 		IL_00b6: conv.r8
 		IL_00b7: ldstr ""
 		IL_00bc: ldc.i4.1
 		IL_00bd: ldc.i4.0
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_ordinaryThis/FunctionObject_FunctionExpression_8D4F3F93_L3C22>(!!0, float64, string, bool, bool)
-		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_ordinaryThis/FunctionObject_FunctionExpression_8D4F3F93_L3C22>(!!0)
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_ordinaryThis/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_ordinaryThis/FunctionObject>(!!0)
 		IL_00c8: stloc.s 15
 		IL_00ca: ldloc.s 15
 		IL_00cc: ldstr "ordinaryThis"
@@ -3891,13 +3891,13 @@
 		IL_00df: ldloc.0
 		IL_00e0: stelem.ref
 		IL_00e1: stloc.s 13
-		IL_00e3: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_strictThis/FunctionObject_FunctionExpression_AE4F2BB5_L7C20::.ctor()
+		IL_00e3: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_strictThis/FunctionObject::.ctor()
 		IL_00e8: ldc.i4.0
 		IL_00e9: conv.r8
 		IL_00ea: ldstr ""
 		IL_00ef: ldc.i4.1
 		IL_00f0: ldc.i4.1
-		IL_00f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_strictThis/FunctionObject_FunctionExpression_AE4F2BB5_L7C20>(!!0, float64, string, bool, bool)
+		IL_00f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_strictThis/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00f6: stloc.s 16
 		IL_00f8: ldloc.s 16
 		IL_00fa: ldstr "strictThis"
@@ -3910,14 +3910,14 @@
 		IL_010d: ldloc.0
 		IL_010e: stelem.ref
 		IL_010f: stloc.s 13
-		IL_0111: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_withArguments/FunctionObject_FunctionExpression_79C15758_L12C23::.ctor()
+		IL_0111: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_withArguments/FunctionObject::.ctor()
 		IL_0116: ldc.i4.1
 		IL_0117: conv.r8
 		IL_0118: ldstr ""
 		IL_011d: ldc.i4.1
 		IL_011e: ldc.i4.0
-		IL_011f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_withArguments/FunctionObject_FunctionExpression_79C15758_L12C23>(!!0, float64, string, bool, bool)
-		IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_withArguments/FunctionObject_FunctionExpression_79C15758_L12C23>(!!0)
+		IL_011f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_withArguments/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_withArguments/FunctionObject>(!!0)
 		IL_0129: stloc.s 17
 		IL_012b: ldloc.s 17
 		IL_012d: ldstr "withArguments"
@@ -3972,14 +3972,14 @@
 		IL_01ac: stelem.ref
 		IL_01ad: stloc.s 13
 		IL_01af: ldloc.s 13
-		IL_01b1: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression/FunctionObject_FunctionExpression_16282285_L19C25::.ctor(object[])
+		IL_01b1: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression/FunctionObject::.ctor(object[])
 		IL_01b6: ldc.i4.1
 		IL_01b7: conv.r8
 		IL_01b8: ldstr ""
 		IL_01bd: ldc.i4.0
 		IL_01be: ldc.i4.0
-		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression/FunctionObject_FunctionExpression_16282285_L19C25>(!!0, float64, string, bool, bool)
-		IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression/FunctionObject_FunctionExpression_16282285_L19C25>(!!0)
+		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_asyncExpression/FunctionObject>(!!0)
 		IL_01c9: stloc.s 20
 		IL_01cb: ldloc.s 20
 		IL_01cd: ldstr "asyncExpression"
@@ -3993,15 +3993,15 @@
 		IL_01e2: stelem.ref
 		IL_01e3: stloc.s 13
 		IL_01e5: ldloc.s 13
-		IL_01e7: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject_FunctionExpression_C3DBE7DB_L22C29::.ctor(object[])
+		IL_01e7: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject::.ctor(object[])
 		IL_01ec: ldc.i4.0
 		IL_01ed: conv.r8
 		IL_01ee: ldstr ""
 		IL_01f3: ldc.i4.1
 		IL_01f4: ldc.i4.0
-		IL_01f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject_FunctionExpression_C3DBE7DB_L22C29>(!!0, float64, string, bool, bool)
+		IL_01f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01fa: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_01ff: castclass Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject_FunctionExpression_C3DBE7DB_L22C29
+		IL_01ff: castclass Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_generatorExpression/FunctionObject
 		IL_0204: stloc.s 21
 		IL_0206: ldloc.s 21
 		IL_0208: ldstr "generatorExpression"
@@ -4014,14 +4014,14 @@
 		IL_021c: ldloc.0
 		IL_021d: stelem.ref
 		IL_021e: stloc.s 13
-		IL_0220: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_receiver/FunctionObject_FunctionExpression_70B327F2_L28C11::.ctor()
+		IL_0220: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_receiver/FunctionObject::.ctor()
 		IL_0225: ldc.i4.0
 		IL_0226: conv.r8
 		IL_0227: ldstr ""
 		IL_022c: ldc.i4.1
 		IL_022d: ldc.i4.0
-		IL_022e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_receiver/FunctionObject_FunctionExpression_70B327F2_L28C11>(!!0, float64, string, bool, bool)
-		IL_0233: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_receiver/FunctionObject_FunctionExpression_70B327F2_L28C11>(!!0)
+		IL_022e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_receiver/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0233: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_receiver/FunctionObject>(!!0)
 		IL_0238: stloc.s 22
 		IL_023a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_023f: dup
@@ -4042,14 +4042,14 @@
 		IL_026c: ldloc.0
 		IL_026d: stelem.ref
 		IL_026e: stloc.s 13
-		IL_0270: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_nestedArrowThis/FunctionObject_FunctionExpression_0669F3FF_L44C25::.ctor()
+		IL_0270: newobj instance void Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_nestedArrowThis/FunctionObject::.ctor()
 		IL_0275: ldc.i4.0
 		IL_0276: conv.r8
 		IL_0277: ldstr ""
 		IL_027c: ldc.i4.1
 		IL_027d: ldc.i4.0
-		IL_027e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_nestedArrowThis/FunctionObject_FunctionExpression_0669F3FF_L44C25>(!!0, float64, string, bool, bool)
-		IL_0283: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_nestedArrowThis/FunctionObject_FunctionExpression_0669F3FF_L44C25>(!!0)
+		IL_027e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_nestedArrowThis/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0283: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/FunctionExpression_nestedArrowThis/FunctionObject>(!!0)
 		IL_0288: stloc.s 23
 		IL_028a: ldloc.s 23
 		IL_028c: ldstr "nestedArrowThis"
@@ -4062,14 +4062,14 @@
 		IL_02a0: ldloc.0
 		IL_02a1: stelem.ref
 		IL_02a2: stloc.s 13
-		IL_02a4: newobj instance void Modules.Function_StableConstCallable_Fallbacks/recurse/FunctionObject_FunctionExpression_AC3524CC_recurse::.ctor()
+		IL_02a4: newobj instance void Modules.Function_StableConstCallable_Fallbacks/recurse/FunctionObject::.ctor()
 		IL_02a9: ldc.i4.1
 		IL_02aa: conv.r8
 		IL_02ab: ldstr "recurse"
 		IL_02b0: ldc.i4.1
 		IL_02b1: ldc.i4.0
-		IL_02b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/recurse/FunctionObject_FunctionExpression_AC3524CC_recurse>(!!0, float64, string, bool, bool)
-		IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/recurse/FunctionObject_FunctionExpression_AC3524CC_recurse>(!!0)
+		IL_02b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/recurse/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/recurse/FunctionObject>(!!0)
 		IL_02bc: stloc.s 11
 		IL_02be: ldc.i4.1
 		IL_02bf: newarr [System.Runtime]System.Object
@@ -4082,14 +4082,14 @@
 		IL_02cc: ldc.i4.0
 		IL_02cd: ldelem.ref
 		IL_02ce: castclass Modules.Function_StableConstCallable_Fallbacks/Scope
-		IL_02d3: newobj instance void Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject_FunctionExpression_22C5D573_ownIdentity::.ctor(class Modules.Function_StableConstCallable_Fallbacks/Scope)
+		IL_02d3: newobj instance void Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject::.ctor(class Modules.Function_StableConstCallable_Fallbacks/Scope)
 		IL_02d8: ldc.i4.0
 		IL_02d9: conv.r8
 		IL_02da: ldstr "ownIdentity"
 		IL_02df: ldc.i4.1
 		IL_02e0: ldc.i4.0
-		IL_02e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject_FunctionExpression_22C5D573_ownIdentity>(!!0, float64, string, bool, bool)
-		IL_02e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject_FunctionExpression_22C5D573_ownIdentity>(!!0)
+		IL_02e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_Fallbacks/ownIdentity/FunctionObject>(!!0)
 		IL_02eb: stloc.s 24
 		IL_02ed: ldloc.0
 		IL_02ee: ldloc.s 24
@@ -4234,7 +4234,7 @@
 		IL_048f: ldc.i4.0
 		IL_0490: ldstr "arg"
 		IL_0495: stelem.ref
-		IL_0496: call object Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject_FunctionDeclaration_FE471DEB_readLexicalArguments::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_0496: call object Modules.Function_StableConstCallable_Fallbacks/readLexicalArguments/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
 		IL_049b: stloc.s 29
 		IL_049d: ldloc.0
 		IL_049e: castclass Modules.Function_StableConstCallable_Fallbacks/Scope

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_TemporalDeadZone.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_StableConstCallable_TemporalDeadZone.verified.txt
@@ -128,7 +128,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E3B7835A_L11C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -142,7 +142,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E3B7835A_L11C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -153,7 +153,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E3B7835A_L11C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -164,7 +164,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E3B7835A_L11C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -178,7 +178,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E3B7835A_L11C31::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -193,7 +193,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Function_StableConstCallable_TemporalDeadZone/FunctionExpression_forwardExpression::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_E3B7835A_L11C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -209,7 +209,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Function_StableConstCallable_TemporalDeadZone/FunctionExpression_forwardExpression::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E3B7835A_L11C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -227,9 +227,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E3B7835A_L11C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E3B7835A_L11C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -372,7 +372,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5A91C160_callHoisted
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -394,12 +394,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Function_StableConstCallable_TemporalDeadZone/Scope/Block_L19C4 Modules.Function_StableConstCallable_TemporalDeadZone/callHoisted/FunctionObject_FunctionDeclaration_5A91C160_callHoisted::_environment1_Block_L19C4
+				IL_0008: stfld class Modules.Function_StableConstCallable_TemporalDeadZone/Scope/Block_L19C4 Modules.Function_StableConstCallable_TemporalDeadZone/callHoisted/FunctionObject::_environment1_Block_L19C4
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Function_StableConstCallable_TemporalDeadZone/callHoisted/FunctionObject_FunctionDeclaration_5A91C160_callHoisted::_transitionalScopes
+				IL_000f: stfld object[] Modules.Function_StableConstCallable_TemporalDeadZone/callHoisted/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A91C160_callHoisted::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -410,7 +410,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A91C160_callHoisted::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -421,7 +421,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A91C160_callHoisted::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -435,7 +435,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A91C160_callHoisted::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -448,11 +448,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Function_StableConstCallable_TemporalDeadZone/callHoisted/FunctionObject_FunctionDeclaration_5A91C160_callHoisted::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Function_StableConstCallable_TemporalDeadZone/callHoisted/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Function_StableConstCallable_TemporalDeadZone/callHoisted::__js_call__(object[], object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A91C160_callHoisted::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -466,11 +466,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Function_StableConstCallable_TemporalDeadZone/callHoisted/FunctionObject_FunctionDeclaration_5A91C160_callHoisted::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Function_StableConstCallable_TemporalDeadZone/callHoisted/FunctionObject::_transitionalScopes
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Function_StableConstCallable_TemporalDeadZone/callHoisted::__js_call__(object[], object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A91C160_callHoisted::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -488,9 +488,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5A91C160_callHoisted::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5A91C160_callHoisted
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -896,7 +896,7 @@
 			[23] object,
 			[24] bool,
 			[25] object,
-			[26] class Modules.Function_StableConstCallable_TemporalDeadZone/FunctionExpression_forwardExpression/FunctionObject_FunctionExpression_E3B7835A_L11C31,
+			[26] class Modules.Function_StableConstCallable_TemporalDeadZone/FunctionExpression_forwardExpression/FunctionObject,
 			[27] class Modules.Function_StableConstCallable_TemporalDeadZone/ArrowFunction_L21C20/FunctionObject,
 			[28] class Modules.Function_StableConstCallable_TemporalDeadZone/ArrowFunction_L34C25/FunctionObject
 		)
@@ -1028,14 +1028,14 @@
 			IL_0125: ldloc.0
 			IL_0126: stelem.ref
 			IL_0127: stloc.s 19
-			IL_0129: newobj instance void Modules.Function_StableConstCallable_TemporalDeadZone/FunctionExpression_forwardExpression/FunctionObject_FunctionExpression_E3B7835A_L11C31::.ctor()
+			IL_0129: newobj instance void Modules.Function_StableConstCallable_TemporalDeadZone/FunctionExpression_forwardExpression/FunctionObject::.ctor()
 			IL_012e: ldc.i4.0
 			IL_012f: conv.r8
 			IL_0130: ldstr ""
 			IL_0135: ldc.i4.0
 			IL_0136: ldc.i4.0
-			IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_TemporalDeadZone/FunctionExpression_forwardExpression/FunctionObject_FunctionExpression_E3B7835A_L11C31>(!!0, float64, string, bool, bool)
-			IL_013c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_TemporalDeadZone/FunctionExpression_forwardExpression/FunctionObject_FunctionExpression_E3B7835A_L11C31>(!!0)
+			IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_StableConstCallable_TemporalDeadZone/FunctionExpression_forwardExpression/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_013c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Function_StableConstCallable_TemporalDeadZone/FunctionExpression_forwardExpression/FunctionObject>(!!0)
 			IL_0141: stloc.s 26
 			IL_0143: ldloc.s 26
 			IL_0145: ldstr "forwardExpression"

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_BasicNext.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_BasicNext.verified.txt
@@ -36,7 +36,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_362D250E_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -56,9 +56,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_BasicNext/g/FunctionObject_FunctionDeclaration_362D250E_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_BasicNext/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_362D250E_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -69,7 +69,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_362D250E_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -80,7 +80,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_362D250E_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -93,15 +93,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_BasicNext/g/FunctionObject_FunctionDeclaration_362D250E_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_BasicNext/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_BasicNext/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_362D250E_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_362D250E_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -144,7 +144,7 @@
 			IL_001f: ldftn object Modules.Generator_BasicNext/g::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_BasicNext/g/FunctionObject_FunctionDeclaration_362D250E_g
+			IL_002b: ldtoken Modules.Generator_BasicNext/g/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -325,7 +325,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_BasicNext/Scope,
-			[1] class Modules.Generator_BasicNext/g/FunctionObject_FunctionDeclaration_362D250E_g,
+			[1] class Modules.Generator_BasicNext/g/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -346,15 +346,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
 		IL_0012: ldloc.s 7
-		IL_0014: newobj instance void Modules.Generator_BasicNext/g/FunctionObject_FunctionDeclaration_362D250E_g::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_BasicNext/g/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "g"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_BasicNext/g/FunctionObject_FunctionDeclaration_362D250E_g>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_BasicNext/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_BasicNext/g/FunctionObject_FunctionDeclaration_362D250E_g
+		IL_002c: castclass Modules.Generator_BasicNext/g/FunctionObject
 		IL_0031: stloc.1
 		IL_0032: nop
 		IL_0033: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_GeneratedFunctionObject_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_GeneratedFunctionObject_Semantics.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ADD11EEA_declared
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -57,9 +57,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_ADD11EEA_declared::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADD11EEA_declared::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -70,7 +70,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADD11EEA_declared::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -81,7 +81,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADD11EEA_declared::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -95,7 +95,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADD11EEA_declared::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -108,7 +108,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_ADD11EEA_declared::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -117,9 +117,9 @@
 				IL_0017: ldarg.0
 				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADD11EEA_declared::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_ADD11EEA_declared
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -163,7 +163,7 @@
 			IL_001f: ldftn object Modules.Generator_GeneratedFunctionObject_Semantics/declared::__js_call__(object[], object, object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_ADD11EEA_declared
+			IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.1
 			IL_0036: newarr [System.Runtime]System.Object
@@ -342,7 +342,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0CB45587_named
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -362,9 +362,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_0CB45587_named::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0CB45587_named::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -375,7 +375,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0CB45587_named::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -386,7 +386,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0CB45587_named::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -400,7 +400,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_0CB45587_named::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -413,7 +413,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_0CB45587_named::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -422,9 +422,9 @@
 				IL_0017: ldarg.0
 				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionExpression_0CB45587_named::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_0CB45587_named
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -468,7 +468,7 @@
 			IL_001f: ldftn object Modules.Generator_GeneratedFunctionObject_Semantics/named::__js_call__(object[], object, object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_0CB45587_named
+			IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.1
 			IL_0036: newarr [System.Runtime]System.Object
@@ -595,7 +595,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B27B374A_L11C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -615,9 +615,9 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject_FunctionExpression_B27B374A_L11C12::_transitionalScopes
+					IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject::_transitionalScopes
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_B27B374A_L11C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -628,7 +628,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_B27B374A_L11C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -639,7 +639,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_B27B374A_L11C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -653,7 +653,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_B27B374A_L11C12::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -666,15 +666,15 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject_FunctionExpression_B27B374A_L11C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11::__js_call__(object[], object)
 					IL_0010: ldarg.0
 					IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 					IL_0016: ret
-				} // end of method FunctionObject_FunctionExpression_B27B374A_L11C12::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_B27B374A_L11C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -714,7 +714,7 @@
 				IL_001f: ldftn object Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11::__js_call__(object[], object)
 				IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 				IL_002a: ldarg.0
-				IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject_FunctionExpression_B27B374A_L11C12
+				IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject
 				IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 				IL_0035: ldc.i4.0
 				IL_0036: newarr [System.Runtime]System.Object
@@ -813,7 +813,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_46672C93_makeGenerator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -827,7 +827,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_46672C93_makeGenerator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -838,7 +838,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_46672C93_makeGenerator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -849,7 +849,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_46672C93_makeGenerator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -863,7 +863,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_46672C93_makeGenerator::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -878,7 +878,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_46672C93_makeGenerator::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -894,7 +894,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_46672C93_makeGenerator::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -912,9 +912,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_46672C93_makeGenerator::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_46672C93_makeGenerator
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -932,7 +932,7 @@
 			.locals init (
 				[0] class Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/Scope,
 				[1] object[],
-				[2] class Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject_FunctionExpression_B27B374A_L11C12
+				[2] class Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/Scope::.ctor()
@@ -940,15 +940,15 @@
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.1
 			IL_000c: ldloc.1
-			IL_000d: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject_FunctionExpression_B27B374A_L11C12::.ctor(object[])
+			IL_000d: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject::.ctor(object[])
 			IL_0012: ldc.i4.0
 			IL_0013: conv.r8
 			IL_0014: ldstr ""
 			IL_0019: ldc.i4.1
 			IL_001a: ldc.i4.0
-			IL_001b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject_FunctionExpression_B27B374A_L11C12>(!!0, float64, string, bool, bool)
+			IL_001b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0020: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-			IL_0025: castclass Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject_FunctionExpression_B27B374A_L11C12
+			IL_0025: castclass Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionExpression_L11C11/FunctionObject
 			IL_002a: stloc.2
 			IL_002b: ldloc.2
 			IL_002c: ret
@@ -990,7 +990,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CCA78AC7_L53C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1014,15 +1014,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject_FunctionExpression_CCA78AC7_L53C12::_environment0_Generator_GeneratedFunctionObject_Semantics
+					IL_0008: stfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject::_environment0_Generator_GeneratedFunctionObject_Semantics
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/Scope Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject_FunctionExpression_CCA78AC7_L53C12::_environment1_makeSharedGenerator
+					IL_000f: stfld class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/Scope Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject::_environment1_makeSharedGenerator
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject_FunctionExpression_CCA78AC7_L53C12::_transitionalScopes
+					IL_0016: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_CCA78AC7_L53C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1033,7 +1033,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CCA78AC7_L53C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1044,7 +1044,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CCA78AC7_L53C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -1058,7 +1058,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_CCA78AC7_L53C12::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1071,15 +1071,15 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject_FunctionExpression_CCA78AC7_L53C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11::__js_call__(object[], object)
 					IL_0010: ldarg.0
 					IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 					IL_0016: ret
-				} // end of method FunctionObject_FunctionExpression_CCA78AC7_L53C12::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_CCA78AC7_L53C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1123,7 +1123,7 @@
 				IL_001f: ldftn object Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11::__js_call__(object[], object)
 				IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 				IL_002a: ldarg.0
-				IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject_FunctionExpression_CCA78AC7_L53C12
+				IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject
 				IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 				IL_0035: ldc.i4.0
 				IL_0036: newarr [System.Runtime]System.Object
@@ -1359,7 +1359,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1379,9 +1379,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator::_environment0_Generator_GeneratedFunctionObject_Semantics
+				IL_0008: stfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject::_environment0_Generator_GeneratedFunctionObject_Semantics
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1392,7 +1392,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1403,7 +1403,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1417,7 +1417,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1430,11 +1430,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator::_environment0_Generator_GeneratedFunctionObject_Semantics
+				IL_0001: ldfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject::_environment0_Generator_GeneratedFunctionObject_Semantics
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator::__js_call__(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1448,11 +1448,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator::_environment0_Generator_GeneratedFunctionObject_Semantics
+				IL_0001: ldfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject::_environment0_Generator_GeneratedFunctionObject_Semantics
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator::__js_call__(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1470,9 +1470,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1493,7 +1493,7 @@
 			.locals init (
 				[0] class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/Scope,
 				[1] object[],
-				[2] class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject_FunctionExpression_CCA78AC7_L53C12
+				[2] class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/Scope::.ctor()
@@ -1522,15 +1522,15 @@
 			IL_0033: ldelem.ref
 			IL_0034: castclass Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/Scope
 			IL_0039: ldloc.1
-			IL_003a: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject_FunctionExpression_CCA78AC7_L53C12::.ctor(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope, class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/Scope, object[])
+			IL_003a: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject::.ctor(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope, class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/Scope, object[])
 			IL_003f: ldc.i4.0
 			IL_0040: conv.r8
 			IL_0041: ldstr ""
 			IL_0046: ldc.i4.1
 			IL_0047: ldc.i4.0
-			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject_FunctionExpression_CCA78AC7_L53C12>(!!0, float64, string, bool, bool)
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_004d: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-			IL_0052: castclass Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject_FunctionExpression_CCA78AC7_L53C12
+			IL_0052: castclass Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionExpression_L53C11/FunctionObject
 			IL_0057: stloc.2
 			IL_0058: ldloc.2
 			IL_0059: ret
@@ -1568,7 +1568,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5633096B_L76C9
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1588,9 +1588,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_5633096B_L76C9::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5633096B_L76C9::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1601,7 +1601,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5633096B_L76C9::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1612,7 +1612,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5633096B_L76C9::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1626,7 +1626,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5633096B_L76C9::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1639,7 +1639,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_5633096B_L76C9::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -1648,9 +1648,9 @@
 				IL_0017: ldarg.0
 				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionExpression_5633096B_L76C9::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_5633096B_L76C9
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1694,7 +1694,7 @@
 			IL_001f: ldftn object Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object::__js_call__(object[], object, object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_5633096B_L76C9
+			IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.1
 			IL_0036: newarr [System.Runtime]System.Object
@@ -1815,7 +1815,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1835,9 +1835,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator::_environment0_Generator_GeneratedFunctionObject_Semantics
+				IL_0008: stfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject::_environment0_Generator_GeneratedFunctionObject_Semantics
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1848,7 +1848,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1859,7 +1859,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1873,7 +1873,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1886,11 +1886,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator::_environment0_Generator_GeneratedFunctionObject_Semantics
+				IL_0001: ldfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject::_environment0_Generator_GeneratedFunctionObject_Semantics
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator::__js_call__(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1904,11 +1904,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator::_environment0_Generator_GeneratedFunctionObject_Semantics
+				IL_0001: ldfld class Modules.Generator_GeneratedFunctionObject_Semantics/Scope Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject::_environment0_Generator_GeneratedFunctionObject_Semantics
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator::__js_call__(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1926,9 +1926,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2024,7 +2024,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2044,9 +2044,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2057,7 +2057,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2068,7 +2068,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -2082,7 +2082,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2095,16 +2095,16 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows::__js_call__(object[], object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2146,7 +2146,7 @@
 			IL_001f: ldftn object Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows::__js_call__(object[], object, object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows
+			IL_002b: ldtoken Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.1
 			IL_0036: newarr [System.Runtime]System.Object
@@ -3327,11 +3327,11 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_GeneratedFunctionObject_Semantics/Scope,
-			[1] class Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_ADD11EEA_declared,
-			[2] class Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject_FunctionDeclaration_46672C93_makeGenerator,
-			[3] class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator,
-			[4] class Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator,
-			[5] class Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows,
+			[1] class Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject,
+			[2] class Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject,
+			[3] class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject,
+			[4] class Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject,
+			[5] class Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject,
 			[6] object,
 			[7] class [System.Runtime]System.Exception,
 			[8] object,
@@ -3355,7 +3355,7 @@
 			[26] object,
 			[27] object,
 			[28] object[],
-			[29] class Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_0CB45587_named,
+			[29] class Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject,
 			[30] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[31] string,
 			[32] object,
@@ -3368,7 +3368,7 @@
 			[39] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[40] object,
 			[41] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[42] class Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_5633096B_L76C9,
+			[42] class Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject,
 			[43] class [System.Runtime]System.Type,
 			[44] class Modules.Generator_GeneratedFunctionObject_Semantics/GeneratorClass/FunctionObject_ClassConstructor_5AB5D10F_GeneratorClass,
 			[45] class Modules.Generator_GeneratedFunctionObject_Semantics/DerivedGeneratorClass/FunctionObject_ClassConstructor_98E5520E_DerivedGeneratorClass,
@@ -3386,15 +3386,15 @@
 		IL_0014: stelem.ref
 		IL_0015: stloc.s 28
 		IL_0017: ldloc.s 28
-		IL_0019: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_ADD11EEA_declared::.ctor(object[])
+		IL_0019: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject::.ctor(object[])
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "declared"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.0
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_ADD11EEA_declared>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_0031: castclass Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject_FunctionDeclaration_ADD11EEA_declared
+		IL_0031: castclass Modules.Generator_GeneratedFunctionObject_Semantics/declared/FunctionObject
 		IL_0036: stloc.1
 		IL_0037: ldc.i4.1
 		IL_0038: newarr [System.Runtime]System.Object
@@ -3403,14 +3403,14 @@
 		IL_003f: ldloc.0
 		IL_0040: stelem.ref
 		IL_0041: stloc.s 28
-		IL_0043: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject_FunctionDeclaration_46672C93_makeGenerator::.ctor()
+		IL_0043: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject::.ctor()
 		IL_0048: ldc.i4.0
 		IL_0049: conv.r8
 		IL_004a: ldstr "makeGenerator"
 		IL_004f: ldc.i4.0
 		IL_0050: ldc.i4.0
-		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject_FunctionDeclaration_46672C93_makeGenerator>(!!0, float64, string, bool, bool)
-		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject_FunctionDeclaration_46672C93_makeGenerator>(!!0)
+		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Generator_GeneratedFunctionObject_Semantics/makeGenerator/FunctionObject>(!!0)
 		IL_005b: stloc.2
 		IL_005c: ldc.i4.1
 		IL_005d: newarr [System.Runtime]System.Object
@@ -3423,14 +3423,14 @@
 		IL_006a: ldc.i4.0
 		IL_006b: ldelem.ref
 		IL_006c: castclass Modules.Generator_GeneratedFunctionObject_Semantics/Scope
-		IL_0071: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator::.ctor(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope)
+		IL_0071: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject::.ctor(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope)
 		IL_0076: ldc.i4.0
 		IL_0077: conv.r8
 		IL_0078: ldstr "makeSharedGenerator"
 		IL_007d: ldc.i4.0
 		IL_007e: ldc.i4.0
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator>(!!0, float64, string, bool, bool)
-		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject_FunctionDeclaration_F8159F08_makeSharedGenerator>(!!0)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Generator_GeneratedFunctionObject_Semantics/makeSharedGenerator/FunctionObject>(!!0)
 		IL_0089: stloc.3
 		IL_008a: ldc.i4.1
 		IL_008b: newarr [System.Runtime]System.Object
@@ -3443,14 +3443,14 @@
 		IL_0098: ldc.i4.0
 		IL_0099: ldelem.ref
 		IL_009a: castclass Modules.Generator_GeneratedFunctionObject_Semantics/Scope
-		IL_009f: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator::.ctor(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope)
+		IL_009f: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject::.ctor(class Modules.Generator_GeneratedFunctionObject_Semantics/Scope)
 		IL_00a4: ldc.i4.0
 		IL_00a5: conv.r8
 		IL_00a6: ldstr "tailCallGenerator"
 		IL_00ab: ldc.i4.0
 		IL_00ac: ldc.i4.0
-		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator>(!!0, float64, string, bool, bool)
-		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject_FunctionDeclaration_B98E9EF7_tailCallGenerator>(!!0)
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Generator_GeneratedFunctionObject_Semantics/tailCallGenerator/FunctionObject>(!!0)
 		IL_00b7: stloc.s 4
 		IL_00b9: ldc.i4.1
 		IL_00ba: newarr [System.Runtime]System.Object
@@ -3460,15 +3460,15 @@
 		IL_00c2: stelem.ref
 		IL_00c3: stloc.s 28
 		IL_00c5: ldloc.s 28
-		IL_00c7: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows::.ctor(object[])
+		IL_00c7: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject::.ctor(object[])
 		IL_00cc: ldc.i4.0
 		IL_00cd: conv.r8
 		IL_00ce: ldstr "parameterThrows"
 		IL_00d3: ldc.i4.1
 		IL_00d4: ldc.i4.0
-		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows>(!!0, float64, string, bool, bool)
+		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00da: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_00df: castclass Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject_FunctionDeclaration_5DCE108A_parameterThrows
+		IL_00df: castclass Modules.Generator_GeneratedFunctionObject_Semantics/parameterThrows/FunctionObject
 		IL_00e4: stloc.s 5
 		IL_00e6: nop
 		IL_00e7: ldc.i4.1
@@ -3479,15 +3479,15 @@
 		IL_00f0: stelem.ref
 		IL_00f1: stloc.s 28
 		IL_00f3: ldloc.s 28
-		IL_00f5: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_0CB45587_named::.ctor(object[])
+		IL_00f5: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject::.ctor(object[])
 		IL_00fa: ldc.i4.1
 		IL_00fb: conv.r8
 		IL_00fc: ldstr "named"
 		IL_0101: ldc.i4.1
 		IL_0102: ldc.i4.0
-		IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_0CB45587_named>(!!0, float64, string, bool, bool)
+		IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0108: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_010d: castclass Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject_FunctionExpression_0CB45587_named
+		IL_010d: castclass Modules.Generator_GeneratedFunctionObject_Semantics/named/FunctionObject
 		IL_0112: stloc.s 29
 		IL_0114: ldloc.0
 		IL_0115: ldloc.s 29
@@ -3919,15 +3919,15 @@
 		IL_05f9: stelem.ref
 		IL_05fa: stloc.s 28
 		IL_05fc: ldloc.s 28
-		IL_05fe: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_5633096B_L76C9::.ctor(object[])
+		IL_05fe: newobj instance void Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject::.ctor(object[])
 		IL_0603: ldc.i4.1
 		IL_0604: conv.r8
 		IL_0605: ldstr ""
 		IL_060a: ldc.i4.1
 		IL_060b: ldc.i4.0
-		IL_060c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_5633096B_L76C9>(!!0, float64, string, bool, bool)
+		IL_060c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0611: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_0616: castclass Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject_FunctionExpression_5633096B_L76C9
+		IL_0616: castclass Modules.Generator_GeneratedFunctionObject_Semantics/FunctionExpression_object/FunctionObject
 		IL_061b: stloc.s 42
 		IL_061d: ldloc.s 39
 		IL_061f: ldstr "run"

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_Constructor.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_Constructor.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C2EB3AE8_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_Prototype_Constructor/g/FunctionObject_FunctionDeclaration_C2EB3AE8_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_Prototype_Constructor/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,15 +87,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_Prototype_Constructor/g/FunctionObject_FunctionDeclaration_C2EB3AE8_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_Prototype_Constructor/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_Prototype_Constructor/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C2EB3AE8_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -135,7 +135,7 @@
 			IL_001f: ldftn object Modules.Generator_Prototype_Constructor/g::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_Prototype_Constructor/g/FunctionObject_FunctionDeclaration_C2EB3AE8_g
+			IL_002b: ldtoken Modules.Generator_Prototype_Constructor/g/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -256,7 +256,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_Prototype_Constructor/Scope,
-			[1] class Modules.Generator_Prototype_Constructor/g/FunctionObject_FunctionDeclaration_C2EB3AE8_g,
+			[1] class Modules.Generator_Prototype_Constructor/g/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -279,15 +279,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
 		IL_0012: ldloc.s 5
-		IL_0014: newobj instance void Modules.Generator_Prototype_Constructor/g/FunctionObject_FunctionDeclaration_C2EB3AE8_g::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_Prototype_Constructor/g/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "g"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Prototype_Constructor/g/FunctionObject_FunctionDeclaration_C2EB3AE8_g>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Prototype_Constructor/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_Prototype_Constructor/g/FunctionObject_FunctionDeclaration_C2EB3AE8_g
+		IL_002c: castclass Modules.Generator_Prototype_Constructor/g/FunctionObject
 		IL_0031: stloc.1
 		IL_0032: nop
 		IL_0033: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_ToStringTag.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_ToStringTag.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5DFC87C8_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_Prototype_ToStringTag/g/FunctionObject_FunctionDeclaration_5DFC87C8_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_Prototype_ToStringTag/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,15 +87,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_Prototype_ToStringTag/g/FunctionObject_FunctionDeclaration_5DFC87C8_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_Prototype_ToStringTag/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_Prototype_ToStringTag/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5DFC87C8_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -135,7 +135,7 @@
 			IL_001f: ldftn object Modules.Generator_Prototype_ToStringTag/g::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_Prototype_ToStringTag/g/FunctionObject_FunctionDeclaration_5DFC87C8_g
+			IL_002b: ldtoken Modules.Generator_Prototype_ToStringTag/g/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -256,7 +256,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_Prototype_ToStringTag/Scope,
-			[1] class Modules.Generator_Prototype_ToStringTag/g/FunctionObject_FunctionDeclaration_5DFC87C8_g,
+			[1] class Modules.Generator_Prototype_ToStringTag/g/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -275,15 +275,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
 		IL_0012: ldloc.s 5
-		IL_0014: newobj instance void Modules.Generator_Prototype_ToStringTag/g/FunctionObject_FunctionDeclaration_5DFC87C8_g::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_Prototype_ToStringTag/g/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "g"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Prototype_ToStringTag/g/FunctionObject_FunctionDeclaration_5DFC87C8_g>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_Prototype_ToStringTag/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_Prototype_ToStringTag/g/FunctionObject_FunctionDeclaration_5DFC87C8_g
+		IL_002c: castclass Modules.Generator_Prototype_ToStringTag/g/FunctionObject
 		IL_0031: stloc.1
 		IL_0032: nop
 		IL_0033: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_SchedulerLocalsAcrossYield.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_SchedulerLocalsAcrossYield.verified.txt
@@ -41,7 +41,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_19D04A4D_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -61,9 +61,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject_FunctionDeclaration_19D04A4D_test::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -85,7 +85,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -98,7 +98,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject_FunctionDeclaration_19D04A4D_test::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -107,9 +107,9 @@
 				IL_0017: ldarg.0
 				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_19D04A4D_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -153,7 +153,7 @@
 			IL_001f: ldftn object Modules.Generator_SchedulerLocalsAcrossYield/test::__js_call__(object[], object, object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject_FunctionDeclaration_19D04A4D_test
+			IL_002b: ldtoken Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.1
 			IL_0036: newarr [System.Runtime]System.Object
@@ -310,7 +310,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_SchedulerLocalsAcrossYield/Scope,
-			[1] class Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject_FunctionDeclaration_19D04A4D_test,
+			[1] class Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -327,15 +327,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
 		IL_0011: ldloc.3
-		IL_0012: newobj instance void Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject_FunctionDeclaration_19D04A4D_test::.ctor(object[])
+		IL_0012: newobj instance void Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "test"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject_FunctionDeclaration_19D04A4D_test>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002a: castclass Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject_FunctionDeclaration_19D04A4D_test
+		IL_002a: castclass Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject
 		IL_002f: stloc.1
 		IL_0030: nop
 		IL_0031: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ReturnWhileSuspended.verified.txt
@@ -89,7 +89,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_93946DCA_g1
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -109,9 +109,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject_FunctionDeclaration_93946DCA_g1::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -122,7 +122,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -133,7 +133,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -146,15 +146,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject_FunctionDeclaration_93946DCA_g1::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_93946DCA_g1
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -198,7 +198,7 @@
 			IL_001f: ldftn object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject_FunctionDeclaration_93946DCA_g1
+			IL_002b: ldtoken Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -554,7 +554,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_92946C37_g2
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -574,9 +574,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject_FunctionDeclaration_92946C37_g2::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -587,7 +587,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -598,7 +598,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -611,15 +611,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject_FunctionDeclaration_92946C37_g2::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_92946C37_g2
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -663,7 +663,7 @@
 			IL_001f: ldftn object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject_FunctionDeclaration_92946C37_g2
+			IL_002b: ldtoken Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -986,8 +986,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/Scope,
-			[1] class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject_FunctionDeclaration_93946DCA_g1,
-			[2] class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject_FunctionDeclaration_92946C37_g2,
+			[1] class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject,
+			[2] class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject,
 			[3] object,
 			[4] object,
 			[5] object,
@@ -1013,15 +1013,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 12
 		IL_0012: ldloc.s 12
-		IL_0014: newobj instance void Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject_FunctionDeclaration_93946DCA_g1::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "g1"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject_FunctionDeclaration_93946DCA_g1>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject_FunctionDeclaration_93946DCA_g1
+		IL_002c: castclass Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject
 		IL_0031: stloc.1
 		IL_0032: ldc.i4.1
 		IL_0033: newarr [System.Runtime]System.Object
@@ -1031,15 +1031,15 @@
 		IL_003b: stelem.ref
 		IL_003c: stloc.s 12
 		IL_003e: ldloc.s 12
-		IL_0040: newobj instance void Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject_FunctionDeclaration_92946C37_g2::.ctor(object[])
+		IL_0040: newobj instance void Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject::.ctor(object[])
 		IL_0045: ldc.i4.0
 		IL_0046: conv.r8
 		IL_0047: ldstr "g2"
 		IL_004c: ldc.i4.1
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject_FunctionDeclaration_92946C37_g2>(!!0, float64, string, bool, bool)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0053: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_0058: castclass Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject_FunctionDeclaration_92946C37_g2
+		IL_0058: castclass Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject
 		IL_005d: stloc.2
 		IL_005e: nop
 		IL_005f: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields.verified.txt
@@ -89,7 +89,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_587AD8E1_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -109,9 +109,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject_FunctionDeclaration_587AD8E1_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -122,7 +122,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -133,7 +133,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -146,15 +146,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject_FunctionDeclaration_587AD8E1_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_587AD8E1_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -198,7 +198,7 @@
 			IL_001f: ldftn object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject_FunctionDeclaration_587AD8E1_g
+			IL_002b: ldtoken Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -522,7 +522,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/Scope,
-			[1] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject_FunctionDeclaration_587AD8E1_g,
+			[1] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -544,15 +544,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
 		IL_0012: ldloc.s 7
-		IL_0014: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject_FunctionDeclaration_587AD8E1_g::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "g"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject_FunctionDeclaration_587AD8E1_g>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject_FunctionDeclaration_587AD8E1_g
+		IL_002c: castclass Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject
 		IL_0031: stloc.1
 		IL_0032: nop
 		IL_0033: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Nested.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Nested.verified.txt
@@ -129,7 +129,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1AC264FF_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -149,9 +149,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject_FunctionDeclaration_1AC264FF_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -162,7 +162,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -173,7 +173,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -186,15 +186,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject_FunctionDeclaration_1AC264FF_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_1AC264FF_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -238,7 +238,7 @@
 			IL_001f: ldftn object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject_FunctionDeclaration_1AC264FF_g
+			IL_002b: ldtoken Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -607,7 +607,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/Scope,
-			[1] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject_FunctionDeclaration_1AC264FF_g,
+			[1] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -628,15 +628,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
 		IL_0012: ldloc.s 6
-		IL_0014: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject_FunctionDeclaration_1AC264FF_g::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "g"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject_FunctionDeclaration_1AC264FF_g>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject_FunctionDeclaration_1AC264FF_g
+		IL_002c: castclass Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject
 		IL_0031: stloc.1
 		IL_0032: nop
 		IL_0033: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow.verified.txt
@@ -89,7 +89,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D7535F87_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -109,9 +109,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject_FunctionDeclaration_D7535F87_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -122,7 +122,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -133,7 +133,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -146,15 +146,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject_FunctionDeclaration_D7535F87_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D7535F87_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -199,7 +199,7 @@
 			IL_001f: ldftn object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject_FunctionDeclaration_D7535F87_g
+			IL_002b: ldtoken Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -494,7 +494,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/Scope,
-			[1] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject_FunctionDeclaration_D7535F87_g,
+			[1] class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] class [System.Runtime]System.Exception,
@@ -518,15 +518,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 9
 		IL_0012: ldloc.s 9
-		IL_0014: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject_FunctionDeclaration_D7535F87_g::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "g"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject_FunctionDeclaration_D7535F87_g>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject_FunctionDeclaration_D7535F87_g
+		IL_002c: castclass Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject
 		IL_0031: stloc.1
 		IL_0032: nop
 		IL_0033: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_Nested_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_Nested_ReturnWhileSuspended.verified.txt
@@ -110,7 +110,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_480897DC_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -130,9 +130,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_480897DC_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_480897DC_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -143,7 +143,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_480897DC_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -154,7 +154,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_480897DC_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -167,15 +167,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_480897DC_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_480897DC_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_480897DC_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -217,7 +217,7 @@
 			IL_001f: ldftn object Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_480897DC_g
+			IL_002b: ldtoken Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -556,7 +556,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/Scope,
-			[1] class Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_480897DC_g,
+			[1] class Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -578,15 +578,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
 		IL_0012: ldloc.s 7
-		IL_0014: newobj instance void Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_480897DC_g::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "g"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_480897DC_g>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_480897DC_g
+		IL_002c: castclass Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject
 		IL_0031: stloc.1
 		IL_0032: nop
 		IL_0033: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ReturnWhileSuspended.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F78F7418_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -90,9 +90,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_F78F7418_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +103,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,7 +114,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -127,15 +127,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_F78F7418_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_TryFinally_ReturnWhileSuspended/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F78F7418_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -177,7 +177,7 @@
 			IL_001f: ldftn object Modules.Generator_TryFinally_ReturnWhileSuspended/g::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_F78F7418_g
+			IL_002b: ldtoken Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -407,7 +407,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryFinally_ReturnWhileSuspended/Scope,
-			[1] class Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_F78F7418_g,
+			[1] class Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -428,15 +428,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
 		IL_0012: ldloc.s 6
-		IL_0014: newobj instance void Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_F78F7418_g::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "g"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_F78F7418_g>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_F78F7418_g
+		IL_002c: castclass Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject
 		IL_0031: stloc.1
 		IL_0032: nop
 		IL_0033: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ThrowWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ThrowWhileSuspended.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C1602072_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -90,9 +90,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject_FunctionDeclaration_C1602072_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1602072_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +103,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1602072_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,7 +114,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1602072_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -127,15 +127,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject_FunctionDeclaration_C1602072_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_TryFinally_ThrowWhileSuspended/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1602072_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C1602072_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -177,7 +177,7 @@
 			IL_001f: ldftn object Modules.Generator_TryFinally_ThrowWhileSuspended/g::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject_FunctionDeclaration_C1602072_g
+			IL_002b: ldtoken Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -441,7 +441,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_TryFinally_ThrowWhileSuspended/Scope,
-			[1] class Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject_FunctionDeclaration_C1602072_g,
+			[1] class Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] class [System.Runtime]System.Exception,
@@ -465,15 +465,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 9
 		IL_0012: ldloc.s 9
-		IL_0014: newobj instance void Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject_FunctionDeclaration_C1602072_g::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "g"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject_FunctionDeclaration_C1602072_g>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject_FunctionDeclaration_C1602072_g
+		IL_002c: castclass Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject
 		IL_0031: stloc.1
 		IL_0032: nop
 		IL_0033: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ArrayBasic.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ArrayBasic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E39A7D38_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject_FunctionDeclaration_E39A7D38_g::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,15 +87,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject_FunctionDeclaration_E39A7D38_g::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_YieldStar_ArrayBasic/g::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E39A7D38_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -145,7 +145,7 @@
 			IL_001f: ldftn object Modules.Generator_YieldStar_ArrayBasic/g::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject_FunctionDeclaration_E39A7D38_g
+			IL_002b: ldtoken Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -451,7 +451,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_YieldStar_ArrayBasic/Scope,
-			[1] class Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject_FunctionDeclaration_E39A7D38_g,
+			[1] class Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -472,15 +472,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
 		IL_0012: ldloc.s 7
-		IL_0014: newobj instance void Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject_FunctionDeclaration_E39A7D38_g::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "g"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject_FunctionDeclaration_E39A7D38_g>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject_FunctionDeclaration_E39A7D38_g
+		IL_002c: castclass Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject
 		IL_0031: stloc.1
 		IL_0032: nop
 		IL_0033: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_NestedGenerator.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_NestedGenerator.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_05E19C5E_inner
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject_FunctionDeclaration_05E19C5E_inner::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,15 +87,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject_FunctionDeclaration_05E19C5E_inner::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_YieldStar_NestedGenerator/inner::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_05E19C5E_inner
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -135,7 +135,7 @@
 			IL_001f: ldftn object Modules.Generator_YieldStar_NestedGenerator/inner::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject_FunctionDeclaration_05E19C5E_inner
+			IL_002b: ldtoken Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -279,7 +279,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0AE70585_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -301,12 +301,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Generator_YieldStar_NestedGenerator/Scope Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject_FunctionDeclaration_0AE70585_outer::_environment0_Generator_YieldStar_NestedGenerator
+				IL_0008: stfld class Modules.Generator_YieldStar_NestedGenerator/Scope Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject::_environment0_Generator_YieldStar_NestedGenerator
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject_FunctionDeclaration_0AE70585_outer::_transitionalScopes
+				IL_000f: stfld object[] Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -317,7 +317,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -328,7 +328,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -341,15 +341,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject_FunctionDeclaration_0AE70585_outer::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_YieldStar_NestedGenerator/outer::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0AE70585_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -401,7 +401,7 @@
 			IL_001f: ldftn object Modules.Generator_YieldStar_NestedGenerator/outer::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject_FunctionDeclaration_0AE70585_outer
+			IL_002b: ldtoken Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -736,14 +736,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_YieldStar_NestedGenerator/Scope,
-			[1] class Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject_FunctionDeclaration_0AE70585_outer,
+			[1] class Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
 			[5] object,
 			[6] object,
 			[7] object[],
-			[8] class Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject_FunctionDeclaration_05E19C5E_inner,
+			[8] class Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[10] object
 		)
@@ -758,15 +758,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
 		IL_0012: ldloc.s 7
-		IL_0014: newobj instance void Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject_FunctionDeclaration_05E19C5E_inner::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "inner"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject_FunctionDeclaration_05E19C5E_inner>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject_FunctionDeclaration_05E19C5E_inner
+		IL_002c: castclass Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject
 		IL_0031: stloc.s 8
 		IL_0033: ldloc.0
 		IL_0034: ldloc.s 8
@@ -783,15 +783,15 @@
 		IL_004a: ldelem.ref
 		IL_004b: castclass Modules.Generator_YieldStar_NestedGenerator/Scope
 		IL_0050: ldloc.s 7
-		IL_0052: newobj instance void Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject_FunctionDeclaration_0AE70585_outer::.ctor(class Modules.Generator_YieldStar_NestedGenerator/Scope, object[])
+		IL_0052: newobj instance void Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject::.ctor(class Modules.Generator_YieldStar_NestedGenerator/Scope, object[])
 		IL_0057: ldc.i4.0
 		IL_0058: conv.r8
 		IL_0059: ldstr "outer"
 		IL_005e: ldc.i4.1
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject_FunctionDeclaration_0AE70585_outer>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_006a: castclass Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject_FunctionDeclaration_0AE70585_outer
+		IL_006a: castclass Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject
 		IL_006f: stloc.1
 		IL_0070: nop
 		IL_0071: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_PassNextValue.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_PassNextValue.verified.txt
@@ -36,7 +36,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2473C97B_inner
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -56,9 +56,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject_FunctionDeclaration_2473C97B_inner::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -69,7 +69,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -80,7 +80,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -93,15 +93,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject_FunctionDeclaration_2473C97B_inner::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_YieldStar_PassNextValue/inner::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2473C97B_inner
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -142,7 +142,7 @@
 			IL_001f: ldftn object Modules.Generator_YieldStar_PassNextValue/inner::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject_FunctionDeclaration_2473C97B_inner
+			IL_002b: ldtoken Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -294,7 +294,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2DAF6340_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -316,12 +316,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Generator_YieldStar_PassNextValue/Scope Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject_FunctionDeclaration_2DAF6340_outer::_environment0_Generator_YieldStar_PassNextValue
+				IL_0008: stfld class Modules.Generator_YieldStar_PassNextValue/Scope Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject::_environment0_Generator_YieldStar_PassNextValue
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject_FunctionDeclaration_2DAF6340_outer::_transitionalScopes
+				IL_000f: stfld object[] Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -332,7 +332,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -343,7 +343,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -356,15 +356,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject_FunctionDeclaration_2DAF6340_outer::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_YieldStar_PassNextValue/outer::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2DAF6340_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -416,7 +416,7 @@
 			IL_001f: ldftn object Modules.Generator_YieldStar_PassNextValue/outer::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject_FunctionDeclaration_2DAF6340_outer
+			IL_002b: ldtoken Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -750,13 +750,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_YieldStar_PassNextValue/Scope,
-			[1] class Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject_FunctionDeclaration_2DAF6340_outer,
+			[1] class Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject_FunctionDeclaration_2473C97B_inner,
+			[7] class Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[9] object
 		)
@@ -771,15 +771,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
 		IL_0012: ldloc.s 6
-		IL_0014: newobj instance void Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject_FunctionDeclaration_2473C97B_inner::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "inner"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject_FunctionDeclaration_2473C97B_inner>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject_FunctionDeclaration_2473C97B_inner
+		IL_002c: castclass Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject
 		IL_0031: stloc.s 7
 		IL_0033: ldloc.0
 		IL_0034: ldloc.s 7
@@ -796,15 +796,15 @@
 		IL_004a: ldelem.ref
 		IL_004b: castclass Modules.Generator_YieldStar_PassNextValue/Scope
 		IL_0050: ldloc.s 6
-		IL_0052: newobj instance void Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject_FunctionDeclaration_2DAF6340_outer::.ctor(class Modules.Generator_YieldStar_PassNextValue/Scope, object[])
+		IL_0052: newobj instance void Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject::.ctor(class Modules.Generator_YieldStar_PassNextValue/Scope, object[])
 		IL_0057: ldc.i4.0
 		IL_0058: conv.r8
 		IL_0059: ldstr "outer"
 		IL_005e: ldc.i4.1
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject_FunctionDeclaration_2DAF6340_outer>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_006a: castclass Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject_FunctionDeclaration_2DAF6340_outer
+		IL_006a: castclass Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject
 		IL_006f: stloc.1
 		IL_0070: nop
 		IL_0071: nop

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ReturnForwards.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ReturnForwards.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C8D33BB4_inner
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject_FunctionDeclaration_C8D33BB4_inner::_transitionalScopes
+				IL_0008: stfld object[] Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,15 +87,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject_FunctionDeclaration_C8D33BB4_inner::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_YieldStar_ReturnForwards/inner::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C8D33BB4_inner
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -135,7 +135,7 @@
 			IL_001f: ldftn object Modules.Generator_YieldStar_ReturnForwards/inner::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject_FunctionDeclaration_C8D33BB4_inner
+			IL_002b: ldtoken Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -279,7 +279,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2976944F_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -301,12 +301,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Generator_YieldStar_ReturnForwards/Scope Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject_FunctionDeclaration_2976944F_outer::_environment0_Generator_YieldStar_ReturnForwards
+				IL_0008: stfld class Modules.Generator_YieldStar_ReturnForwards/Scope Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject::_environment0_Generator_YieldStar_ReturnForwards
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject_FunctionDeclaration_2976944F_outer::_transitionalScopes
+				IL_000f: stfld object[] Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -317,7 +317,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -328,7 +328,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -341,15 +341,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject_FunctionDeclaration_2976944F_outer::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Generator_YieldStar_ReturnForwards/outer::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2976944F_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -401,7 +401,7 @@
 			IL_001f: ldftn object Modules.Generator_YieldStar_ReturnForwards/outer::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject_FunctionDeclaration_2976944F_outer
+			IL_002b: ldtoken Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -769,12 +769,12 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Generator_YieldStar_ReturnForwards/Scope,
-			[1] class Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject_FunctionDeclaration_2976944F_outer,
+			[1] class Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject_FunctionDeclaration_C8D33BB4_inner,
+			[6] class Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] object
 		)
@@ -789,15 +789,15 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
 		IL_0012: ldloc.s 5
-		IL_0014: newobj instance void Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject_FunctionDeclaration_C8D33BB4_inner::.ctor(object[])
+		IL_0014: newobj instance void Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject::.ctor(object[])
 		IL_0019: ldc.i4.0
 		IL_001a: conv.r8
 		IL_001b: ldstr "inner"
 		IL_0020: ldc.i4.1
 		IL_0021: ldc.i4.1
-		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject_FunctionDeclaration_C8D33BB4_inner>(!!0, float64, string, bool, bool)
+		IL_0022: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0027: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002c: castclass Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject_FunctionDeclaration_C8D33BB4_inner
+		IL_002c: castclass Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject
 		IL_0031: stloc.s 6
 		IL_0033: ldloc.0
 		IL_0034: ldloc.s 6
@@ -814,15 +814,15 @@
 		IL_004a: ldelem.ref
 		IL_004b: castclass Modules.Generator_YieldStar_ReturnForwards/Scope
 		IL_0050: ldloc.s 5
-		IL_0052: newobj instance void Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject_FunctionDeclaration_2976944F_outer::.ctor(class Modules.Generator_YieldStar_ReturnForwards/Scope, object[])
+		IL_0052: newobj instance void Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject::.ctor(class Modules.Generator_YieldStar_ReturnForwards/Scope, object[])
 		IL_0057: ldc.i4.0
 		IL_0058: conv.r8
 		IL_0059: ldstr "outer"
 		IL_005e: ldc.i4.1
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject_FunctionDeclaration_2976944F_outer>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_006a: castclass Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject_FunctionDeclaration_2976944F_outer
+		IL_006a: castclass Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject
 		IL_006f: stloc.1
 		IL_0070: nop
 		IL_0071: nop

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
@@ -773,7 +773,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_986BE060_L6C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -793,9 +793,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject_FunctionExpression_986BE060_L6C8::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
+				IL_0008: stfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -806,7 +806,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -817,7 +817,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -830,13 +830,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject_FunctionExpression_986BE060_L6C8::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7::__js_call__(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_986BE060_L6C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -898,7 +898,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E8D4DA26_L9C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -918,9 +918,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
+				IL_0008: stfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -931,7 +931,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -942,7 +942,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -955,13 +955,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13::__js_call__(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_E8D4DA26_L9C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1031,8 +1031,8 @@
 			[0] class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[2] object[],
-			[3] class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject_FunctionExpression_986BE060_L6C8,
-			[4] class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14,
+			[3] class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject,
+			[4] class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject,
 			[5] object
 		)
 
@@ -1056,14 +1056,14 @@
 		IL_002d: ldc.i4.0
 		IL_002e: ldelem.ref
 		IL_002f: castclass Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope
-		IL_0034: newobj instance void Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject_FunctionExpression_986BE060_L6C8::.ctor(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope)
+		IL_0034: newobj instance void Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject::.ctor(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope)
 		IL_0039: ldc.i4.0
 		IL_003a: conv.r8
 		IL_003b: ldstr ""
 		IL_0040: ldc.i4.0
 		IL_0041: ldc.i4.1
-		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject_FunctionExpression_986BE060_L6C8>(!!0, float64, string, bool, bool)
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject_FunctionExpression_986BE060_L6C8>(!!0)
+		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject>(!!0)
 		IL_004c: stloc.3
 		IL_004d: ldloc.1
 		IL_004e: ldstr "inc"
@@ -1081,14 +1081,14 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope
-		IL_006d: newobj instance void Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14::.ctor(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope)
+		IL_006d: newobj instance void Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject::.ctor(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope)
 		IL_0072: ldc.i4.0
 		IL_0073: conv.r8
 		IL_0074: ldstr ""
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14>(!!0, float64, string, bool, bool)
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14>(!!0)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject>(!!0)
 		IL_0085: stloc.s 4
 		IL_0087: ldloc.s 4
 		IL_0089: ldstr "value"

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
@@ -739,7 +739,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CFBAD72C_L3C28
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -759,9 +759,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_CFBAD72C_L3C28::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -772,7 +772,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -783,7 +783,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -796,11 +796,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_CFBAD72C_L3C28::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -814,11 +814,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_CFBAD72C_L3C28::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -836,9 +836,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_CFBAD72C_L3C28
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -889,7 +889,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5B6EF069_L4C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -909,9 +909,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_5B6EF069_L4C26::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -922,7 +922,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -933,7 +933,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -946,11 +946,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_5B6EF069_L4C26::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -964,11 +964,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_5B6EF069_L4C26::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -986,9 +986,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5B6EF069_L4C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1037,7 +1037,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A72B20E7_L5C30
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1057,9 +1057,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_A72B20E7_L5C30::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1070,7 +1070,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1081,7 +1081,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1094,11 +1094,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_A72B20E7_L5C30::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1112,11 +1112,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_A72B20E7_L5C30::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1134,9 +1134,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A72B20E7_L5C30
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1185,7 +1185,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3E2D2BB6_inc
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1205,9 +1205,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject_FunctionDeclaration_3E2D2BB6_inc::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1218,7 +1218,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1229,7 +1229,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1242,11 +1242,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject_FunctionDeclaration_3E2D2BB6_inc::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/inc::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1260,11 +1260,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject_FunctionDeclaration_3E2D2BB6_inc::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/inc::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1282,9 +1282,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3E2D2BB6_inc
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1348,7 +1348,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F229B707_readValue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1368,9 +1368,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject_FunctionDeclaration_F229B707_readValue::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1381,7 +1381,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1392,7 +1392,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1405,11 +1405,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject_FunctionDeclaration_F229B707_readValue::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1423,11 +1423,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject_FunctionDeclaration_F229B707_readValue::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1445,9 +1445,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F229B707_readValue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1519,7 +1519,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1539,9 +1539,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1552,7 +1552,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1563,7 +1563,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1576,11 +1576,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1594,11 +1594,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1616,9 +1616,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1724,7 +1724,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1738,7 +1738,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1749,7 +1749,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1760,7 +1760,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1778,7 +1778,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1797,7 +1797,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1815,9 +1815,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1920,7 +1920,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1934,7 +1934,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1945,7 +1945,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1956,7 +1956,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1977,7 +1977,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1999,7 +1999,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2017,9 +2017,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2077,7 +2077,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_510E3483_L44C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -2101,15 +2101,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+					IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -2120,7 +2120,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -2131,7 +2131,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -2144,11 +2144,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -2162,11 +2162,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -2184,9 +2184,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_510E3483_L44C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -2236,7 +2236,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3E619586_L45C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -2260,15 +2260,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+					IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -2279,7 +2279,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -2290,7 +2290,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -2303,11 +2303,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -2321,11 +2321,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -2343,9 +2343,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_3E619586_L45C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -2399,7 +2399,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7A56BCB4_L55C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -2425,18 +2425,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+						IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::_environment2_FunctionExpression_L54C9
+						IL_0016: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject::_environment2_FunctionExpression_L54C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -2447,7 +2447,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -2458,7 +2458,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -2471,11 +2471,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -2489,11 +2489,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -2511,9 +2511,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_7A56BCB4_L55C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -2578,7 +2578,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A43F1FA8_L54C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -2602,15 +2602,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+					IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -2621,7 +2621,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -2632,7 +2632,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -2645,14 +2645,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -2666,14 +2666,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -2691,9 +2691,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_A43F1FA8_L54C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -2715,7 +2715,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87,
+					[4] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -2765,13 +2765,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -2981,7 +2981,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3001,9 +3001,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3014,7 +3014,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3025,7 +3025,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3038,14 +3038,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3059,14 +3059,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3084,9 +3084,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3126,12 +3126,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87,
-				[21] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94,
+				[20] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject,
+				[21] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10
+				[25] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -3337,13 +3337,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -3387,13 +3387,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -3563,13 +3563,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -3680,7 +3680,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3700,9 +3700,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3713,7 +3713,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3724,7 +3724,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3737,7 +3737,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -3748,7 +3748,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3762,7 +3762,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_DynamicImport_Esm_Namespace_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -3773,7 +3773,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3791,9 +3791,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3914,19 +3914,19 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope,
-			[1] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default,
-			[2] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get,
-			[3] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace,
-			[4] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export,
+			[1] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject,
 			[5] object[],
-			[6] class Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject_FunctionDeclaration_3E2D2BB6_inc,
-			[7] class Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject_FunctionDeclaration_F229B707_readValue,
-			[8] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark,
+			[6] class Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject,
+			[7] class Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject,
+			[8] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject,
 			[9] object,
 			[10] object[],
-			[11] class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_CFBAD72C_L3C28,
-			[12] class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_5B6EF069_L4C26,
-			[13] class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_A72B20E7_L5C30
+			[11] class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject,
+			[12] class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject,
+			[13] class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::.ctor()
@@ -3945,13 +3945,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0022: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject_FunctionDeclaration_3E2D2BB6_inc::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_0022: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "inc"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject_FunctionDeclaration_3E2D2BB6_inc>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 6
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 6
@@ -3967,13 +3967,13 @@
 		IL_004d: ldc.i4.0
 		IL_004e: ldelem.ref
 		IL_004f: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0054: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject_FunctionDeclaration_F229B707_readValue::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_0054: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr "readValue"
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject_FunctionDeclaration_F229B707_readValue>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 7
 		IL_0069: ldloc.0
 		IL_006a: ldloc.s 7
@@ -3989,13 +3989,13 @@
 		IL_007f: ldc.i4.0
 		IL_0080: ldelem.ref
 		IL_0081: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0086: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_0086: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_008b: ldc.i4.0
 		IL_008c: conv.r8
 		IL_008d: ldstr "__jroc_esm_mark"
 		IL_0092: ldc.i4.0
 		IL_0093: ldc.i4.1
-		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0099: stloc.s 8
 		IL_009b: ldloc.0
 		IL_009c: ldloc.s 8
@@ -4007,13 +4007,13 @@
 		IL_00ab: ldloc.0
 		IL_00ac: stelem.ref
 		IL_00ad: stloc.s 5
-		IL_00af: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::.ctor()
+		IL_00af: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default/FunctionObject::.ctor()
 		IL_00b4: ldc.i4.1
 		IL_00b5: conv.r8
 		IL_00b6: ldstr "__jroc_esm_default"
 		IL_00bb: ldc.i4.0
 		IL_00bc: ldc.i4.1
-		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c2: stloc.1
 		IL_00c3: ldc.i4.1
 		IL_00c4: newarr [System.Runtime]System.Object
@@ -4022,13 +4022,13 @@
 		IL_00cb: ldloc.0
 		IL_00cc: stelem.ref
 		IL_00cd: stloc.s 5
-		IL_00cf: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::.ctor()
+		IL_00cf: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get/FunctionObject::.ctor()
 		IL_00d4: ldc.i4.2
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "__jroc_esm_get"
 		IL_00db: ldc.i4.0
 		IL_00dc: ldc.i4.1
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00e2: stloc.2
 		IL_00e3: ldc.i4.1
 		IL_00e4: newarr [System.Runtime]System.Object
@@ -4041,13 +4041,13 @@
 		IL_00f1: ldc.i4.0
 		IL_00f2: ldelem.ref
 		IL_00f3: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_00f8: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_00f8: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_00fd: ldc.i4.1
 		IL_00fe: conv.r8
 		IL_00ff: ldstr "__jroc_esm_namespace"
 		IL_0104: ldc.i4.0
 		IL_0105: ldc.i4.1
-		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_010b: stloc.3
 		IL_010c: ldc.i4.1
 		IL_010d: newarr [System.Runtime]System.Object
@@ -4060,13 +4060,13 @@
 		IL_011a: ldc.i4.0
 		IL_011b: ldelem.ref
 		IL_011c: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0121: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_0121: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_0126: ldc.i4.2
 		IL_0127: conv.r8
 		IL_0128: ldstr "__jroc_esm_export"
 		IL_012d: ldc.i4.0
 		IL_012e: ldc.i4.1
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0134: stloc.s 4
 		IL_0136: nop
 		IL_0137: ldloc.0
@@ -4089,13 +4089,13 @@
 		IL_0161: ldc.i4.0
 		IL_0162: ldelem.ref
 		IL_0163: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0168: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_CFBAD72C_L3C28::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_0168: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_016d: ldc.i4.0
 		IL_016e: conv.r8
 		IL_016f: ldstr ""
 		IL_0174: ldc.i4.0
 		IL_0175: ldc.i4.1
-		IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_CFBAD72C_L3C28>(!!0, float64, string, bool, bool)
+		IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_017b: stloc.s 11
 		IL_017d: ldloc.s 4
 		IL_017f: ldloc.s 5
@@ -4116,13 +4116,13 @@
 		IL_01a3: ldc.i4.0
 		IL_01a4: ldelem.ref
 		IL_01a5: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_01aa: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_5B6EF069_L4C26::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_01aa: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_01af: ldc.i4.0
 		IL_01b0: conv.r8
 		IL_01b1: ldstr ""
 		IL_01b6: ldc.i4.0
 		IL_01b7: ldc.i4.1
-		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_5B6EF069_L4C26>(!!0, float64, string, bool, bool)
+		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01bd: stloc.s 12
 		IL_01bf: ldloc.s 4
 		IL_01c1: ldloc.s 5
@@ -4143,13 +4143,13 @@
 		IL_01e5: ldc.i4.0
 		IL_01e6: ldelem.ref
 		IL_01e7: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_01ec: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_A72B20E7_L5C30::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_01ec: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_01f1: ldc.i4.0
 		IL_01f2: conv.r8
 		IL_01f3: ldstr ""
 		IL_01f8: ldc.i4.0
 		IL_01f9: ldc.i4.1
-		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_A72B20E7_L5C30>(!!0, float64, string, bool, bool)
+		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01ff: stloc.s 13
 		IL_0201: ldloc.s 4
 		IL_0203: ldloc.s 5

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -71,9 +71,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::_environment0_Import_ExportNamedFrom
+				IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportNamedFrom
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -84,7 +84,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -108,11 +108,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::_environment0_Import_ExportNamedFrom
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportNamedFrom
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportNamedFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,11 +126,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::_environment0_Import_ExportNamedFrom
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportNamedFrom
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -148,9 +148,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -256,7 +256,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -270,7 +270,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -281,7 +281,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -292,7 +292,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -310,7 +310,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_ExportNamedFrom/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -329,7 +329,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_ExportNamedFrom/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -347,9 +347,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -452,7 +452,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -466,7 +466,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -477,7 +477,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -488,7 +488,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -510,7 +510,7 @@
 				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0018: call object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, string)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -533,7 +533,7 @@
 				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0014: call object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, string)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -551,9 +551,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -611,7 +611,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_34E1A920_L37C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -635,15 +635,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87::_environment0_Import_ExportNamedFrom
+					IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject::_environment0_Import_ExportNamedFrom
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -654,7 +654,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -665,7 +665,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -678,11 +678,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -696,11 +696,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -718,9 +718,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_34E1A920_L37C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -770,7 +770,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4DC27BA3_L38C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -794,15 +794,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94::_environment0_Import_ExportNamedFrom
+					IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject::_environment0_Import_ExportNamedFrom
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -813,7 +813,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -824,7 +824,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -837,11 +837,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -855,11 +855,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -877,9 +877,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_4DC27BA3_L38C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -933,7 +933,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8BD69ABA_L48C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -959,18 +959,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::_environment0_Import_ExportNamedFrom
+						IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject::_environment0_Import_ExportNamedFrom
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::_environment2_FunctionExpression_L47C9
+						IL_0016: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject::_environment2_FunctionExpression_L47C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -981,7 +981,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -992,7 +992,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1005,11 +1005,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1023,11 +1023,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1045,9 +1045,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_8BD69ABA_L48C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1112,7 +1112,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2217D24C_L47C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1136,15 +1136,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10::_environment0_Import_ExportNamedFrom
+					IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject::_environment0_Import_ExportNamedFrom
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1155,7 +1155,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1166,7 +1166,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1179,14 +1179,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1200,14 +1200,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1225,9 +1225,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_2217D24C_L47C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1249,7 +1249,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87,
+					[4] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -1299,13 +1299,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -1515,7 +1515,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1535,9 +1535,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::_environment0_Import_ExportNamedFrom
+				IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportNamedFrom
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1548,7 +1548,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1559,7 +1559,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1572,14 +1572,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::_environment0_Import_ExportNamedFrom
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportNamedFrom
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1593,14 +1593,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::_environment0_Import_ExportNamedFrom
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportNamedFrom
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1618,9 +1618,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1660,12 +1660,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87,
-				[21] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94,
+				[20] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject,
+				[21] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10
+				[25] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::.ctor()
@@ -1871,13 +1871,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1921,13 +1921,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2097,13 +2097,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -2214,7 +2214,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2234,9 +2234,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::_environment0_Import_ExportNamedFrom
+				IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject::_environment0_Import_ExportNamedFrom
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2247,7 +2247,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2258,7 +2258,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2271,7 +2271,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::_environment0_Import_ExportNamedFrom
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject::_environment0_Import_ExportNamedFrom
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2281,7 +2281,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Import_ExportNamedFrom/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2295,7 +2295,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::_environment0_Import_ExportNamedFrom
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject::_environment0_Import_ExportNamedFrom
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2305,7 +2305,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Import_ExportNamedFrom/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2323,9 +2323,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2437,13 +2437,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportNamedFrom/Scope,
-			[1] class Modules.Import_ExportNamedFrom/__jroc_esm_default/FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default,
-			[2] class Modules.Import_ExportNamedFrom/__jroc_esm_get/FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get,
-			[3] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace,
-			[4] class Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export,
+			[1] class Modules.Import_ExportNamedFrom/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_ExportNamedFrom/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark,
+			[7] class Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject,
 			[8] object,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -2464,13 +2464,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportNamedFrom/Scope
-		IL_0022: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::.ctor(class Modules.Import_ExportNamedFrom/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -2482,13 +2482,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_default/FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_default/FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -2497,13 +2497,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_get/FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_get/FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -2516,13 +2516,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportNamedFrom/Scope
-		IL_0094: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::.ctor(class Modules.Import_ExportNamedFrom/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -2535,13 +2535,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportNamedFrom/Scope
-		IL_00bd: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::.ctor(class Modules.Import_ExportNamedFrom/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -2625,7 +2625,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_64A3B1F3_L7C28
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2645,9 +2645,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject_FunctionExpression_64A3B1F3_L7C28::_environment0_Import_ExportNamedFrom_LibB
+				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2658,7 +2658,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2669,7 +2669,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2682,11 +2682,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject_FunctionExpression_64A3B1F3_L7C28::_environment0_Import_ExportNamedFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2700,11 +2700,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject_FunctionExpression_64A3B1F3_L7C28::_environment0_Import_ExportNamedFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2722,9 +2722,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_64A3B1F3_L7C28
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2780,7 +2780,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_59981EE9_L8C30
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2800,9 +2800,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject_FunctionExpression_59981EE9_L8C30::_environment0_Import_ExportNamedFrom_LibB
+				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2813,7 +2813,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2824,7 +2824,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2837,11 +2837,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject_FunctionExpression_59981EE9_L8C30::_environment0_Import_ExportNamedFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2855,11 +2855,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject_FunctionExpression_59981EE9_L8C30::_environment0_Import_ExportNamedFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2877,9 +2877,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_59981EE9_L8C30
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2956,7 +2956,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2976,9 +2976,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::_environment0_Import_ExportNamedFrom_LibB
+				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2989,7 +2989,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3000,7 +3000,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3013,11 +3013,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::_environment0_Import_ExportNamedFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3031,11 +3031,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::_environment0_Import_ExportNamedFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3053,9 +3053,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3161,7 +3161,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3175,7 +3175,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3186,7 +3186,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3197,7 +3197,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3215,7 +3215,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3234,7 +3234,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3252,9 +3252,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3357,7 +3357,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3371,7 +3371,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3382,7 +3382,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3393,7 +3393,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3414,7 +3414,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3436,7 +3436,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3454,9 +3454,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3514,7 +3514,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FF471FD3_L36C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3538,15 +3538,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87::_environment0_Import_ExportNamedFrom_LibB
+					IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3557,7 +3557,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3568,7 +3568,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3581,11 +3581,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3599,11 +3599,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3621,9 +3621,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_FF471FD3_L36C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3673,7 +3673,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7803A6D6_L37C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3697,15 +3697,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94::_environment0_Import_ExportNamedFrom_LibB
+					IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3716,7 +3716,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3727,7 +3727,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3740,11 +3740,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3758,11 +3758,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3780,9 +3780,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_7803A6D6_L37C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3836,7 +3836,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_42DBC8A8_L47C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -3862,18 +3862,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::_environment0_Import_ExportNamedFrom_LibB
+						IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::_environment2_FunctionExpression_L46C9
+						IL_0016: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::_environment2_FunctionExpression_L46C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -3884,7 +3884,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -3895,7 +3895,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -3908,11 +3908,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -3926,11 +3926,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -3948,9 +3948,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_42DBC8A8_L47C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -4015,7 +4015,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_69D44793_L46C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4039,15 +4039,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10::_environment0_Import_ExportNamedFrom_LibB
+					IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4058,7 +4058,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4069,7 +4069,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4082,14 +4082,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4103,14 +4103,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4128,9 +4128,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_69D44793_L46C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4152,7 +4152,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87,
+					[4] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -4202,13 +4202,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -4418,7 +4418,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4438,9 +4438,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::_environment0_Import_ExportNamedFrom_LibB
+				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4451,7 +4451,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4462,7 +4462,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4475,14 +4475,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::_environment0_Import_ExportNamedFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4496,14 +4496,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::_environment0_Import_ExportNamedFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4521,9 +4521,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4563,12 +4563,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87,
-				[21] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94,
+				[20] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject,
+				[21] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10
+				[25] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::.ctor()
@@ -4774,13 +4774,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -4824,13 +4824,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -5000,13 +5000,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -5117,7 +5117,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5137,9 +5137,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::_environment0_Import_ExportNamedFrom_LibB
+				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5150,7 +5150,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5161,7 +5161,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5174,7 +5174,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::_environment0_Import_ExportNamedFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -5185,7 +5185,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5199,7 +5199,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::_environment0_Import_ExportNamedFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject::_environment0_Import_ExportNamedFrom_LibB
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -5210,7 +5210,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5228,9 +5228,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5343,16 +5343,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportNamedFrom_LibB/Scope,
-			[1] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default,
-			[2] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get,
-			[3] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace,
-			[4] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export,
+			[1] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject,
 			[5] object[],
-			[6] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark,
+			[6] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject,
 			[7] object,
 			[8] object[],
-			[9] class Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject_FunctionExpression_64A3B1F3_L7C28,
-			[10] class Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject_FunctionExpression_59981EE9_L8C30
+			[9] class Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject,
+			[10] class Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportNamedFrom_LibB/Scope::.ctor()
@@ -5371,13 +5371,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_0022: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 6
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 6
@@ -5389,13 +5389,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 5
-		IL_004b: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -5404,13 +5404,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 5
-		IL_006b: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -5423,13 +5423,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_0094: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -5442,13 +5442,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_00bd: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -5478,13 +5478,13 @@
 		IL_0112: ldc.i4.0
 		IL_0113: ldelem.ref
 		IL_0114: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_0119: newobj instance void Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject_FunctionExpression_64A3B1F3_L7C28::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
+		IL_0119: newobj instance void Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
 		IL_011e: ldc.i4.0
 		IL_011f: conv.r8
 		IL_0120: ldstr ""
 		IL_0125: ldc.i4.0
 		IL_0126: ldc.i4.1
-		IL_0127: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject_FunctionExpression_64A3B1F3_L7C28>(!!0, float64, string, bool, bool)
+		IL_0127: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_012c: stloc.s 9
 		IL_012e: ldloc.s 4
 		IL_0130: ldloc.s 5
@@ -5505,13 +5505,13 @@
 		IL_0154: ldc.i4.0
 		IL_0155: ldelem.ref
 		IL_0156: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_015b: newobj instance void Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject_FunctionExpression_59981EE9_L8C30::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
+		IL_015b: newobj instance void Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
 		IL_0160: ldc.i4.0
 		IL_0161: conv.r8
 		IL_0162: ldstr ""
 		IL_0167: ldc.i4.0
 		IL_0168: ldc.i4.1
-		IL_0169: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject_FunctionExpression_59981EE9_L8C30>(!!0, float64, string, bool, bool)
+		IL_0169: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_016e: stloc.s 10
 		IL_0170: ldloc.s 4
 		IL_0172: ldloc.s 5
@@ -5551,7 +5551,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B2972973_L5C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -5565,7 +5565,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5576,7 +5576,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5587,7 +5587,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5605,9 +5605,9 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_B2972973_L5C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5671,7 +5671,7 @@
 			[0] class Modules.Import_ExportNamedFrom_LibA/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[2] object[],
-			[3] class Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11/FunctionObject_FunctionExpression_B2972973_L5C12
+			[3] class Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportNamedFrom_LibA/Scope::.ctor()
@@ -5691,14 +5691,14 @@
 		IL_002a: ldloc.0
 		IL_002b: stelem.ref
 		IL_002c: stloc.2
-		IL_002d: newobj instance void Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11/FunctionObject_FunctionExpression_B2972973_L5C12::.ctor()
+		IL_002d: newobj instance void Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11/FunctionObject::.ctor()
 		IL_0032: ldc.i4.1
 		IL_0033: conv.r8
 		IL_0034: ldstr ""
 		IL_0039: ldc.i4.0
 		IL_003a: ldc.i4.1
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11/FunctionObject_FunctionExpression_B2972973_L5C12>(!!0, float64, string, bool, bool)
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11/FunctionObject_FunctionExpression_B2972973_L5C12>(!!0)
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11/FunctionObject>(!!0)
 		IL_0045: stloc.3
 		IL_0046: ldloc.1
 		IL_0047: ldstr "doubled"

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -71,9 +71,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::_environment0_Import_ExportStarFrom
+				IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFrom
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -84,7 +84,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -108,11 +108,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::_environment0_Import_ExportStarFrom
+				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFrom
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportStarFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,11 +126,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::_environment0_Import_ExportStarFrom
+				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFrom
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -148,9 +148,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -256,7 +256,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -270,7 +270,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -281,7 +281,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -292,7 +292,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -310,7 +310,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_ExportStarFrom/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -329,7 +329,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_ExportStarFrom/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -347,9 +347,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -452,7 +452,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -466,7 +466,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -477,7 +477,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -488,7 +488,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -509,7 +509,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_ExportStarFrom/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -531,7 +531,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_ExportStarFrom/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -549,9 +549,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -609,7 +609,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5774ECAB_L39C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -633,15 +633,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87::_environment0_Import_ExportStarFrom
+					IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_environment0_Import_ExportStarFrom
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -652,7 +652,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -663,7 +663,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -676,11 +676,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -694,11 +694,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -716,9 +716,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_5774ECAB_L39C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -768,7 +768,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5849C53F_L40C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -792,15 +792,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94::_environment0_Import_ExportStarFrom
+					IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_environment0_Import_ExportStarFrom
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -811,7 +811,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -822,7 +822,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -835,11 +835,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -853,11 +853,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -875,9 +875,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_5849C53F_L40C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -931,7 +931,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8E8605EC_L50C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -957,18 +957,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::_environment0_Import_ExportStarFrom
+						IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_environment0_Import_ExportStarFrom
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::_environment2_FunctionExpression_L49C9
+						IL_0016: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_environment2_FunctionExpression_L49C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -979,7 +979,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -990,7 +990,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1003,11 +1003,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1021,11 +1021,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1043,9 +1043,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_8E8605EC_L50C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1110,7 +1110,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6930940B_L49C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1134,15 +1134,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10::_environment0_Import_ExportStarFrom
+					IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_environment0_Import_ExportStarFrom
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1153,7 +1153,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1164,7 +1164,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1177,14 +1177,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1198,14 +1198,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1223,9 +1223,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_6930940B_L49C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1247,7 +1247,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87,
+					[4] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -1297,13 +1297,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -1513,7 +1513,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1533,9 +1533,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::_environment0_Import_ExportStarFrom
+				IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFrom
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1546,7 +1546,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1557,7 +1557,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1570,14 +1570,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::_environment0_Import_ExportStarFrom
+				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFrom
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1591,14 +1591,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::_environment0_Import_ExportStarFrom
+				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFrom
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1616,9 +1616,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1658,12 +1658,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87,
-				[21] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94,
+				[20] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject,
+				[21] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10
+				[25] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::.ctor()
@@ -1869,13 +1869,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1919,13 +1919,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2095,13 +2095,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -2212,7 +2212,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_52197845___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2232,9 +2232,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::_environment0_Import_ExportStarFrom
+				IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFrom
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2245,7 +2245,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2256,7 +2256,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2269,7 +2269,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::_environment0_Import_ExportStarFrom
+				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFrom
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2279,7 +2279,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Import_ExportStarFrom/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2293,7 +2293,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::_environment0_Import_ExportStarFrom
+				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFrom
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2303,7 +2303,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Import_ExportStarFrom/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2321,9 +2321,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_52197845___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2435,14 +2435,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFrom/Scope,
-			[1] class Modules.Import_ExportStarFrom/__jroc_esm_default/FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default,
-			[2] class Modules.Import_ExportStarFrom/__jroc_esm_get/FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get,
-			[3] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace,
-			[4] class Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_52197845___jroc_esm_export,
+			[1] class Modules.Import_ExportStarFrom/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_ExportStarFrom/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject,
 			[5] object,
 			[6] object,
 			[7] object[],
-			[8] class Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark,
+			[8] class Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject,
 			[9] object,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -2463,13 +2463,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportStarFrom/Scope
-		IL_0022: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFrom/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_ExportStarFrom/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 8
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 8
@@ -2481,13 +2481,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 7
-		IL_004b: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_default/FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_default/FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -2496,13 +2496,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 7
-		IL_006b: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_get/FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_get/FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -2515,13 +2515,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportStarFrom/Scope
-		IL_0094: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFrom/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_ExportStarFrom/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -2534,13 +2534,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportStarFrom/Scope
-		IL_00bd: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::.ctor(class Modules.Import_ExportStarFrom/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_ExportStarFrom/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_52197845___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -2669,7 +2669,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2689,9 +2689,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::_environment0_Import_ExportStarFrom_LibB
+				IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2702,7 +2702,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2713,7 +2713,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2726,11 +2726,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::_environment0_Import_ExportStarFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2744,11 +2744,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::_environment0_Import_ExportStarFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2766,9 +2766,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2874,7 +2874,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2888,7 +2888,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2899,7 +2899,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2910,7 +2910,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2928,7 +2928,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2947,7 +2947,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2965,9 +2965,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3070,7 +3070,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3084,7 +3084,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3095,7 +3095,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3106,7 +3106,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3127,7 +3127,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3149,7 +3149,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3167,9 +3167,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3227,7 +3227,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_19C9F4C3_L39C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3251,15 +3251,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87::_environment0_Import_ExportStarFrom_LibB
+					IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3270,7 +3270,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3281,7 +3281,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3294,11 +3294,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3312,11 +3312,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3334,9 +3334,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_19C9F4C3_L39C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3386,7 +3386,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D1AA4B47_L40C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3410,15 +3410,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94::_environment0_Import_ExportStarFrom_LibB
+					IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3429,7 +3429,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3440,7 +3440,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3453,11 +3453,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3471,11 +3471,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3493,9 +3493,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_D1AA4B47_L40C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3549,7 +3549,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2C8A7AA4_L50C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -3575,18 +3575,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_environment0_Import_ExportStarFrom_LibB
+						IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_environment2_FunctionExpression_L49C9
+						IL_0016: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_environment2_FunctionExpression_L49C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -3597,7 +3597,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -3608,7 +3608,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -3621,11 +3621,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -3639,11 +3639,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -3661,9 +3661,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_2C8A7AA4_L50C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -3728,7 +3728,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_14DFC423_L49C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3752,15 +3752,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10::_environment0_Import_ExportStarFrom_LibB
+					IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3771,7 +3771,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3782,7 +3782,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3795,14 +3795,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3816,14 +3816,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3841,9 +3841,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_14DFC423_L49C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3865,7 +3865,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87,
+					[4] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -3915,13 +3915,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -4131,7 +4131,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4151,9 +4151,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::_environment0_Import_ExportStarFrom_LibB
+				IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4164,7 +4164,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4175,7 +4175,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4188,14 +4188,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::_environment0_Import_ExportStarFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4209,14 +4209,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::_environment0_Import_ExportStarFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4234,9 +4234,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4276,12 +4276,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87,
-				[21] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94,
+				[20] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject,
+				[21] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10
+				[25] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::.ctor()
@@ -4487,13 +4487,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -4537,13 +4537,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -4713,13 +4713,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -4830,7 +4830,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4850,9 +4850,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::_environment0_Import_ExportStarFrom_LibB
+				IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4863,7 +4863,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4874,7 +4874,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4887,7 +4887,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::_environment0_Import_ExportStarFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -4897,7 +4897,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4911,7 +4911,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::_environment0_Import_ExportStarFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -4921,7 +4921,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4939,9 +4939,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5033,7 +5033,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3D87220C_L10C43
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -5057,15 +5057,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43::_environment0_Import_ExportStarFrom_LibB
+					IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43::_environment1_FunctionExpression_L10C3
+					IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject::_environment1_FunctionExpression_L10C3
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -5076,7 +5076,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -5087,7 +5087,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -5100,11 +5100,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -5118,11 +5118,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -5140,9 +5140,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_3D87220C_L10C43
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -5208,7 +5208,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_599477C0_L10C4
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5228,9 +5228,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject_FunctionExpression_599477C0_L10C4::_environment0_Import_ExportStarFrom_LibB
+				IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5241,7 +5241,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5252,7 +5252,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5265,14 +5265,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject_FunctionExpression_599477C0_L10C4::_environment0_Import_ExportStarFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5286,14 +5286,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject_FunctionExpression_599477C0_L10C4::_environment0_Import_ExportStarFrom_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject::_environment0_Import_ExportStarFrom_LibB
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5311,9 +5311,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_599477C0_L10C4
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5338,7 +5338,7 @@
 				[2] object[],
 				[3] object,
 				[4] object[],
-				[5] class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43
+				[5] class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope::.ctor()
@@ -5379,13 +5379,13 @@
 			IL_0042: ldelem.ref
 			IL_0043: castclass Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope
 			IL_0048: ldloc.s 4
-			IL_004a: newobj instance void Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope, object[])
+			IL_004a: newobj instance void Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope, object[])
 			IL_004f: ldc.i4.0
 			IL_0050: conv.r8
 			IL_0051: ldstr ""
 			IL_0056: ldc.i4.0
 			IL_0057: ldc.i4.1
-			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43>(!!0, float64, string, bool, bool)
+			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_005d: stloc.s 5
 			IL_005f: ldloc.1
 			IL_0060: ldloc.2
@@ -5508,14 +5508,14 @@
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Import_ExportStarFrom_LibB/Scope,
-			[1] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default,
-			[2] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get,
-			[3] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace,
+			[1] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject,
 			[4] object,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark,
-			[8] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export,
+			[7] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject,
+			[8] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject,
 			[9] object,
 			[10] bool,
 			[11] object,
@@ -5524,7 +5524,7 @@
 			[14] object,
 			[15] object,
 			[16] object,
-			[17] class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject_FunctionExpression_599477C0_L10C4
+			[17] class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope::.ctor()
@@ -5543,13 +5543,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportStarFrom_LibB/Scope
-		IL_0022: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -5561,13 +5561,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -5576,13 +5576,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -5595,13 +5595,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportStarFrom_LibB/Scope
-		IL_0094: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -5614,13 +5614,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportStarFrom_LibB/Scope
-		IL_00bd: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 8
 		IL_00d2: ldloc.0
 		IL_00d3: ldloc.s 8
@@ -5761,13 +5761,13 @@
 			IL_0245: ldc.i4.0
 			IL_0246: ldelem.ref
 			IL_0247: castclass Modules.Import_ExportStarFrom_LibB/Scope
-			IL_024c: newobj instance void Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject_FunctionExpression_599477C0_L10C4::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
+			IL_024c: newobj instance void Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
 			IL_0251: ldc.i4.1
 			IL_0252: conv.r8
 			IL_0253: ldstr ""
 			IL_0258: ldc.i4.0
 			IL_0259: ldc.i4.1
-			IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject_FunctionExpression_599477C0_L10C4>(!!0, float64, string, bool, bool)
+			IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_025f: stloc.s 17
 			IL_0261: ldloc.s 17
 			IL_0263: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -5810,7 +5810,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A96CE50C_Base
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -5824,7 +5824,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5835,7 +5835,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5846,7 +5846,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5861,7 +5861,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Import_ExportStarFrom_LibA/Base::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5877,7 +5877,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Import_ExportStarFrom_LibA/Base::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5895,9 +5895,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A96CE50C_Base
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5961,7 +5961,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFrom_LibA/Scope,
-			[1] class Modules.Import_ExportStarFrom_LibA/Base/FunctionObject_FunctionDeclaration_A96CE50C_Base,
+			[1] class Modules.Import_ExportStarFrom_LibA/Base/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] object
@@ -5976,13 +5976,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Import_ExportStarFrom_LibA/Base/FunctionObject_FunctionDeclaration_A96CE50C_Base::.ctor()
+		IL_0011: newobj instance void Modules.Import_ExportStarFrom_LibA/Base/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "Base"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibA/Base/FunctionObject_FunctionDeclaration_A96CE50C_Base>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibA/Base/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -71,9 +71,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -84,7 +84,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -108,11 +108,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,11 +126,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -148,9 +148,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -256,7 +256,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -270,7 +270,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -281,7 +281,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -292,7 +292,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -310,7 +310,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -329,7 +329,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -347,9 +347,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -452,7 +452,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -466,7 +466,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -477,7 +477,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -488,7 +488,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -510,7 +510,7 @@
 				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0018: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, string)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -533,7 +533,7 @@
 				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0014: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, string)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -551,9 +551,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -611,7 +611,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_426DB65A_L38C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -635,15 +635,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87::_environment0_Import_ExportStarFromMultiHop
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -654,7 +654,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -665,7 +665,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -678,11 +678,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -696,11 +696,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -718,9 +718,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_426DB65A_L38C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -770,7 +770,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_551A5557_L39C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -794,15 +794,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94::_environment0_Import_ExportStarFromMultiHop
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -813,7 +813,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -824,7 +824,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -837,11 +837,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -855,11 +855,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -877,9 +877,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_551A5557_L39C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -933,7 +933,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DD0FD664_L49C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -959,18 +959,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::_environment0_Import_ExportStarFromMultiHop
+						IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::_environment2_FunctionExpression_L48C9
+						IL_0016: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment2_FunctionExpression_L48C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -981,7 +981,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -992,7 +992,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1005,11 +1005,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1023,11 +1023,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1045,9 +1045,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_DD0FD664_L49C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1112,7 +1112,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BF7DD9E1_L48C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1136,15 +1136,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_environment0_Import_ExportStarFromMultiHop
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1155,7 +1155,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1166,7 +1166,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1179,14 +1179,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1200,14 +1200,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1225,9 +1225,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_BF7DD9E1_L48C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1249,7 +1249,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87,
+					[4] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -1299,13 +1299,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -1515,7 +1515,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1535,9 +1535,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1548,7 +1548,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1559,7 +1559,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1572,14 +1572,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1593,14 +1593,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1618,9 +1618,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1660,12 +1660,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87,
-				[21] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94,
+				[20] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject,
+				[21] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10
+				[25] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::.ctor()
@@ -1871,13 +1871,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1921,13 +1921,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2097,13 +2097,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -2214,7 +2214,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2234,9 +2234,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2247,7 +2247,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2258,7 +2258,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2271,7 +2271,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2281,7 +2281,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2295,7 +2295,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFromMultiHop
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2305,7 +2305,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2323,9 +2323,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2437,13 +2437,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop/Scope,
-			[1] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_default/FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default,
-			[2] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_get/FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get,
-			[3] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace,
-			[4] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export,
+			[1] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark,
+			[7] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject,
 			[8] object,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -2464,13 +2464,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportStarFromMultiHop/Scope
-		IL_0022: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -2482,13 +2482,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_default/FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_default/FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -2497,13 +2497,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_get/FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_get/FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -2516,13 +2516,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportStarFromMultiHop/Scope
-		IL_0094: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -2535,13 +2535,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportStarFromMultiHop/Scope
-		IL_00bd: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -2653,7 +2653,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2673,9 +2673,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2686,7 +2686,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2697,7 +2697,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2710,11 +2710,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2728,11 +2728,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2750,9 +2750,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2858,7 +2858,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2872,7 +2872,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2883,7 +2883,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2894,7 +2894,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2912,7 +2912,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2931,7 +2931,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2949,9 +2949,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3054,7 +3054,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3068,7 +3068,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3079,7 +3079,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3090,7 +3090,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3111,7 +3111,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3133,7 +3133,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3151,9 +3151,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3211,7 +3211,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3C5C10DA_L39C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3235,15 +3235,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87::_environment0_Import_ExportStarFromMultiHop_LibC
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3254,7 +3254,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3265,7 +3265,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3278,11 +3278,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3296,11 +3296,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3318,9 +3318,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_3C5C10DA_L39C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3370,7 +3370,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1B8705E6_L40C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3394,15 +3394,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94::_environment0_Import_ExportStarFromMultiHop_LibC
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3413,7 +3413,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3424,7 +3424,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3437,11 +3437,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3455,11 +3455,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3477,9 +3477,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_1B8705E6_L40C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3533,7 +3533,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_73299A15_L50C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -3559,18 +3559,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::_environment0_Import_ExportStarFromMultiHop_LibC
+						IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::_environment2_FunctionExpression_L49C9
+						IL_0016: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_environment2_FunctionExpression_L49C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -3581,7 +3581,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -3592,7 +3592,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -3605,11 +3605,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -3623,11 +3623,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -3645,9 +3645,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_73299A15_L50C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -3712,7 +3712,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1CF36C60_L49C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3736,15 +3736,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10::_environment0_Import_ExportStarFromMultiHop_LibC
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3755,7 +3755,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3766,7 +3766,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3779,14 +3779,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3800,14 +3800,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3825,9 +3825,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_1CF36C60_L49C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3849,7 +3849,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87,
+					[4] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -3899,13 +3899,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -4115,7 +4115,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4135,9 +4135,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4148,7 +4148,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4159,7 +4159,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4172,14 +4172,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4193,14 +4193,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4218,9 +4218,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4260,12 +4260,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87,
-				[21] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94,
+				[20] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject,
+				[21] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10
+				[25] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::.ctor()
@@ -4471,13 +4471,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -4521,13 +4521,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -4697,13 +4697,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -4814,7 +4814,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4834,9 +4834,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4847,7 +4847,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4858,7 +4858,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4871,7 +4871,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -4881,7 +4881,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4895,7 +4895,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -4905,7 +4905,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4923,9 +4923,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5017,7 +5017,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3220FB25_L10C43
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -5041,15 +5041,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43::_environment0_Import_ExportStarFromMultiHop_LibC
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43::_environment1_FunctionExpression_L10C3
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject::_environment1_FunctionExpression_L10C3
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -5060,7 +5060,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -5071,7 +5071,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -5084,11 +5084,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -5102,11 +5102,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -5124,9 +5124,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_3220FB25_L10C43
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -5192,7 +5192,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DA9C5919_L10C4
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5212,9 +5212,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject_FunctionExpression_DA9C5919_L10C4::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5225,7 +5225,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5236,7 +5236,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5249,14 +5249,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject_FunctionExpression_DA9C5919_L10C4::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5270,14 +5270,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject_FunctionExpression_DA9C5919_L10C4::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibC
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5295,9 +5295,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_DA9C5919_L10C4
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5322,7 +5322,7 @@
 				[2] object[],
 				[3] object,
 				[4] object[],
-				[5] class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43
+				[5] class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope::.ctor()
@@ -5363,13 +5363,13 @@
 			IL_0042: ldelem.ref
 			IL_0043: castclass Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope
 			IL_0048: ldloc.s 4
-			IL_004a: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope, object[])
+			IL_004a: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope, object[])
 			IL_004f: ldc.i4.0
 			IL_0050: conv.r8
 			IL_0051: ldstr ""
 			IL_0056: ldc.i4.0
 			IL_0057: ldc.i4.1
-			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43>(!!0, float64, string, bool, bool)
+			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_005d: stloc.s 5
 			IL_005f: ldloc.1
 			IL_0060: ldloc.2
@@ -5492,14 +5492,14 @@
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop_LibC/Scope,
-			[1] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default/FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default,
-			[2] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get/FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get,
-			[3] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace,
+			[1] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject,
 			[4] object,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark,
-			[8] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export,
+			[7] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject,
+			[8] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject,
 			[9] object,
 			[10] bool,
 			[11] object,
@@ -5508,7 +5508,7 @@
 			[14] object,
 			[15] object,
 			[16] object,
-			[17] class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject_FunctionExpression_DA9C5919_L10C4
+			[17] class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope::.ctor()
@@ -5527,13 +5527,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-		IL_0022: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -5545,13 +5545,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default/FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default/FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -5560,13 +5560,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get/FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get/FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -5579,13 +5579,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-		IL_0094: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -5598,13 +5598,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-		IL_00bd: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 8
 		IL_00d2: ldloc.0
 		IL_00d3: ldloc.s 8
@@ -5745,13 +5745,13 @@
 			IL_0245: ldc.i4.0
 			IL_0246: ldelem.ref
 			IL_0247: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-			IL_024c: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject_FunctionExpression_DA9C5919_L10C4::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
+			IL_024c: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
 			IL_0251: ldc.i4.1
 			IL_0252: conv.r8
 			IL_0253: ldstr ""
 			IL_0258: ldc.i4.0
 			IL_0259: ldc.i4.1
-			IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject_FunctionExpression_DA9C5919_L10C4>(!!0, float64, string, bool, bool)
+			IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_025f: stloc.s 17
 			IL_0261: ldloc.s 17
 			IL_0263: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -5794,7 +5794,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_19A18F00_L3C28
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5814,9 +5814,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject_FunctionExpression_19A18F00_L3C28::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5827,7 +5827,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5838,7 +5838,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5851,11 +5851,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject_FunctionExpression_19A18F00_L3C28::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5869,11 +5869,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject_FunctionExpression_19A18F00_L3C28::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5891,9 +5891,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_19A18F00_L3C28
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5965,7 +5965,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5985,9 +5985,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5998,7 +5998,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6009,7 +6009,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6022,11 +6022,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6040,11 +6040,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6062,9 +6062,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6170,7 +6170,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -6184,7 +6184,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6195,7 +6195,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6206,7 +6206,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6224,7 +6224,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6243,7 +6243,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6261,9 +6261,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6366,7 +6366,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -6380,7 +6380,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6391,7 +6391,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6402,7 +6402,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6423,7 +6423,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6445,7 +6445,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6463,9 +6463,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6523,7 +6523,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_11771A92_L41C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -6547,15 +6547,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87::_environment0_Import_ExportStarFromMultiHop_LibB
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -6566,7 +6566,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -6577,7 +6577,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -6590,11 +6590,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -6608,11 +6608,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -6630,9 +6630,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_11771A92_L41C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -6682,7 +6682,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_00CEFBE9_L42C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -6706,15 +6706,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94::_environment0_Import_ExportStarFromMultiHop_LibB
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -6725,7 +6725,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -6736,7 +6736,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -6749,11 +6749,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -6767,11 +6767,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -6789,9 +6789,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_00CEFBE9_L42C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -6845,7 +6845,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_269D42B9_L52C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -6871,18 +6871,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::_environment0_Import_ExportStarFromMultiHop_LibB
+						IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::_environment2_FunctionExpression_L51C9
+						IL_0016: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject::_environment2_FunctionExpression_L51C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -6893,7 +6893,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -6904,7 +6904,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -6917,11 +6917,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -6935,11 +6935,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -6957,9 +6957,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_269D42B9_L52C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -7024,7 +7024,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_63D03172_L51C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -7048,15 +7048,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10::_environment0_Import_ExportStarFromMultiHop_LibB
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -7067,7 +7067,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -7078,7 +7078,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -7091,14 +7091,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -7112,14 +7112,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -7137,9 +7137,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_63D03172_L51C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -7161,7 +7161,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87,
+					[4] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -7211,13 +7211,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -7427,7 +7427,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -7447,9 +7447,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7460,7 +7460,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7471,7 +7471,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7484,14 +7484,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7505,14 +7505,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7530,9 +7530,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7572,12 +7572,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87,
-				[21] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94,
+				[20] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject,
+				[21] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10
+				[25] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::.ctor()
@@ -7783,13 +7783,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -7833,13 +7833,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -8009,13 +8009,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -8126,7 +8126,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8146,9 +8146,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8159,7 +8159,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8170,7 +8170,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8183,7 +8183,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -8193,7 +8193,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8207,7 +8207,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -8217,7 +8217,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8235,9 +8235,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8329,7 +8329,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_777D73E3_L11C43
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -8353,15 +8353,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43::_environment0_Import_ExportStarFromMultiHop_LibB
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43::_environment1_FunctionExpression_L11C3
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject::_environment1_FunctionExpression_L11C3
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -8372,7 +8372,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -8383,7 +8383,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -8396,11 +8396,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -8414,11 +8414,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -8436,9 +8436,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_777D73E3_L11C43
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -8504,7 +8504,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9F0212B6_L11C4
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8524,9 +8524,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject_FunctionExpression_9F0212B6_L11C4::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8537,7 +8537,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8548,7 +8548,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8561,14 +8561,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject_FunctionExpression_9F0212B6_L11C4::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8582,14 +8582,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject_FunctionExpression_9F0212B6_L11C4::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibB
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8607,9 +8607,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_9F0212B6_L11C4
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8634,7 +8634,7 @@
 				[2] object[],
 				[3] object,
 				[4] object[],
-				[5] class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43
+				[5] class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope::.ctor()
@@ -8675,13 +8675,13 @@
 			IL_0042: ldelem.ref
 			IL_0043: castclass Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope
 			IL_0048: ldloc.s 4
-			IL_004a: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope, object[])
+			IL_004a: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope, object[])
 			IL_004f: ldc.i4.0
 			IL_0050: conv.r8
 			IL_0051: ldstr ""
 			IL_0056: ldc.i4.0
 			IL_0057: ldc.i4.1
-			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43>(!!0, float64, string, bool, bool)
+			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_005d: stloc.s 5
 			IL_005f: ldloc.1
 			IL_0060: ldloc.2
@@ -8809,17 +8809,17 @@
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop_LibB/Scope,
-			[1] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default,
-			[2] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get,
-			[3] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace,
+			[1] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject,
 			[4] object,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark,
-			[8] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export,
+			[7] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject,
+			[8] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject,
 			[9] object,
 			[10] object[],
-			[11] class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject_FunctionExpression_19A18F00_L3C28,
+			[11] class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject,
 			[12] bool,
 			[13] object,
 			[14] object,
@@ -8827,7 +8827,7 @@
 			[16] object,
 			[17] object,
 			[18] object,
-			[19] class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject_FunctionExpression_9F0212B6_L11C4
+			[19] class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope::.ctor()
@@ -8846,13 +8846,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_0022: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -8864,13 +8864,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -8879,13 +8879,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -8898,13 +8898,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_0094: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -8917,13 +8917,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_00bd: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 8
 		IL_00d2: ldloc.0
 		IL_00d3: ldloc.s 8
@@ -8952,13 +8952,13 @@
 		IL_010d: ldc.i4.0
 		IL_010e: ldelem.ref
 		IL_010f: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_0114: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject_FunctionExpression_19A18F00_L3C28::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
+		IL_0114: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
 		IL_0119: ldc.i4.0
 		IL_011a: conv.r8
 		IL_011b: ldstr ""
 		IL_0120: ldc.i4.0
 		IL_0121: ldc.i4.1
-		IL_0122: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject_FunctionExpression_19A18F00_L3C28>(!!0, float64, string, bool, bool)
+		IL_0122: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0127: stloc.s 11
 		IL_0129: ldloc.s 9
 		IL_012b: ldloc.s 6
@@ -9094,13 +9094,13 @@
 			IL_028f: ldc.i4.0
 			IL_0290: ldelem.ref
 			IL_0291: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-			IL_0296: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject_FunctionExpression_9F0212B6_L11C4::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
+			IL_0296: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
 			IL_029b: ldc.i4.1
 			IL_029c: conv.r8
 			IL_029d: ldstr ""
 			IL_02a2: ldc.i4.0
 			IL_02a3: ldc.i4.1
-			IL_02a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject_FunctionExpression_9F0212B6_L11C4>(!!0, float64, string, bool, bool)
+			IL_02a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02a9: stloc.s 19
 			IL_02ab: ldloc.s 19
 			IL_02ad: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -9146,7 +9146,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_732A343F_L3C28
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -9166,9 +9166,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject_FunctionExpression_732A343F_L3C28::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9179,7 +9179,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9190,7 +9190,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9203,11 +9203,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject_FunctionExpression_732A343F_L3C28::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9221,11 +9221,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject_FunctionExpression_732A343F_L3C28::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -9243,9 +9243,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_732A343F_L3C28
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -9296,7 +9296,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D475FD19_L4C27
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -9316,9 +9316,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject_FunctionExpression_D475FD19_L4C27::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9329,7 +9329,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9340,7 +9340,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9353,11 +9353,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject_FunctionExpression_D475FD19_L4C27::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9371,11 +9371,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject_FunctionExpression_D475FD19_L4C27::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -9393,9 +9393,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D475FD19_L4C27
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -9467,7 +9467,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -9487,9 +9487,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9500,7 +9500,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9511,7 +9511,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9524,11 +9524,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9542,11 +9542,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -9564,9 +9564,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -9672,7 +9672,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -9686,7 +9686,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9697,7 +9697,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9708,7 +9708,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9726,7 +9726,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9745,7 +9745,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -9763,9 +9763,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -9868,7 +9868,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -9882,7 +9882,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9893,7 +9893,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9904,7 +9904,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9925,7 +9925,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9947,7 +9947,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -9965,9 +9965,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -10025,7 +10025,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C376DAAB_L36C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -10049,15 +10049,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87::_environment0_Import_ExportStarFromMultiHop_LibA
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -10068,7 +10068,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -10079,7 +10079,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -10092,11 +10092,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -10110,11 +10110,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -10132,9 +10132,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_C376DAAB_L36C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -10184,7 +10184,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3D70962E_L37C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -10208,15 +10208,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94::_environment0_Import_ExportStarFromMultiHop_LibA
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -10227,7 +10227,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -10238,7 +10238,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -10251,11 +10251,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -10269,11 +10269,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -10291,9 +10291,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_3D70962E_L37C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -10347,7 +10347,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_085B51F0_L47C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -10373,18 +10373,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::_environment0_Import_ExportStarFromMultiHop_LibA
+						IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::_environment2_FunctionExpression_L46C9
+						IL_0016: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::_environment2_FunctionExpression_L46C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -10395,7 +10395,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -10406,7 +10406,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -10419,11 +10419,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -10437,11 +10437,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -10459,9 +10459,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_085B51F0_L47C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -10526,7 +10526,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_39AC3F9B_L46C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -10550,15 +10550,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10::_environment0_Import_ExportStarFromMultiHop_LibA
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -10569,7 +10569,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -10580,7 +10580,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -10593,14 +10593,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -10614,14 +10614,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -10639,9 +10639,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_39AC3F9B_L46C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -10663,7 +10663,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87,
+					[4] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -10713,13 +10713,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -10929,7 +10929,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -10949,9 +10949,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -10962,7 +10962,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -10973,7 +10973,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -10986,14 +10986,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -11007,14 +11007,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -11032,9 +11032,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -11074,12 +11074,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87,
-				[21] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94,
+				[20] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject,
+				[21] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10
+				[25] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::.ctor()
@@ -11285,13 +11285,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -11335,13 +11335,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -11511,13 +11511,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -11628,7 +11628,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -11648,9 +11648,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -11661,7 +11661,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -11672,7 +11672,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -11685,7 +11685,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -11696,7 +11696,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -11710,7 +11710,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject::_environment0_Import_ExportStarFromMultiHop_LibA
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -11721,7 +11721,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -11739,9 +11739,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -11863,16 +11863,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop_LibA/Scope,
-			[1] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default/FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default,
-			[2] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get/FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get,
-			[3] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace,
-			[4] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export,
+			[1] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject,
 			[5] object[],
-			[6] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark,
+			[6] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject,
 			[7] object,
 			[8] object[],
-			[9] class Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject_FunctionExpression_732A343F_L3C28,
-			[10] class Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject_FunctionExpression_D475FD19_L4C27
+			[9] class Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject,
+			[10] class Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/Scope::.ctor()
@@ -11891,13 +11891,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_0022: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 6
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 6
@@ -11909,13 +11909,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 5
-		IL_004b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default/FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default/FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -11924,13 +11924,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 5
-		IL_006b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get/FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get/FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -11943,13 +11943,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_0094: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -11962,13 +11962,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_00bd: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -11991,13 +11991,13 @@
 		IL_00fd: ldc.i4.0
 		IL_00fe: ldelem.ref
 		IL_00ff: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_0104: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject_FunctionExpression_732A343F_L3C28::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
+		IL_0104: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
 		IL_0109: ldc.i4.0
 		IL_010a: conv.r8
 		IL_010b: ldstr ""
 		IL_0110: ldc.i4.0
 		IL_0111: ldc.i4.1
-		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject_FunctionExpression_732A343F_L3C28>(!!0, float64, string, bool, bool)
+		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0117: stloc.s 9
 		IL_0119: ldloc.s 4
 		IL_011b: ldloc.s 5
@@ -12018,13 +12018,13 @@
 		IL_013f: ldc.i4.0
 		IL_0140: ldelem.ref
 		IL_0141: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_0146: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject_FunctionExpression_D475FD19_L4C27::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
+		IL_0146: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
 		IL_014b: ldc.i4.0
 		IL_014c: conv.r8
 		IL_014d: ldstr ""
 		IL_0152: ldc.i4.0
 		IL_0153: ldc.i4.1
-		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject_FunctionExpression_D475FD19_L4C27>(!!0, float64, string, bool, bool)
+		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0159: stloc.s 10
 		IL_015b: ldloc.s 4
 		IL_015d: ldloc.s 5

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -71,9 +71,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::_environment0_Import_ImportMeta_Url
+				IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject::_environment0_Import_ImportMeta_Url
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -84,7 +84,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -108,11 +108,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::_environment0_Import_ImportMeta_Url
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject::_environment0_Import_ImportMeta_Url
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ImportMeta_Url/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,11 +126,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::_environment0_Import_ImportMeta_Url
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject::_environment0_Import_ImportMeta_Url
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -148,9 +148,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -256,7 +256,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -270,7 +270,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -281,7 +281,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -292,7 +292,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -310,7 +310,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_ImportMeta_Url/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -329,7 +329,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_ImportMeta_Url/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -347,9 +347,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -452,7 +452,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -466,7 +466,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -477,7 +477,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -488,7 +488,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -510,7 +510,7 @@
 				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0018: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, string)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -533,7 +533,7 @@
 				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0014: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, string)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -551,9 +551,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -611,7 +611,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F53969EA_L49C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -635,15 +635,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87::_environment0_Import_ImportMeta_Url
+					IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject::_environment0_Import_ImportMeta_Url
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -654,7 +654,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -665,7 +665,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -678,11 +678,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -696,11 +696,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -718,9 +718,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_F53969EA_L49C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -770,7 +770,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_195CD488_L50C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -794,15 +794,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94::_environment0_Import_ImportMeta_Url
+					IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject::_environment0_Import_ImportMeta_Url
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -813,7 +813,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -824,7 +824,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -837,11 +837,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -855,11 +855,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -877,9 +877,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_195CD488_L50C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -933,7 +933,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D44B8B4D_L60C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -959,18 +959,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::_environment0_Import_ImportMeta_Url
+						IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::_environment0_Import_ImportMeta_Url
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::_environment2_FunctionExpression_L59C9
+						IL_0016: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::_environment2_FunctionExpression_L59C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -981,7 +981,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -992,7 +992,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1005,11 +1005,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1023,11 +1023,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1045,9 +1045,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_D44B8B4D_L60C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1112,7 +1112,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_24DD1933_L59C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1136,15 +1136,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10::_environment0_Import_ImportMeta_Url
+					IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject::_environment0_Import_ImportMeta_Url
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1155,7 +1155,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1166,7 +1166,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1179,14 +1179,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1200,14 +1200,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1225,9 +1225,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_24DD1933_L59C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1249,7 +1249,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87,
+					[4] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -1299,13 +1299,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -1515,7 +1515,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1535,9 +1535,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::_environment0_Import_ImportMeta_Url
+				IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject::_environment0_Import_ImportMeta_Url
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1548,7 +1548,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1559,7 +1559,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1572,14 +1572,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::_environment0_Import_ImportMeta_Url
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject::_environment0_Import_ImportMeta_Url
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1593,14 +1593,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::_environment0_Import_ImportMeta_Url
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject::_environment0_Import_ImportMeta_Url
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1618,9 +1618,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1660,12 +1660,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87,
-				[21] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94,
+				[20] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject,
+				[21] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10
+				[25] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::.ctor()
@@ -1871,13 +1871,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1921,13 +1921,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2097,13 +2097,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -2214,7 +2214,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2234,9 +2234,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::_environment0_Import_ImportMeta_Url
+				IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject::_environment0_Import_ImportMeta_Url
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2247,7 +2247,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2258,7 +2258,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2271,7 +2271,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::_environment0_Import_ImportMeta_Url
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject::_environment0_Import_ImportMeta_Url
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2281,7 +2281,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Import_ImportMeta_Url/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2295,7 +2295,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::_environment0_Import_ImportMeta_Url
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject::_environment0_Import_ImportMeta_Url
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2305,7 +2305,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Import_ImportMeta_Url/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2323,9 +2323,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2437,10 +2437,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url/Scope,
-			[1] class Modules.Import_ImportMeta_Url/__jroc_esm_default/FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default,
-			[2] class Modules.Import_ImportMeta_Url/__jroc_esm_get/FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get,
-			[3] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace,
-			[4] class Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export,
+			[1] class Modules.Import_ImportMeta_Url/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_ImportMeta_Url/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject,
 			[5] object,
 			[6] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule,
 			[7] object,
@@ -2448,7 +2448,7 @@
 			[9] object,
 			[10] object,
 			[11] object[],
-			[12] class Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark,
+			[12] class Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject,
 			[13] object,
 			[14] object,
 			[15] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -2472,13 +2472,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ImportMeta_Url/Scope
-		IL_0022: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::.ctor(class Modules.Import_ImportMeta_Url/Scope)
+		IL_0022: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 12
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 12
@@ -2490,13 +2490,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 11
-		IL_004b: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_default/FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_default/FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -2505,13 +2505,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 11
-		IL_006b: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_get/FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_get/FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -2524,13 +2524,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ImportMeta_Url/Scope
-		IL_0094: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::.ctor(class Modules.Import_ImportMeta_Url/Scope)
+		IL_0094: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -2543,13 +2543,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ImportMeta_Url/Scope
-		IL_00bd: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::.ctor(class Modules.Import_ImportMeta_Url/Scope)
+		IL_00bd: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -2841,7 +2841,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5F55E90D_L3C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2861,9 +2861,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject_FunctionExpression_5F55E90D_L3C34::_environment0_Import_ImportMeta_Url_Lib
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2874,7 +2874,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2885,7 +2885,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2898,11 +2898,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject_FunctionExpression_5F55E90D_L3C34::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2916,11 +2916,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject_FunctionExpression_5F55E90D_L3C34::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2938,9 +2938,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5F55E90D_L3C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2991,7 +2991,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9FE7D048_L4C47
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3011,9 +3011,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject_FunctionExpression_9FE7D048_L4C47::_environment0_Import_ImportMeta_Url_Lib
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3024,7 +3024,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3035,7 +3035,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3048,11 +3048,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject_FunctionExpression_9FE7D048_L4C47::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3066,11 +3066,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject_FunctionExpression_9FE7D048_L4C47::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3088,9 +3088,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_9FE7D048_L4C47
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3141,7 +3141,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_40C0441F_L5C52
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3161,9 +3161,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject_FunctionExpression_40C0441F_L5C52::_environment0_Import_ImportMeta_Url_Lib
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3174,7 +3174,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3185,7 +3185,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3198,11 +3198,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject_FunctionExpression_40C0441F_L5C52::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3216,11 +3216,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject_FunctionExpression_40C0441F_L5C52::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3238,9 +3238,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_40C0441F_L5C52
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3291,7 +3291,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_53921123_L6C48
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3311,9 +3311,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject_FunctionExpression_53921123_L6C48::_environment0_Import_ImportMeta_Url_Lib
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_53921123_L6C48::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3324,7 +3324,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_53921123_L6C48::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3335,7 +3335,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_53921123_L6C48::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3348,11 +3348,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject_FunctionExpression_53921123_L6C48::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_53921123_L6C48::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3366,11 +3366,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject_FunctionExpression_53921123_L6C48::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_53921123_L6C48::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3388,9 +3388,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_53921123_L6C48::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_53921123_L6C48
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3462,7 +3462,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3482,9 +3482,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::_environment0_Import_ImportMeta_Url_Lib
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3495,7 +3495,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3506,7 +3506,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3519,11 +3519,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3537,11 +3537,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3559,9 +3559,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3667,7 +3667,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3681,7 +3681,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3692,7 +3692,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3703,7 +3703,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3721,7 +3721,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3740,7 +3740,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3758,9 +3758,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3863,7 +3863,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3877,7 +3877,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3888,7 +3888,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3899,7 +3899,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3920,7 +3920,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3942,7 +3942,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3960,9 +3960,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4020,7 +4020,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AB4BFBDB_L40C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4044,15 +4044,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_environment0_Import_ImportMeta_Url_Lib
+					IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4063,7 +4063,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4074,7 +4074,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4087,11 +4087,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4105,11 +4105,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4127,9 +4127,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_AB4BFBDB_L40C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4179,7 +4179,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_989F5CDE_L41C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4203,15 +4203,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94::_environment0_Import_ImportMeta_Url_Lib
+					IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4222,7 +4222,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4233,7 +4233,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4246,11 +4246,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4264,11 +4264,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4286,9 +4286,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_989F5CDE_L41C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4342,7 +4342,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2BD4DD7C_L51C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -4368,18 +4368,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_environment0_Import_ImportMeta_Url_Lib
+						IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_environment2_FunctionExpression_L50C9
+						IL_0016: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject::_environment2_FunctionExpression_L50C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -4390,7 +4390,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -4401,7 +4401,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -4414,11 +4414,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -4432,11 +4432,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -4454,9 +4454,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_2BD4DD7C_L51C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -4521,7 +4521,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A9BE71C4_L50C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4545,15 +4545,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10::_environment0_Import_ImportMeta_Url_Lib
+					IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4564,7 +4564,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4575,7 +4575,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4588,14 +4588,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4609,14 +4609,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4634,9 +4634,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_A9BE71C4_L50C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4658,7 +4658,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87,
+					[4] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -4708,13 +4708,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -4924,7 +4924,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4944,9 +4944,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::_environment0_Import_ImportMeta_Url_Lib
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4957,7 +4957,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4968,7 +4968,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4981,14 +4981,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5002,14 +5002,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5027,9 +5027,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5069,12 +5069,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87,
-				[21] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94,
+				[20] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject,
+				[21] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10
+				[25] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -5280,13 +5280,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -5330,13 +5330,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -5506,13 +5506,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -5623,7 +5623,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5643,9 +5643,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::_environment0_Import_ImportMeta_Url_Lib
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5656,7 +5656,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5667,7 +5667,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5680,7 +5680,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -5691,7 +5691,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5705,7 +5705,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::_environment0_Import_ImportMeta_Url_Lib
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_ImportMeta_Url_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -5716,7 +5716,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5734,9 +5734,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5877,18 +5877,18 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url_Lib/Scope,
-			[1] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default,
-			[2] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get,
-			[3] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace,
-			[4] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export,
+			[1] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject,
 			[5] object[],
-			[6] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark,
+			[6] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject,
 			[7] object,
 			[8] object[],
-			[9] class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject_FunctionExpression_5F55E90D_L3C34,
-			[10] class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject_FunctionExpression_9FE7D048_L4C47,
-			[11] class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject_FunctionExpression_40C0441F_L5C52,
-			[12] class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject_FunctionExpression_53921123_L6C48,
+			[9] class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject,
+			[10] class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject,
+			[11] class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject,
+			[12] class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject,
 			[13] bool,
 			[14] object,
 			[15] object
@@ -5910,13 +5910,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0022: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_0022: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 6
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 6
@@ -5928,13 +5928,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 5
-		IL_004b: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -5943,13 +5943,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 5
-		IL_006b: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -5962,13 +5962,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0094: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_0094: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -5981,13 +5981,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_00bd: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_00bd: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -6010,13 +6010,13 @@
 		IL_00fd: ldc.i4.0
 		IL_00fe: ldelem.ref
 		IL_00ff: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0104: newobj instance void Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject_FunctionExpression_5F55E90D_L3C34::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_0104: newobj instance void Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_0109: ldc.i4.0
 		IL_010a: conv.r8
 		IL_010b: ldstr ""
 		IL_0110: ldc.i4.0
 		IL_0111: ldc.i4.1
-		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject_FunctionExpression_5F55E90D_L3C34>(!!0, float64, string, bool, bool)
+		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0117: stloc.s 9
 		IL_0119: ldloc.s 4
 		IL_011b: ldloc.s 5
@@ -6037,13 +6037,13 @@
 		IL_013f: ldc.i4.0
 		IL_0140: ldelem.ref
 		IL_0141: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0146: newobj instance void Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject_FunctionExpression_9FE7D048_L4C47::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_0146: newobj instance void Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_014b: ldc.i4.0
 		IL_014c: conv.r8
 		IL_014d: ldstr ""
 		IL_0152: ldc.i4.0
 		IL_0153: ldc.i4.1
-		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject_FunctionExpression_9FE7D048_L4C47>(!!0, float64, string, bool, bool)
+		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0159: stloc.s 10
 		IL_015b: ldloc.s 4
 		IL_015d: ldloc.s 5
@@ -6064,13 +6064,13 @@
 		IL_0181: ldc.i4.0
 		IL_0182: ldelem.ref
 		IL_0183: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0188: newobj instance void Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject_FunctionExpression_40C0441F_L5C52::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_0188: newobj instance void Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_018d: ldc.i4.0
 		IL_018e: conv.r8
 		IL_018f: ldstr ""
 		IL_0194: ldc.i4.0
 		IL_0195: ldc.i4.1
-		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject_FunctionExpression_40C0441F_L5C52>(!!0, float64, string, bool, bool)
+		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_019b: stloc.s 11
 		IL_019d: ldloc.s 4
 		IL_019f: ldloc.s 5
@@ -6091,13 +6091,13 @@
 		IL_01c3: ldc.i4.0
 		IL_01c4: ldelem.ref
 		IL_01c5: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_01ca: newobj instance void Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject_FunctionExpression_53921123_L6C48::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_01ca: newobj instance void Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_01cf: ldc.i4.0
 		IL_01d0: conv.r8
 		IL_01d1: ldstr ""
 		IL_01d6: ldc.i4.0
 		IL_01d7: ldc.i4.1
-		IL_01d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject_FunctionExpression_53921123_L6C48>(!!0, float64, string, bool, bool)
+		IL_01d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01dd: stloc.s 12
 		IL_01df: ldloc.s 4
 		IL_01e1: ldloc.s 5

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -71,9 +71,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Cycle
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -84,7 +84,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -108,11 +108,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Cycle
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,11 +126,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Cycle
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -148,9 +148,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -256,7 +256,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -270,7 +270,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -281,7 +281,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -292,7 +292,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -310,7 +310,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -329,7 +329,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -347,9 +347,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -452,7 +452,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -466,7 +466,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -477,7 +477,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -488,7 +488,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -510,7 +510,7 @@
 				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0018: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, string)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -533,7 +533,7 @@
 				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0014: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, string)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -551,9 +551,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -611,7 +611,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_24F05EA7_L49C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -635,15 +635,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87::_environment0_Import_LiveBindings_Cycle
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject::_environment0_Import_LiveBindings_Cycle
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -654,7 +654,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -665,7 +665,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -678,11 +678,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -696,11 +696,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -718,9 +718,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_24F05EA7_L49C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -770,7 +770,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_41B20EC9_L50C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -794,15 +794,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94::_environment0_Import_LiveBindings_Cycle
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject::_environment0_Import_LiveBindings_Cycle
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -813,7 +813,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -824,7 +824,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -837,11 +837,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -855,11 +855,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -877,9 +877,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_41B20EC9_L50C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -933,7 +933,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C20CC8F8_L60C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -959,18 +959,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::_environment0_Import_LiveBindings_Cycle
+						IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::_environment0_Import_LiveBindings_Cycle
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::_environment2_FunctionExpression_L59C9
+						IL_0016: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::_environment2_FunctionExpression_L59C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -981,7 +981,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -992,7 +992,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1005,11 +1005,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1023,11 +1023,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1045,9 +1045,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_C20CC8F8_L60C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1112,7 +1112,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EA77382C_L59C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1136,15 +1136,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10::_environment0_Import_LiveBindings_Cycle
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject::_environment0_Import_LiveBindings_Cycle
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1155,7 +1155,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1166,7 +1166,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1179,14 +1179,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1200,14 +1200,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1225,9 +1225,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_EA77382C_L59C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1249,7 +1249,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87,
+					[4] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -1299,13 +1299,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -1515,7 +1515,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1535,9 +1535,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Cycle
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1548,7 +1548,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1559,7 +1559,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1572,14 +1572,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Cycle
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1593,14 +1593,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Cycle
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1618,9 +1618,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1660,12 +1660,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87,
-				[21] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94,
+				[20] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject,
+				[21] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10
+				[25] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::.ctor()
@@ -1871,13 +1871,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1921,13 +1921,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2097,13 +2097,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -2214,7 +2214,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2234,9 +2234,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::_environment0_Import_LiveBindings_Cycle
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Cycle
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2247,7 +2247,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2258,7 +2258,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2271,7 +2271,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::_environment0_Import_LiveBindings_Cycle
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Cycle
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2281,7 +2281,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2295,7 +2295,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::_environment0_Import_LiveBindings_Cycle
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Cycle
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2305,7 +2305,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2323,9 +2323,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2437,14 +2437,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Cycle/Scope,
-			[1] class Modules.Import_LiveBindings_Cycle/__jroc_esm_default/FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default,
-			[2] class Modules.Import_LiveBindings_Cycle/__jroc_esm_get/FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get,
-			[3] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace,
-			[4] class Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export,
+			[1] class Modules.Import_LiveBindings_Cycle/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_LiveBindings_Cycle/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject,
 			[5] object,
 			[6] object,
 			[7] object[],
-			[8] class Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark,
+			[8] class Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject,
 			[9] object,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -2465,13 +2465,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_LiveBindings_Cycle/Scope
-		IL_0022: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Cycle/Scope)
+		IL_0022: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 8
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 8
@@ -2483,13 +2483,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 7
-		IL_004b: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_default/FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_default/FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -2498,13 +2498,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 7
-		IL_006b: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_get/FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_get/FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -2517,13 +2517,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_LiveBindings_Cycle/Scope
-		IL_0094: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Cycle/Scope)
+		IL_0094: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -2536,13 +2536,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_LiveBindings_Cycle/Scope
-		IL_00bd: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Cycle/Scope)
+		IL_00bd: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -2752,7 +2752,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F51DDE75_L3C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2772,9 +2772,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject_FunctionExpression_F51DDE75_L3C24::_environment0_Import_LiveBindings_Cycle_A
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2785,7 +2785,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2796,7 +2796,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2809,11 +2809,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject_FunctionExpression_F51DDE75_L3C24::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2827,11 +2827,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject_FunctionExpression_F51DDE75_L3C24::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2849,9 +2849,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F51DDE75_L3C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2902,7 +2902,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F52E2FA3_L4C27
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2922,9 +2922,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject_FunctionExpression_F52E2FA3_L4C27::_environment0_Import_LiveBindings_Cycle_A
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2935,7 +2935,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2946,7 +2946,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2959,11 +2959,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject_FunctionExpression_F52E2FA3_L4C27::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2977,11 +2977,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject_FunctionExpression_F52E2FA3_L4C27::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2999,9 +2999,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F52E2FA3_L4C27
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3050,7 +3050,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DB677C44_L5C32
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3070,9 +3070,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject_FunctionExpression_DB677C44_L5C32::_environment0_Import_LiveBindings_Cycle_A
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3083,7 +3083,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3094,7 +3094,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3107,11 +3107,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject_FunctionExpression_DB677C44_L5C32::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3125,11 +3125,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject_FunctionExpression_DB677C44_L5C32::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3147,9 +3147,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_DB677C44_L5C32
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3198,7 +3198,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A6850688_incA
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3218,9 +3218,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject_FunctionDeclaration_A6850688_incA::_environment0_Import_LiveBindings_Cycle_A
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3231,7 +3231,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3242,7 +3242,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3255,11 +3255,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject_FunctionDeclaration_A6850688_incA::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle_A/incA::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3273,11 +3273,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject_FunctionDeclaration_A6850688_incA::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle_A/incA::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3295,9 +3295,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A6850688_incA
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3361,7 +3361,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FF39EC14_getBFromA
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3381,9 +3381,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::_environment0_Import_LiveBindings_Cycle_A
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3394,7 +3394,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3405,7 +3405,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3418,11 +3418,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle_A/getBFromA::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3436,11 +3436,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle_A/getBFromA::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3458,9 +3458,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_FF39EC14_getBFromA
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3550,7 +3550,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3570,9 +3570,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_A
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3583,7 +3583,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3594,7 +3594,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3607,11 +3607,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3625,11 +3625,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3647,9 +3647,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3755,7 +3755,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3769,7 +3769,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3780,7 +3780,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3791,7 +3791,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3809,7 +3809,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3828,7 +3828,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3846,9 +3846,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3951,7 +3951,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3965,7 +3965,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3976,7 +3976,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3987,7 +3987,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4009,7 +4009,7 @@
 				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0018: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get::__js_call__(object, object, string)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4032,7 +4032,7 @@
 				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0014: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get::__js_call__(object, object, string)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4050,9 +4050,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4110,7 +4110,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3611CC4D_L47C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4134,15 +4134,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87::_environment0_Import_LiveBindings_Cycle_A
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4153,7 +4153,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4164,7 +4164,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4177,11 +4177,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4195,11 +4195,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4217,9 +4217,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_3611CC4D_L47C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4269,7 +4269,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_675FF296_L48C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4293,15 +4293,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94::_environment0_Import_LiveBindings_Cycle_A
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4312,7 +4312,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4323,7 +4323,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4336,11 +4336,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4354,11 +4354,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4376,9 +4376,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_675FF296_L48C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4432,7 +4432,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_ECD7FE35_L58C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -4458,18 +4458,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::_environment0_Import_LiveBindings_Cycle_A
+						IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::_environment2_FunctionExpression_L57C9
+						IL_0016: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::_environment2_FunctionExpression_L57C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -4480,7 +4480,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -4491,7 +4491,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -4504,11 +4504,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -4522,11 +4522,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -4544,9 +4544,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_ECD7FE35_L58C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -4611,7 +4611,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F16F71B4_L57C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4635,15 +4635,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10::_environment0_Import_LiveBindings_Cycle_A
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4654,7 +4654,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4665,7 +4665,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4678,14 +4678,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4699,14 +4699,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4724,9 +4724,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_F16F71B4_L57C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4748,7 +4748,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87,
+					[4] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -4798,13 +4798,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -5014,7 +5014,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5034,9 +5034,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_A
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5047,7 +5047,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5058,7 +5058,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5071,14 +5071,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5092,14 +5092,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5117,9 +5117,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5159,12 +5159,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87,
-				[21] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94,
+				[20] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject,
+				[21] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10
+				[25] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::.ctor()
@@ -5370,13 +5370,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -5420,13 +5420,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -5596,13 +5596,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -5713,7 +5713,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5733,9 +5733,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_A
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5746,7 +5746,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5757,7 +5757,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5770,7 +5770,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -5781,7 +5781,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5795,7 +5795,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_A
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Cycle_A
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -5806,7 +5806,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5824,9 +5824,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5948,19 +5948,19 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Cycle_A/Scope,
-			[1] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default/FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default,
-			[2] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace,
-			[3] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export,
+			[1] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject,
+			[3] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject,
 			[4] object[],
-			[5] class Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject_FunctionDeclaration_A6850688_incA,
-			[6] class Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject_FunctionDeclaration_FF39EC14_getBFromA,
-			[7] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark,
-			[8] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get/FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get,
+			[5] class Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject,
+			[6] class Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject,
+			[7] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject,
+			[8] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get/FunctionObject,
 			[9] object,
 			[10] object[],
-			[11] class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject_FunctionExpression_F51DDE75_L3C24,
-			[12] class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject_FunctionExpression_F52E2FA3_L4C27,
-			[13] class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject_FunctionExpression_DB677C44_L5C32
+			[11] class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject,
+			[12] class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject,
+			[13] class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle_A/Scope::.ctor()
@@ -5979,13 +5979,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0022: newobj instance void Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject_FunctionDeclaration_A6850688_incA::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_0022: newobj instance void Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "incA"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject_FunctionDeclaration_A6850688_incA>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 5
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 5
@@ -6001,13 +6001,13 @@
 		IL_004d: ldc.i4.0
 		IL_004e: ldelem.ref
 		IL_004f: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0054: newobj instance void Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_0054: newobj instance void Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr "getBFromA"
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject_FunctionDeclaration_FF39EC14_getBFromA>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 6
 		IL_0069: ldloc.0
 		IL_006a: ldloc.s 6
@@ -6023,13 +6023,13 @@
 		IL_007f: ldc.i4.0
 		IL_0080: ldelem.ref
 		IL_0081: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0086: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_0086: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_008b: ldc.i4.0
 		IL_008c: conv.r8
 		IL_008d: ldstr "__jroc_esm_mark"
 		IL_0092: ldc.i4.0
 		IL_0093: ldc.i4.1
-		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0099: stloc.s 7
 		IL_009b: ldloc.0
 		IL_009c: ldloc.s 7
@@ -6041,13 +6041,13 @@
 		IL_00ab: ldloc.0
 		IL_00ac: stelem.ref
 		IL_00ad: stloc.s 4
-		IL_00af: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default/FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::.ctor()
+		IL_00af: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default/FunctionObject::.ctor()
 		IL_00b4: ldc.i4.1
 		IL_00b5: conv.r8
 		IL_00b6: ldstr "__jroc_esm_default"
 		IL_00bb: ldc.i4.0
 		IL_00bc: ldc.i4.1
-		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default/FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c2: stloc.1
 		IL_00c3: ldc.i4.1
 		IL_00c4: newarr [System.Runtime]System.Object
@@ -6056,13 +6056,13 @@
 		IL_00cb: ldloc.0
 		IL_00cc: stelem.ref
 		IL_00cd: stloc.s 4
-		IL_00cf: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get/FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::.ctor()
+		IL_00cf: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get/FunctionObject::.ctor()
 		IL_00d4: ldc.i4.2
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "__jroc_esm_get"
 		IL_00db: ldc.i4.0
 		IL_00dc: ldc.i4.1
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get/FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00e2: stloc.s 8
 		IL_00e4: ldloc.0
 		IL_00e5: ldloc.s 8
@@ -6078,13 +6078,13 @@
 		IL_00fa: ldc.i4.0
 		IL_00fb: ldelem.ref
 		IL_00fc: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0101: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_0101: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_0106: ldc.i4.1
 		IL_0107: conv.r8
 		IL_0108: ldstr "__jroc_esm_namespace"
 		IL_010d: ldc.i4.0
 		IL_010e: ldc.i4.1
-		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0114: stloc.2
 		IL_0115: ldc.i4.1
 		IL_0116: newarr [System.Runtime]System.Object
@@ -6097,13 +6097,13 @@
 		IL_0123: ldc.i4.0
 		IL_0124: ldelem.ref
 		IL_0125: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_012a: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_012a: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_012f: ldc.i4.2
 		IL_0130: conv.r8
 		IL_0131: ldstr "__jroc_esm_export"
 		IL_0136: ldc.i4.0
 		IL_0137: ldc.i4.1
-		IL_0138: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_0138: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_013d: stloc.3
 		IL_013e: nop
 		IL_013f: ldloc.0
@@ -6126,13 +6126,13 @@
 		IL_0169: ldc.i4.0
 		IL_016a: ldelem.ref
 		IL_016b: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0170: newobj instance void Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject_FunctionExpression_F51DDE75_L3C24::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_0170: newobj instance void Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_0175: ldc.i4.0
 		IL_0176: conv.r8
 		IL_0177: ldstr ""
 		IL_017c: ldc.i4.0
 		IL_017d: ldc.i4.1
-		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject_FunctionExpression_F51DDE75_L3C24>(!!0, float64, string, bool, bool)
+		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0183: stloc.s 11
 		IL_0185: ldloc.3
 		IL_0186: ldloc.s 4
@@ -6153,13 +6153,13 @@
 		IL_01aa: ldc.i4.0
 		IL_01ab: ldelem.ref
 		IL_01ac: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_01b1: newobj instance void Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject_FunctionExpression_F52E2FA3_L4C27::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_01b1: newobj instance void Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_01b6: ldc.i4.0
 		IL_01b7: conv.r8
 		IL_01b8: ldstr ""
 		IL_01bd: ldc.i4.0
 		IL_01be: ldc.i4.1
-		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject_FunctionExpression_F52E2FA3_L4C27>(!!0, float64, string, bool, bool)
+		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01c4: stloc.s 12
 		IL_01c6: ldloc.3
 		IL_01c7: ldloc.s 4
@@ -6180,13 +6180,13 @@
 		IL_01eb: ldc.i4.0
 		IL_01ec: ldelem.ref
 		IL_01ed: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_01f2: newobj instance void Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject_FunctionExpression_DB677C44_L5C32::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_01f2: newobj instance void Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_01f7: ldc.i4.0
 		IL_01f8: conv.r8
 		IL_01f9: ldstr ""
 		IL_01fe: ldc.i4.0
 		IL_01ff: ldc.i4.1
-		IL_0200: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject_FunctionExpression_DB677C44_L5C32>(!!0, float64, string, bool, bool)
+		IL_0200: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0205: stloc.s 13
 		IL_0207: ldloc.3
 		IL_0208: ldloc.s 4
@@ -6237,7 +6237,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C9BC5402_L3C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6257,9 +6257,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject_FunctionExpression_C9BC5402_L3C24::_environment0_Import_LiveBindings_Cycle_B
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6270,7 +6270,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6281,7 +6281,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6294,11 +6294,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject_FunctionExpression_C9BC5402_L3C24::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6312,11 +6312,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject_FunctionExpression_C9BC5402_L3C24::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6334,9 +6334,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C9BC5402_L3C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6387,7 +6387,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_80025DF0_L4C27
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6407,9 +6407,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject_FunctionExpression_80025DF0_L4C27::_environment0_Import_LiveBindings_Cycle_B
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6420,7 +6420,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6431,7 +6431,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6444,11 +6444,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject_FunctionExpression_80025DF0_L4C27::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6462,11 +6462,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject_FunctionExpression_80025DF0_L4C27::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6484,9 +6484,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_80025DF0_L4C27
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6535,7 +6535,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0C08ABDF_L5C32
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6555,9 +6555,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject_FunctionExpression_0C08ABDF_L5C32::_environment0_Import_LiveBindings_Cycle_B
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6568,7 +6568,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6579,7 +6579,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6592,11 +6592,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject_FunctionExpression_0C08ABDF_L5C32::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6610,11 +6610,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject_FunctionExpression_0C08ABDF_L5C32::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6632,9 +6632,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_0C08ABDF_L5C32
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6683,7 +6683,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ED85635A_incB
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6703,9 +6703,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject_FunctionDeclaration_ED85635A_incB::_environment0_Import_LiveBindings_Cycle_B
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6716,7 +6716,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6727,7 +6727,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6740,11 +6740,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject_FunctionDeclaration_ED85635A_incB::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle_B/incB::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6758,11 +6758,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject_FunctionDeclaration_ED85635A_incB::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle_B/incB::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6780,9 +6780,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_ED85635A_incB
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6846,7 +6846,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DB44C203_getAFromB
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6866,9 +6866,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject_FunctionDeclaration_DB44C203_getAFromB::_environment0_Import_LiveBindings_Cycle_B
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6879,7 +6879,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6890,7 +6890,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6903,11 +6903,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject_FunctionDeclaration_DB44C203_getAFromB::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle_B/getAFromB::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6921,11 +6921,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject_FunctionDeclaration_DB44C203_getAFromB::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle_B/getAFromB::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6943,9 +6943,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DB44C203_getAFromB
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7035,7 +7035,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -7055,9 +7055,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_B
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7068,7 +7068,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7079,7 +7079,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7092,11 +7092,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7110,11 +7110,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7132,9 +7132,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7240,7 +7240,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -7254,7 +7254,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7265,7 +7265,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7276,7 +7276,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7294,7 +7294,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7313,7 +7313,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7331,9 +7331,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7436,7 +7436,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -7450,7 +7450,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7461,7 +7461,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7472,7 +7472,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7494,7 +7494,7 @@
 				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0018: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get::__js_call__(object, object, string)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7517,7 +7517,7 @@
 				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0014: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get::__js_call__(object, object, string)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7535,9 +7535,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7595,7 +7595,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C63EA5BE_L47C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -7619,15 +7619,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87::_environment0_Import_LiveBindings_Cycle_B
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -7638,7 +7638,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -7649,7 +7649,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -7662,11 +7662,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -7680,11 +7680,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -7702,9 +7702,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_C63EA5BE_L47C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -7754,7 +7754,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AFA10769_L48C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -7778,15 +7778,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94::_environment0_Import_LiveBindings_Cycle_B
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -7797,7 +7797,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -7808,7 +7808,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -7821,11 +7821,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -7839,11 +7839,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -7861,9 +7861,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_AFA10769_L48C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -7917,7 +7917,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CF15D56A_L58C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -7943,18 +7943,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::_environment0_Import_LiveBindings_Cycle_B
+						IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::_environment2_FunctionExpression_L57C9
+						IL_0016: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::_environment2_FunctionExpression_L57C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -7965,7 +7965,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -7976,7 +7976,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -7989,11 +7989,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -8007,11 +8007,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -8029,9 +8029,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_CF15D56A_L58C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -8096,7 +8096,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D61C0121_L57C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -8120,15 +8120,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10::_environment0_Import_LiveBindings_Cycle_B
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -8139,7 +8139,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -8150,7 +8150,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -8163,14 +8163,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -8184,14 +8184,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -8209,9 +8209,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_D61C0121_L57C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -8233,7 +8233,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87,
+					[4] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -8283,13 +8283,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -8499,7 +8499,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8519,9 +8519,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_B
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8532,7 +8532,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8543,7 +8543,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8556,14 +8556,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8577,14 +8577,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8602,9 +8602,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8644,12 +8644,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87,
-				[21] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94,
+				[20] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject,
+				[21] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10
+				[25] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::.ctor()
@@ -8855,13 +8855,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -8905,13 +8905,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -9081,13 +9081,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -9198,7 +9198,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -9218,9 +9218,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_B
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9231,7 +9231,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9242,7 +9242,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9255,7 +9255,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -9266,7 +9266,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9280,7 +9280,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_B
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Cycle_B
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -9291,7 +9291,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -9309,9 +9309,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -9433,19 +9433,19 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Cycle_B/Scope,
-			[1] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default/FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default,
-			[2] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace,
-			[3] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export,
+			[1] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject,
+			[3] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject,
 			[4] object[],
-			[5] class Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject_FunctionDeclaration_ED85635A_incB,
-			[6] class Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject_FunctionDeclaration_DB44C203_getAFromB,
-			[7] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark,
-			[8] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get/FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get,
+			[5] class Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject,
+			[6] class Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject,
+			[7] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject,
+			[8] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get/FunctionObject,
 			[9] object,
 			[10] object[],
-			[11] class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject_FunctionExpression_C9BC5402_L3C24,
-			[12] class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject_FunctionExpression_80025DF0_L4C27,
-			[13] class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject_FunctionExpression_0C08ABDF_L5C32
+			[11] class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject,
+			[12] class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject,
+			[13] class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle_B/Scope::.ctor()
@@ -9464,13 +9464,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0022: newobj instance void Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject_FunctionDeclaration_ED85635A_incB::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_0022: newobj instance void Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "incB"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject_FunctionDeclaration_ED85635A_incB>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 5
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 5
@@ -9486,13 +9486,13 @@
 		IL_004d: ldc.i4.0
 		IL_004e: ldelem.ref
 		IL_004f: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0054: newobj instance void Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject_FunctionDeclaration_DB44C203_getAFromB::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_0054: newobj instance void Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr "getAFromB"
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject_FunctionDeclaration_DB44C203_getAFromB>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 6
 		IL_0069: ldloc.0
 		IL_006a: ldloc.s 6
@@ -9508,13 +9508,13 @@
 		IL_007f: ldc.i4.0
 		IL_0080: ldelem.ref
 		IL_0081: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0086: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_0086: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_008b: ldc.i4.0
 		IL_008c: conv.r8
 		IL_008d: ldstr "__jroc_esm_mark"
 		IL_0092: ldc.i4.0
 		IL_0093: ldc.i4.1
-		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0099: stloc.s 7
 		IL_009b: ldloc.0
 		IL_009c: ldloc.s 7
@@ -9526,13 +9526,13 @@
 		IL_00ab: ldloc.0
 		IL_00ac: stelem.ref
 		IL_00ad: stloc.s 4
-		IL_00af: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default/FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::.ctor()
+		IL_00af: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default/FunctionObject::.ctor()
 		IL_00b4: ldc.i4.1
 		IL_00b5: conv.r8
 		IL_00b6: ldstr "__jroc_esm_default"
 		IL_00bb: ldc.i4.0
 		IL_00bc: ldc.i4.1
-		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default/FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c2: stloc.1
 		IL_00c3: ldc.i4.1
 		IL_00c4: newarr [System.Runtime]System.Object
@@ -9541,13 +9541,13 @@
 		IL_00cb: ldloc.0
 		IL_00cc: stelem.ref
 		IL_00cd: stloc.s 4
-		IL_00cf: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get/FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::.ctor()
+		IL_00cf: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get/FunctionObject::.ctor()
 		IL_00d4: ldc.i4.2
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "__jroc_esm_get"
 		IL_00db: ldc.i4.0
 		IL_00dc: ldc.i4.1
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get/FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00e2: stloc.s 8
 		IL_00e4: ldloc.0
 		IL_00e5: ldloc.s 8
@@ -9563,13 +9563,13 @@
 		IL_00fa: ldc.i4.0
 		IL_00fb: ldelem.ref
 		IL_00fc: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0101: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_0101: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_0106: ldc.i4.1
 		IL_0107: conv.r8
 		IL_0108: ldstr "__jroc_esm_namespace"
 		IL_010d: ldc.i4.0
 		IL_010e: ldc.i4.1
-		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0114: stloc.2
 		IL_0115: ldc.i4.1
 		IL_0116: newarr [System.Runtime]System.Object
@@ -9582,13 +9582,13 @@
 		IL_0123: ldc.i4.0
 		IL_0124: ldelem.ref
 		IL_0125: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_012a: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_012a: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_012f: ldc.i4.2
 		IL_0130: conv.r8
 		IL_0131: ldstr "__jroc_esm_export"
 		IL_0136: ldc.i4.0
 		IL_0137: ldc.i4.1
-		IL_0138: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_0138: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_013d: stloc.3
 		IL_013e: nop
 		IL_013f: ldloc.0
@@ -9611,13 +9611,13 @@
 		IL_0169: ldc.i4.0
 		IL_016a: ldelem.ref
 		IL_016b: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0170: newobj instance void Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject_FunctionExpression_C9BC5402_L3C24::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_0170: newobj instance void Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_0175: ldc.i4.0
 		IL_0176: conv.r8
 		IL_0177: ldstr ""
 		IL_017c: ldc.i4.0
 		IL_017d: ldc.i4.1
-		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject_FunctionExpression_C9BC5402_L3C24>(!!0, float64, string, bool, bool)
+		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0183: stloc.s 11
 		IL_0185: ldloc.3
 		IL_0186: ldloc.s 4
@@ -9638,13 +9638,13 @@
 		IL_01aa: ldc.i4.0
 		IL_01ab: ldelem.ref
 		IL_01ac: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_01b1: newobj instance void Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject_FunctionExpression_80025DF0_L4C27::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_01b1: newobj instance void Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_01b6: ldc.i4.0
 		IL_01b7: conv.r8
 		IL_01b8: ldstr ""
 		IL_01bd: ldc.i4.0
 		IL_01be: ldc.i4.1
-		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject_FunctionExpression_80025DF0_L4C27>(!!0, float64, string, bool, bool)
+		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01c4: stloc.s 12
 		IL_01c6: ldloc.3
 		IL_01c7: ldloc.s 4
@@ -9665,13 +9665,13 @@
 		IL_01eb: ldc.i4.0
 		IL_01ec: ldelem.ref
 		IL_01ed: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_01f2: newobj instance void Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject_FunctionExpression_0C08ABDF_L5C32::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_01f2: newobj instance void Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_01f7: ldc.i4.0
 		IL_01f8: conv.r8
 		IL_01f9: ldstr ""
 		IL_01fe: ldc.i4.0
 		IL_01ff: ldc.i4.1
-		IL_0200: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject_FunctionExpression_0C08ABDF_L5C32>(!!0, float64, string, bool, bool)
+		IL_0200: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0205: stloc.s 13
 		IL_0207: ldloc.3
 		IL_0208: ldloc.s 4

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -71,9 +71,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::_environment0_Import_LiveBindings_Named
+				IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Named
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -84,7 +84,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -108,11 +108,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::_environment0_Import_LiveBindings_Named
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Named
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Named/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,11 +126,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::_environment0_Import_LiveBindings_Named
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Named
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -148,9 +148,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -256,7 +256,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -270,7 +270,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -281,7 +281,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -292,7 +292,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -310,7 +310,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_LiveBindings_Named/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -329,7 +329,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_LiveBindings_Named/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -347,9 +347,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -452,7 +452,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -466,7 +466,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -477,7 +477,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -488,7 +488,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -510,7 +510,7 @@
 				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0018: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, string)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -533,7 +533,7 @@
 				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0014: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, string)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -551,9 +551,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -611,7 +611,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_10552A8E_L38C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -635,15 +635,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87::_environment0_Import_LiveBindings_Named
+					IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_environment0_Import_LiveBindings_Named
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -654,7 +654,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -665,7 +665,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -678,11 +678,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -696,11 +696,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -718,9 +718,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_10552A8E_L38C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -770,7 +770,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2301C98B_L39C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -794,15 +794,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94::_environment0_Import_LiveBindings_Named
+					IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_environment0_Import_LiveBindings_Named
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -813,7 +813,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -824,7 +824,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -837,11 +837,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -855,11 +855,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -877,9 +877,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_2301C98B_L39C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -933,7 +933,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EB245588_L49C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -959,18 +959,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::_environment0_Import_LiveBindings_Named
+						IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment0_Import_LiveBindings_Named
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::_environment2_FunctionExpression_L48C9
+						IL_0016: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment2_FunctionExpression_L48C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -981,7 +981,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -992,7 +992,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1005,11 +1005,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1023,11 +1023,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1045,9 +1045,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_EB245588_L49C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1112,7 +1112,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C05233E5_L48C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1136,15 +1136,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10::_environment0_Import_LiveBindings_Named
+					IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_environment0_Import_LiveBindings_Named
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1155,7 +1155,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1166,7 +1166,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1179,14 +1179,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1200,14 +1200,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1225,9 +1225,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_C05233E5_L48C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1249,7 +1249,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87,
+					[4] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -1299,13 +1299,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -1515,7 +1515,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1535,9 +1535,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::_environment0_Import_LiveBindings_Named
+				IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Named
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1548,7 +1548,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1559,7 +1559,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1572,14 +1572,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::_environment0_Import_LiveBindings_Named
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Named
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1593,14 +1593,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::_environment0_Import_LiveBindings_Named
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Named
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1618,9 +1618,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1660,12 +1660,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87,
-				[21] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94,
+				[20] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject,
+				[21] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10
+				[25] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::.ctor()
@@ -1871,13 +1871,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1921,13 +1921,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2097,13 +2097,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -2214,7 +2214,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2234,9 +2234,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::_environment0_Import_LiveBindings_Named
+				IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Named
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2247,7 +2247,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2258,7 +2258,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2271,7 +2271,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::_environment0_Import_LiveBindings_Named
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Named
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2281,7 +2281,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Import_LiveBindings_Named/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2295,7 +2295,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::_environment0_Import_LiveBindings_Named
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Named
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2305,7 +2305,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Import_LiveBindings_Named/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2323,9 +2323,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2437,13 +2437,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Named/Scope,
-			[1] class Modules.Import_LiveBindings_Named/__jroc_esm_default/FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default,
-			[2] class Modules.Import_LiveBindings_Named/__jroc_esm_get/FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get,
-			[3] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace,
-			[4] class Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export,
+			[1] class Modules.Import_LiveBindings_Named/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_LiveBindings_Named/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark,
+			[7] class Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject,
 			[8] object,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -2464,13 +2464,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_LiveBindings_Named/Scope
-		IL_0022: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Named/Scope)
+		IL_0022: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -2482,13 +2482,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_default/FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_default/FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -2497,13 +2497,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_get/FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_get/FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -2516,13 +2516,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_LiveBindings_Named/Scope
-		IL_0094: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Named/Scope)
+		IL_0094: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -2535,13 +2535,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_LiveBindings_Named/Scope
-		IL_00bd: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Named/Scope)
+		IL_00bd: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -2629,7 +2629,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_66DDEB30_L3C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2649,9 +2649,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_66DDEB30_L3C24::_environment0_Import_LiveBindings_Named_Lib
+				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2662,7 +2662,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2673,7 +2673,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2686,11 +2686,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_66DDEB30_L3C24::_environment0_Import_LiveBindings_Named_Lib
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2704,11 +2704,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_66DDEB30_L3C24::_environment0_Import_LiveBindings_Named_Lib
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2726,9 +2726,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_66DDEB30_L3C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2779,7 +2779,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0FCF6501_L4C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2799,9 +2799,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_0FCF6501_L4C26::_environment0_Import_LiveBindings_Named_Lib
+				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2812,7 +2812,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2823,7 +2823,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2836,11 +2836,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_0FCF6501_L4C26::_environment0_Import_LiveBindings_Named_Lib
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2854,11 +2854,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_0FCF6501_L4C26::_environment0_Import_LiveBindings_Named_Lib
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2876,9 +2876,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_0FCF6501_L4C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2927,7 +2927,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AF3BD2AE_inc
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2947,9 +2947,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject_FunctionDeclaration_AF3BD2AE_inc::_environment0_Import_LiveBindings_Named_Lib
+				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2960,7 +2960,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2971,7 +2971,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2984,11 +2984,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject_FunctionDeclaration_AF3BD2AE_inc::_environment0_Import_LiveBindings_Named_Lib
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Named_Lib/inc::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3002,11 +3002,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject_FunctionDeclaration_AF3BD2AE_inc::_environment0_Import_LiveBindings_Named_Lib
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Named_Lib/inc::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3024,9 +3024,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_AF3BD2AE_inc
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3111,7 +3111,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3131,9 +3131,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::_environment0_Import_LiveBindings_Named_Lib
+				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3144,7 +3144,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3155,7 +3155,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3168,11 +3168,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::_environment0_Import_LiveBindings_Named_Lib
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3186,11 +3186,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::_environment0_Import_LiveBindings_Named_Lib
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3208,9 +3208,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3316,7 +3316,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3330,7 +3330,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3341,7 +3341,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3352,7 +3352,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3370,7 +3370,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3389,7 +3389,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3407,9 +3407,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3512,7 +3512,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3526,7 +3526,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3537,7 +3537,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3548,7 +3548,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3569,7 +3569,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3591,7 +3591,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3609,9 +3609,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3669,7 +3669,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F24EF04E_L38C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3693,15 +3693,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87::_environment0_Import_LiveBindings_Named_Lib
+					IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3712,7 +3712,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3723,7 +3723,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3736,11 +3736,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3754,11 +3754,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3776,9 +3776,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_F24EF04E_L38C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3828,7 +3828,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_04FB8F4B_L39C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3852,15 +3852,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94::_environment0_Import_LiveBindings_Named_Lib
+					IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3871,7 +3871,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3882,7 +3882,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3895,11 +3895,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3913,11 +3913,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3935,9 +3935,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_04FB8F4B_L39C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3991,7 +3991,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E975A0C8_L49C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -4017,18 +4017,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::_environment0_Import_LiveBindings_Named_Lib
+						IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::_environment2_FunctionExpression_L48C9
+						IL_0016: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment2_FunctionExpression_L48C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -4039,7 +4039,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -4050,7 +4050,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -4063,11 +4063,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -4081,11 +4081,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -4103,9 +4103,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_E975A0C8_L49C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -4170,7 +4170,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3B7B1C25_L48C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4194,15 +4194,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10::_environment0_Import_LiveBindings_Named_Lib
+					IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4213,7 +4213,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4224,7 +4224,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4237,14 +4237,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4258,14 +4258,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4283,9 +4283,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_3B7B1C25_L48C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4307,7 +4307,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87,
+					[4] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -4357,13 +4357,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -4573,7 +4573,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4593,9 +4593,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::_environment0_Import_LiveBindings_Named_Lib
+				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4606,7 +4606,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4617,7 +4617,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4630,14 +4630,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::_environment0_Import_LiveBindings_Named_Lib
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4651,14 +4651,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::_environment0_Import_LiveBindings_Named_Lib
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4676,9 +4676,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4718,12 +4718,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87,
-				[21] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94,
+				[20] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject,
+				[21] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10
+				[25] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -4929,13 +4929,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -4979,13 +4979,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -5155,13 +5155,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -5272,7 +5272,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5292,9 +5292,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::_environment0_Import_LiveBindings_Named_Lib
+				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5305,7 +5305,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5316,7 +5316,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5329,7 +5329,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::_environment0_Import_LiveBindings_Named_Lib
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -5340,7 +5340,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5354,7 +5354,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::_environment0_Import_LiveBindings_Named_Lib
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_LiveBindings_Named_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -5365,7 +5365,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5383,9 +5383,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5503,17 +5503,17 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Named_Lib/Scope,
-			[1] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default,
-			[2] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get,
-			[3] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace,
-			[4] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export,
+			[1] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject,
 			[5] object[],
-			[6] class Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject_FunctionDeclaration_AF3BD2AE_inc,
-			[7] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark,
+			[6] class Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject,
+			[7] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject,
 			[8] object,
 			[9] object[],
-			[10] class Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_66DDEB30_L3C24,
-			[11] class Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_0FCF6501_L4C26
+			[10] class Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject,
+			[11] class Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_LiveBindings_Named_Lib/Scope::.ctor()
@@ -5532,13 +5532,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0022: newobj instance void Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject_FunctionDeclaration_AF3BD2AE_inc::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
+		IL_0022: newobj instance void Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "inc"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject_FunctionDeclaration_AF3BD2AE_inc>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 6
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 6
@@ -5554,13 +5554,13 @@
 		IL_004d: ldc.i4.0
 		IL_004e: ldelem.ref
 		IL_004f: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0054: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
+		IL_0054: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr "__jroc_esm_mark"
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 7
 		IL_0069: ldloc.0
 		IL_006a: ldloc.s 7
@@ -5572,13 +5572,13 @@
 		IL_0079: ldloc.0
 		IL_007a: stelem.ref
 		IL_007b: stloc.s 5
-		IL_007d: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::.ctor()
+		IL_007d: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0082: ldc.i4.1
 		IL_0083: conv.r8
 		IL_0084: ldstr "__jroc_esm_default"
 		IL_0089: ldc.i4.0
 		IL_008a: ldc.i4.1
-		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0090: stloc.1
 		IL_0091: ldc.i4.1
 		IL_0092: newarr [System.Runtime]System.Object
@@ -5587,13 +5587,13 @@
 		IL_0099: ldloc.0
 		IL_009a: stelem.ref
 		IL_009b: stloc.s 5
-		IL_009d: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::.ctor()
+		IL_009d: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get/FunctionObject::.ctor()
 		IL_00a2: ldc.i4.2
 		IL_00a3: conv.r8
 		IL_00a4: ldstr "__jroc_esm_get"
 		IL_00a9: ldc.i4.0
 		IL_00aa: ldc.i4.1
-		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00b0: stloc.2
 		IL_00b1: ldc.i4.1
 		IL_00b2: newarr [System.Runtime]System.Object
@@ -5606,13 +5606,13 @@
 		IL_00bf: ldc.i4.0
 		IL_00c0: ldelem.ref
 		IL_00c1: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_00c6: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
+		IL_00c6: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
 		IL_00cb: ldc.i4.1
 		IL_00cc: conv.r8
 		IL_00cd: ldstr "__jroc_esm_namespace"
 		IL_00d2: ldc.i4.0
 		IL_00d3: ldc.i4.1
-		IL_00d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d9: stloc.3
 		IL_00da: ldc.i4.1
 		IL_00db: newarr [System.Runtime]System.Object
@@ -5625,13 +5625,13 @@
 		IL_00e8: ldc.i4.0
 		IL_00e9: ldelem.ref
 		IL_00ea: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_00ef: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
+		IL_00ef: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
 		IL_00f4: ldc.i4.2
 		IL_00f5: conv.r8
 		IL_00f6: ldstr "__jroc_esm_export"
 		IL_00fb: ldc.i4.0
 		IL_00fc: ldc.i4.1
-		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0102: stloc.s 4
 		IL_0104: nop
 		IL_0105: ldloc.0
@@ -5654,13 +5654,13 @@
 		IL_012f: ldc.i4.0
 		IL_0130: ldelem.ref
 		IL_0131: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0136: newobj instance void Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_66DDEB30_L3C24::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
+		IL_0136: newobj instance void Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
 		IL_013b: ldc.i4.0
 		IL_013c: conv.r8
 		IL_013d: ldstr ""
 		IL_0142: ldc.i4.0
 		IL_0143: ldc.i4.1
-		IL_0144: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_66DDEB30_L3C24>(!!0, float64, string, bool, bool)
+		IL_0144: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0149: stloc.s 10
 		IL_014b: ldloc.s 4
 		IL_014d: ldloc.s 5
@@ -5681,13 +5681,13 @@
 		IL_0171: ldc.i4.0
 		IL_0172: ldelem.ref
 		IL_0173: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0178: newobj instance void Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_0FCF6501_L4C26::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
+		IL_0178: newobj instance void Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
 		IL_017d: ldc.i4.0
 		IL_017e: conv.r8
 		IL_017f: ldstr ""
 		IL_0184: ldc.i4.0
 		IL_0185: ldc.i4.1
-		IL_0186: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_0FCF6501_L4C26>(!!0, float64, string, bool, bool)
+		IL_0186: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_018b: stloc.s 11
 		IL_018d: ldloc.s 4
 		IL_018f: ldloc.s 5

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -71,9 +71,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -84,7 +84,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -108,11 +108,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,11 +126,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -148,9 +148,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -256,7 +256,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -270,7 +270,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -281,7 +281,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -292,7 +292,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -310,7 +310,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -329,7 +329,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -347,9 +347,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -452,7 +452,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -466,7 +466,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -477,7 +477,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -488,7 +488,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -509,7 +509,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -531,7 +531,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -549,9 +549,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -609,7 +609,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_006DDFD4_L45C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -633,15 +633,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87::_environment0_Import_Namespace_Esm_Basic
+					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -652,7 +652,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -663,7 +663,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -676,11 +676,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -694,11 +694,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -716,9 +716,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_006DDFD4_L45C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -768,7 +768,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_61BBEADB_L46C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -792,15 +792,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94::_environment0_Import_Namespace_Esm_Basic
+					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -811,7 +811,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -822,7 +822,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -835,11 +835,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -853,11 +853,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -875,9 +875,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_61BBEADB_L46C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -931,7 +931,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7839B813_L56C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -957,18 +957,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::_environment0_Import_Namespace_Esm_Basic
+						IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::_environment2_FunctionExpression_L55C9
+						IL_0016: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject::_environment2_FunctionExpression_L55C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -979,7 +979,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -990,7 +990,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1003,11 +1003,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1021,11 +1021,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1043,9 +1043,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_7839B813_L56C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1110,7 +1110,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CCE895B8_L55C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1134,15 +1134,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10::_environment0_Import_Namespace_Esm_Basic
+					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1153,7 +1153,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1164,7 +1164,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1177,14 +1177,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1198,14 +1198,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1223,9 +1223,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_CCE895B8_L55C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1247,7 +1247,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87,
+					[4] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -1297,13 +1297,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -1513,7 +1513,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1533,9 +1533,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1546,7 +1546,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1557,7 +1557,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1570,14 +1570,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1591,14 +1591,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1616,9 +1616,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1658,12 +1658,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87,
-				[21] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94,
+				[20] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject,
+				[21] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10
+				[25] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::.ctor()
@@ -1869,13 +1869,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1919,13 +1919,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2095,13 +2095,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -2212,7 +2212,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2232,9 +2232,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2245,7 +2245,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2256,7 +2256,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2269,7 +2269,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2279,7 +2279,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2293,7 +2293,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_Esm_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2303,7 +2303,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2321,9 +2321,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2435,14 +2435,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_Esm_Basic/Scope,
-			[1] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_default/FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default,
-			[2] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_get/FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get,
-			[3] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace,
-			[4] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export,
+			[1] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject,
 			[5] object,
 			[6] object,
 			[7] object[],
-			[8] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark,
+			[8] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject,
 			[9] object,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -2463,13 +2463,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_Namespace_Esm_Basic/Scope
-		IL_0022: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope)
+		IL_0022: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 8
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 8
@@ -2481,13 +2481,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 7
-		IL_004b: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_default/FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_default/FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -2496,13 +2496,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 7
-		IL_006b: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_get/FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_get/FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -2515,13 +2515,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_Namespace_Esm_Basic/Scope
-		IL_0094: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope)
+		IL_0094: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -2534,13 +2534,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_Namespace_Esm_Basic/Scope
-		IL_00bd: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope)
+		IL_00bd: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -2730,7 +2730,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_359263CA_L3C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2750,9 +2750,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_359263CA_L3C24::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2763,7 +2763,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2774,7 +2774,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2787,11 +2787,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_359263CA_L3C24::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2805,11 +2805,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_359263CA_L3C24::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2827,9 +2827,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_359263CA_L3C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2880,7 +2880,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6DC6BB6B_L4C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2900,9 +2900,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_6DC6BB6B_L4C26::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2913,7 +2913,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2924,7 +2924,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2937,11 +2937,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_6DC6BB6B_L4C26::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2955,11 +2955,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_6DC6BB6B_L4C26::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2977,9 +2977,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_6DC6BB6B_L4C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3028,7 +3028,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7ACDD46D_L5C30
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3048,9 +3048,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_7ACDD46D_L5C30::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3061,7 +3061,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3072,7 +3072,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3085,11 +3085,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_7ACDD46D_L5C30::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3103,11 +3103,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_7ACDD46D_L5C30::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3125,9 +3125,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7ACDD46D_L5C30
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3176,7 +3176,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AA155EE4_inc
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3196,9 +3196,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject_FunctionDeclaration_AA155EE4_inc::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3209,7 +3209,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3220,7 +3220,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3233,11 +3233,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject_FunctionDeclaration_AA155EE4_inc::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/inc::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3251,11 +3251,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject_FunctionDeclaration_AA155EE4_inc::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/inc::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3273,9 +3273,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_AA155EE4_inc
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3339,7 +3339,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6DC8C2FC_getX
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3359,9 +3359,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject_FunctionDeclaration_6DC8C2FC_getX::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3372,7 +3372,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3383,7 +3383,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3396,11 +3396,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject_FunctionDeclaration_6DC8C2FC_getX::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/getX::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3414,11 +3414,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject_FunctionDeclaration_6DC8C2FC_getX::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/getX::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3436,9 +3436,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6DC8C2FC_getX
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3510,7 +3510,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3530,9 +3530,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3543,7 +3543,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3554,7 +3554,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3567,11 +3567,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3585,11 +3585,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3607,9 +3607,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3715,7 +3715,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3729,7 +3729,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3740,7 +3740,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3751,7 +3751,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3769,7 +3769,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3788,7 +3788,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3806,9 +3806,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3911,7 +3911,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_72668557___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3925,7 +3925,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3936,7 +3936,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3947,7 +3947,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3968,7 +3968,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3990,7 +3990,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4008,9 +4008,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_72668557___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4068,7 +4068,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A97A51A2_L43C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4092,15 +4092,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87::_environment0_Import_Namespace_Esm_Basic_Lib
+					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4111,7 +4111,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4122,7 +4122,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4135,11 +4135,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4153,11 +4153,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4175,9 +4175,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_A97A51A2_L43C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4227,7 +4227,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3F83402D_L44C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4251,15 +4251,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94::_environment0_Import_Namespace_Esm_Basic_Lib
+					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4270,7 +4270,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4281,7 +4281,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4294,11 +4294,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4312,11 +4312,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4334,9 +4334,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_3F83402D_L44C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4390,7 +4390,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9C1A8725_L54C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -4416,18 +4416,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::_environment0_Import_Namespace_Esm_Basic_Lib
+						IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::_environment2_FunctionExpression_L53C9
+						IL_0016: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::_environment2_FunctionExpression_L53C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -4438,7 +4438,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -4449,7 +4449,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -4462,11 +4462,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -4480,11 +4480,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -4502,9 +4502,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_9C1A8725_L54C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -4569,7 +4569,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CBC7A6C8_L53C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -4593,15 +4593,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_environment0_Import_Namespace_Esm_Basic_Lib
+					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4612,7 +4612,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4623,7 +4623,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4636,14 +4636,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4657,14 +4657,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4682,9 +4682,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_CBC7A6C8_L53C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4706,7 +4706,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87,
+					[4] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -4756,13 +4756,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -4972,7 +4972,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4992,9 +4992,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5005,7 +5005,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5016,7 +5016,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5029,14 +5029,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5050,14 +5050,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5075,9 +5075,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5117,12 +5117,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87,
-				[21] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94,
+				[20] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject,
+				[21] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10
+				[25] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -5328,13 +5328,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -5378,13 +5378,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -5554,13 +5554,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -5671,7 +5671,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5691,9 +5691,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5704,7 +5704,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5715,7 +5715,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5728,7 +5728,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -5739,7 +5739,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5753,7 +5753,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_Esm_Basic_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -5764,7 +5764,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5782,9 +5782,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5904,19 +5904,19 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_Esm_Basic_Lib/Scope,
-			[1] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default,
-			[2] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_72668557___jroc_esm_get,
-			[3] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace,
-			[4] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export,
+			[1] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject,
 			[5] object[],
-			[6] class Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject_FunctionDeclaration_AA155EE4_inc,
-			[7] class Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject_FunctionDeclaration_6DC8C2FC_getX,
-			[8] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark,
+			[6] class Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject,
+			[7] class Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject,
+			[8] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject,
 			[9] object,
 			[10] object[],
-			[11] class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_359263CA_L3C24,
-			[12] class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_6DC6BB6B_L4C26,
-			[13] class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_7ACDD46D_L5C30
+			[11] class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject,
+			[12] class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject,
+			[13] class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/Scope::.ctor()
@@ -5935,13 +5935,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0022: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject_FunctionDeclaration_AA155EE4_inc::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_0022: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "inc"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject_FunctionDeclaration_AA155EE4_inc>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 6
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 6
@@ -5957,13 +5957,13 @@
 		IL_004d: ldc.i4.0
 		IL_004e: ldelem.ref
 		IL_004f: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0054: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject_FunctionDeclaration_6DC8C2FC_getX::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_0054: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr "getX"
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject_FunctionDeclaration_6DC8C2FC_getX>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 7
 		IL_0069: ldloc.0
 		IL_006a: ldloc.s 7
@@ -5979,13 +5979,13 @@
 		IL_007f: ldc.i4.0
 		IL_0080: ldelem.ref
 		IL_0081: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0086: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_0086: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_008b: ldc.i4.0
 		IL_008c: conv.r8
 		IL_008d: ldstr "__jroc_esm_mark"
 		IL_0092: ldc.i4.0
 		IL_0093: ldc.i4.1
-		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0099: stloc.s 8
 		IL_009b: ldloc.0
 		IL_009c: ldloc.s 8
@@ -5997,13 +5997,13 @@
 		IL_00ab: ldloc.0
 		IL_00ac: stelem.ref
 		IL_00ad: stloc.s 5
-		IL_00af: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::.ctor()
+		IL_00af: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default/FunctionObject::.ctor()
 		IL_00b4: ldc.i4.1
 		IL_00b5: conv.r8
 		IL_00b6: ldstr "__jroc_esm_default"
 		IL_00bb: ldc.i4.0
 		IL_00bc: ldc.i4.1
-		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c2: stloc.1
 		IL_00c3: ldc.i4.1
 		IL_00c4: newarr [System.Runtime]System.Object
@@ -6012,13 +6012,13 @@
 		IL_00cb: ldloc.0
 		IL_00cc: stelem.ref
 		IL_00cd: stloc.s 5
-		IL_00cf: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::.ctor()
+		IL_00cf: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get/FunctionObject::.ctor()
 		IL_00d4: ldc.i4.2
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "__jroc_esm_get"
 		IL_00db: ldc.i4.0
 		IL_00dc: ldc.i4.1
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_72668557___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00e2: stloc.2
 		IL_00e3: ldc.i4.1
 		IL_00e4: newarr [System.Runtime]System.Object
@@ -6031,13 +6031,13 @@
 		IL_00f1: ldc.i4.0
 		IL_00f2: ldelem.ref
 		IL_00f3: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_00f8: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_00f8: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_00fd: ldc.i4.1
 		IL_00fe: conv.r8
 		IL_00ff: ldstr "__jroc_esm_namespace"
 		IL_0104: ldc.i4.0
 		IL_0105: ldc.i4.1
-		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_010b: stloc.3
 		IL_010c: ldc.i4.1
 		IL_010d: newarr [System.Runtime]System.Object
@@ -6050,13 +6050,13 @@
 		IL_011a: ldc.i4.0
 		IL_011b: ldelem.ref
 		IL_011c: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0121: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_0121: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_0126: ldc.i4.2
 		IL_0127: conv.r8
 		IL_0128: ldstr "__jroc_esm_export"
 		IL_012d: ldc.i4.0
 		IL_012e: ldc.i4.1
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0134: stloc.s 4
 		IL_0136: nop
 		IL_0137: ldloc.0
@@ -6079,13 +6079,13 @@
 		IL_0161: ldc.i4.0
 		IL_0162: ldelem.ref
 		IL_0163: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0168: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_359263CA_L3C24::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_0168: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_016d: ldc.i4.0
 		IL_016e: conv.r8
 		IL_016f: ldstr ""
 		IL_0174: ldc.i4.0
 		IL_0175: ldc.i4.1
-		IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_359263CA_L3C24>(!!0, float64, string, bool, bool)
+		IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_017b: stloc.s 11
 		IL_017d: ldloc.s 4
 		IL_017f: ldloc.s 5
@@ -6106,13 +6106,13 @@
 		IL_01a3: ldc.i4.0
 		IL_01a4: ldelem.ref
 		IL_01a5: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_01aa: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_6DC6BB6B_L4C26::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_01aa: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_01af: ldc.i4.0
 		IL_01b0: conv.r8
 		IL_01b1: ldstr ""
 		IL_01b6: ldc.i4.0
 		IL_01b7: ldc.i4.1
-		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_6DC6BB6B_L4C26>(!!0, float64, string, bool, bool)
+		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01bd: stloc.s 12
 		IL_01bf: ldloc.s 4
 		IL_01c1: ldloc.s 5
@@ -6133,13 +6133,13 @@
 		IL_01e5: ldc.i4.0
 		IL_01e6: ldelem.ref
 		IL_01e7: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_01ec: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_7ACDD46D_L5C30::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_01ec: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_01f1: ldc.i4.0
 		IL_01f2: conv.r8
 		IL_01f3: ldstr ""
 		IL_01f8: ldc.i4.0
 		IL_01f9: ldc.i4.1
-		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_7ACDD46D_L5C30>(!!0, float64, string, bool, bool)
+		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01ff: stloc.s 13
 		IL_0201: ldloc.s 4
 		IL_0203: ldloc.s 5

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -71,9 +71,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -84,7 +84,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -108,11 +108,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,11 +126,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -148,9 +148,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -256,7 +256,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -270,7 +270,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -281,7 +281,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -292,7 +292,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -310,7 +310,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -329,7 +329,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -347,9 +347,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -452,7 +452,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -466,7 +466,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -477,7 +477,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -488,7 +488,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -510,7 +510,7 @@
 				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0018: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, string)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -533,7 +533,7 @@
 				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0014: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, string)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -551,9 +551,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -611,7 +611,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DC2ECB5E_L43C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -635,15 +635,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_environment0_Import_Namespace_FromCjs_Stable
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -654,7 +654,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -665,7 +665,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -678,11 +678,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -696,11 +696,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -718,9 +718,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_DC2ECB5E_L43C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -770,7 +770,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A8084EC1_L44C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -794,15 +794,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94::_environment0_Import_Namespace_FromCjs_Stable
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -813,7 +813,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -824,7 +824,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -837,11 +837,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -855,11 +855,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -877,9 +877,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_A8084EC1_L44C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -933,7 +933,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4C2D45B9_L54C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -959,18 +959,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::_environment0_Import_Namespace_FromCjs_Stable
+						IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::_environment2_FunctionExpression_L53C9
+						IL_0016: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::_environment2_FunctionExpression_L53C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -981,7 +981,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -992,7 +992,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1005,11 +1005,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1023,11 +1023,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1045,9 +1045,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_4C2D45B9_L54C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1112,7 +1112,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9F4A7CF4_L53C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1136,15 +1136,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_environment0_Import_Namespace_FromCjs_Stable
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1155,7 +1155,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1166,7 +1166,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1179,14 +1179,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1200,14 +1200,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1225,9 +1225,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_9F4A7CF4_L53C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1249,7 +1249,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87,
+					[4] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -1299,13 +1299,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -1515,7 +1515,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1535,9 +1535,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1548,7 +1548,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1559,7 +1559,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1572,14 +1572,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1593,14 +1593,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1618,9 +1618,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1660,12 +1660,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87,
-				[21] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94,
+				[20] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject,
+				[21] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10
+				[25] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::.ctor()
@@ -1871,13 +1871,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1921,13 +1921,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2097,13 +2097,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -2214,7 +2214,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2234,9 +2234,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2247,7 +2247,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2258,7 +2258,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2271,7 +2271,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2281,7 +2281,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2295,7 +2295,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2305,7 +2305,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2323,9 +2323,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2437,14 +2437,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable/Scope,
-			[1] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default/FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default,
-			[2] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get/FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get,
-			[3] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace,
-			[4] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export,
+			[1] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject,
 			[5] object,
 			[6] object,
 			[7] object[],
-			[8] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark,
+			[8] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject,
 			[9] object,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[11] object,
@@ -2468,13 +2468,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_Namespace_FromCjs_Stable/Scope
-		IL_0022: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope)
+		IL_0022: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 8
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 8
@@ -2486,13 +2486,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 7
-		IL_004b: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default/FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default/FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -2501,13 +2501,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 7
-		IL_006b: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get/FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get/FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -2520,13 +2520,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_Namespace_FromCjs_Stable/Scope
-		IL_0094: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope)
+		IL_0094: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -2539,13 +2539,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_Namespace_FromCjs_Stable/Scope
-		IL_00bd: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope)
+		IL_00bd: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -2743,7 +2743,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D865E319_L10C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2763,9 +2763,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject_FunctionExpression_D865E319_L10C25::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2776,7 +2776,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2787,7 +2787,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2800,11 +2800,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject_FunctionExpression_D865E319_L10C25::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2818,11 +2818,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject_FunctionExpression_D865E319_L10C25::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2840,9 +2840,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D865E319_L10C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2912,7 +2912,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2932,9 +2932,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2945,7 +2945,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2956,7 +2956,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2969,11 +2969,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2987,11 +2987,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3009,9 +3009,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3117,7 +3117,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3131,7 +3131,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3142,7 +3142,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3153,7 +3153,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3171,7 +3171,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3190,7 +3190,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3208,9 +3208,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3313,7 +3313,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3327,7 +3327,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3338,7 +3338,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3349,7 +3349,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3370,7 +3370,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3392,7 +3392,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3410,9 +3410,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3470,7 +3470,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EC5DD978_L38C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3494,15 +3494,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87::_environment0_Import_Namespace_FromCjs_Stable_A
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3513,7 +3513,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3524,7 +3524,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3537,11 +3537,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3555,11 +3555,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3577,9 +3577,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_EC5DD978_L38C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3629,7 +3629,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0C4BA5B9_L39C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3653,15 +3653,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_environment0_Import_Namespace_FromCjs_Stable_A
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3672,7 +3672,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3683,7 +3683,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3696,11 +3696,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -3714,11 +3714,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -3736,9 +3736,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_0C4BA5B9_L39C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3792,7 +3792,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DC3B754A_L49C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -3818,18 +3818,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::_environment0_Import_Namespace_FromCjs_Stable_A
+						IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::_environment2_FunctionExpression_L48C9
+						IL_0016: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment2_FunctionExpression_L48C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -3840,7 +3840,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -3851,7 +3851,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -3864,11 +3864,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -3882,11 +3882,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -3904,9 +3904,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_DC3B754A_L49C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -3971,7 +3971,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6078F843_L48C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3995,15 +3995,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10::_environment0_Import_Namespace_FromCjs_Stable_A
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -4014,7 +4014,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -4025,7 +4025,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -4038,14 +4038,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -4059,14 +4059,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -4084,9 +4084,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_6078F843_L48C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -4108,7 +4108,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87,
+					[4] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -4158,13 +4158,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -4374,7 +4374,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4394,9 +4394,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4407,7 +4407,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4418,7 +4418,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4431,14 +4431,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4452,14 +4452,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4477,9 +4477,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4519,12 +4519,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87,
-				[21] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94,
+				[20] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject,
+				[21] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10
+				[25] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::.ctor()
@@ -4730,13 +4730,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -4780,13 +4780,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -4956,13 +4956,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -5073,7 +5073,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5093,9 +5093,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5106,7 +5106,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5117,7 +5117,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5130,7 +5130,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -5141,7 +5141,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5155,7 +5155,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_A
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -5166,7 +5166,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5184,9 +5184,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5300,16 +5300,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable_A/Scope,
-			[1] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default/FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default,
-			[2] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get/FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get,
-			[3] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace,
-			[4] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export,
+			[1] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark,
+			[7] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject,
 			[8] object,
 			[9] object[],
-			[10] class Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject_FunctionExpression_D865E319_L10C25
+			[10] class Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/Scope::.ctor()
@@ -5328,13 +5328,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_0022: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
+		IL_0022: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -5346,13 +5346,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default/FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default/FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -5361,13 +5361,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get/FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get/FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -5380,13 +5380,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_0094: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
+		IL_0094: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -5399,13 +5399,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_00bd: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
+		IL_00bd: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -5440,13 +5440,13 @@
 		IL_0121: ldc.i4.0
 		IL_0122: ldelem.ref
 		IL_0123: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_0128: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject_FunctionExpression_D865E319_L10C25::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
+		IL_0128: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
 		IL_012d: ldc.i4.0
 		IL_012e: conv.r8
 		IL_012f: ldstr ""
 		IL_0134: ldc.i4.0
 		IL_0135: ldc.i4.1
-		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject_FunctionExpression_D865E319_L10C25>(!!0, float64, string, bool, bool)
+		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_013b: stloc.s 10
 		IL_013d: ldloc.s 4
 		IL_013f: ldloc.s 6
@@ -5486,7 +5486,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_23B80F39_L4C15
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5506,9 +5506,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject_FunctionExpression_23B80F39_L4C15::_environment0_Import_Namespace_FromCjs_Stable_Lib
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5519,7 +5519,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5530,7 +5530,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5543,11 +5543,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject_FunctionExpression_23B80F39_L4C15::_environment0_Import_Namespace_FromCjs_Stable_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5561,11 +5561,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject_FunctionExpression_23B80F39_L4C15::_environment0_Import_Namespace_FromCjs_Stable_Lib
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5583,9 +5583,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_23B80F39_L4C15
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5677,7 +5677,7 @@
 			[0] class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope,
 			[1] object,
 			[2] object[],
-			[3] class Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject_FunctionExpression_23B80F39_L4C15
+			[3] class Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_Lib/Scope::.ctor()
@@ -5709,13 +5709,13 @@
 		IL_003e: ldc.i4.0
 		IL_003f: ldelem.ref
 		IL_0040: castclass Modules.Import_Namespace_FromCjs_Stable_Lib/Scope
-		IL_0045: newobj instance void Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject_FunctionExpression_23B80F39_L4C15::.ctor(class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope)
+		IL_0045: newobj instance void Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope)
 		IL_004a: ldc.i4.0
 		IL_004b: conv.r8
 		IL_004c: ldstr ""
 		IL_0051: ldc.i4.0
 		IL_0052: ldc.i4.1
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject_FunctionExpression_23B80F39_L4C15>(!!0, float64, string, bool, bool)
+		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0058: stloc.3
 		IL_0059: ldloc.1
 		IL_005a: ldstr "inc"
@@ -5755,7 +5755,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_273665B4_L10C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5775,9 +5775,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject_FunctionExpression_273665B4_L10C25::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5788,7 +5788,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5799,7 +5799,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5812,11 +5812,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject_FunctionExpression_273665B4_L10C25::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5830,11 +5830,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject_FunctionExpression_273665B4_L10C25::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5852,9 +5852,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_273665B4_L10C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5924,7 +5924,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5944,9 +5944,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5957,7 +5957,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5968,7 +5968,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5981,11 +5981,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5999,11 +5999,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6021,9 +6021,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6129,7 +6129,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -6143,7 +6143,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6154,7 +6154,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6165,7 +6165,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6183,7 +6183,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6202,7 +6202,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6220,9 +6220,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6325,7 +6325,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -6339,7 +6339,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6350,7 +6350,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6361,7 +6361,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6382,7 +6382,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6404,7 +6404,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6422,9 +6422,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6482,7 +6482,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BAD62F07_L38C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -6506,15 +6506,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87::_environment0_Import_Namespace_FromCjs_Stable_B
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -6525,7 +6525,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -6536,7 +6536,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -6549,11 +6549,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -6567,11 +6567,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -6589,9 +6589,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_BAD62F07_L38C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -6641,7 +6641,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2828C68A_L39C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -6665,15 +6665,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94::_environment0_Import_Namespace_FromCjs_Stable_B
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -6684,7 +6684,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -6695,7 +6695,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -6708,11 +6708,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -6726,11 +6726,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -6748,9 +6748,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_2828C68A_L39C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -6804,7 +6804,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3D876629_L49C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -6830,18 +6830,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::_environment0_Import_Namespace_FromCjs_Stable_B
+						IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::_environment2_FunctionExpression_L48C9
+						IL_0016: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_environment2_FunctionExpression_L48C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -6852,7 +6852,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -6863,7 +6863,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -6876,11 +6876,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -6894,11 +6894,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -6916,9 +6916,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_3D876629_L49C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -6983,7 +6983,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_804B477E_L48C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -7007,15 +7007,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10::_environment0_Import_Namespace_FromCjs_Stable_B
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -7026,7 +7026,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -7037,7 +7037,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -7050,14 +7050,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -7071,14 +7071,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -7096,9 +7096,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_804B477E_L48C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -7120,7 +7120,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87,
+					[4] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -7170,13 +7170,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -7386,7 +7386,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -7406,9 +7406,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7419,7 +7419,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7430,7 +7430,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7443,14 +7443,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7464,14 +7464,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7489,9 +7489,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7531,12 +7531,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87,
-				[21] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94,
+				[20] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject,
+				[21] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10
+				[25] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::.ctor()
@@ -7742,13 +7742,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -7792,13 +7792,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -7968,13 +7968,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -8085,7 +8085,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8105,9 +8105,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8118,7 +8118,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8129,7 +8129,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8142,7 +8142,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -8153,7 +8153,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8167,7 +8167,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject::_environment0_Import_Namespace_FromCjs_Stable_B
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -8178,7 +8178,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8196,9 +8196,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8312,16 +8312,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable_B/Scope,
-			[1] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default/FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default,
-			[2] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get/FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get,
-			[3] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace,
-			[4] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export,
+			[1] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark,
+			[7] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject,
 			[8] object,
 			[9] object[],
-			[10] class Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject_FunctionExpression_273665B4_L10C25
+			[10] class Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/Scope::.ctor()
@@ -8340,13 +8340,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_0022: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
+		IL_0022: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -8358,13 +8358,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default/FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default/FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -8373,13 +8373,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get/FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get/FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -8392,13 +8392,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_0094: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
+		IL_0094: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -8411,13 +8411,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_00bd: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
+		IL_00bd: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -8452,13 +8452,13 @@
 		IL_0121: ldc.i4.0
 		IL_0122: ldelem.ref
 		IL_0123: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_0128: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject_FunctionExpression_273665B4_L10C25::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
+		IL_0128: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
 		IL_012d: ldc.i4.0
 		IL_012e: conv.r8
 		IL_012f: ldstr ""
 		IL_0134: ldc.i4.0
 		IL_0135: ldc.i4.1
-		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject_FunctionExpression_273665B4_L10C25>(!!0, float64, string, bool, bool)
+		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_013b: stloc.s 10
 		IL_013d: ldloc.s 4
 		IL_013f: ldloc.s 6

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
@@ -124,7 +124,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_05B9A985_L6C28
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -144,9 +144,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27/FunctionObject_FunctionExpression_05B9A985_L6C28::_environment0_Import_RequireEsmModule_Lib
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_05B9A985_L6C28::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -157,7 +157,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_05B9A985_L6C28::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -168,7 +168,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_05B9A985_L6C28::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -181,11 +181,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27/FunctionObject_FunctionExpression_05B9A985_L6C28::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_05B9A985_L6C28::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -199,11 +199,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27/FunctionObject_FunctionExpression_05B9A985_L6C28::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_05B9A985_L6C28::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -221,9 +221,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_05B9A985_L6C28::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_05B9A985_L6C28
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -274,7 +274,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A60A65FE_L7C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -294,9 +294,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25/FunctionObject_FunctionExpression_A60A65FE_L7C26::_environment0_Import_RequireEsmModule_Lib
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A60A65FE_L7C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -307,7 +307,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A60A65FE_L7C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -318,7 +318,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A60A65FE_L7C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -331,11 +331,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25/FunctionObject_FunctionExpression_A60A65FE_L7C26::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_A60A65FE_L7C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -349,11 +349,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25/FunctionObject_FunctionExpression_A60A65FE_L7C26::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_A60A65FE_L7C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -371,9 +371,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A60A65FE_L7C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A60A65FE_L7C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -422,7 +422,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DA032AFE_L8C30
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -442,9 +442,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29/FunctionObject_FunctionExpression_DA032AFE_L8C30::_environment0_Import_RequireEsmModule_Lib
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DA032AFE_L8C30::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -455,7 +455,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DA032AFE_L8C30::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -466,7 +466,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DA032AFE_L8C30::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -479,11 +479,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29/FunctionObject_FunctionExpression_DA032AFE_L8C30::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_DA032AFE_L8C30::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -497,11 +497,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29/FunctionObject_FunctionExpression_DA032AFE_L8C30::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_DA032AFE_L8C30::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -519,9 +519,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DA032AFE_L8C30::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_DA032AFE_L8C30
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -594,7 +594,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_66259425_sum
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -608,7 +608,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_66259425_sum::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -619,7 +619,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_66259425_sum::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -630,7 +630,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_66259425_sum::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -651,7 +651,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_RequireEsmModule_Lib/sum::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_66259425_sum::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -673,7 +673,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_RequireEsmModule_Lib/sum::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_66259425_sum::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -691,9 +691,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_66259425_sum::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_66259425_sum
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -768,7 +768,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -788,9 +788,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::_environment0_Import_RequireEsmModule_Lib
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -801,7 +801,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -812,7 +812,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -825,11 +825,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -843,11 +843,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -865,9 +865,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -973,7 +973,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -987,7 +987,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -998,7 +998,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1009,7 +1009,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1027,7 +1027,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1046,7 +1046,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1064,9 +1064,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1169,7 +1169,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1183,7 +1183,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1194,7 +1194,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1205,7 +1205,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1226,7 +1226,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1248,7 +1248,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_get::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1266,9 +1266,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1326,7 +1326,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9E6CBA5D_L46C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1350,15 +1350,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject_FunctionExpression_9E6CBA5D_L46C87::_environment0_Import_RequireEsmModule_Lib
+					IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject_FunctionExpression_9E6CBA5D_L46C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject_FunctionExpression_9E6CBA5D_L46C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_9E6CBA5D_L46C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1369,7 +1369,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_9E6CBA5D_L46C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1380,7 +1380,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_9E6CBA5D_L46C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1393,11 +1393,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject_FunctionExpression_9E6CBA5D_L46C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_9E6CBA5D_L46C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1411,11 +1411,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject_FunctionExpression_9E6CBA5D_L46C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_9E6CBA5D_L46C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1433,9 +1433,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_9E6CBA5D_L46C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_9E6CBA5D_L46C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1485,7 +1485,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5E7EBBBC_L47C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1509,15 +1509,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject_FunctionExpression_5E7EBBBC_L47C94::_environment0_Import_RequireEsmModule_Lib
+					IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject_FunctionExpression_5E7EBBBC_L47C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject_FunctionExpression_5E7EBBBC_L47C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_5E7EBBBC_L47C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1528,7 +1528,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_5E7EBBBC_L47C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1539,7 +1539,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_5E7EBBBC_L47C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1552,11 +1552,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject_FunctionExpression_5E7EBBBC_L47C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_5E7EBBBC_L47C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1570,11 +1570,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject_FunctionExpression_5E7EBBBC_L47C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_5E7EBBBC_L47C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1592,9 +1592,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_5E7EBBBC_L47C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_5E7EBBBC_L47C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1648,7 +1648,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_863DD9B2_L57C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -1674,18 +1674,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject_FunctionExpression_863DD9B2_L57C87::_environment0_Import_RequireEsmModule_Lib
+						IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject_FunctionExpression_863DD9B2_L57C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject_FunctionExpression_863DD9B2_L57C87::_environment2_FunctionExpression_L56C9
+						IL_0016: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject::_environment2_FunctionExpression_L56C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject_FunctionExpression_863DD9B2_L57C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_863DD9B2_L57C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -1696,7 +1696,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_863DD9B2_L57C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -1707,7 +1707,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_863DD9B2_L57C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1720,11 +1720,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject_FunctionExpression_863DD9B2_L57C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_863DD9B2_L57C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1738,11 +1738,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject_FunctionExpression_863DD9B2_L57C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_863DD9B2_L57C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1760,9 +1760,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_863DD9B2_L57C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_863DD9B2_L57C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1827,7 +1827,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0CDD2FC0_L56C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1851,15 +1851,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject_FunctionExpression_0CDD2FC0_L56C10::_environment0_Import_RequireEsmModule_Lib
+					IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject_FunctionExpression_0CDD2FC0_L56C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject_FunctionExpression_0CDD2FC0_L56C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_0CDD2FC0_L56C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1870,7 +1870,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_0CDD2FC0_L56C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1881,7 +1881,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_0CDD2FC0_L56C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1894,14 +1894,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject_FunctionExpression_0CDD2FC0_L56C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_0CDD2FC0_L56C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1915,14 +1915,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject_FunctionExpression_0CDD2FC0_L56C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_0CDD2FC0_L56C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1940,9 +1940,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_0CDD2FC0_L56C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_0CDD2FC0_L56C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1964,7 +1964,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject_FunctionExpression_863DD9B2_L57C87,
+					[4] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -2014,13 +2014,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject_FunctionExpression_863DD9B2_L57C87::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject_FunctionExpression_863DD9B2_L57C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionExpression_L57C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -2230,7 +2230,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2250,9 +2250,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::_environment0_Import_RequireEsmModule_Lib
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2263,7 +2263,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2274,7 +2274,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2287,14 +2287,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2308,14 +2308,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2333,9 +2333,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2375,12 +2375,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject_FunctionExpression_9E6CBA5D_L46C87,
-				[21] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject_FunctionExpression_5E7EBBBC_L47C94,
+				[20] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject,
+				[21] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject_FunctionExpression_0CDD2FC0_L56C10
+				[25] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -2586,13 +2586,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject_FunctionExpression_9E6CBA5D_L46C87::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject_FunctionExpression_9E6CBA5D_L46C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L46C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -2636,13 +2636,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject_FunctionExpression_5E7EBBBC_L47C94::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject_FunctionExpression_5E7EBBBC_L47C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L47C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2812,13 +2812,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject_FunctionExpression_0CDD2FC0_L56C10::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject_FunctionExpression_0CDD2FC0_L56C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L56C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -2929,7 +2929,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2949,9 +2949,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::_environment0_Import_RequireEsmModule_Lib
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2962,7 +2962,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2973,7 +2973,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2986,7 +2986,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2997,7 +2997,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3011,7 +3011,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -3022,7 +3022,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3040,9 +3040,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3151,7 +3151,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3171,9 +3171,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding/FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding::_environment0_Import_RequireEsmModule_Lib
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3184,7 +3184,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3195,7 +3195,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3208,7 +3208,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding/FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -3219,7 +3219,7 @@
 				IL_0019: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_001e: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object, string)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3233,7 +3233,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding/FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding::_environment0_Import_RequireEsmModule_Lib
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding/FunctionObject::_environment0_Import_RequireEsmModule_Lib
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -3244,7 +3244,7 @@
 				IL_0015: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_001a: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object, string)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3262,9 +3262,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3385,20 +3385,20 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_RequireEsmModule_Lib/Scope,
-			[1] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default,
-			[2] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get,
-			[3] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace,
-			[4] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export,
+			[1] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject,
 			[5] object[],
-			[6] class Modules.Import_RequireEsmModule_Lib/sum/FunctionObject_FunctionDeclaration_66259425_sum,
-			[7] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark,
-			[8] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding/FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding,
+			[6] class Modules.Import_RequireEsmModule_Lib/sum/FunctionObject,
+			[7] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject,
+			[8] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding/FunctionObject,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[10] object,
 			[11] object[],
-			[12] class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27/FunctionObject_FunctionExpression_05B9A985_L6C28,
-			[13] class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25/FunctionObject_FunctionExpression_A60A65FE_L7C26,
-			[14] class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29/FunctionObject_FunctionExpression_DA032AFE_L8C30
+			[12] class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27/FunctionObject,
+			[13] class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25/FunctionObject,
+			[14] class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Import_RequireEsmModule_Lib/Scope::.ctor()
@@ -3413,13 +3413,13 @@
 		IL_0015: ldloc.0
 		IL_0016: stelem.ref
 		IL_0017: stloc.s 5
-		IL_0019: newobj instance void Modules.Import_RequireEsmModule_Lib/sum/FunctionObject_FunctionDeclaration_66259425_sum::.ctor()
+		IL_0019: newobj instance void Modules.Import_RequireEsmModule_Lib/sum/FunctionObject::.ctor()
 		IL_001e: ldc.i4.2
 		IL_001f: conv.r8
 		IL_0020: ldstr "sum"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/sum/FunctionObject_FunctionDeclaration_66259425_sum>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/sum/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.s 6
 		IL_002e: ldloc.0
 		IL_002f: ldloc.s 6
@@ -3435,13 +3435,13 @@
 		IL_0044: ldc.i4.0
 		IL_0045: ldelem.ref
 		IL_0046: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_004b: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_004b: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_0050: ldc.i4.0
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_mark"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.s 7
 		IL_0060: ldloc.0
 		IL_0061: ldloc.s 7
@@ -3453,13 +3453,13 @@
 		IL_0070: ldloc.0
 		IL_0071: stelem.ref
 		IL_0072: stloc.s 5
-		IL_0074: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::.ctor()
+		IL_0074: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0079: ldc.i4.1
 		IL_007a: conv.r8
 		IL_007b: ldstr "__jroc_esm_default"
 		IL_0080: ldc.i4.0
 		IL_0081: ldc.i4.1
-		IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0087: stloc.1
 		IL_0088: ldc.i4.1
 		IL_0089: newarr [System.Runtime]System.Object
@@ -3468,13 +3468,13 @@
 		IL_0090: ldloc.0
 		IL_0091: stelem.ref
 		IL_0092: stloc.s 5
-		IL_0094: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::.ctor()
+		IL_0094: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0099: ldc.i4.2
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_get"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.2
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -3487,13 +3487,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_00bd: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_00bd: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_00c2: ldc.i4.1
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_namespace"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.3
 		IL_00d1: ldc.i4.1
 		IL_00d2: newarr [System.Runtime]System.Object
@@ -3506,13 +3506,13 @@
 		IL_00df: ldc.i4.0
 		IL_00e0: ldelem.ref
 		IL_00e1: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_00e6: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_00e6: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_00eb: ldc.i4.2
 		IL_00ec: conv.r8
 		IL_00ed: ldstr "__jroc_esm_export"
 		IL_00f2: ldc.i4.0
 		IL_00f3: ldc.i4.1
-		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00f9: stloc.s 4
 		IL_00fb: ldc.i4.1
 		IL_00fc: newarr [System.Runtime]System.Object
@@ -3525,13 +3525,13 @@
 		IL_0109: ldc.i4.0
 		IL_010a: ldelem.ref
 		IL_010b: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_0110: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding/FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_0110: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding/FunctionObject::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_0115: ldc.i4.2
 		IL_0116: conv.r8
 		IL_0117: ldstr "__jroc_esm_read_binding"
 		IL_011c: ldc.i4.0
 		IL_011d: ldc.i4.1
-		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding/FunctionObject_FunctionDeclaration_136931B5___jroc_esm_read_binding>(!!0, float64, string, bool, bool)
+		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_read_binding/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0123: stloc.s 8
 		IL_0125: ldloc.0
 		IL_0126: ldloc.s 8
@@ -3590,13 +3590,13 @@
 		IL_01b9: ldc.i4.0
 		IL_01ba: ldelem.ref
 		IL_01bb: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_01c0: newobj instance void Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27/FunctionObject_FunctionExpression_05B9A985_L6C28::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_01c0: newobj instance void Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27/FunctionObject::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_01c5: ldc.i4.0
 		IL_01c6: conv.r8
 		IL_01c7: ldstr ""
 		IL_01cc: ldc.i4.0
 		IL_01cd: ldc.i4.1
-		IL_01ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27/FunctionObject_FunctionExpression_05B9A985_L6C28>(!!0, float64, string, bool, bool)
+		IL_01ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L6C27/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01d3: stloc.s 12
 		IL_01d5: ldloc.s 4
 		IL_01d7: ldloc.s 5
@@ -3617,13 +3617,13 @@
 		IL_01fb: ldc.i4.0
 		IL_01fc: ldelem.ref
 		IL_01fd: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_0202: newobj instance void Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25/FunctionObject_FunctionExpression_A60A65FE_L7C26::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_0202: newobj instance void Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25/FunctionObject::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_0207: ldc.i4.0
 		IL_0208: conv.r8
 		IL_0209: ldstr ""
 		IL_020e: ldc.i4.0
 		IL_020f: ldc.i4.1
-		IL_0210: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25/FunctionObject_FunctionExpression_A60A65FE_L7C26>(!!0, float64, string, bool, bool)
+		IL_0210: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L7C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0215: stloc.s 13
 		IL_0217: ldloc.s 4
 		IL_0219: ldloc.s 5
@@ -3644,13 +3644,13 @@
 		IL_023d: ldc.i4.0
 		IL_023e: ldelem.ref
 		IL_023f: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_0244: newobj instance void Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29/FunctionObject_FunctionExpression_DA032AFE_L8C30::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_0244: newobj instance void Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29/FunctionObject::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_0249: ldc.i4.0
 		IL_024a: conv.r8
 		IL_024b: ldstr ""
 		IL_0250: ldc.i4.0
 		IL_0251: ldc.i4.1
-		IL_0252: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29/FunctionObject_FunctionExpression_DA032AFE_L8C30>(!!0, float64, string, bool, bool)
+		IL_0252: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L8C29/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0257: stloc.s 14
 		IL_0259: ldloc.s 4
 		IL_025b: ldloc.s 5

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -71,9 +71,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::_environment0_Import_StaticImport_FromCjs
+				IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject::_environment0_Import_StaticImport_FromCjs
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -84,7 +84,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -108,11 +108,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::_environment0_Import_StaticImport_FromCjs
+				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject::_environment0_Import_StaticImport_FromCjs
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_mark::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,11 +126,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::_environment0_Import_StaticImport_FromCjs
+				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject::_environment0_Import_StaticImport_FromCjs
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_mark::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -148,9 +148,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -256,7 +256,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -270,7 +270,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -281,7 +281,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -292,7 +292,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -310,7 +310,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_default::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -329,7 +329,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_default::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -347,9 +347,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -452,7 +452,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -466,7 +466,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -477,7 +477,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -488,7 +488,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -510,7 +510,7 @@
 				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0018: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_get::__js_call__(object, object, string)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -533,7 +533,7 @@
 				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0014: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_get::__js_call__(object, object, string)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -551,9 +551,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -611,7 +611,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C4FD07CD_L42C87
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -635,15 +635,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87::_environment0_Import_StaticImport_FromCjs
+					IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject::_environment0_Import_StaticImport_FromCjs
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -654,7 +654,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -665,7 +665,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -678,11 +678,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -696,11 +696,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -718,9 +718,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_C4FD07CD_L42C87
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -770,7 +770,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F868AEAC_L43C94
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -794,15 +794,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94::_environment0_Import_StaticImport_FromCjs
+					IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject::_environment0_Import_StaticImport_FromCjs
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -813,7 +813,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -824,7 +824,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -837,11 +837,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -855,11 +855,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -877,9 +877,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_F868AEAC_L43C94
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -933,7 +933,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_69B7ACEA_L53C87
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -959,18 +959,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::_environment0_Import_StaticImport_FromCjs
+						IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject::_environment0_Import_StaticImport_FromCjs
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::_environment1___jroc_esm_namespace
+						IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject::_environment1___jroc_esm_namespace
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::_environment2_FunctionExpression_L52C9
+						IL_0016: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject::_environment2_FunctionExpression_L52C9
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::_transitionalScopes
+						IL_001e: stfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -981,7 +981,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -992,7 +992,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1005,11 +1005,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1023,11 +1023,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1045,9 +1045,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_69B7ACEA_L53C87
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1112,7 +1112,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1A1351AC_L52C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1136,15 +1136,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10::_environment0_Import_StaticImport_FromCjs
+					IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject::_environment0_Import_StaticImport_FromCjs
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10::_environment1___jroc_esm_namespace
+					IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject::_environment1___jroc_esm_namespace
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10::_transitionalScopes
+					IL_0016: stfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1155,7 +1155,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1166,7 +1166,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1179,14 +1179,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1200,14 +1200,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1225,9 +1225,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_1A1351AC_L52C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1249,7 +1249,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87,
+					[4] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -1299,13 +1299,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -1515,7 +1515,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1535,9 +1535,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::_environment0_Import_StaticImport_FromCjs
+				IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject::_environment0_Import_StaticImport_FromCjs
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1548,7 +1548,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1559,7 +1559,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1572,14 +1572,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::_environment0_Import_StaticImport_FromCjs
+				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject::_environment0_Import_StaticImport_FromCjs
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1593,14 +1593,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::_environment0_Import_StaticImport_FromCjs
+				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject::_environment0_Import_StaticImport_FromCjs
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1618,9 +1618,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1660,12 +1660,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87,
-				[21] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94,
+				[20] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject,
+				[21] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10
+				[25] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::.ctor()
@@ -1871,13 +1871,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1921,13 +1921,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2097,13 +2097,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldloc.s 25
 				IL_0488: ldc.i4.1
@@ -2214,7 +2214,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2234,9 +2234,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::_environment0_Import_StaticImport_FromCjs
+				IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject::_environment0_Import_StaticImport_FromCjs
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2247,7 +2247,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2258,7 +2258,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2271,7 +2271,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::_environment0_Import_StaticImport_FromCjs
+				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject::_environment0_Import_StaticImport_FromCjs
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2281,7 +2281,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_export::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2295,7 +2295,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::_environment0_Import_StaticImport_FromCjs
+				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject::_environment0_Import_StaticImport_FromCjs
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2305,7 +2305,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_export::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2323,9 +2323,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2437,15 +2437,15 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_StaticImport_FromCjs/Scope,
-			[1] class Modules.Import_StaticImport_FromCjs/__jroc_esm_default/FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default,
-			[2] class Modules.Import_StaticImport_FromCjs/__jroc_esm_get/FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get,
-			[3] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace,
-			[4] class Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export,
+			[1] class Modules.Import_StaticImport_FromCjs/__jroc_esm_default/FunctionObject,
+			[2] class Modules.Import_StaticImport_FromCjs/__jroc_esm_get/FunctionObject,
+			[3] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject,
+			[4] class Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject,
 			[5] object,
 			[6] object,
 			[7] object,
 			[8] object[],
-			[9] class Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark,
+			[9] class Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject,
 			[10] object,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -2466,13 +2466,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_StaticImport_FromCjs/Scope
-		IL_0022: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::.ctor(class Modules.Import_StaticImport_FromCjs/Scope)
+		IL_0022: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject::.ctor(class Modules.Import_StaticImport_FromCjs/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 9
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 9
@@ -2484,13 +2484,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 8
-		IL_004b: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_default/FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_default/FunctionObject::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_default/FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_default/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -2499,13 +2499,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 8
-		IL_006b: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_get/FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_get/FunctionObject::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_get/FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_get/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -2518,13 +2518,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_StaticImport_FromCjs/Scope
-		IL_0094: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::.ctor(class Modules.Import_StaticImport_FromCjs/Scope)
+		IL_0094: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject::.ctor(class Modules.Import_StaticImport_FromCjs/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -2537,13 +2537,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_StaticImport_FromCjs/Scope
-		IL_00bd: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::.ctor(class Modules.Import_StaticImport_FromCjs/Scope)
+		IL_00bd: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject::.ctor(class Modules.Import_StaticImport_FromCjs/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0

--- a/tests/Jroc.Tests/Integration/GeneratedFunctionObjectEmissionTests.cs
+++ b/tests/Jroc.Tests/Integration/GeneratedFunctionObjectEmissionTests.cs
@@ -139,10 +139,12 @@ public sealed class GeneratedFunctionObjectEmissionTests
 
         var answerType = Assert.Single(
             GetFunctionObjectTypes(first.Assembly),
-            type => type.Name.EndsWith("_answer", StringComparison.Ordinal));
+            type => type.Name == GeneratedFunctionObjectNaming.WrapperTypeName
+                && type.DeclaringType?.Name == "answer");
         var innerType = Assert.Single(
             GetFunctionObjectTypes(first.Assembly),
-            type => type.Name.EndsWith("_inner", StringComparison.Ordinal));
+            type => type.Name == GeneratedFunctionObjectNaming.WrapperTypeName
+                && type.DeclaringType?.Name == "inner");
         var arrowTypes = GetFunctionObjectTypes(first.Assembly)
             .Where(type => type.DeclaringType?.Name.StartsWith(
                     "ArrowFunction_",
@@ -205,12 +207,37 @@ public sealed class GeneratedFunctionObjectEmissionTests
     }
 
     [Fact]
+    public void FunctionObjectTypesUseTheirDistinctOwnersForIdentity()
+    {
+        using var compiled = CompileAndLoad(
+            """
+            function first() { return 1; }
+            function second() { return 2; }
+            const third = function() { return 3; };
+            const fourth = function() { return 4; };
+            """);
+
+        var ordinaryFunctionObjects = GetFunctionObjectTypes(compiled.Assembly)
+            .Where(type => type.Name == GeneratedFunctionObjectNaming.WrapperTypeName)
+            .ToArray();
+
+        Assert.Equal(4, ordinaryFunctionObjects.Length);
+        Assert.Equal(
+            ordinaryFunctionObjects.Length,
+            ordinaryFunctionObjects
+                .Select(type => type.DeclaringType)
+                .Distinct()
+                .Count());
+    }
+
+    [Fact]
     public void TypedBodyAndDynamicAdapterKeepSeparateSignatures()
     {
         using var compiled = CompileAndLoad(Source);
         var answerType = Assert.Single(
             GetFunctionObjectTypes(compiled.Assembly),
-            type => type.Name.EndsWith("_answer", StringComparison.Ordinal));
+            type => type.Name == GeneratedFunctionObjectNaming.WrapperTypeName
+                && type.DeclaringType?.Name == "answer");
 
         var functionObject = Assert.IsAssignableFrom<JsFunctionObject>(
             Activator.CreateInstance(answerType));

--- a/tests/Jroc.Tests/Integration/GeneratedFunctionObjectPlanningTests.cs
+++ b/tests/Jroc.Tests/Integration/GeneratedFunctionObjectPlanningTests.cs
@@ -104,6 +104,33 @@ public sealed class GeneratedFunctionObjectPlanningTests
     }
 
     [Fact]
+    public void PlannerUsesSimpleFunctionObjectNamesForNestedOrdinaryCallables()
+    {
+        const string source = """
+            function declaration(value) { return value; }
+            const expression = function(value) { return value; };
+            const first = function() { return 1; };
+            const second = function() { return 2; };
+            """;
+
+        var (symbolTable, coordinator, registry) = Build(source);
+        coordinator.RunPhase1Discovery(symbolTable);
+
+        var ordinaryCallables = registry.GetPlansInStableOrder()
+            .Where(plan => plan.Callable.Kind is CallableKind.FunctionDeclaration
+                or CallableKind.FunctionExpression)
+            .ToArray();
+
+        Assert.Equal(4, ordinaryCallables.Length);
+        Assert.All(
+            ordinaryCallables,
+            plan => Assert.Equal(GeneratedFunctionObjectNaming.WrapperTypeName, plan.TypeName));
+        Assert.Equal(
+            ordinaryCallables.Length,
+            ordinaryCallables.Select(plan => plan.CanonicalOwnerTypeName).Distinct().Count());
+    }
+
+    [Fact]
     public void SpecializedEntryPointsRemainOnCanonicalGeneratedType()
     {
         var (symbolTable, coordinator, registry) = Build(

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0503C5DA_startTest
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -89,7 +89,7 @@
 				IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_001d: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest::__js_call__(object, string, string)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -113,7 +113,7 @@
 				IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0019: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest::__js_call__(object, string, string)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -131,9 +131,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0503C5DA_startTest
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -180,7 +180,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3950DF5B_endTest
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -194,7 +194,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -205,7 +205,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -216,7 +216,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -231,7 +231,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -247,7 +247,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -265,9 +265,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3950DF5B_endTest
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -333,7 +333,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5501B021_prep
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -347,7 +347,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -358,7 +358,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -369,7 +369,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -387,7 +387,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -406,7 +406,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -424,9 +424,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5501B021_prep
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -512,7 +512,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_31AC3262_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -526,7 +526,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -537,7 +537,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -548,7 +548,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -570,7 +570,7 @@
 				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0018: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -593,7 +593,7 @@
 				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0014: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -611,9 +611,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_31AC3262_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2063,10 +2063,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope,
-			[1] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest/FunctionObject_FunctionDeclaration_0503C5DA_startTest,
-			[2] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest/FunctionObject_FunctionDeclaration_3950DF5B_endTest,
-			[3] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep/FunctionObject_FunctionDeclaration_5501B021_prep,
-			[4] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test/FunctionObject_FunctionDeclaration_31AC3262_test,
+			[1] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest/FunctionObject,
+			[2] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest/FunctionObject,
+			[3] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep/FunctionObject,
+			[4] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test/FunctionObject,
 			[5] float64,
 			[6] object[],
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -2090,13 +2090,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest/FunctionObject_FunctionDeclaration_0503C5DA_startTest::.ctor()
+		IL_0012: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "startTest"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest/FunctionObject_FunctionDeclaration_0503C5DA_startTest>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -2105,13 +2105,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 6
-		IL_0032: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest/FunctionObject_FunctionDeclaration_3950DF5B_endTest::.ctor()
+		IL_0032: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest/FunctionObject::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "endTest"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest/FunctionObject_FunctionDeclaration_3950DF5B_endTest>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -2120,13 +2120,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 6
-		IL_0052: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep/FunctionObject_FunctionDeclaration_5501B021_prep::.ctor()
+		IL_0052: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep/FunctionObject::.ctor()
 		IL_0057: ldc.i4.1
 		IL_0058: conv.r8
 		IL_0059: ldstr "prep"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep/FunctionObject_FunctionDeclaration_5501B021_prep>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -2135,13 +2135,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 6
-		IL_0072: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test/FunctionObject_FunctionDeclaration_31AC3262_test::.ctor()
+		IL_0072: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test/FunctionObject::.ctor()
 		IL_0077: ldc.i4.2
 		IL_0078: conv.r8
 		IL_0079: ldstr "test"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test/FunctionObject_FunctionDeclaration_31AC3262_test>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: nop
 		IL_0088: nop

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6CF2F656_startTest
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -89,7 +89,7 @@
 				IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_001d: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest::__js_call__(object, string, string)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -113,7 +113,7 @@
 				IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0019: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest::__js_call__(object, string, string)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -131,9 +131,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6CF2F656_startTest
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -180,7 +180,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B7494A8F_endTest
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -194,7 +194,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -205,7 +205,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -216,7 +216,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -231,7 +231,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -247,7 +247,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -265,9 +265,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B7494A8F_endTest
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -333,7 +333,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6F708165_prep
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -347,7 +347,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -358,7 +358,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -369,7 +369,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -387,7 +387,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -406,7 +406,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -424,9 +424,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6F708165_prep
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -512,7 +512,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F3312FC6_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -526,7 +526,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -537,7 +537,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -548,7 +548,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -570,7 +570,7 @@
 				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0018: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -593,7 +593,7 @@
 				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0014: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -611,9 +611,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F3312FC6_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -679,7 +679,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7C555EF1_randomChar
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -693,7 +693,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -704,7 +704,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -715,7 +715,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -730,7 +730,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -746,7 +746,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -764,9 +764,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7C555EF1_randomChar
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -878,7 +878,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_244F5225_generateTestStrings
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -898,9 +898,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -911,7 +911,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -922,7 +922,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -935,7 +935,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -943,7 +943,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -957,7 +957,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -965,7 +965,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -983,9 +983,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_244F5225_generateTestStrings
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1247,7 +1247,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_84CD8439_L48C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1267,9 +1267,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject_FunctionExpression_84CD8439_L48C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1280,7 +1280,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1291,7 +1291,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1304,11 +1304,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject_FunctionExpression_84CD8439_L48C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1322,11 +1322,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject_FunctionExpression_84CD8439_L48C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1344,9 +1344,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_84CD8439_L48C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1424,7 +1424,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_40DF050A_L56C37
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1444,9 +1444,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject_FunctionExpression_40DF050A_L56C37::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1457,7 +1457,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1468,7 +1468,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1481,11 +1481,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject_FunctionExpression_40DF050A_L56C37::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1499,11 +1499,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject_FunctionExpression_40DF050A_L56C37::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1521,9 +1521,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_40DF050A_L56C37
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1615,7 +1615,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_367F8A10_L61C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1635,9 +1635,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject_FunctionExpression_367F8A10_L61C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1648,7 +1648,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1659,7 +1659,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1672,11 +1672,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject_FunctionExpression_367F8A10_L61C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1690,11 +1690,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject_FunctionExpression_367F8A10_L61C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1712,9 +1712,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_367F8A10_L61C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1792,7 +1792,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_048224EC_L66C36
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1812,9 +1812,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject_FunctionExpression_048224EC_L66C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1825,7 +1825,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1836,7 +1836,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1849,11 +1849,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject_FunctionExpression_048224EC_L66C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1867,11 +1867,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject_FunctionExpression_048224EC_L66C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1889,9 +1889,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_048224EC_L66C36
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1983,7 +1983,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7C0CF449_L71C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2003,9 +2003,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject_FunctionExpression_7C0CF449_L71C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2016,7 +2016,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2027,7 +2027,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2040,11 +2040,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject_FunctionExpression_7C0CF449_L71C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2058,11 +2058,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject_FunctionExpression_7C0CF449_L71C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2080,9 +2080,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7C0CF449_L71C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2160,7 +2160,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_99D19962_L76C40
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2180,9 +2180,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject_FunctionExpression_99D19962_L76C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2193,7 +2193,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2204,7 +2204,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2217,11 +2217,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject_FunctionExpression_99D19962_L76C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2235,11 +2235,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject_FunctionExpression_99D19962_L76C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2257,9 +2257,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_99D19962_L76C40
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2351,7 +2351,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F1E0E698_L83C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2371,9 +2371,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject_FunctionExpression_F1E0E698_L83C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2384,7 +2384,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2395,7 +2395,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2408,11 +2408,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject_FunctionExpression_F1E0E698_L83C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2426,11 +2426,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject_FunctionExpression_F1E0E698_L83C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2448,9 +2448,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F1E0E698_L83C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2528,7 +2528,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E322D6B7_L88C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2548,9 +2548,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject_FunctionExpression_E322D6B7_L88C24::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2561,7 +2561,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2572,7 +2572,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2585,11 +2585,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject_FunctionExpression_E322D6B7_L88C24::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2603,11 +2603,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject_FunctionExpression_E322D6B7_L88C24::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2625,9 +2625,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E322D6B7_L88C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2719,7 +2719,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_83D3F4FD_L93C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2739,9 +2739,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject_FunctionExpression_83D3F4FD_L93C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2752,7 +2752,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2763,7 +2763,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2776,11 +2776,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject_FunctionExpression_83D3F4FD_L93C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2794,11 +2794,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject_FunctionExpression_83D3F4FD_L93C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2816,9 +2816,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_83D3F4FD_L93C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2888,7 +2888,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_300CE2EA_L97C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2908,9 +2908,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject_FunctionExpression_300CE2EA_L97C23::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2921,7 +2921,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2932,7 +2932,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2945,11 +2945,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject_FunctionExpression_300CE2EA_L97C23::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2963,11 +2963,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject_FunctionExpression_300CE2EA_L97C23::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2985,9 +2985,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_300CE2EA_L97C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3077,7 +3077,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_15168718_L102C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3097,9 +3097,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject_FunctionExpression_15168718_L102C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_15168718_L102C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3110,7 +3110,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_15168718_L102C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3121,7 +3121,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_15168718_L102C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3134,11 +3134,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject_FunctionExpression_15168718_L102C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_15168718_L102C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3152,11 +3152,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject_FunctionExpression_15168718_L102C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_15168718_L102C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3174,9 +3174,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_15168718_L102C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_15168718_L102C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3246,7 +3246,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AADD4623_L106C32
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3266,9 +3266,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject_FunctionExpression_AADD4623_L106C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3279,7 +3279,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3290,7 +3290,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3303,11 +3303,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject_FunctionExpression_AADD4623_L106C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3321,11 +3321,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject_FunctionExpression_AADD4623_L106C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3343,9 +3343,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_AADD4623_L106C32
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3438,7 +3438,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_35949A34_L111C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3458,9 +3458,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject_FunctionExpression_35949A34_L111C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3471,7 +3471,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3482,7 +3482,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3495,11 +3495,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject_FunctionExpression_35949A34_L111C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3513,11 +3513,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject_FunctionExpression_35949A34_L111C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3535,9 +3535,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_35949A34_L111C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3607,7 +3607,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_123E59E1_L115C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3627,9 +3627,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject_FunctionExpression_123E59E1_L115C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3640,7 +3640,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3651,7 +3651,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3664,11 +3664,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject_FunctionExpression_123E59E1_L115C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3682,11 +3682,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject_FunctionExpression_123E59E1_L115C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3704,9 +3704,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_123E59E1_L115C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3799,7 +3799,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1A1A3900_L120C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3819,9 +3819,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject_FunctionExpression_1A1A3900_L120C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3832,7 +3832,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3843,7 +3843,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3856,11 +3856,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject_FunctionExpression_1A1A3900_L120C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3874,11 +3874,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject_FunctionExpression_1A1A3900_L120C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3896,9 +3896,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1A1A3900_L120C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3976,7 +3976,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A14DF61B_L125C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3996,9 +3996,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject_FunctionExpression_A14DF61B_L125C31::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4009,7 +4009,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4020,7 +4020,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4033,11 +4033,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject_FunctionExpression_A14DF61B_L125C31::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4051,11 +4051,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject_FunctionExpression_A14DF61B_L125C31::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4073,9 +4073,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A14DF61B_L125C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4167,7 +4167,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FEC96B05_L130C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4187,9 +4187,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject_FunctionExpression_FEC96B05_L130C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4200,7 +4200,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4211,7 +4211,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4224,11 +4224,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject_FunctionExpression_FEC96B05_L130C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4242,11 +4242,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject_FunctionExpression_FEC96B05_L130C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4264,9 +4264,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_FEC96B05_L130C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4336,7 +4336,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A2B06A06_L134C30
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4356,9 +4356,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject_FunctionExpression_A2B06A06_L134C30::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4369,7 +4369,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4380,7 +4380,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4393,11 +4393,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject_FunctionExpression_A2B06A06_L134C30::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4411,11 +4411,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject_FunctionExpression_A2B06A06_L134C30::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4433,9 +4433,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A2B06A06_L134C30
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4525,7 +4525,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_826BD7E2_L139C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4545,9 +4545,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject_FunctionExpression_826BD7E2_L139C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4558,7 +4558,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4569,7 +4569,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4582,11 +4582,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject_FunctionExpression_826BD7E2_L139C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4600,11 +4600,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject_FunctionExpression_826BD7E2_L139C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4622,9 +4622,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_826BD7E2_L139C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4694,7 +4694,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_52BFD713_L143C39
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4714,9 +4714,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject_FunctionExpression_52BFD713_L143C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4727,7 +4727,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4738,7 +4738,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4751,11 +4751,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject_FunctionExpression_52BFD713_L143C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4769,11 +4769,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject_FunctionExpression_52BFD713_L143C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4791,9 +4791,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_52BFD713_L143C39
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4886,7 +4886,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_ADF86AB6_L148C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4906,9 +4906,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject_FunctionExpression_ADF86AB6_L148C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4919,7 +4919,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4930,7 +4930,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4943,11 +4943,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject_FunctionExpression_ADF86AB6_L148C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4961,11 +4961,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject_FunctionExpression_ADF86AB6_L148C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4983,9 +4983,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_ADF86AB6_L148C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5055,7 +5055,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6A51803A_L152C41
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5075,9 +5075,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject_FunctionExpression_6A51803A_L152C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5088,7 +5088,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5099,7 +5099,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5112,11 +5112,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject_FunctionExpression_6A51803A_L152C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5130,11 +5130,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject_FunctionExpression_6A51803A_L152C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5152,9 +5152,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_6A51803A_L152C41
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5247,7 +5247,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_59F53CDE_L157C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5267,9 +5267,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject_FunctionExpression_59F53CDE_L157C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5280,7 +5280,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5291,7 +5291,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5304,11 +5304,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject_FunctionExpression_59F53CDE_L157C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5322,11 +5322,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject_FunctionExpression_59F53CDE_L157C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5344,9 +5344,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_59F53CDE_L157C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5420,7 +5420,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D2F1EA44_L163C34
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -5434,7 +5434,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -5445,7 +5445,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -5456,7 +5456,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -5474,7 +5474,7 @@
 					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
 					IL_0011: ret
-				} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -5493,7 +5493,7 @@
 					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -5511,9 +5511,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_D2F1EA44_L163C34
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -5555,7 +5555,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F7D2F9E6_L161C50
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5575,9 +5575,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject_FunctionExpression_F7D2F9E6_L161C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5588,7 +5588,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5599,7 +5599,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5612,11 +5612,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject_FunctionExpression_F7D2F9E6_L161C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5630,11 +5630,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject_FunctionExpression_F7D2F9E6_L161C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5652,9 +5652,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F7D2F9E6_L161C50
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5679,7 +5679,7 @@
 				[3] string,
 				[4] object,
 				[5] object[],
-				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33/FunctionObject_FunctionExpression_D2F1EA44_L163C34
+				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/Scope::.ctor()
@@ -5714,13 +5714,13 @@
 				IL_0051: ldarg.0
 				IL_0052: stelem.ref
 				IL_0053: stloc.s 5
-				IL_0055: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33/FunctionObject_FunctionExpression_D2F1EA44_L163C34::.ctor()
+				IL_0055: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33/FunctionObject::.ctor()
 				IL_005a: ldc.i4.1
 				IL_005b: conv.r8
 				IL_005c: ldstr ""
 				IL_0061: ldc.i4.0
 				IL_0062: ldc.i4.1
-				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33/FunctionObject_FunctionExpression_D2F1EA44_L163C34>(!!0, float64, string, bool, bool)
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0068: stloc.s 6
 				IL_006a: ldloc.3
 				IL_006b: ldstr "replace"
@@ -5767,7 +5767,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5BE125D1_L170C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5787,9 +5787,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject_FunctionExpression_5BE125D1_L170C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5800,7 +5800,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5811,7 +5811,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -5824,11 +5824,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject_FunctionExpression_5BE125D1_L170C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -5842,11 +5842,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject_FunctionExpression_5BE125D1_L170C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -5864,9 +5864,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5BE125D1_L170C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5944,7 +5944,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E6D30A9E_L175C33
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -5964,9 +5964,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject_FunctionExpression_E6D30A9E_L175C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5977,7 +5977,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5988,7 +5988,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6001,11 +6001,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject_FunctionExpression_E6D30A9E_L175C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6019,11 +6019,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject_FunctionExpression_E6D30A9E_L175C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6041,9 +6041,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E6D30A9E_L175C33
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6135,7 +6135,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_316E4A1A_L180C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6155,9 +6155,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject_FunctionExpression_316E4A1A_L180C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6168,7 +6168,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6179,7 +6179,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6192,11 +6192,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject_FunctionExpression_316E4A1A_L180C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6210,11 +6210,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject_FunctionExpression_316E4A1A_L180C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6232,9 +6232,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_316E4A1A_L180C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6304,7 +6304,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F75042ED_L184C32
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6324,9 +6324,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject_FunctionExpression_F75042ED_L184C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6337,7 +6337,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6348,7 +6348,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6361,11 +6361,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject_FunctionExpression_F75042ED_L184C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6379,11 +6379,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject_FunctionExpression_F75042ED_L184C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6401,9 +6401,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F75042ED_L184C32
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6493,7 +6493,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DE23A66D_L189C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6513,9 +6513,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject_FunctionExpression_DE23A66D_L189C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6526,7 +6526,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6537,7 +6537,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6550,11 +6550,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject_FunctionExpression_DE23A66D_L189C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6568,11 +6568,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject_FunctionExpression_DE23A66D_L189C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6590,9 +6590,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_DE23A66D_L189C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6662,7 +6662,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_59F2FA63_L193C41
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6682,9 +6682,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject_FunctionExpression_59F2FA63_L193C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6695,7 +6695,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6706,7 +6706,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6719,11 +6719,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject_FunctionExpression_59F2FA63_L193C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6737,11 +6737,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject_FunctionExpression_59F2FA63_L193C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6759,9 +6759,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_59F2FA63_L193C41
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6854,7 +6854,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FD52FD47_L198C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6874,9 +6874,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject_FunctionExpression_FD52FD47_L198C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6887,7 +6887,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6898,7 +6898,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6911,11 +6911,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject_FunctionExpression_FD52FD47_L198C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6929,11 +6929,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject_FunctionExpression_FD52FD47_L198C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6951,9 +6951,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_FD52FD47_L198C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7023,7 +7023,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AB7296C4_L202C43
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -7043,9 +7043,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject_FunctionExpression_AB7296C4_L202C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7056,7 +7056,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7067,7 +7067,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7080,11 +7080,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject_FunctionExpression_AB7296C4_L202C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7098,11 +7098,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject_FunctionExpression_AB7296C4_L202C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7120,9 +7120,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_AB7296C4_L202C43
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7215,7 +7215,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6250884E_L207C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -7235,9 +7235,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject_FunctionExpression_6250884E_L207C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7248,7 +7248,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7259,7 +7259,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7272,11 +7272,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject_FunctionExpression_6250884E_L207C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7290,11 +7290,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject_FunctionExpression_6250884E_L207C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7312,9 +7312,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_6250884E_L207C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7392,7 +7392,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9FBA592E_L212C40
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -7412,9 +7412,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject_FunctionExpression_9FBA592E_L212C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7425,7 +7425,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7436,7 +7436,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7449,11 +7449,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject_FunctionExpression_9FBA592E_L212C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7467,11 +7467,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject_FunctionExpression_9FBA592E_L212C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7489,9 +7489,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_9FBA592E_L212C40
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7583,7 +7583,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6442B403_L217C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -7603,9 +7603,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject_FunctionExpression_6442B403_L217C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7616,7 +7616,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7627,7 +7627,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7640,11 +7640,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject_FunctionExpression_6442B403_L217C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7658,11 +7658,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject_FunctionExpression_6442B403_L217C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7680,9 +7680,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_6442B403_L217C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7752,7 +7752,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7B23A4A4_L221C39
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -7772,9 +7772,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject_FunctionExpression_7B23A4A4_L221C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7785,7 +7785,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7796,7 +7796,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7809,11 +7809,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject_FunctionExpression_7B23A4A4_L221C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7827,11 +7827,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject_FunctionExpression_7B23A4A4_L221C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7849,9 +7849,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7B23A4A4_L221C39
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7941,7 +7941,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_15CEA57B_L226C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -7961,9 +7961,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject_FunctionExpression_15CEA57B_L226C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7974,7 +7974,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7985,7 +7985,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7998,11 +7998,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject_FunctionExpression_15CEA57B_L226C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8016,11 +8016,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject_FunctionExpression_15CEA57B_L226C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8038,9 +8038,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_15CEA57B_L226C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8110,7 +8110,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CE64C73E_L230C48
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8130,9 +8130,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject_FunctionExpression_CE64C73E_L230C48::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8143,7 +8143,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8154,7 +8154,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8167,11 +8167,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject_FunctionExpression_CE64C73E_L230C48::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8185,11 +8185,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject_FunctionExpression_CE64C73E_L230C48::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8207,9 +8207,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_CE64C73E_L230C48
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8302,7 +8302,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6B3295AB_L235C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8322,9 +8322,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject_FunctionExpression_6B3295AB_L235C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8335,7 +8335,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8346,7 +8346,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8359,11 +8359,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject_FunctionExpression_6B3295AB_L235C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8377,11 +8377,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject_FunctionExpression_6B3295AB_L235C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8399,9 +8399,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_6B3295AB_L235C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8471,7 +8471,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1419E03E_L239C50
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8491,9 +8491,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject_FunctionExpression_1419E03E_L239C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8504,7 +8504,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8515,7 +8515,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8528,11 +8528,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject_FunctionExpression_1419E03E_L239C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8546,11 +8546,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject_FunctionExpression_1419E03E_L239C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8568,9 +8568,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1419E03E_L239C50
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8663,7 +8663,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1AD25763_L244C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8683,9 +8683,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject_FunctionExpression_1AD25763_L244C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8696,7 +8696,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8707,7 +8707,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8720,11 +8720,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject_FunctionExpression_1AD25763_L244C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8738,11 +8738,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject_FunctionExpression_1AD25763_L244C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8760,9 +8760,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1AD25763_L244C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8836,7 +8836,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_44DC3DAF_L250C34
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -8850,7 +8850,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -8861,7 +8861,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -8872,7 +8872,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -8890,7 +8890,7 @@
 					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
 					IL_0011: ret
-				} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -8909,7 +8909,7 @@
 					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -8927,9 +8927,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_44DC3DAF_L250C34
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -8971,7 +8971,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B68C9781_L248C59
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8991,9 +8991,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject_FunctionExpression_B68C9781_L248C59::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9004,7 +9004,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9015,7 +9015,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9028,11 +9028,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject_FunctionExpression_B68C9781_L248C59::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9046,11 +9046,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject_FunctionExpression_B68C9781_L248C59::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -9068,9 +9068,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_B68C9781_L248C59
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -9095,7 +9095,7 @@
 				[3] string,
 				[4] object,
 				[5] object[],
-				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33/FunctionObject_FunctionExpression_44DC3DAF_L250C34
+				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/Scope::.ctor()
@@ -9130,13 +9130,13 @@
 				IL_0051: ldarg.0
 				IL_0052: stelem.ref
 				IL_0053: stloc.s 5
-				IL_0055: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33/FunctionObject_FunctionExpression_44DC3DAF_L250C34::.ctor()
+				IL_0055: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33/FunctionObject::.ctor()
 				IL_005a: ldc.i4.1
 				IL_005b: conv.r8
 				IL_005c: ldstr ""
 				IL_0061: ldc.i4.0
 				IL_0062: ldc.i4.1
-				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33/FunctionObject_FunctionExpression_44DC3DAF_L250C34>(!!0, float64, string, bool, bool)
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0068: stloc.s 6
 				IL_006a: ldloc.3
 				IL_006b: ldstr "replace"
@@ -9183,7 +9183,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_62C7C36F_L257C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -9203,9 +9203,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject_FunctionExpression_62C7C36F_L257C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9216,7 +9216,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9227,7 +9227,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9240,11 +9240,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject_FunctionExpression_62C7C36F_L257C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9258,11 +9258,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject_FunctionExpression_62C7C36F_L257C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -9280,9 +9280,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_62C7C36F_L257C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -9360,7 +9360,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BE52CC8A_L262C32
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -9380,9 +9380,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject_FunctionExpression_BE52CC8A_L262C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9393,7 +9393,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9404,7 +9404,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9417,11 +9417,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject_FunctionExpression_BE52CC8A_L262C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9435,11 +9435,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject_FunctionExpression_BE52CC8A_L262C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -9457,9 +9457,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_BE52CC8A_L262C32
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -9551,7 +9551,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1AD7FAC4_L267C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -9571,9 +9571,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject_FunctionExpression_1AD7FAC4_L267C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9584,7 +9584,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9595,7 +9595,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9608,11 +9608,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject_FunctionExpression_1AD7FAC4_L267C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9626,11 +9626,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject_FunctionExpression_1AD7FAC4_L267C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -9648,9 +9648,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1AD7FAC4_L267C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -9720,7 +9720,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_75E34588_L271C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -9740,9 +9740,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject_FunctionExpression_75E34588_L271C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9753,7 +9753,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9764,7 +9764,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9777,11 +9777,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject_FunctionExpression_75E34588_L271C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9795,11 +9795,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject_FunctionExpression_75E34588_L271C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -9817,9 +9817,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_75E34588_L271C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -9912,7 +9912,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_98DF622E_L276C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -9932,9 +9932,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject_FunctionExpression_98DF622E_L276C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -9945,7 +9945,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -9956,7 +9956,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -9969,11 +9969,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject_FunctionExpression_98DF622E_L276C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -9987,11 +9987,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject_FunctionExpression_98DF622E_L276C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -10009,9 +10009,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_98DF622E_L276C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -10081,7 +10081,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6EF0F712_L280C47
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -10101,9 +10101,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject_FunctionExpression_6EF0F712_L280C47::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -10114,7 +10114,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -10125,7 +10125,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -10138,11 +10138,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject_FunctionExpression_6EF0F712_L280C47::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -10156,11 +10156,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject_FunctionExpression_6EF0F712_L280C47::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -10178,9 +10178,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_6EF0F712_L280C47
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -10273,7 +10273,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0304DE8C_L285C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -10293,9 +10293,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject_FunctionExpression_0304DE8C_L285C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -10306,7 +10306,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -10317,7 +10317,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -10330,11 +10330,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject_FunctionExpression_0304DE8C_L285C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -10348,11 +10348,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject_FunctionExpression_0304DE8C_L285C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -10370,9 +10370,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_0304DE8C_L285C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -10446,7 +10446,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_561F59BC_L291C34
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -10460,7 +10460,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -10471,7 +10471,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -10482,7 +10482,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -10503,7 +10503,7 @@
 					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0013: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
 					IL_0018: ret
-				} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -10525,7 +10525,7 @@
 					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -10543,9 +10543,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_561F59BC_L291C34
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -10599,7 +10599,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D94750FD_L289C56
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -10619,9 +10619,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject_FunctionExpression_D94750FD_L289C56::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -10632,7 +10632,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -10643,7 +10643,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -10656,11 +10656,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject_FunctionExpression_D94750FD_L289C56::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -10674,11 +10674,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject_FunctionExpression_D94750FD_L289C56::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -10696,9 +10696,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D94750FD_L289C56
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -10723,7 +10723,7 @@
 				[3] string,
 				[4] object,
 				[5] object[],
-				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33/FunctionObject_FunctionExpression_561F59BC_L291C34
+				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/Scope::.ctor()
@@ -10758,13 +10758,13 @@
 				IL_0051: ldarg.0
 				IL_0052: stelem.ref
 				IL_0053: stloc.s 5
-				IL_0055: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33/FunctionObject_FunctionExpression_561F59BC_L291C34::.ctor()
+				IL_0055: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33/FunctionObject::.ctor()
 				IL_005a: ldc.i4.2
 				IL_005b: conv.r8
 				IL_005c: ldstr ""
 				IL_0061: ldc.i4.0
 				IL_0062: ldc.i4.1
-				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33/FunctionObject_FunctionExpression_561F59BC_L291C34>(!!0, float64, string, bool, bool)
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0068: stloc.s 6
 				IL_006a: ldloc.3
 				IL_006b: ldstr "replace"
@@ -10811,7 +10811,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_29656618_L296C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -10831,9 +10831,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject_FunctionExpression_29656618_L296C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_29656618_L296C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -10844,7 +10844,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_29656618_L296C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -10855,7 +10855,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_29656618_L296C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -10868,11 +10868,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject_FunctionExpression_29656618_L296C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_29656618_L296C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -10886,11 +10886,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject_FunctionExpression_29656618_L296C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_29656618_L296C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -10908,9 +10908,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_29656618_L296C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_29656618_L296C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -10984,7 +10984,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_691C8819_L302C34
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -10998,7 +10998,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -11009,7 +11009,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -11020,7 +11020,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -11041,7 +11041,7 @@
 					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0013: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
 					IL_0018: ret
-				} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -11063,7 +11063,7 @@
 					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -11081,9 +11081,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_691C8819_L302C34
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -11134,7 +11134,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1062EA27_L300C65
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -11154,9 +11154,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject_FunctionExpression_1062EA27_L300C65::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -11167,7 +11167,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -11178,7 +11178,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -11191,11 +11191,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject_FunctionExpression_1062EA27_L300C65::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -11209,11 +11209,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject_FunctionExpression_1062EA27_L300C65::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -11231,9 +11231,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1062EA27_L300C65
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -11258,7 +11258,7 @@
 				[3] string,
 				[4] object,
 				[5] object[],
-				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33/FunctionObject_FunctionExpression_691C8819_L302C34
+				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/Scope::.ctor()
@@ -11293,13 +11293,13 @@
 				IL_0051: ldarg.0
 				IL_0052: stelem.ref
 				IL_0053: stloc.s 5
-				IL_0055: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33/FunctionObject_FunctionExpression_691C8819_L302C34::.ctor()
+				IL_0055: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33/FunctionObject::.ctor()
 				IL_005a: ldc.i4.2
 				IL_005b: conv.r8
 				IL_005c: ldstr ""
 				IL_0061: ldc.i4.0
 				IL_0062: ldc.i4.1
-				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33/FunctionObject_FunctionExpression_691C8819_L302C34>(!!0, float64, string, bool, bool)
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0068: stloc.s 6
 				IL_006a: ldloc.3
 				IL_006b: ldstr "replace"
@@ -11346,7 +11346,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_612413E3_L309C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -11366,9 +11366,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject_FunctionExpression_612413E3_L309C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -11379,7 +11379,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -11390,7 +11390,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -11403,11 +11403,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject_FunctionExpression_612413E3_L309C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -11421,11 +11421,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject_FunctionExpression_612413E3_L309C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -11443,9 +11443,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_612413E3_L309C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -11515,7 +11515,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5D299276_L313C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -11535,9 +11535,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject_FunctionExpression_5D299276_L313C26::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -11548,7 +11548,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -11559,7 +11559,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -11572,11 +11572,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject_FunctionExpression_5D299276_L313C26::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -11590,11 +11590,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject_FunctionExpression_5D299276_L313C26::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -11612,9 +11612,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5D299276_L313C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -11708,7 +11708,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AF818725_L318C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -11728,9 +11728,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject_FunctionExpression_AF818725_L318C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -11741,7 +11741,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -11752,7 +11752,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -11765,11 +11765,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject_FunctionExpression_AF818725_L318C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -11783,11 +11783,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject_FunctionExpression_AF818725_L318C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -11805,9 +11805,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_AF818725_L318C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -11877,7 +11877,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_64DC70FB_L322C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -11897,9 +11897,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject_FunctionExpression_64DC70FB_L322C25::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -11910,7 +11910,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -11921,7 +11921,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -11934,11 +11934,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject_FunctionExpression_64DC70FB_L322C25::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -11952,11 +11952,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject_FunctionExpression_64DC70FB_L322C25::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -11974,9 +11974,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_64DC70FB_L322C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -12066,7 +12066,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_455C0AC7_L327C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -12086,9 +12086,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject_FunctionExpression_455C0AC7_L327C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -12099,7 +12099,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -12110,7 +12110,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -12123,11 +12123,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject_FunctionExpression_455C0AC7_L327C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -12141,11 +12141,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject_FunctionExpression_455C0AC7_L327C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -12163,9 +12163,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_455C0AC7_L327C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -12235,7 +12235,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C0E29ED5_L331C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -12255,9 +12255,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject_FunctionExpression_C0E29ED5_L331C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -12268,7 +12268,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -12279,7 +12279,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -12292,11 +12292,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject_FunctionExpression_C0E29ED5_L331C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -12310,11 +12310,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject_FunctionExpression_C0E29ED5_L331C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -12332,9 +12332,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C0E29ED5_L331C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -12429,7 +12429,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_78E8D78D_L336C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -12449,9 +12449,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject_FunctionExpression_78E8D78D_L336C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -12462,7 +12462,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -12473,7 +12473,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -12486,11 +12486,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject_FunctionExpression_78E8D78D_L336C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -12504,11 +12504,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject_FunctionExpression_78E8D78D_L336C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -12526,9 +12526,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_78E8D78D_L336C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -12598,7 +12598,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_31C4DBA7_L340C36
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -12618,9 +12618,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject_FunctionExpression_31C4DBA7_L340C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -12631,7 +12631,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -12642,7 +12642,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -12655,11 +12655,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject_FunctionExpression_31C4DBA7_L340C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -12673,11 +12673,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject_FunctionExpression_31C4DBA7_L340C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -12695,9 +12695,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_31C4DBA7_L340C36
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -12792,7 +12792,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_ADC77423_L345C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -12812,9 +12812,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject_FunctionExpression_ADC77423_L345C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -12825,7 +12825,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -12836,7 +12836,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -12849,11 +12849,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject_FunctionExpression_ADC77423_L345C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -12867,11 +12867,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject_FunctionExpression_ADC77423_L345C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -12889,9 +12889,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_ADC77423_L345C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -12961,7 +12961,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AB0D0A79_L349C33
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -12981,9 +12981,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject_FunctionExpression_AB0D0A79_L349C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -12994,7 +12994,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -13005,7 +13005,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -13018,11 +13018,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject_FunctionExpression_AB0D0A79_L349C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -13036,11 +13036,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject_FunctionExpression_AB0D0A79_L349C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -13058,9 +13058,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_AB0D0A79_L349C33
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -13154,7 +13154,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FE9F5065_L354C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -13174,9 +13174,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject_FunctionExpression_FE9F5065_L354C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -13187,7 +13187,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -13198,7 +13198,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -13211,11 +13211,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject_FunctionExpression_FE9F5065_L354C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -13229,11 +13229,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject_FunctionExpression_FE9F5065_L354C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -13251,9 +13251,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_FE9F5065_L354C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -13323,7 +13323,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_48BE92D8_L358C32
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -13343,9 +13343,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject_FunctionExpression_48BE92D8_L358C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -13356,7 +13356,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -13367,7 +13367,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -13380,11 +13380,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject_FunctionExpression_48BE92D8_L358C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -13398,11 +13398,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject_FunctionExpression_48BE92D8_L358C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -13420,9 +13420,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_48BE92D8_L358C32
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -13512,7 +13512,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4D9B395F_L363C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -13532,9 +13532,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject_FunctionExpression_4D9B395F_L363C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -13545,7 +13545,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -13556,7 +13556,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -13569,11 +13569,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject_FunctionExpression_4D9B395F_L363C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -13587,11 +13587,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject_FunctionExpression_4D9B395F_L363C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -13609,9 +13609,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_4D9B395F_L363C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -13681,7 +13681,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_222F9CF0_L367C41
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -13701,9 +13701,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject_FunctionExpression_222F9CF0_L367C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -13714,7 +13714,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -13725,7 +13725,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -13738,11 +13738,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject_FunctionExpression_222F9CF0_L367C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -13756,11 +13756,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject_FunctionExpression_222F9CF0_L367C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -13778,9 +13778,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_222F9CF0_L367C41
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -13875,7 +13875,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F85E69FD_L372C6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -13895,9 +13895,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject_FunctionExpression_F85E69FD_L372C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -13908,7 +13908,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -13919,7 +13919,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -13932,11 +13932,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject_FunctionExpression_F85E69FD_L372C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -13950,11 +13950,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject_FunctionExpression_F85E69FD_L372C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -13972,9 +13972,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F85E69FD_L372C6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -14044,7 +14044,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9DF3FAC8_L376C43
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -14064,9 +14064,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject_FunctionExpression_9DF3FAC8_L376C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -14077,7 +14077,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -14088,7 +14088,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -14101,11 +14101,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject_FunctionExpression_9DF3FAC8_L376C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -14119,11 +14119,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject_FunctionExpression_9DF3FAC8_L376C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject::_environment0_Compile_Performance_Dromaeo_Object_Regexp
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -14141,9 +14141,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_9DF3FAC8_L376C43
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -14273,88 +14273,88 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope,
-			[1] class Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest/FunctionObject_FunctionDeclaration_6CF2F656_startTest,
-			[2] class Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest/FunctionObject_FunctionDeclaration_B7494A8F_endTest,
-			[3] class Modules.Compile_Performance_Dromaeo_Object_Regexp/prep/FunctionObject_FunctionDeclaration_6F708165_prep,
-			[4] class Modules.Compile_Performance_Dromaeo_Object_Regexp/test/FunctionObject_FunctionDeclaration_F3312FC6_test,
+			[1] class Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest/FunctionObject,
+			[2] class Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest/FunctionObject,
+			[3] class Modules.Compile_Performance_Dromaeo_Object_Regexp/prep/FunctionObject,
+			[4] class Modules.Compile_Performance_Dromaeo_Object_Regexp/test/FunctionObject,
 			[5] float64,
 			[6] object[],
-			[7] class Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar/FunctionObject_FunctionDeclaration_7C555EF1_randomChar,
-			[8] class Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject_FunctionDeclaration_244F5225_generateTestStrings,
+			[7] class Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar/FunctionObject,
+			[8] class Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[10] float64,
 			[11] object,
 			[12] object,
 			[13] object,
 			[14] object[],
-			[15] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject_FunctionExpression_84CD8439_L48C6,
-			[16] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject_FunctionExpression_40DF050A_L56C37,
-			[17] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject_FunctionExpression_367F8A10_L61C6,
-			[18] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject_FunctionExpression_048224EC_L66C36,
-			[19] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject_FunctionExpression_7C0CF449_L71C6,
-			[20] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject_FunctionExpression_99D19962_L76C40,
-			[21] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject_FunctionExpression_F1E0E698_L83C6,
-			[22] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject_FunctionExpression_E322D6B7_L88C24,
-			[23] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject_FunctionExpression_83D3F4FD_L93C6,
-			[24] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject_FunctionExpression_300CE2EA_L97C23,
-			[25] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject_FunctionExpression_15168718_L102C6,
-			[26] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject_FunctionExpression_AADD4623_L106C32,
-			[27] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject_FunctionExpression_35949A34_L111C6,
-			[28] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject_FunctionExpression_123E59E1_L115C34,
-			[29] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject_FunctionExpression_1A1A3900_L120C6,
-			[30] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject_FunctionExpression_A14DF61B_L125C31,
-			[31] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject_FunctionExpression_FEC96B05_L130C6,
-			[32] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject_FunctionExpression_A2B06A06_L134C30,
-			[33] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject_FunctionExpression_826BD7E2_L139C6,
-			[34] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject_FunctionExpression_52BFD713_L143C39,
-			[35] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject_FunctionExpression_ADF86AB6_L148C6,
-			[36] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject_FunctionExpression_6A51803A_L152C41,
-			[37] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject_FunctionExpression_59F53CDE_L157C6,
-			[38] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject_FunctionExpression_F7D2F9E6_L161C50,
-			[39] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject_FunctionExpression_5BE125D1_L170C6,
-			[40] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject_FunctionExpression_E6D30A9E_L175C33,
-			[41] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject_FunctionExpression_316E4A1A_L180C6,
-			[42] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject_FunctionExpression_F75042ED_L184C32,
-			[43] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject_FunctionExpression_DE23A66D_L189C6,
-			[44] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject_FunctionExpression_59F2FA63_L193C41,
-			[45] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject_FunctionExpression_FD52FD47_L198C6,
-			[46] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject_FunctionExpression_AB7296C4_L202C43,
-			[47] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject_FunctionExpression_6250884E_L207C6,
-			[48] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject_FunctionExpression_9FBA592E_L212C40,
-			[49] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject_FunctionExpression_6442B403_L217C6,
-			[50] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject_FunctionExpression_7B23A4A4_L221C39,
-			[51] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject_FunctionExpression_15CEA57B_L226C6,
-			[52] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject_FunctionExpression_CE64C73E_L230C48,
-			[53] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject_FunctionExpression_6B3295AB_L235C6,
-			[54] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject_FunctionExpression_1419E03E_L239C50,
-			[55] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject_FunctionExpression_1AD25763_L244C6,
-			[56] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject_FunctionExpression_B68C9781_L248C59,
-			[57] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject_FunctionExpression_62C7C36F_L257C6,
-			[58] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject_FunctionExpression_BE52CC8A_L262C32,
-			[59] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject_FunctionExpression_1AD7FAC4_L267C6,
-			[60] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject_FunctionExpression_75E34588_L271C34,
-			[61] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject_FunctionExpression_98DF622E_L276C6,
-			[62] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject_FunctionExpression_6EF0F712_L280C47,
-			[63] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject_FunctionExpression_0304DE8C_L285C6,
-			[64] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject_FunctionExpression_D94750FD_L289C56,
-			[65] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject_FunctionExpression_29656618_L296C6,
-			[66] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject_FunctionExpression_1062EA27_L300C65,
-			[67] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject_FunctionExpression_612413E3_L309C6,
-			[68] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject_FunctionExpression_5D299276_L313C26,
-			[69] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject_FunctionExpression_AF818725_L318C6,
-			[70] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject_FunctionExpression_64DC70FB_L322C25,
-			[71] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject_FunctionExpression_455C0AC7_L327C6,
-			[72] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject_FunctionExpression_C0E29ED5_L331C34,
-			[73] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject_FunctionExpression_78E8D78D_L336C6,
-			[74] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject_FunctionExpression_31C4DBA7_L340C36,
-			[75] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject_FunctionExpression_ADC77423_L345C6,
-			[76] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject_FunctionExpression_AB0D0A79_L349C33,
-			[77] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject_FunctionExpression_FE9F5065_L354C6,
-			[78] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject_FunctionExpression_48BE92D8_L358C32,
-			[79] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject_FunctionExpression_4D9B395F_L363C6,
-			[80] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject_FunctionExpression_222F9CF0_L367C41,
-			[81] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject_FunctionExpression_F85E69FD_L372C6,
-			[82] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject_FunctionExpression_9DF3FAC8_L376C43
+			[15] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject,
+			[16] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject,
+			[17] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject,
+			[18] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject,
+			[19] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject,
+			[20] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject,
+			[21] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject,
+			[22] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject,
+			[23] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject,
+			[24] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject,
+			[25] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject,
+			[26] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject,
+			[27] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject,
+			[28] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject,
+			[29] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject,
+			[30] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject,
+			[31] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject,
+			[32] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject,
+			[33] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject,
+			[34] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject,
+			[35] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject,
+			[36] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject,
+			[37] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject,
+			[38] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject,
+			[39] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject,
+			[40] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject,
+			[41] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject,
+			[42] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject,
+			[43] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject,
+			[44] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject,
+			[45] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject,
+			[46] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject,
+			[47] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject,
+			[48] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject,
+			[49] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject,
+			[50] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject,
+			[51] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject,
+			[52] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject,
+			[53] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject,
+			[54] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject,
+			[55] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject,
+			[56] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject,
+			[57] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject,
+			[58] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject,
+			[59] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject,
+			[60] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject,
+			[61] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject,
+			[62] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject,
+			[63] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject,
+			[64] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject,
+			[65] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject,
+			[66] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject,
+			[67] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject,
+			[68] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject,
+			[69] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject,
+			[70] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject,
+			[71] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject,
+			[72] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject,
+			[73] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject,
+			[74] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject,
+			[75] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject,
+			[76] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject,
+			[77] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject,
+			[78] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject,
+			[79] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject,
+			[80] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject,
+			[81] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject,
+			[82] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::.ctor()
@@ -14366,13 +14366,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest/FunctionObject_FunctionDeclaration_6CF2F656_startTest::.ctor()
+		IL_0012: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "startTest"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest/FunctionObject_FunctionDeclaration_6CF2F656_startTest>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -14381,13 +14381,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 6
-		IL_0032: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest/FunctionObject_FunctionDeclaration_B7494A8F_endTest::.ctor()
+		IL_0032: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest/FunctionObject::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "endTest"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest/FunctionObject_FunctionDeclaration_B7494A8F_endTest>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -14396,13 +14396,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 6
-		IL_0052: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/prep/FunctionObject_FunctionDeclaration_6F708165_prep::.ctor()
+		IL_0052: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/prep/FunctionObject::.ctor()
 		IL_0057: ldc.i4.1
 		IL_0058: conv.r8
 		IL_0059: ldstr "prep"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/prep/FunctionObject_FunctionDeclaration_6F708165_prep>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/prep/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -14411,13 +14411,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 6
-		IL_0072: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/test/FunctionObject_FunctionDeclaration_F3312FC6_test::.ctor()
+		IL_0072: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/test/FunctionObject::.ctor()
 		IL_0077: ldc.i4.2
 		IL_0078: conv.r8
 		IL_0079: ldstr "test"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/test/FunctionObject_FunctionDeclaration_F3312FC6_test>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/test/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -14426,13 +14426,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 6
-		IL_0093: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar/FunctionObject_FunctionDeclaration_7C555EF1_randomChar::.ctor()
+		IL_0093: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar/FunctionObject::.ctor()
 		IL_0098: ldc.i4.0
 		IL_0099: conv.r8
 		IL_009a: ldstr "randomChar"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar/FunctionObject_FunctionDeclaration_7C555EF1_randomChar>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 7
 		IL_00a8: ldloc.0
 		IL_00a9: ldloc.s 7
@@ -14448,13 +14448,13 @@
 		IL_00be: ldc.i4.0
 		IL_00bf: ldelem.ref
 		IL_00c0: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_00c5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_00c5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_00ca: ldc.i4.1
 		IL_00cb: conv.r8
 		IL_00cc: ldstr "generateTestStrings"
 		IL_00d1: ldc.i4.0
 		IL_00d2: ldc.i4.1
-		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject_FunctionDeclaration_244F5225_generateTestStrings>(!!0, float64, string, bool, bool)
+		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d8: stloc.s 8
 		IL_00da: ldloc.0
 		IL_00db: ldloc.s 8
@@ -14579,13 +14579,13 @@
 		IL_022e: ldc.i4.0
 		IL_022f: ldelem.ref
 		IL_0230: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0235: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject_FunctionExpression_84CD8439_L48C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0235: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_023a: ldc.i4.0
 		IL_023b: conv.r8
 		IL_023c: ldstr ""
 		IL_0241: ldc.i4.0
 		IL_0242: ldc.i4.1
-		IL_0243: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject_FunctionExpression_84CD8439_L48C6>(!!0, float64, string, bool, bool)
+		IL_0243: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0248: stloc.s 15
 		IL_024a: ldloc.3
 		IL_024b: ldloc.s 6
@@ -14605,13 +14605,13 @@
 		IL_026a: ldc.i4.0
 		IL_026b: ldelem.ref
 		IL_026c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0271: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject_FunctionExpression_40DF050A_L56C37::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0271: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0276: ldc.i4.0
 		IL_0277: conv.r8
 		IL_0278: ldstr ""
 		IL_027d: ldc.i4.0
 		IL_027e: ldc.i4.1
-		IL_027f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject_FunctionExpression_40DF050A_L56C37>(!!0, float64, string, bool, bool)
+		IL_027f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0284: stloc.s 16
 		IL_0286: ldloc.s 4
 		IL_0288: ldloc.s 6
@@ -14632,13 +14632,13 @@
 		IL_02ac: ldc.i4.0
 		IL_02ad: ldelem.ref
 		IL_02ae: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_02b3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject_FunctionExpression_367F8A10_L61C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_02b3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_02b8: ldc.i4.0
 		IL_02b9: conv.r8
 		IL_02ba: ldstr ""
 		IL_02bf: ldc.i4.0
 		IL_02c0: ldc.i4.1
-		IL_02c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject_FunctionExpression_367F8A10_L61C6>(!!0, float64, string, bool, bool)
+		IL_02c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02c6: stloc.s 17
 		IL_02c8: ldloc.3
 		IL_02c9: ldloc.s 6
@@ -14658,13 +14658,13 @@
 		IL_02e8: ldc.i4.0
 		IL_02e9: ldelem.ref
 		IL_02ea: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_02ef: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject_FunctionExpression_048224EC_L66C36::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_02ef: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_02f4: ldc.i4.0
 		IL_02f5: conv.r8
 		IL_02f6: ldstr ""
 		IL_02fb: ldc.i4.0
 		IL_02fc: ldc.i4.1
-		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject_FunctionExpression_048224EC_L66C36>(!!0, float64, string, bool, bool)
+		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0302: stloc.s 18
 		IL_0304: ldloc.s 4
 		IL_0306: ldloc.s 6
@@ -14685,13 +14685,13 @@
 		IL_032a: ldc.i4.0
 		IL_032b: ldelem.ref
 		IL_032c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0331: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject_FunctionExpression_7C0CF449_L71C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0331: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0336: ldc.i4.0
 		IL_0337: conv.r8
 		IL_0338: ldstr ""
 		IL_033d: ldc.i4.0
 		IL_033e: ldc.i4.1
-		IL_033f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject_FunctionExpression_7C0CF449_L71C6>(!!0, float64, string, bool, bool)
+		IL_033f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0344: stloc.s 19
 		IL_0346: ldloc.3
 		IL_0347: ldloc.s 6
@@ -14711,13 +14711,13 @@
 		IL_0366: ldc.i4.0
 		IL_0367: ldelem.ref
 		IL_0368: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_036d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject_FunctionExpression_99D19962_L76C40::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_036d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0372: ldc.i4.0
 		IL_0373: conv.r8
 		IL_0374: ldstr ""
 		IL_0379: ldc.i4.0
 		IL_037a: ldc.i4.1
-		IL_037b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject_FunctionExpression_99D19962_L76C40>(!!0, float64, string, bool, bool)
+		IL_037b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0380: stloc.s 20
 		IL_0382: ldloc.s 4
 		IL_0384: ldloc.s 6
@@ -14738,13 +14738,13 @@
 		IL_03a8: ldc.i4.0
 		IL_03a9: ldelem.ref
 		IL_03aa: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_03af: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject_FunctionExpression_F1E0E698_L83C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_03af: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_03b4: ldc.i4.0
 		IL_03b5: conv.r8
 		IL_03b6: ldstr ""
 		IL_03bb: ldc.i4.0
 		IL_03bc: ldc.i4.1
-		IL_03bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject_FunctionExpression_F1E0E698_L83C6>(!!0, float64, string, bool, bool)
+		IL_03bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_03c2: stloc.s 21
 		IL_03c4: ldloc.3
 		IL_03c5: ldloc.s 6
@@ -14764,13 +14764,13 @@
 		IL_03e4: ldc.i4.0
 		IL_03e5: ldelem.ref
 		IL_03e6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_03eb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject_FunctionExpression_E322D6B7_L88C24::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_03eb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_03f0: ldc.i4.0
 		IL_03f1: conv.r8
 		IL_03f2: ldstr ""
 		IL_03f7: ldc.i4.0
 		IL_03f8: ldc.i4.1
-		IL_03f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject_FunctionExpression_E322D6B7_L88C24>(!!0, float64, string, bool, bool)
+		IL_03f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_03fe: stloc.s 22
 		IL_0400: ldloc.s 4
 		IL_0402: ldloc.s 6
@@ -14791,13 +14791,13 @@
 		IL_0426: ldc.i4.0
 		IL_0427: ldelem.ref
 		IL_0428: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_042d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject_FunctionExpression_83D3F4FD_L93C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_042d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0432: ldc.i4.0
 		IL_0433: conv.r8
 		IL_0434: ldstr ""
 		IL_0439: ldc.i4.0
 		IL_043a: ldc.i4.1
-		IL_043b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject_FunctionExpression_83D3F4FD_L93C6>(!!0, float64, string, bool, bool)
+		IL_043b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0440: stloc.s 23
 		IL_0442: ldloc.3
 		IL_0443: ldloc.s 6
@@ -14817,13 +14817,13 @@
 		IL_0462: ldc.i4.0
 		IL_0463: ldelem.ref
 		IL_0464: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0469: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject_FunctionExpression_300CE2EA_L97C23::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0469: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_046e: ldc.i4.0
 		IL_046f: conv.r8
 		IL_0470: ldstr ""
 		IL_0475: ldc.i4.0
 		IL_0476: ldc.i4.1
-		IL_0477: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject_FunctionExpression_300CE2EA_L97C23>(!!0, float64, string, bool, bool)
+		IL_0477: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_047c: stloc.s 24
 		IL_047e: ldloc.s 4
 		IL_0480: ldloc.s 6
@@ -14844,13 +14844,13 @@
 		IL_04a4: ldc.i4.0
 		IL_04a5: ldelem.ref
 		IL_04a6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_04ab: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject_FunctionExpression_15168718_L102C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_04ab: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_04b0: ldc.i4.0
 		IL_04b1: conv.r8
 		IL_04b2: ldstr ""
 		IL_04b7: ldc.i4.0
 		IL_04b8: ldc.i4.1
-		IL_04b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject_FunctionExpression_15168718_L102C6>(!!0, float64, string, bool, bool)
+		IL_04b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_04be: stloc.s 25
 		IL_04c0: ldloc.3
 		IL_04c1: ldloc.s 6
@@ -14870,13 +14870,13 @@
 		IL_04e0: ldc.i4.0
 		IL_04e1: ldelem.ref
 		IL_04e2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_04e7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject_FunctionExpression_AADD4623_L106C32::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_04e7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_04ec: ldc.i4.0
 		IL_04ed: conv.r8
 		IL_04ee: ldstr ""
 		IL_04f3: ldc.i4.0
 		IL_04f4: ldc.i4.1
-		IL_04f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject_FunctionExpression_AADD4623_L106C32>(!!0, float64, string, bool, bool)
+		IL_04f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_04fa: stloc.s 26
 		IL_04fc: ldloc.s 4
 		IL_04fe: ldloc.s 6
@@ -14897,13 +14897,13 @@
 		IL_0522: ldc.i4.0
 		IL_0523: ldelem.ref
 		IL_0524: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0529: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject_FunctionExpression_35949A34_L111C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0529: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_052e: ldc.i4.0
 		IL_052f: conv.r8
 		IL_0530: ldstr ""
 		IL_0535: ldc.i4.0
 		IL_0536: ldc.i4.1
-		IL_0537: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject_FunctionExpression_35949A34_L111C6>(!!0, float64, string, bool, bool)
+		IL_0537: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_053c: stloc.s 27
 		IL_053e: ldloc.3
 		IL_053f: ldloc.s 6
@@ -14923,13 +14923,13 @@
 		IL_055e: ldc.i4.0
 		IL_055f: ldelem.ref
 		IL_0560: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0565: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject_FunctionExpression_123E59E1_L115C34::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0565: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_056a: ldc.i4.0
 		IL_056b: conv.r8
 		IL_056c: ldstr ""
 		IL_0571: ldc.i4.0
 		IL_0572: ldc.i4.1
-		IL_0573: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject_FunctionExpression_123E59E1_L115C34>(!!0, float64, string, bool, bool)
+		IL_0573: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0578: stloc.s 28
 		IL_057a: ldloc.s 4
 		IL_057c: ldloc.s 6
@@ -14950,13 +14950,13 @@
 		IL_05a0: ldc.i4.0
 		IL_05a1: ldelem.ref
 		IL_05a2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_05a7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject_FunctionExpression_1A1A3900_L120C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_05a7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_05ac: ldc.i4.0
 		IL_05ad: conv.r8
 		IL_05ae: ldstr ""
 		IL_05b3: ldc.i4.0
 		IL_05b4: ldc.i4.1
-		IL_05b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject_FunctionExpression_1A1A3900_L120C6>(!!0, float64, string, bool, bool)
+		IL_05b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_05ba: stloc.s 29
 		IL_05bc: ldloc.3
 		IL_05bd: ldloc.s 6
@@ -14976,13 +14976,13 @@
 		IL_05dc: ldc.i4.0
 		IL_05dd: ldelem.ref
 		IL_05de: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_05e3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject_FunctionExpression_A14DF61B_L125C31::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_05e3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_05e8: ldc.i4.0
 		IL_05e9: conv.r8
 		IL_05ea: ldstr ""
 		IL_05ef: ldc.i4.0
 		IL_05f0: ldc.i4.1
-		IL_05f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject_FunctionExpression_A14DF61B_L125C31>(!!0, float64, string, bool, bool)
+		IL_05f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_05f6: stloc.s 30
 		IL_05f8: ldloc.s 4
 		IL_05fa: ldloc.s 6
@@ -15003,13 +15003,13 @@
 		IL_061e: ldc.i4.0
 		IL_061f: ldelem.ref
 		IL_0620: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0625: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject_FunctionExpression_FEC96B05_L130C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0625: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_062a: ldc.i4.0
 		IL_062b: conv.r8
 		IL_062c: ldstr ""
 		IL_0631: ldc.i4.0
 		IL_0632: ldc.i4.1
-		IL_0633: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject_FunctionExpression_FEC96B05_L130C6>(!!0, float64, string, bool, bool)
+		IL_0633: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0638: stloc.s 31
 		IL_063a: ldloc.3
 		IL_063b: ldloc.s 6
@@ -15029,13 +15029,13 @@
 		IL_065a: ldc.i4.0
 		IL_065b: ldelem.ref
 		IL_065c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0661: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject_FunctionExpression_A2B06A06_L134C30::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0661: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0666: ldc.i4.0
 		IL_0667: conv.r8
 		IL_0668: ldstr ""
 		IL_066d: ldc.i4.0
 		IL_066e: ldc.i4.1
-		IL_066f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject_FunctionExpression_A2B06A06_L134C30>(!!0, float64, string, bool, bool)
+		IL_066f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0674: stloc.s 32
 		IL_0676: ldloc.s 4
 		IL_0678: ldloc.s 6
@@ -15056,13 +15056,13 @@
 		IL_069c: ldc.i4.0
 		IL_069d: ldelem.ref
 		IL_069e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_06a3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject_FunctionExpression_826BD7E2_L139C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_06a3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_06a8: ldc.i4.0
 		IL_06a9: conv.r8
 		IL_06aa: ldstr ""
 		IL_06af: ldc.i4.0
 		IL_06b0: ldc.i4.1
-		IL_06b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject_FunctionExpression_826BD7E2_L139C6>(!!0, float64, string, bool, bool)
+		IL_06b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_06b6: stloc.s 33
 		IL_06b8: ldloc.3
 		IL_06b9: ldloc.s 6
@@ -15082,13 +15082,13 @@
 		IL_06d8: ldc.i4.0
 		IL_06d9: ldelem.ref
 		IL_06da: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_06df: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject_FunctionExpression_52BFD713_L143C39::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_06df: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_06e4: ldc.i4.0
 		IL_06e5: conv.r8
 		IL_06e6: ldstr ""
 		IL_06eb: ldc.i4.0
 		IL_06ec: ldc.i4.1
-		IL_06ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject_FunctionExpression_52BFD713_L143C39>(!!0, float64, string, bool, bool)
+		IL_06ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_06f2: stloc.s 34
 		IL_06f4: ldloc.s 4
 		IL_06f6: ldloc.s 6
@@ -15109,13 +15109,13 @@
 		IL_071a: ldc.i4.0
 		IL_071b: ldelem.ref
 		IL_071c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0721: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject_FunctionExpression_ADF86AB6_L148C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0721: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0726: ldc.i4.0
 		IL_0727: conv.r8
 		IL_0728: ldstr ""
 		IL_072d: ldc.i4.0
 		IL_072e: ldc.i4.1
-		IL_072f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject_FunctionExpression_ADF86AB6_L148C6>(!!0, float64, string, bool, bool)
+		IL_072f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0734: stloc.s 35
 		IL_0736: ldloc.3
 		IL_0737: ldloc.s 6
@@ -15135,13 +15135,13 @@
 		IL_0756: ldc.i4.0
 		IL_0757: ldelem.ref
 		IL_0758: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_075d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject_FunctionExpression_6A51803A_L152C41::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_075d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0762: ldc.i4.0
 		IL_0763: conv.r8
 		IL_0764: ldstr ""
 		IL_0769: ldc.i4.0
 		IL_076a: ldc.i4.1
-		IL_076b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject_FunctionExpression_6A51803A_L152C41>(!!0, float64, string, bool, bool)
+		IL_076b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0770: stloc.s 36
 		IL_0772: ldloc.s 4
 		IL_0774: ldloc.s 6
@@ -15162,13 +15162,13 @@
 		IL_0798: ldc.i4.0
 		IL_0799: ldelem.ref
 		IL_079a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_079f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject_FunctionExpression_59F53CDE_L157C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_079f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_07a4: ldc.i4.0
 		IL_07a5: conv.r8
 		IL_07a6: ldstr ""
 		IL_07ab: ldc.i4.0
 		IL_07ac: ldc.i4.1
-		IL_07ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject_FunctionExpression_59F53CDE_L157C6>(!!0, float64, string, bool, bool)
+		IL_07ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_07b2: stloc.s 37
 		IL_07b4: ldloc.3
 		IL_07b5: ldloc.s 6
@@ -15188,13 +15188,13 @@
 		IL_07d4: ldc.i4.0
 		IL_07d5: ldelem.ref
 		IL_07d6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_07db: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject_FunctionExpression_F7D2F9E6_L161C50::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_07db: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_07e0: ldc.i4.0
 		IL_07e1: conv.r8
 		IL_07e2: ldstr ""
 		IL_07e7: ldc.i4.0
 		IL_07e8: ldc.i4.1
-		IL_07e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject_FunctionExpression_F7D2F9E6_L161C50>(!!0, float64, string, bool, bool)
+		IL_07e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_07ee: stloc.s 38
 		IL_07f0: ldloc.s 4
 		IL_07f2: ldloc.s 6
@@ -15215,13 +15215,13 @@
 		IL_0816: ldc.i4.0
 		IL_0817: ldelem.ref
 		IL_0818: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_081d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject_FunctionExpression_5BE125D1_L170C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_081d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0822: ldc.i4.0
 		IL_0823: conv.r8
 		IL_0824: ldstr ""
 		IL_0829: ldc.i4.0
 		IL_082a: ldc.i4.1
-		IL_082b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject_FunctionExpression_5BE125D1_L170C6>(!!0, float64, string, bool, bool)
+		IL_082b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0830: stloc.s 39
 		IL_0832: ldloc.3
 		IL_0833: ldloc.s 6
@@ -15241,13 +15241,13 @@
 		IL_0852: ldc.i4.0
 		IL_0853: ldelem.ref
 		IL_0854: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0859: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject_FunctionExpression_E6D30A9E_L175C33::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0859: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_085e: ldc.i4.0
 		IL_085f: conv.r8
 		IL_0860: ldstr ""
 		IL_0865: ldc.i4.0
 		IL_0866: ldc.i4.1
-		IL_0867: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject_FunctionExpression_E6D30A9E_L175C33>(!!0, float64, string, bool, bool)
+		IL_0867: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_086c: stloc.s 40
 		IL_086e: ldloc.s 4
 		IL_0870: ldloc.s 6
@@ -15268,13 +15268,13 @@
 		IL_0894: ldc.i4.0
 		IL_0895: ldelem.ref
 		IL_0896: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_089b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject_FunctionExpression_316E4A1A_L180C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_089b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_08a0: ldc.i4.0
 		IL_08a1: conv.r8
 		IL_08a2: ldstr ""
 		IL_08a7: ldc.i4.0
 		IL_08a8: ldc.i4.1
-		IL_08a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject_FunctionExpression_316E4A1A_L180C6>(!!0, float64, string, bool, bool)
+		IL_08a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_08ae: stloc.s 41
 		IL_08b0: ldloc.3
 		IL_08b1: ldloc.s 6
@@ -15294,13 +15294,13 @@
 		IL_08d0: ldc.i4.0
 		IL_08d1: ldelem.ref
 		IL_08d2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_08d7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject_FunctionExpression_F75042ED_L184C32::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_08d7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_08dc: ldc.i4.0
 		IL_08dd: conv.r8
 		IL_08de: ldstr ""
 		IL_08e3: ldc.i4.0
 		IL_08e4: ldc.i4.1
-		IL_08e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject_FunctionExpression_F75042ED_L184C32>(!!0, float64, string, bool, bool)
+		IL_08e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_08ea: stloc.s 42
 		IL_08ec: ldloc.s 4
 		IL_08ee: ldloc.s 6
@@ -15321,13 +15321,13 @@
 		IL_0912: ldc.i4.0
 		IL_0913: ldelem.ref
 		IL_0914: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0919: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject_FunctionExpression_DE23A66D_L189C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0919: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_091e: ldc.i4.0
 		IL_091f: conv.r8
 		IL_0920: ldstr ""
 		IL_0925: ldc.i4.0
 		IL_0926: ldc.i4.1
-		IL_0927: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject_FunctionExpression_DE23A66D_L189C6>(!!0, float64, string, bool, bool)
+		IL_0927: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_092c: stloc.s 43
 		IL_092e: ldloc.3
 		IL_092f: ldloc.s 6
@@ -15347,13 +15347,13 @@
 		IL_094e: ldc.i4.0
 		IL_094f: ldelem.ref
 		IL_0950: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0955: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject_FunctionExpression_59F2FA63_L193C41::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0955: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_095a: ldc.i4.0
 		IL_095b: conv.r8
 		IL_095c: ldstr ""
 		IL_0961: ldc.i4.0
 		IL_0962: ldc.i4.1
-		IL_0963: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject_FunctionExpression_59F2FA63_L193C41>(!!0, float64, string, bool, bool)
+		IL_0963: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0968: stloc.s 44
 		IL_096a: ldloc.s 4
 		IL_096c: ldloc.s 6
@@ -15374,13 +15374,13 @@
 		IL_0990: ldc.i4.0
 		IL_0991: ldelem.ref
 		IL_0992: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0997: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject_FunctionExpression_FD52FD47_L198C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0997: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_099c: ldc.i4.0
 		IL_099d: conv.r8
 		IL_099e: ldstr ""
 		IL_09a3: ldc.i4.0
 		IL_09a4: ldc.i4.1
-		IL_09a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject_FunctionExpression_FD52FD47_L198C6>(!!0, float64, string, bool, bool)
+		IL_09a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_09aa: stloc.s 45
 		IL_09ac: ldloc.3
 		IL_09ad: ldloc.s 6
@@ -15400,13 +15400,13 @@
 		IL_09cc: ldc.i4.0
 		IL_09cd: ldelem.ref
 		IL_09ce: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_09d3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject_FunctionExpression_AB7296C4_L202C43::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_09d3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_09d8: ldc.i4.0
 		IL_09d9: conv.r8
 		IL_09da: ldstr ""
 		IL_09df: ldc.i4.0
 		IL_09e0: ldc.i4.1
-		IL_09e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject_FunctionExpression_AB7296C4_L202C43>(!!0, float64, string, bool, bool)
+		IL_09e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_09e6: stloc.s 46
 		IL_09e8: ldloc.s 4
 		IL_09ea: ldloc.s 6
@@ -15427,13 +15427,13 @@
 		IL_0a0e: ldc.i4.0
 		IL_0a0f: ldelem.ref
 		IL_0a10: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a15: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject_FunctionExpression_6250884E_L207C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a15: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0a1a: ldc.i4.0
 		IL_0a1b: conv.r8
 		IL_0a1c: ldstr ""
 		IL_0a21: ldc.i4.0
 		IL_0a22: ldc.i4.1
-		IL_0a23: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject_FunctionExpression_6250884E_L207C6>(!!0, float64, string, bool, bool)
+		IL_0a23: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0a28: stloc.s 47
 		IL_0a2a: ldloc.3
 		IL_0a2b: ldloc.s 6
@@ -15453,13 +15453,13 @@
 		IL_0a4a: ldc.i4.0
 		IL_0a4b: ldelem.ref
 		IL_0a4c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a51: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject_FunctionExpression_9FBA592E_L212C40::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a51: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0a56: ldc.i4.0
 		IL_0a57: conv.r8
 		IL_0a58: ldstr ""
 		IL_0a5d: ldc.i4.0
 		IL_0a5e: ldc.i4.1
-		IL_0a5f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject_FunctionExpression_9FBA592E_L212C40>(!!0, float64, string, bool, bool)
+		IL_0a5f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0a64: stloc.s 48
 		IL_0a66: ldloc.s 4
 		IL_0a68: ldloc.s 6
@@ -15480,13 +15480,13 @@
 		IL_0a8c: ldc.i4.0
 		IL_0a8d: ldelem.ref
 		IL_0a8e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a93: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject_FunctionExpression_6442B403_L217C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a93: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0a98: ldc.i4.0
 		IL_0a99: conv.r8
 		IL_0a9a: ldstr ""
 		IL_0a9f: ldc.i4.0
 		IL_0aa0: ldc.i4.1
-		IL_0aa1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject_FunctionExpression_6442B403_L217C6>(!!0, float64, string, bool, bool)
+		IL_0aa1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0aa6: stloc.s 49
 		IL_0aa8: ldloc.3
 		IL_0aa9: ldloc.s 6
@@ -15506,13 +15506,13 @@
 		IL_0ac8: ldc.i4.0
 		IL_0ac9: ldelem.ref
 		IL_0aca: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0acf: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject_FunctionExpression_7B23A4A4_L221C39::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0acf: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0ad4: ldc.i4.0
 		IL_0ad5: conv.r8
 		IL_0ad6: ldstr ""
 		IL_0adb: ldc.i4.0
 		IL_0adc: ldc.i4.1
-		IL_0add: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject_FunctionExpression_7B23A4A4_L221C39>(!!0, float64, string, bool, bool)
+		IL_0add: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0ae2: stloc.s 50
 		IL_0ae4: ldloc.s 4
 		IL_0ae6: ldloc.s 6
@@ -15533,13 +15533,13 @@
 		IL_0b0a: ldc.i4.0
 		IL_0b0b: ldelem.ref
 		IL_0b0c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b11: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject_FunctionExpression_15CEA57B_L226C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b11: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0b16: ldc.i4.0
 		IL_0b17: conv.r8
 		IL_0b18: ldstr ""
 		IL_0b1d: ldc.i4.0
 		IL_0b1e: ldc.i4.1
-		IL_0b1f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject_FunctionExpression_15CEA57B_L226C6>(!!0, float64, string, bool, bool)
+		IL_0b1f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0b24: stloc.s 51
 		IL_0b26: ldloc.3
 		IL_0b27: ldloc.s 6
@@ -15559,13 +15559,13 @@
 		IL_0b46: ldc.i4.0
 		IL_0b47: ldelem.ref
 		IL_0b48: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b4d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject_FunctionExpression_CE64C73E_L230C48::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b4d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0b52: ldc.i4.0
 		IL_0b53: conv.r8
 		IL_0b54: ldstr ""
 		IL_0b59: ldc.i4.0
 		IL_0b5a: ldc.i4.1
-		IL_0b5b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject_FunctionExpression_CE64C73E_L230C48>(!!0, float64, string, bool, bool)
+		IL_0b5b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0b60: stloc.s 52
 		IL_0b62: ldloc.s 4
 		IL_0b64: ldloc.s 6
@@ -15586,13 +15586,13 @@
 		IL_0b88: ldc.i4.0
 		IL_0b89: ldelem.ref
 		IL_0b8a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b8f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject_FunctionExpression_6B3295AB_L235C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b8f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0b94: ldc.i4.0
 		IL_0b95: conv.r8
 		IL_0b96: ldstr ""
 		IL_0b9b: ldc.i4.0
 		IL_0b9c: ldc.i4.1
-		IL_0b9d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject_FunctionExpression_6B3295AB_L235C6>(!!0, float64, string, bool, bool)
+		IL_0b9d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0ba2: stloc.s 53
 		IL_0ba4: ldloc.3
 		IL_0ba5: ldloc.s 6
@@ -15612,13 +15612,13 @@
 		IL_0bc4: ldc.i4.0
 		IL_0bc5: ldelem.ref
 		IL_0bc6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0bcb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject_FunctionExpression_1419E03E_L239C50::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0bcb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0bd0: ldc.i4.0
 		IL_0bd1: conv.r8
 		IL_0bd2: ldstr ""
 		IL_0bd7: ldc.i4.0
 		IL_0bd8: ldc.i4.1
-		IL_0bd9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject_FunctionExpression_1419E03E_L239C50>(!!0, float64, string, bool, bool)
+		IL_0bd9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0bde: stloc.s 54
 		IL_0be0: ldloc.s 4
 		IL_0be2: ldloc.s 6
@@ -15639,13 +15639,13 @@
 		IL_0c06: ldc.i4.0
 		IL_0c07: ldelem.ref
 		IL_0c08: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c0d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject_FunctionExpression_1AD25763_L244C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c0d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0c12: ldc.i4.0
 		IL_0c13: conv.r8
 		IL_0c14: ldstr ""
 		IL_0c19: ldc.i4.0
 		IL_0c1a: ldc.i4.1
-		IL_0c1b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject_FunctionExpression_1AD25763_L244C6>(!!0, float64, string, bool, bool)
+		IL_0c1b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0c20: stloc.s 55
 		IL_0c22: ldloc.3
 		IL_0c23: ldloc.s 6
@@ -15665,13 +15665,13 @@
 		IL_0c42: ldc.i4.0
 		IL_0c43: ldelem.ref
 		IL_0c44: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c49: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject_FunctionExpression_B68C9781_L248C59::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c49: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0c4e: ldc.i4.0
 		IL_0c4f: conv.r8
 		IL_0c50: ldstr ""
 		IL_0c55: ldc.i4.0
 		IL_0c56: ldc.i4.1
-		IL_0c57: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject_FunctionExpression_B68C9781_L248C59>(!!0, float64, string, bool, bool)
+		IL_0c57: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0c5c: stloc.s 56
 		IL_0c5e: ldloc.s 4
 		IL_0c60: ldloc.s 6
@@ -15692,13 +15692,13 @@
 		IL_0c84: ldc.i4.0
 		IL_0c85: ldelem.ref
 		IL_0c86: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c8b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject_FunctionExpression_62C7C36F_L257C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c8b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0c90: ldc.i4.0
 		IL_0c91: conv.r8
 		IL_0c92: ldstr ""
 		IL_0c97: ldc.i4.0
 		IL_0c98: ldc.i4.1
-		IL_0c99: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject_FunctionExpression_62C7C36F_L257C6>(!!0, float64, string, bool, bool)
+		IL_0c99: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0c9e: stloc.s 57
 		IL_0ca0: ldloc.3
 		IL_0ca1: ldloc.s 6
@@ -15718,13 +15718,13 @@
 		IL_0cc0: ldc.i4.0
 		IL_0cc1: ldelem.ref
 		IL_0cc2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0cc7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject_FunctionExpression_BE52CC8A_L262C32::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0cc7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0ccc: ldc.i4.0
 		IL_0ccd: conv.r8
 		IL_0cce: ldstr ""
 		IL_0cd3: ldc.i4.0
 		IL_0cd4: ldc.i4.1
-		IL_0cd5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject_FunctionExpression_BE52CC8A_L262C32>(!!0, float64, string, bool, bool)
+		IL_0cd5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0cda: stloc.s 58
 		IL_0cdc: ldloc.s 4
 		IL_0cde: ldloc.s 6
@@ -15745,13 +15745,13 @@
 		IL_0d02: ldc.i4.0
 		IL_0d03: ldelem.ref
 		IL_0d04: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d09: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject_FunctionExpression_1AD7FAC4_L267C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d09: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0d0e: ldc.i4.0
 		IL_0d0f: conv.r8
 		IL_0d10: ldstr ""
 		IL_0d15: ldc.i4.0
 		IL_0d16: ldc.i4.1
-		IL_0d17: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject_FunctionExpression_1AD7FAC4_L267C6>(!!0, float64, string, bool, bool)
+		IL_0d17: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0d1c: stloc.s 59
 		IL_0d1e: ldloc.3
 		IL_0d1f: ldloc.s 6
@@ -15771,13 +15771,13 @@
 		IL_0d3e: ldc.i4.0
 		IL_0d3f: ldelem.ref
 		IL_0d40: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d45: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject_FunctionExpression_75E34588_L271C34::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d45: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0d4a: ldc.i4.0
 		IL_0d4b: conv.r8
 		IL_0d4c: ldstr ""
 		IL_0d51: ldc.i4.0
 		IL_0d52: ldc.i4.1
-		IL_0d53: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject_FunctionExpression_75E34588_L271C34>(!!0, float64, string, bool, bool)
+		IL_0d53: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0d58: stloc.s 60
 		IL_0d5a: ldloc.s 4
 		IL_0d5c: ldloc.s 6
@@ -15798,13 +15798,13 @@
 		IL_0d80: ldc.i4.0
 		IL_0d81: ldelem.ref
 		IL_0d82: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d87: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject_FunctionExpression_98DF622E_L276C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d87: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0d8c: ldc.i4.0
 		IL_0d8d: conv.r8
 		IL_0d8e: ldstr ""
 		IL_0d93: ldc.i4.0
 		IL_0d94: ldc.i4.1
-		IL_0d95: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject_FunctionExpression_98DF622E_L276C6>(!!0, float64, string, bool, bool)
+		IL_0d95: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0d9a: stloc.s 61
 		IL_0d9c: ldloc.3
 		IL_0d9d: ldloc.s 6
@@ -15824,13 +15824,13 @@
 		IL_0dbc: ldc.i4.0
 		IL_0dbd: ldelem.ref
 		IL_0dbe: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0dc3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject_FunctionExpression_6EF0F712_L280C47::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0dc3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0dc8: ldc.i4.0
 		IL_0dc9: conv.r8
 		IL_0dca: ldstr ""
 		IL_0dcf: ldc.i4.0
 		IL_0dd0: ldc.i4.1
-		IL_0dd1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject_FunctionExpression_6EF0F712_L280C47>(!!0, float64, string, bool, bool)
+		IL_0dd1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0dd6: stloc.s 62
 		IL_0dd8: ldloc.s 4
 		IL_0dda: ldloc.s 6
@@ -15851,13 +15851,13 @@
 		IL_0dfe: ldc.i4.0
 		IL_0dff: ldelem.ref
 		IL_0e00: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e05: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject_FunctionExpression_0304DE8C_L285C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e05: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0e0a: ldc.i4.0
 		IL_0e0b: conv.r8
 		IL_0e0c: ldstr ""
 		IL_0e11: ldc.i4.0
 		IL_0e12: ldc.i4.1
-		IL_0e13: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject_FunctionExpression_0304DE8C_L285C6>(!!0, float64, string, bool, bool)
+		IL_0e13: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0e18: stloc.s 63
 		IL_0e1a: ldloc.3
 		IL_0e1b: ldloc.s 6
@@ -15877,13 +15877,13 @@
 		IL_0e3a: ldc.i4.0
 		IL_0e3b: ldelem.ref
 		IL_0e3c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e41: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject_FunctionExpression_D94750FD_L289C56::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e41: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0e46: ldc.i4.0
 		IL_0e47: conv.r8
 		IL_0e48: ldstr ""
 		IL_0e4d: ldc.i4.0
 		IL_0e4e: ldc.i4.1
-		IL_0e4f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject_FunctionExpression_D94750FD_L289C56>(!!0, float64, string, bool, bool)
+		IL_0e4f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0e54: stloc.s 64
 		IL_0e56: ldloc.s 4
 		IL_0e58: ldloc.s 6
@@ -15904,13 +15904,13 @@
 		IL_0e7c: ldc.i4.0
 		IL_0e7d: ldelem.ref
 		IL_0e7e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e83: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject_FunctionExpression_29656618_L296C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e83: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0e88: ldc.i4.0
 		IL_0e89: conv.r8
 		IL_0e8a: ldstr ""
 		IL_0e8f: ldc.i4.0
 		IL_0e90: ldc.i4.1
-		IL_0e91: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject_FunctionExpression_29656618_L296C6>(!!0, float64, string, bool, bool)
+		IL_0e91: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0e96: stloc.s 65
 		IL_0e98: ldloc.3
 		IL_0e99: ldloc.s 6
@@ -15930,13 +15930,13 @@
 		IL_0eb8: ldc.i4.0
 		IL_0eb9: ldelem.ref
 		IL_0eba: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ebf: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject_FunctionExpression_1062EA27_L300C65::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ebf: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0ec4: ldc.i4.0
 		IL_0ec5: conv.r8
 		IL_0ec6: ldstr ""
 		IL_0ecb: ldc.i4.0
 		IL_0ecc: ldc.i4.1
-		IL_0ecd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject_FunctionExpression_1062EA27_L300C65>(!!0, float64, string, bool, bool)
+		IL_0ecd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0ed2: stloc.s 66
 		IL_0ed4: ldloc.s 4
 		IL_0ed6: ldloc.s 6
@@ -15957,13 +15957,13 @@
 		IL_0efa: ldc.i4.0
 		IL_0efb: ldelem.ref
 		IL_0efc: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f01: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject_FunctionExpression_612413E3_L309C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f01: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0f06: ldc.i4.0
 		IL_0f07: conv.r8
 		IL_0f08: ldstr ""
 		IL_0f0d: ldc.i4.0
 		IL_0f0e: ldc.i4.1
-		IL_0f0f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject_FunctionExpression_612413E3_L309C6>(!!0, float64, string, bool, bool)
+		IL_0f0f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0f14: stloc.s 67
 		IL_0f16: ldloc.3
 		IL_0f17: ldloc.s 6
@@ -15983,13 +15983,13 @@
 		IL_0f36: ldc.i4.0
 		IL_0f37: ldelem.ref
 		IL_0f38: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f3d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject_FunctionExpression_5D299276_L313C26::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f3d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0f42: ldc.i4.0
 		IL_0f43: conv.r8
 		IL_0f44: ldstr ""
 		IL_0f49: ldc.i4.0
 		IL_0f4a: ldc.i4.1
-		IL_0f4b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject_FunctionExpression_5D299276_L313C26>(!!0, float64, string, bool, bool)
+		IL_0f4b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0f50: stloc.s 68
 		IL_0f52: ldloc.s 4
 		IL_0f54: ldloc.s 6
@@ -16010,13 +16010,13 @@
 		IL_0f78: ldc.i4.0
 		IL_0f79: ldelem.ref
 		IL_0f7a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f7f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject_FunctionExpression_AF818725_L318C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f7f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0f84: ldc.i4.0
 		IL_0f85: conv.r8
 		IL_0f86: ldstr ""
 		IL_0f8b: ldc.i4.0
 		IL_0f8c: ldc.i4.1
-		IL_0f8d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject_FunctionExpression_AF818725_L318C6>(!!0, float64, string, bool, bool)
+		IL_0f8d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0f92: stloc.s 69
 		IL_0f94: ldloc.3
 		IL_0f95: ldloc.s 6
@@ -16036,13 +16036,13 @@
 		IL_0fb4: ldc.i4.0
 		IL_0fb5: ldelem.ref
 		IL_0fb6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0fbb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject_FunctionExpression_64DC70FB_L322C25::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0fbb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0fc0: ldc.i4.0
 		IL_0fc1: conv.r8
 		IL_0fc2: ldstr ""
 		IL_0fc7: ldc.i4.0
 		IL_0fc8: ldc.i4.1
-		IL_0fc9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject_FunctionExpression_64DC70FB_L322C25>(!!0, float64, string, bool, bool)
+		IL_0fc9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0fce: stloc.s 70
 		IL_0fd0: ldloc.s 4
 		IL_0fd2: ldloc.s 6
@@ -16063,13 +16063,13 @@
 		IL_0ff6: ldc.i4.0
 		IL_0ff7: ldelem.ref
 		IL_0ff8: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ffd: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject_FunctionExpression_455C0AC7_L327C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ffd: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_1002: ldc.i4.0
 		IL_1003: conv.r8
 		IL_1004: ldstr ""
 		IL_1009: ldc.i4.0
 		IL_100a: ldc.i4.1
-		IL_100b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject_FunctionExpression_455C0AC7_L327C6>(!!0, float64, string, bool, bool)
+		IL_100b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_1010: stloc.s 71
 		IL_1012: ldloc.3
 		IL_1013: ldloc.s 6
@@ -16089,13 +16089,13 @@
 		IL_1032: ldc.i4.0
 		IL_1033: ldelem.ref
 		IL_1034: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1039: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject_FunctionExpression_C0E29ED5_L331C34::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1039: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_103e: ldc.i4.0
 		IL_103f: conv.r8
 		IL_1040: ldstr ""
 		IL_1045: ldc.i4.0
 		IL_1046: ldc.i4.1
-		IL_1047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject_FunctionExpression_C0E29ED5_L331C34>(!!0, float64, string, bool, bool)
+		IL_1047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_104c: stloc.s 72
 		IL_104e: ldloc.s 4
 		IL_1050: ldloc.s 6
@@ -16116,13 +16116,13 @@
 		IL_1074: ldc.i4.0
 		IL_1075: ldelem.ref
 		IL_1076: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_107b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject_FunctionExpression_78E8D78D_L336C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_107b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_1080: ldc.i4.0
 		IL_1081: conv.r8
 		IL_1082: ldstr ""
 		IL_1087: ldc.i4.0
 		IL_1088: ldc.i4.1
-		IL_1089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject_FunctionExpression_78E8D78D_L336C6>(!!0, float64, string, bool, bool)
+		IL_1089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_108e: stloc.s 73
 		IL_1090: ldloc.3
 		IL_1091: ldloc.s 6
@@ -16142,13 +16142,13 @@
 		IL_10b0: ldc.i4.0
 		IL_10b1: ldelem.ref
 		IL_10b2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_10b7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject_FunctionExpression_31C4DBA7_L340C36::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_10b7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_10bc: ldc.i4.0
 		IL_10bd: conv.r8
 		IL_10be: ldstr ""
 		IL_10c3: ldc.i4.0
 		IL_10c4: ldc.i4.1
-		IL_10c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject_FunctionExpression_31C4DBA7_L340C36>(!!0, float64, string, bool, bool)
+		IL_10c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_10ca: stloc.s 74
 		IL_10cc: ldloc.s 4
 		IL_10ce: ldloc.s 6
@@ -16169,13 +16169,13 @@
 		IL_10f2: ldc.i4.0
 		IL_10f3: ldelem.ref
 		IL_10f4: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_10f9: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject_FunctionExpression_ADC77423_L345C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_10f9: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_10fe: ldc.i4.0
 		IL_10ff: conv.r8
 		IL_1100: ldstr ""
 		IL_1105: ldc.i4.0
 		IL_1106: ldc.i4.1
-		IL_1107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject_FunctionExpression_ADC77423_L345C6>(!!0, float64, string, bool, bool)
+		IL_1107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_110c: stloc.s 75
 		IL_110e: ldloc.3
 		IL_110f: ldloc.s 6
@@ -16195,13 +16195,13 @@
 		IL_112e: ldc.i4.0
 		IL_112f: ldelem.ref
 		IL_1130: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1135: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject_FunctionExpression_AB0D0A79_L349C33::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1135: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_113a: ldc.i4.0
 		IL_113b: conv.r8
 		IL_113c: ldstr ""
 		IL_1141: ldc.i4.0
 		IL_1142: ldc.i4.1
-		IL_1143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject_FunctionExpression_AB0D0A79_L349C33>(!!0, float64, string, bool, bool)
+		IL_1143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_1148: stloc.s 76
 		IL_114a: ldloc.s 4
 		IL_114c: ldloc.s 6
@@ -16222,13 +16222,13 @@
 		IL_1170: ldc.i4.0
 		IL_1171: ldelem.ref
 		IL_1172: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1177: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject_FunctionExpression_FE9F5065_L354C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1177: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_117c: ldc.i4.0
 		IL_117d: conv.r8
 		IL_117e: ldstr ""
 		IL_1183: ldc.i4.0
 		IL_1184: ldc.i4.1
-		IL_1185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject_FunctionExpression_FE9F5065_L354C6>(!!0, float64, string, bool, bool)
+		IL_1185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_118a: stloc.s 77
 		IL_118c: ldloc.3
 		IL_118d: ldloc.s 6
@@ -16248,13 +16248,13 @@
 		IL_11ac: ldc.i4.0
 		IL_11ad: ldelem.ref
 		IL_11ae: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_11b3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject_FunctionExpression_48BE92D8_L358C32::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_11b3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_11b8: ldc.i4.0
 		IL_11b9: conv.r8
 		IL_11ba: ldstr ""
 		IL_11bf: ldc.i4.0
 		IL_11c0: ldc.i4.1
-		IL_11c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject_FunctionExpression_48BE92D8_L358C32>(!!0, float64, string, bool, bool)
+		IL_11c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_11c6: stloc.s 78
 		IL_11c8: ldloc.s 4
 		IL_11ca: ldloc.s 6
@@ -16275,13 +16275,13 @@
 		IL_11ee: ldc.i4.0
 		IL_11ef: ldelem.ref
 		IL_11f0: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_11f5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject_FunctionExpression_4D9B395F_L363C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_11f5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_11fa: ldc.i4.0
 		IL_11fb: conv.r8
 		IL_11fc: ldstr ""
 		IL_1201: ldc.i4.0
 		IL_1202: ldc.i4.1
-		IL_1203: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject_FunctionExpression_4D9B395F_L363C6>(!!0, float64, string, bool, bool)
+		IL_1203: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_1208: stloc.s 79
 		IL_120a: ldloc.3
 		IL_120b: ldloc.s 6
@@ -16301,13 +16301,13 @@
 		IL_122a: ldc.i4.0
 		IL_122b: ldelem.ref
 		IL_122c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1231: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject_FunctionExpression_222F9CF0_L367C41::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1231: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_1236: ldc.i4.0
 		IL_1237: conv.r8
 		IL_1238: ldstr ""
 		IL_123d: ldc.i4.0
 		IL_123e: ldc.i4.1
-		IL_123f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject_FunctionExpression_222F9CF0_L367C41>(!!0, float64, string, bool, bool)
+		IL_123f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_1244: stloc.s 80
 		IL_1246: ldloc.s 4
 		IL_1248: ldloc.s 6
@@ -16328,13 +16328,13 @@
 		IL_126c: ldc.i4.0
 		IL_126d: ldelem.ref
 		IL_126e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1273: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject_FunctionExpression_F85E69FD_L372C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1273: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_1278: ldc.i4.0
 		IL_1279: conv.r8
 		IL_127a: ldstr ""
 		IL_127f: ldc.i4.0
 		IL_1280: ldc.i4.1
-		IL_1281: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject_FunctionExpression_F85E69FD_L372C6>(!!0, float64, string, bool, bool)
+		IL_1281: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_1286: stloc.s 81
 		IL_1288: ldloc.3
 		IL_1289: ldloc.s 6
@@ -16354,13 +16354,13 @@
 		IL_12a8: ldc.i4.0
 		IL_12a9: ldelem.ref
 		IL_12aa: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_12af: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject_FunctionExpression_9DF3FAC8_L376C43::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_12af: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_12b4: ldc.i4.0
 		IL_12b5: conv.r8
 		IL_12b6: ldstr ""
 		IL_12bb: ldc.i4.0
 		IL_12bc: ldc.i4.1
-		IL_12bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject_FunctionExpression_9DF3FAC8_L376C43>(!!0, float64, string, bool, bool)
+		IL_12bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_12c2: stloc.s 82
 		IL_12c4: ldloc.s 4
 		IL_12c6: ldloc.s 6

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3AA9AEF9_startTest
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -89,7 +89,7 @@
 				IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_001d: call object Modules.Compile_Resources_Dromaeo_3d_Cube/startTest::__js_call__(object, string, string)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -113,7 +113,7 @@
 				IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0019: call object Modules.Compile_Resources_Dromaeo_3d_Cube/startTest::__js_call__(object, string, string)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -131,9 +131,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3AA9AEF9_startTest
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -180,7 +180,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_118F8B84_endTest
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -194,7 +194,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -205,7 +205,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -216,7 +216,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -231,7 +231,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Compile_Resources_Dromaeo_3d_Cube/endTest::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -247,7 +247,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Compile_Resources_Dromaeo_3d_Cube/endTest::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -265,9 +265,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_118F8B84_endTest
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -333,7 +333,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D89CEA64_prep
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -347,7 +347,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -358,7 +358,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -369,7 +369,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -387,7 +387,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Resources_Dromaeo_3d_Cube/prep::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -406,7 +406,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Resources_Dromaeo_3d_Cube/prep::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -424,9 +424,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D89CEA64_prep
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -512,7 +512,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E8689847_test
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -526,7 +526,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E8689847_test::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -537,7 +537,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E8689847_test::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -548,7 +548,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E8689847_test::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -570,7 +570,7 @@
 				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0018: call object Modules.Compile_Resources_Dromaeo_3d_Cube/test::__js_call__(object, string, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E8689847_test::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -593,7 +593,7 @@
 				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0014: call object Modules.Compile_Resources_Dromaeo_3d_Cube/test::__js_call__(object, string, object)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_E8689847_test::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -611,9 +611,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E8689847_test::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E8689847_test
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -835,7 +835,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -855,9 +855,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -868,7 +868,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -879,7 +879,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -892,7 +892,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -902,7 +902,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -916,7 +916,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -926,7 +926,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -944,9 +944,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1283,7 +1283,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D57260FA_CalcCross
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1297,7 +1297,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1308,7 +1308,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1319,7 +1319,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1342,7 +1342,7 @@
 				IL_0018: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1366,7 +1366,7 @@
 				IL_0014: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1384,9 +1384,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D57260FA_CalcCross
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1564,7 +1564,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_828AC649_CalcNormal
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1584,9 +1584,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject_FunctionDeclaration_828AC649_CalcNormal::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1597,7 +1597,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1608,7 +1608,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1621,7 +1621,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject_FunctionDeclaration_828AC649_CalcNormal::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -1634,7 +1634,7 @@
 				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object, object)
 				IL_0025: ret
-			} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1648,7 +1648,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject_FunctionDeclaration_828AC649_CalcNormal::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -1661,7 +1661,7 @@
 				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object, object)
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1679,9 +1679,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_828AC649_CalcNormal
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1908,7 +1908,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_437DD829_CreateP
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1922,7 +1922,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1933,7 +1933,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1944,7 +1944,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1971,7 +1971,7 @@
 				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0029: call object Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP::__js_call__(object, float64, float64, float64)
 				IL_002e: ret
-			} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1999,7 +1999,7 @@
 				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0025: call object Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP::__js_call__(object, float64, float64, float64)
 				IL_002a: ret
-			} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2017,9 +2017,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_437DD829_CreateP
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2113,7 +2113,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ABC69D1B_MMulti
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2127,7 +2127,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2138,7 +2138,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2149,7 +2149,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2172,7 +2172,7 @@
 				IL_0018: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_0022: ret
-			} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2196,7 +2196,7 @@
 				IL_0014: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
 				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2214,9 +2214,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_ABC69D1B_MMulti
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2421,7 +2421,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8F6544F8_VMulti
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2435,7 +2435,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2446,7 +2446,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2457,7 +2457,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2479,7 +2479,7 @@
 				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2502,7 +2502,7 @@
 				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2520,9 +2520,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8F6544F8_VMulti
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2680,7 +2680,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_866B49FE_VMulti2
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2694,7 +2694,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2705,7 +2705,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2716,7 +2716,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2738,7 +2738,7 @@
 				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2761,7 +2761,7 @@
 				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2779,9 +2779,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_866B49FE_VMulti2
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2940,7 +2940,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0DAEB721_MAdd
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2954,7 +2954,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2965,7 +2965,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2976,7 +2976,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2997,7 +2997,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3019,7 +3019,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3037,9 +3037,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0DAEB721_MAdd
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3181,7 +3181,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EE9ED553_Translate
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3201,9 +3201,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject_FunctionDeclaration_EE9ED553_Translate::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3214,7 +3214,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3225,7 +3225,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3238,7 +3238,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject_FunctionDeclaration_EE9ED553_Translate::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -3255,7 +3255,7 @@
 				IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, object, object)
 				IL_0031: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3269,7 +3269,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject_FunctionDeclaration_EE9ED553_Translate::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -3286,7 +3286,7 @@
 				IL_0023: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, object, object)
 				IL_002d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3304,9 +3304,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_EE9ED553_Translate
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3445,7 +3445,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5E4252E8_RotateX
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3465,9 +3465,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject_FunctionDeclaration_5E4252E8_RotateX::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3478,7 +3478,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3489,7 +3489,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3502,7 +3502,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject_FunctionDeclaration_5E4252E8_RotateX::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -3514,7 +3514,7 @@
 				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
 				IL_0028: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3528,7 +3528,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject_FunctionDeclaration_5E4252E8_RotateX::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -3540,7 +3540,7 @@
 				IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
 				IL_0024: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3558,9 +3558,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5E4252E8_RotateX
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3724,7 +3724,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5F42547B_RotateY
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3744,9 +3744,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject_FunctionDeclaration_5F42547B_RotateY::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3757,7 +3757,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3768,7 +3768,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3781,7 +3781,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject_FunctionDeclaration_5F42547B_RotateY::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -3793,7 +3793,7 @@
 				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
 				IL_0028: ret
-			} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3807,7 +3807,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject_FunctionDeclaration_5F42547B_RotateY::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -3819,7 +3819,7 @@
 				IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
 				IL_0024: ret
-			} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3837,9 +3837,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5F42547B_RotateY
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4003,7 +4003,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6042560E_RotateZ
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4023,9 +4023,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject_FunctionDeclaration_6042560E_RotateZ::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4036,7 +4036,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4047,7 +4047,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4060,7 +4060,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject_FunctionDeclaration_6042560E_RotateZ::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -4072,7 +4072,7 @@
 				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
 				IL_0028: ret
-			} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4086,7 +4086,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject_FunctionDeclaration_6042560E_RotateZ::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -4098,7 +4098,7 @@
 				IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
 				IL_0024: ret
-			} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4116,9 +4116,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6042560E_RotateZ
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4866,7 +4866,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B9CB8406_DrawQube
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4886,9 +4886,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4899,7 +4899,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4910,7 +4910,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4923,11 +4923,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4941,11 +4941,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4963,9 +4963,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B9CB8406_DrawQube
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -6656,7 +6656,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C322C861_Loop
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -6676,9 +6676,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject_FunctionDeclaration_C322C861_Loop::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -6689,7 +6689,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -6700,7 +6700,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -6713,11 +6713,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject_FunctionDeclaration_C322C861_Loop::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Loop::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -6731,11 +6731,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject_FunctionDeclaration_C322C861_Loop::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Loop::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -6753,9 +6753,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C322C861_Loop
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -7199,7 +7199,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A3F3852D_Init
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -7219,9 +7219,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject_FunctionDeclaration_A3F3852D_Init::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -7232,7 +7232,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -7243,7 +7243,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -7256,7 +7256,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject_FunctionDeclaration_A3F3852D_Init::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -7264,7 +7264,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Init::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -7278,7 +7278,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject_FunctionDeclaration_A3F3852D_Init::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -7286,7 +7286,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Init::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -7304,9 +7304,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A3F3852D_Init
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8427,7 +8427,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_144008FC_L334C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -8447,9 +8447,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject_FunctionExpression_144008FC_L334C24::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -8460,7 +8460,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -8471,7 +8471,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -8484,11 +8484,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject_FunctionExpression_144008FC_L334C24::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -8502,11 +8502,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject_FunctionExpression_144008FC_L334C24::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject::_environment0_Compile_Resources_Dromaeo_3d_Cube
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -8524,9 +8524,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_144008FC_L334C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -8657,31 +8657,31 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope,
-			[1] class Modules.Compile_Resources_Dromaeo_3d_Cube/startTest/FunctionObject_FunctionDeclaration_3AA9AEF9_startTest,
-			[2] class Modules.Compile_Resources_Dromaeo_3d_Cube/endTest/FunctionObject_FunctionDeclaration_118F8B84_endTest,
-			[3] class Modules.Compile_Resources_Dromaeo_3d_Cube/prep/FunctionObject_FunctionDeclaration_D89CEA64_prep,
-			[4] class Modules.Compile_Resources_Dromaeo_3d_Cube/test/FunctionObject_FunctionDeclaration_E8689847_test,
-			[5] class Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd/FunctionObject_FunctionDeclaration_0DAEB721_MAdd,
+			[1] class Modules.Compile_Resources_Dromaeo_3d_Cube/startTest/FunctionObject,
+			[2] class Modules.Compile_Resources_Dromaeo_3d_Cube/endTest/FunctionObject,
+			[3] class Modules.Compile_Resources_Dromaeo_3d_Cube/prep/FunctionObject,
+			[4] class Modules.Compile_Resources_Dromaeo_3d_Cube/test/FunctionObject,
+			[5] class Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd/FunctionObject,
 			[6] object,
 			[7] object,
 			[8] object[],
-			[9] class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine,
-			[10] class Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross/FunctionObject_FunctionDeclaration_D57260FA_CalcCross,
-			[11] class Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject_FunctionDeclaration_828AC649_CalcNormal,
-			[12] class Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP/FunctionObject_FunctionDeclaration_437DD829_CreateP,
-			[13] class Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti/FunctionObject_FunctionDeclaration_ABC69D1B_MMulti,
-			[14] class Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti/FunctionObject_FunctionDeclaration_8F6544F8_VMulti,
-			[15] class Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2/FunctionObject_FunctionDeclaration_866B49FE_VMulti2,
-			[16] class Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject_FunctionDeclaration_EE9ED553_Translate,
-			[17] class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject_FunctionDeclaration_5E4252E8_RotateX,
-			[18] class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject_FunctionDeclaration_5F42547B_RotateY,
-			[19] class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject_FunctionDeclaration_6042560E_RotateZ,
-			[20] class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject_FunctionDeclaration_B9CB8406_DrawQube,
-			[21] class Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject_FunctionDeclaration_C322C861_Loop,
-			[22] class Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject_FunctionDeclaration_A3F3852D_Init,
+			[9] class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject,
+			[10] class Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross/FunctionObject,
+			[11] class Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject,
+			[12] class Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP/FunctionObject,
+			[13] class Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti/FunctionObject,
+			[14] class Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti/FunctionObject,
+			[15] class Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2/FunctionObject,
+			[16] class Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject,
+			[17] class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject,
+			[18] class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject,
+			[19] class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject,
+			[20] class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject,
+			[21] class Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject,
+			[22] class Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject,
 			[23] object,
 			[24] object[],
-			[25] class Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject_FunctionExpression_144008FC_L334C24
+			[25] class Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::.ctor()
@@ -8693,13 +8693,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 8
-		IL_0012: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/startTest/FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::.ctor()
+		IL_0012: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/startTest/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "startTest"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/startTest/FunctionObject_FunctionDeclaration_3AA9AEF9_startTest>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/startTest/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -8708,13 +8708,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 8
-		IL_0032: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/endTest/FunctionObject_FunctionDeclaration_118F8B84_endTest::.ctor()
+		IL_0032: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/endTest/FunctionObject::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "endTest"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/endTest/FunctionObject_FunctionDeclaration_118F8B84_endTest>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/endTest/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -8723,13 +8723,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 8
-		IL_0052: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/prep/FunctionObject_FunctionDeclaration_D89CEA64_prep::.ctor()
+		IL_0052: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/prep/FunctionObject::.ctor()
 		IL_0057: ldc.i4.1
 		IL_0058: conv.r8
 		IL_0059: ldstr "prep"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/prep/FunctionObject_FunctionDeclaration_D89CEA64_prep>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/prep/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -8738,13 +8738,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 8
-		IL_0072: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/test/FunctionObject_FunctionDeclaration_E8689847_test::.ctor()
+		IL_0072: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/test/FunctionObject::.ctor()
 		IL_0077: ldc.i4.2
 		IL_0078: conv.r8
 		IL_0079: ldstr "test"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/test/FunctionObject_FunctionDeclaration_E8689847_test>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/test/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -8757,13 +8757,13 @@
 		IL_0095: ldc.i4.0
 		IL_0096: ldelem.ref
 		IL_0097: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_009c: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_009c: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_00a1: ldc.i4.2
 		IL_00a2: conv.r8
 		IL_00a3: ldstr "DrawLine"
 		IL_00a8: ldc.i4.0
 		IL_00a9: ldc.i4.1
-		IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine>(!!0, float64, string, bool, bool)
+		IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00af: stloc.s 9
 		IL_00b1: ldloc.0
 		IL_00b2: ldloc.s 9
@@ -8775,13 +8775,13 @@
 		IL_00c1: ldloc.0
 		IL_00c2: stelem.ref
 		IL_00c3: stloc.s 8
-		IL_00c5: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross/FunctionObject_FunctionDeclaration_D57260FA_CalcCross::.ctor()
+		IL_00c5: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross/FunctionObject::.ctor()
 		IL_00ca: ldc.i4.2
 		IL_00cb: conv.r8
 		IL_00cc: ldstr "CalcCross"
 		IL_00d1: ldc.i4.0
 		IL_00d2: ldc.i4.1
-		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross/FunctionObject_FunctionDeclaration_D57260FA_CalcCross>(!!0, float64, string, bool, bool)
+		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d8: stloc.s 10
 		IL_00da: ldloc.0
 		IL_00db: ldloc.s 10
@@ -8797,13 +8797,13 @@
 		IL_00f0: ldc.i4.0
 		IL_00f1: ldelem.ref
 		IL_00f2: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_00f7: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject_FunctionDeclaration_828AC649_CalcNormal::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_00f7: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_00fc: ldc.i4.3
 		IL_00fd: conv.r8
 		IL_00fe: ldstr "CalcNormal"
 		IL_0103: ldc.i4.0
 		IL_0104: ldc.i4.1
-		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject_FunctionDeclaration_828AC649_CalcNormal>(!!0, float64, string, bool, bool)
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_010a: stloc.s 11
 		IL_010c: ldloc.0
 		IL_010d: ldloc.s 11
@@ -8815,13 +8815,13 @@
 		IL_011c: ldloc.0
 		IL_011d: stelem.ref
 		IL_011e: stloc.s 8
-		IL_0120: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP/FunctionObject_FunctionDeclaration_437DD829_CreateP::.ctor()
+		IL_0120: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP/FunctionObject::.ctor()
 		IL_0125: ldc.i4.3
 		IL_0126: conv.r8
 		IL_0127: ldstr "CreateP"
 		IL_012c: ldc.i4.1
 		IL_012d: ldc.i4.1
-		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP/FunctionObject_FunctionDeclaration_437DD829_CreateP>(!!0, float64, string, bool, bool)
+		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0133: stloc.s 12
 		IL_0135: ldloc.0
 		IL_0136: ldloc.s 12
@@ -8833,13 +8833,13 @@
 		IL_0145: ldloc.0
 		IL_0146: stelem.ref
 		IL_0147: stloc.s 8
-		IL_0149: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti/FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::.ctor()
+		IL_0149: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti/FunctionObject::.ctor()
 		IL_014e: ldc.i4.2
 		IL_014f: conv.r8
 		IL_0150: ldstr "MMulti"
 		IL_0155: ldc.i4.0
 		IL_0156: ldc.i4.1
-		IL_0157: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti/FunctionObject_FunctionDeclaration_ABC69D1B_MMulti>(!!0, float64, string, bool, bool)
+		IL_0157: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_015c: stloc.s 13
 		IL_015e: ldloc.0
 		IL_015f: ldloc.s 13
@@ -8851,13 +8851,13 @@
 		IL_016e: ldloc.0
 		IL_016f: stelem.ref
 		IL_0170: stloc.s 8
-		IL_0172: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti/FunctionObject_FunctionDeclaration_8F6544F8_VMulti::.ctor()
+		IL_0172: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti/FunctionObject::.ctor()
 		IL_0177: ldc.i4.2
 		IL_0178: conv.r8
 		IL_0179: ldstr "VMulti"
 		IL_017e: ldc.i4.0
 		IL_017f: ldc.i4.1
-		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti/FunctionObject_FunctionDeclaration_8F6544F8_VMulti>(!!0, float64, string, bool, bool)
+		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0185: stloc.s 14
 		IL_0187: ldloc.0
 		IL_0188: ldloc.s 14
@@ -8869,13 +8869,13 @@
 		IL_0197: ldloc.0
 		IL_0198: stelem.ref
 		IL_0199: stloc.s 8
-		IL_019b: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2/FunctionObject_FunctionDeclaration_866B49FE_VMulti2::.ctor()
+		IL_019b: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2/FunctionObject::.ctor()
 		IL_01a0: ldc.i4.2
 		IL_01a1: conv.r8
 		IL_01a2: ldstr "VMulti2"
 		IL_01a7: ldc.i4.0
 		IL_01a8: ldc.i4.1
-		IL_01a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2/FunctionObject_FunctionDeclaration_866B49FE_VMulti2>(!!0, float64, string, bool, bool)
+		IL_01a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01ae: stloc.s 15
 		IL_01b0: ldloc.0
 		IL_01b1: ldloc.s 15
@@ -8887,13 +8887,13 @@
 		IL_01c0: ldloc.0
 		IL_01c1: stelem.ref
 		IL_01c2: stloc.s 8
-		IL_01c4: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd/FunctionObject_FunctionDeclaration_0DAEB721_MAdd::.ctor()
+		IL_01c4: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd/FunctionObject::.ctor()
 		IL_01c9: ldc.i4.2
 		IL_01ca: conv.r8
 		IL_01cb: ldstr "MAdd"
 		IL_01d0: ldc.i4.0
 		IL_01d1: ldc.i4.1
-		IL_01d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd/FunctionObject_FunctionDeclaration_0DAEB721_MAdd>(!!0, float64, string, bool, bool)
+		IL_01d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01d7: stloc.s 5
 		IL_01d9: ldc.i4.1
 		IL_01da: newarr [System.Runtime]System.Object
@@ -8906,13 +8906,13 @@
 		IL_01e7: ldc.i4.0
 		IL_01e8: ldelem.ref
 		IL_01e9: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_01ee: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject_FunctionDeclaration_EE9ED553_Translate::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_01ee: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_01f3: ldc.i4.4
 		IL_01f4: conv.r8
 		IL_01f5: ldstr "Translate"
 		IL_01fa: ldc.i4.0
 		IL_01fb: ldc.i4.1
-		IL_01fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject_FunctionDeclaration_EE9ED553_Translate>(!!0, float64, string, bool, bool)
+		IL_01fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0201: stloc.s 16
 		IL_0203: ldloc.0
 		IL_0204: ldloc.s 16
@@ -8928,13 +8928,13 @@
 		IL_0219: ldc.i4.0
 		IL_021a: ldelem.ref
 		IL_021b: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_0220: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject_FunctionDeclaration_5E4252E8_RotateX::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_0220: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_0225: ldc.i4.2
 		IL_0226: conv.r8
 		IL_0227: ldstr "RotateX"
 		IL_022c: ldc.i4.0
 		IL_022d: ldc.i4.1
-		IL_022e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject_FunctionDeclaration_5E4252E8_RotateX>(!!0, float64, string, bool, bool)
+		IL_022e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0233: stloc.s 17
 		IL_0235: ldloc.0
 		IL_0236: ldloc.s 17
@@ -8950,13 +8950,13 @@
 		IL_024b: ldc.i4.0
 		IL_024c: ldelem.ref
 		IL_024d: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_0252: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject_FunctionDeclaration_5F42547B_RotateY::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_0252: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_0257: ldc.i4.2
 		IL_0258: conv.r8
 		IL_0259: ldstr "RotateY"
 		IL_025e: ldc.i4.0
 		IL_025f: ldc.i4.1
-		IL_0260: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject_FunctionDeclaration_5F42547B_RotateY>(!!0, float64, string, bool, bool)
+		IL_0260: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0265: stloc.s 18
 		IL_0267: ldloc.0
 		IL_0268: ldloc.s 18
@@ -8972,13 +8972,13 @@
 		IL_027d: ldc.i4.0
 		IL_027e: ldelem.ref
 		IL_027f: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_0284: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject_FunctionDeclaration_6042560E_RotateZ::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_0284: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_0289: ldc.i4.2
 		IL_028a: conv.r8
 		IL_028b: ldstr "RotateZ"
 		IL_0290: ldc.i4.0
 		IL_0291: ldc.i4.1
-		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject_FunctionDeclaration_6042560E_RotateZ>(!!0, float64, string, bool, bool)
+		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0297: stloc.s 19
 		IL_0299: ldloc.0
 		IL_029a: ldloc.s 19
@@ -8994,13 +8994,13 @@
 		IL_02af: ldc.i4.0
 		IL_02b0: ldelem.ref
 		IL_02b1: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_02b6: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_02b6: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_02bb: ldc.i4.0
 		IL_02bc: conv.r8
 		IL_02bd: ldstr "DrawQube"
 		IL_02c2: ldc.i4.0
 		IL_02c3: ldc.i4.1
-		IL_02c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject_FunctionDeclaration_B9CB8406_DrawQube>(!!0, float64, string, bool, bool)
+		IL_02c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02c9: stloc.s 20
 		IL_02cb: ldloc.0
 		IL_02cc: ldloc.s 20
@@ -9016,13 +9016,13 @@
 		IL_02e1: ldc.i4.0
 		IL_02e2: ldelem.ref
 		IL_02e3: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_02e8: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject_FunctionDeclaration_C322C861_Loop::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_02e8: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_02ed: ldc.i4.0
 		IL_02ee: conv.r8
 		IL_02ef: ldstr "Loop"
 		IL_02f4: ldc.i4.0
 		IL_02f5: ldc.i4.1
-		IL_02f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject_FunctionDeclaration_C322C861_Loop>(!!0, float64, string, bool, bool)
+		IL_02f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02fb: stloc.s 21
 		IL_02fd: ldloc.0
 		IL_02fe: ldloc.s 21
@@ -9038,13 +9038,13 @@
 		IL_0313: ldc.i4.0
 		IL_0314: ldelem.ref
 		IL_0315: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_031a: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject_FunctionDeclaration_A3F3852D_Init::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_031a: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_031f: ldc.i4.1
 		IL_0320: conv.r8
 		IL_0321: ldstr "Init"
 		IL_0326: ldc.i4.0
 		IL_0327: ldc.i4.1
-		IL_0328: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject_FunctionDeclaration_A3F3852D_Init>(!!0, float64, string, bool, bool)
+		IL_0328: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_032d: stloc.s 22
 		IL_032f: ldloc.0
 		IL_0330: ldloc.s 22
@@ -9163,13 +9163,13 @@
 		IL_0465: ldc.i4.0
 		IL_0466: ldelem.ref
 		IL_0467: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_046c: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject_FunctionExpression_144008FC_L334C24::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_046c: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_0471: ldc.i4.0
 		IL_0472: conv.r8
 		IL_0473: ldstr ""
 		IL_0478: ldc.i4.0
 		IL_0479: ldc.i4.1
-		IL_047a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject_FunctionExpression_144008FC_L334C24>(!!0, float64, string, bool, bool)
+		IL_047a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_047f: stloc.s 25
 		IL_0481: ldloc.s 4
 		IL_0483: ldloc.s 8

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E165DCE7_readFile
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject_FunctionDeclaration_E165DCE7_readFile::_environment0_Compile_Scripts_BumpVersion
+				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject_FunctionDeclaration_E165DCE7_readFile::_environment0_Compile_Scripts_BumpVersion
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject_FunctionDeclaration_E165DCE7_readFile::_environment0_Compile_Scripts_BumpVersion
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E165DCE7_readFile
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -196,7 +196,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9E2A195E_writeFile
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -216,9 +216,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject_FunctionDeclaration_9E2A195E_writeFile::_environment0_Compile_Scripts_BumpVersion
+				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -229,7 +229,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -240,7 +240,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -253,7 +253,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject_FunctionDeclaration_9E2A195E_writeFile::_environment0_Compile_Scripts_BumpVersion
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -263,7 +263,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -277,7 +277,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject_FunctionDeclaration_9E2A195E_writeFile::_environment0_Compile_Scripts_BumpVersion
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -287,7 +287,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -305,9 +305,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9E2A195E_writeFile
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -368,7 +368,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -382,7 +382,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -393,7 +393,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -404,7 +404,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -422,7 +422,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -441,7 +441,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -459,9 +459,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -806,7 +806,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_37FCF14D_incVersion
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -820,7 +820,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -831,7 +831,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -842,7 +842,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -863,7 +863,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -885,7 +885,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -903,9 +903,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_37FCF14D_incVersion
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1294,7 +1294,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1314,9 +1314,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::_environment0_Compile_Scripts_BumpVersion
+				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1327,7 +1327,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1338,7 +1338,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1351,7 +1351,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::_environment0_Compile_Scripts_BumpVersion
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -1361,7 +1361,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_BumpVersion/resolveTargetVersion::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1375,7 +1375,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::_environment0_Compile_Scripts_BumpVersion
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -1385,7 +1385,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_BumpVersion/resolveTargetVersion::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1403,9 +1403,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1566,7 +1566,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1580,7 +1580,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1591,7 +1591,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1602,7 +1602,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1623,7 +1623,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1645,7 +1645,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1663,9 +1663,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1798,7 +1798,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1812,7 +1812,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1823,7 +1823,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1834,7 +1834,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1855,7 +1855,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1877,7 +1877,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1895,9 +1895,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2021,7 +2021,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2041,9 +2041,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::_environment0_Compile_Scripts_BumpVersion
+				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2054,7 +2054,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2065,7 +2065,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2078,14 +2078,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::_environment0_Compile_Scripts_BumpVersion
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_BumpVersion/extractUnreleased::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2099,14 +2099,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::_environment0_Compile_Scripts_BumpVersion
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_BumpVersion/extractUnreleased::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2124,9 +2124,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2362,7 +2362,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2376,7 +2376,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2387,7 +2387,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2398,7 +2398,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2416,7 +2416,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Scripts_BumpVersion/isPlaceholder::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2435,7 +2435,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Scripts_BumpVersion/isPlaceholder::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2453,9 +2453,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2704,7 +2704,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2724,9 +2724,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::_environment0_Compile_Scripts_BumpVersion
+				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2737,7 +2737,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2748,7 +2748,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2761,7 +2761,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::_environment0_Compile_Scripts_BumpVersion
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2771,7 +2771,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_BumpVersion/generateReleaseSection::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2785,7 +2785,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::_environment0_Compile_Scripts_BumpVersion
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2795,7 +2795,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_BumpVersion/generateReleaseSection::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2813,9 +2813,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3200,7 +3200,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F66C72E6_perform
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3220,9 +3220,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/perform/FunctionObject_FunctionDeclaration_F66C72E6_perform::_environment0_Compile_Scripts_BumpVersion
+				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/perform/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3233,7 +3233,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3244,7 +3244,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3257,11 +3257,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/perform/FunctionObject_FunctionDeclaration_F66C72E6_perform::_environment0_Compile_Scripts_BumpVersion
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/perform/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Scripts_BumpVersion/perform::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3275,11 +3275,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/perform/FunctionObject_FunctionDeclaration_F66C72E6_perform::_environment0_Compile_Scripts_BumpVersion
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/perform/FunctionObject::_environment0_Compile_Scripts_BumpVersion
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Scripts_BumpVersion/perform::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3297,9 +3297,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F66C72E6_perform
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4222,7 +4222,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_BumpVersion/Scope,
-			[1] class Modules.Compile_Scripts_BumpVersion/perform/FunctionObject_FunctionDeclaration_F66C72E6_perform,
+			[1] class Modules.Compile_Scripts_BumpVersion/perform/FunctionObject,
 			[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
 			[3] object,
 			[4] class [System.Runtime]System.Exception,
@@ -4230,16 +4230,16 @@
 			[6] object,
 			[7] object,
 			[8] object[],
-			[9] class Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject_FunctionDeclaration_E165DCE7_readFile,
-			[10] class Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject_FunctionDeclaration_9E2A195E_writeFile,
-			[11] class Modules.Compile_Scripts_BumpVersion/parseCurrentVersion/FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion,
-			[12] class Modules.Compile_Scripts_BumpVersion/incVersion/FunctionObject_FunctionDeclaration_37FCF14D_incVersion,
-			[13] class Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion,
-			[14] class Modules.Compile_Scripts_BumpVersion/updateCsprojVersion/FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion,
-			[15] class Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion/FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion,
-			[16] class Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased,
-			[17] class Modules.Compile_Scripts_BumpVersion/isPlaceholder/FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder,
-			[18] class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection,
+			[9] class Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject,
+			[10] class Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject,
+			[11] class Modules.Compile_Scripts_BumpVersion/parseCurrentVersion/FunctionObject,
+			[12] class Modules.Compile_Scripts_BumpVersion/incVersion/FunctionObject,
+			[13] class Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject,
+			[14] class Modules.Compile_Scripts_BumpVersion/updateCsprojVersion/FunctionObject,
+			[15] class Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion/FunctionObject,
+			[16] class Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject,
+			[17] class Modules.Compile_Scripts_BumpVersion/isPlaceholder/FunctionObject,
+			[18] class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject,
 			[19] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[20] object,
 			[21] object
@@ -4258,13 +4258,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Compile_Scripts_BumpVersion/Scope
-		IL_001b: newobj instance void Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject_FunctionDeclaration_E165DCE7_readFile::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
+		IL_001b: newobj instance void Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "readFile"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject_FunctionDeclaration_E165DCE7_readFile>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.s 9
 		IL_0030: ldloc.0
 		IL_0031: ldloc.s 9
@@ -4280,13 +4280,13 @@
 		IL_0046: ldc.i4.0
 		IL_0047: ldelem.ref
 		IL_0048: castclass Modules.Compile_Scripts_BumpVersion/Scope
-		IL_004d: newobj instance void Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject_FunctionDeclaration_9E2A195E_writeFile::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
+		IL_004d: newobj instance void Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
 		IL_0052: ldc.i4.2
 		IL_0053: conv.r8
 		IL_0054: ldstr "writeFile"
 		IL_0059: ldc.i4.0
 		IL_005a: ldc.i4.1
-		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject_FunctionDeclaration_9E2A195E_writeFile>(!!0, float64, string, bool, bool)
+		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0060: stloc.s 10
 		IL_0062: ldloc.0
 		IL_0063: ldloc.s 10
@@ -4298,13 +4298,13 @@
 		IL_0072: ldloc.0
 		IL_0073: stelem.ref
 		IL_0074: stloc.s 8
-		IL_0076: newobj instance void Modules.Compile_Scripts_BumpVersion/parseCurrentVersion/FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::.ctor()
+		IL_0076: newobj instance void Modules.Compile_Scripts_BumpVersion/parseCurrentVersion/FunctionObject::.ctor()
 		IL_007b: ldc.i4.1
 		IL_007c: conv.r8
 		IL_007d: ldstr "parseCurrentVersion"
 		IL_0082: ldc.i4.0
 		IL_0083: ldc.i4.1
-		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/parseCurrentVersion/FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion>(!!0, float64, string, bool, bool)
+		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/parseCurrentVersion/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0089: stloc.s 11
 		IL_008b: ldloc.0
 		IL_008c: ldloc.s 11
@@ -4316,13 +4316,13 @@
 		IL_009b: ldloc.0
 		IL_009c: stelem.ref
 		IL_009d: stloc.s 8
-		IL_009f: newobj instance void Modules.Compile_Scripts_BumpVersion/incVersion/FunctionObject_FunctionDeclaration_37FCF14D_incVersion::.ctor()
+		IL_009f: newobj instance void Modules.Compile_Scripts_BumpVersion/incVersion/FunctionObject::.ctor()
 		IL_00a4: ldc.i4.2
 		IL_00a5: conv.r8
 		IL_00a6: ldstr "incVersion"
 		IL_00ab: ldc.i4.0
 		IL_00ac: ldc.i4.1
-		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/incVersion/FunctionObject_FunctionDeclaration_37FCF14D_incVersion>(!!0, float64, string, bool, bool)
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/incVersion/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00b2: stloc.s 12
 		IL_00b4: ldloc.0
 		IL_00b5: ldloc.s 12
@@ -4338,13 +4338,13 @@
 		IL_00ca: ldc.i4.0
 		IL_00cb: ldelem.ref
 		IL_00cc: castclass Modules.Compile_Scripts_BumpVersion/Scope
-		IL_00d1: newobj instance void Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
+		IL_00d1: newobj instance void Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
 		IL_00d6: ldc.i4.2
 		IL_00d7: conv.r8
 		IL_00d8: ldstr "resolveTargetVersion"
 		IL_00dd: ldc.i4.0
 		IL_00de: ldc.i4.1
-		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion>(!!0, float64, string, bool, bool)
+		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00e4: stloc.s 13
 		IL_00e6: ldloc.0
 		IL_00e7: ldloc.s 13
@@ -4356,13 +4356,13 @@
 		IL_00f6: ldloc.0
 		IL_00f7: stelem.ref
 		IL_00f8: stloc.s 8
-		IL_00fa: newobj instance void Modules.Compile_Scripts_BumpVersion/updateCsprojVersion/FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::.ctor()
+		IL_00fa: newobj instance void Modules.Compile_Scripts_BumpVersion/updateCsprojVersion/FunctionObject::.ctor()
 		IL_00ff: ldc.i4.2
 		IL_0100: conv.r8
 		IL_0101: ldstr "updateCsprojVersion"
 		IL_0106: ldc.i4.0
 		IL_0107: ldc.i4.1
-		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/updateCsprojVersion/FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion>(!!0, float64, string, bool, bool)
+		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/updateCsprojVersion/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_010d: stloc.s 14
 		IL_010f: ldloc.0
 		IL_0110: ldloc.s 14
@@ -4374,13 +4374,13 @@
 		IL_011f: ldloc.0
 		IL_0120: stelem.ref
 		IL_0121: stloc.s 8
-		IL_0123: newobj instance void Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion/FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::.ctor()
+		IL_0123: newobj instance void Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion/FunctionObject::.ctor()
 		IL_0128: ldc.i4.2
 		IL_0129: conv.r8
 		IL_012a: ldstr "updateSamplesPropsVersion"
 		IL_012f: ldc.i4.0
 		IL_0130: ldc.i4.1
-		IL_0131: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion/FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion>(!!0, float64, string, bool, bool)
+		IL_0131: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0136: stloc.s 15
 		IL_0138: ldloc.0
 		IL_0139: ldloc.s 15
@@ -4396,13 +4396,13 @@
 		IL_014e: ldc.i4.0
 		IL_014f: ldelem.ref
 		IL_0150: castclass Modules.Compile_Scripts_BumpVersion/Scope
-		IL_0155: newobj instance void Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
+		IL_0155: newobj instance void Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
 		IL_015a: ldc.i4.1
 		IL_015b: conv.r8
 		IL_015c: ldstr "extractUnreleased"
 		IL_0161: ldc.i4.0
 		IL_0162: ldc.i4.1
-		IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased>(!!0, float64, string, bool, bool)
+		IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0168: stloc.s 16
 		IL_016a: ldloc.0
 		IL_016b: ldloc.s 16
@@ -4414,13 +4414,13 @@
 		IL_017a: ldloc.0
 		IL_017b: stelem.ref
 		IL_017c: stloc.s 8
-		IL_017e: newobj instance void Modules.Compile_Scripts_BumpVersion/isPlaceholder/FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::.ctor()
+		IL_017e: newobj instance void Modules.Compile_Scripts_BumpVersion/isPlaceholder/FunctionObject::.ctor()
 		IL_0183: ldc.i4.1
 		IL_0184: conv.r8
 		IL_0185: ldstr "isPlaceholder"
 		IL_018a: ldc.i4.0
 		IL_018b: ldc.i4.1
-		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/isPlaceholder/FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder>(!!0, float64, string, bool, bool)
+		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/isPlaceholder/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0191: stloc.s 17
 		IL_0193: ldloc.0
 		IL_0194: ldloc.s 17
@@ -4436,13 +4436,13 @@
 		IL_01a9: ldc.i4.0
 		IL_01aa: ldelem.ref
 		IL_01ab: castclass Modules.Compile_Scripts_BumpVersion/Scope
-		IL_01b0: newobj instance void Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
+		IL_01b0: newobj instance void Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
 		IL_01b5: ldc.i4.2
 		IL_01b6: conv.r8
 		IL_01b7: ldstr "generateReleaseSection"
 		IL_01bc: ldc.i4.0
 		IL_01bd: ldc.i4.1
-		IL_01be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection>(!!0, float64, string, bool, bool)
+		IL_01be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01c3: stloc.s 18
 		IL_01c5: ldloc.0
 		IL_01c6: ldloc.s 18
@@ -4458,13 +4458,13 @@
 		IL_01db: ldc.i4.0
 		IL_01dc: ldelem.ref
 		IL_01dd: castclass Modules.Compile_Scripts_BumpVersion/Scope
-		IL_01e2: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/FunctionObject_FunctionDeclaration_F66C72E6_perform::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
+		IL_01e2: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/FunctionObject::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
 		IL_01e7: ldc.i4.0
 		IL_01e8: conv.r8
 		IL_01e9: ldstr "perform"
 		IL_01ee: ldc.i4.0
 		IL_01ef: ldc.i4.1
-		IL_01f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/perform/FunctionObject_FunctionDeclaration_F66C72E6_perform>(!!0, float64, string, bool, bool)
+		IL_01f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/perform/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01f5: stloc.1
 		IL_01f6: nop
 		IL_01f7: ldarg.1

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -148,7 +148,7 @@
 
 		} // end of class Scope_For_L21C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0544688E_parseArgs
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -168,9 +168,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject_FunctionDeclaration_0544688E_parseArgs::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -181,7 +181,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -192,7 +192,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -205,14 +205,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject_FunctionDeclaration_0544688E_parseArgs::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -226,14 +226,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject_FunctionDeclaration_0544688E_parseArgs::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -251,9 +251,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0544688E_parseArgs
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -556,7 +556,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_15C44BEA_L61C16
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -570,7 +570,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -581,7 +581,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -592,7 +592,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -613,9 +613,9 @@
 					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0013: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15::__js_call__(object, object, object)
 					IL_0018: ret
-				} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_15C44BEA_L61C16
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -806,7 +806,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8A5C527C_L74C16
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -820,7 +820,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -831,7 +831,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -842,7 +842,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -860,9 +860,9 @@
 					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000c: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15::__js_call__(object, object)
 					IL_0011: ret
-				} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_8A5C527C_L74C16
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -964,7 +964,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DD415412_L82C11
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -978,7 +978,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -989,7 +989,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1000,7 +1000,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1018,9 +1018,9 @@
 					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000c: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10::__js_call__(object, object)
 					IL_0011: ret
-				} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_DD415412_L82C11
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1309,7 +1309,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8E7AE75C_L85C16
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1331,12 +1331,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+					IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16::_transitionalScopes
+					IL_000f: stfld object[] Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1347,7 +1347,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1358,7 +1358,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1371,7 +1371,7 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
@@ -1381,9 +1381,9 @@
 					IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0019: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15::__js_call__(object[], object, object, object)
 					IL_001e: ret
-				} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_8E7AE75C_L85C16
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1585,7 +1585,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1605,9 +1605,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1618,7 +1618,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1629,7 +1629,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1642,14 +1642,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1663,14 +1663,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1688,9 +1688,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1717,10 +1717,10 @@
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[6] object[],
-				[7] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15/FunctionObject_FunctionExpression_15C44BEA_L61C16,
-				[8] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject_FunctionExpression_8A5C527C_L74C16,
-				[9] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject_FunctionExpression_DD415412_L82C11,
-				[10] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16,
+				[7] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15/FunctionObject,
+				[8] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject,
+				[9] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject,
+				[10] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject,
 				[11] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 				[12] object
 			)
@@ -1782,14 +1782,14 @@
 			IL_00ac: ldarg.0
 			IL_00ad: stelem.ref
 			IL_00ae: stloc.s 6
-			IL_00b0: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15/FunctionObject_FunctionExpression_15C44BEA_L61C16::.ctor()
+			IL_00b0: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15/FunctionObject::.ctor()
 			IL_00b5: ldc.i4.2
 			IL_00b6: conv.r8
 			IL_00b7: ldstr ""
 			IL_00bc: ldc.i4.0
 			IL_00bd: ldc.i4.1
-			IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15/FunctionObject_FunctionExpression_15C44BEA_L61C16>(!!0, float64, string, bool, bool)
-			IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15/FunctionObject_FunctionExpression_15C44BEA_L61C16>(!!0)
+			IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15/FunctionObject>(!!0)
 			IL_00c8: stloc.s 7
 			IL_00ca: ldloc.s 4
 			IL_00cc: ldstr "replacement"
@@ -1831,14 +1831,14 @@
 			IL_013a: ldarg.0
 			IL_013b: stelem.ref
 			IL_013c: stloc.s 6
-			IL_013e: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject_FunctionExpression_8A5C527C_L74C16::.ctor()
+			IL_013e: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject::.ctor()
 			IL_0143: ldc.i4.1
 			IL_0144: conv.r8
 			IL_0145: ldstr ""
 			IL_014a: ldc.i4.0
 			IL_014b: ldc.i4.1
-			IL_014c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject_FunctionExpression_8A5C527C_L74C16>(!!0, float64, string, bool, bool)
-			IL_0151: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject_FunctionExpression_8A5C527C_L74C16>(!!0)
+			IL_014c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0151: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15/FunctionObject>(!!0)
 			IL_0156: stloc.s 8
 			IL_0158: ldloc.s 4
 			IL_015a: ldstr "replacement"
@@ -1863,14 +1863,14 @@
 			IL_0190: ldarg.0
 			IL_0191: stelem.ref
 			IL_0192: stloc.s 6
-			IL_0194: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject_FunctionExpression_DD415412_L82C11::.ctor()
+			IL_0194: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject::.ctor()
 			IL_0199: ldc.i4.1
 			IL_019a: conv.r8
 			IL_019b: ldstr ""
 			IL_01a0: ldc.i4.0
 			IL_01a1: ldc.i4.1
-			IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject_FunctionExpression_DD415412_L82C11>(!!0, float64, string, bool, bool)
-			IL_01a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject_FunctionExpression_DD415412_L82C11>(!!0)
+			IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_01a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10/FunctionObject>(!!0)
 			IL_01ac: stloc.s 9
 			IL_01ae: ldloc.s 4
 			IL_01b0: ldstr "filter"
@@ -1893,14 +1893,14 @@
 			IL_01d0: ldelem.ref
 			IL_01d1: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
 			IL_01d6: ldloc.s 6
-			IL_01d8: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object[])
+			IL_01d8: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object[])
 			IL_01dd: ldc.i4.2
 			IL_01de: conv.r8
 			IL_01df: ldstr ""
 			IL_01e4: ldc.i4.0
 			IL_01e5: ldc.i4.1
-			IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16>(!!0, float64, string, bool, bool)
-			IL_01eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16>(!!0)
+			IL_01e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_01eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject>(!!0)
 			IL_01f0: stloc.s 10
 			IL_01f2: ldloc.s 4
 			IL_01f4: ldstr "replacement"
@@ -1970,7 +1970,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_71696E19_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1990,9 +1990,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject_FunctionDeclaration_71696E19_main::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_71696E19_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2003,7 +2003,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_71696E19_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2014,7 +2014,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_71696E19_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2027,11 +2027,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject_FunctionDeclaration_71696E19_main::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_71696E19_main::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2045,11 +2045,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject_FunctionDeclaration_71696E19_main::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_71696E19_main::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2067,9 +2067,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_71696E19_main::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_71696E19_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2567,15 +2567,15 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope,
-			[1] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject_FunctionDeclaration_71696E19_main,
+			[1] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject,
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
 			[5] object,
 			[6] object,
 			[7] object[],
-			[8] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject_FunctionDeclaration_0544688E_parseArgs,
-			[9] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown,
+			[8] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject,
+			[9] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject,
 			[10] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[11] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
 			[12] object,
@@ -2598,13 +2598,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-		IL_001b: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject_FunctionDeclaration_0544688E_parseArgs::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope)
+		IL_001b: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "parseArgs"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject_FunctionDeclaration_0544688E_parseArgs>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.s 8
 		IL_0030: ldloc.0
 		IL_0031: ldloc.s 8
@@ -2620,13 +2620,13 @@
 		IL_0046: ldc.i4.0
 		IL_0047: ldelem.ref
 		IL_0048: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-		IL_004d: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope)
+		IL_004d: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope)
 		IL_0052: ldc.i4.1
 		IL_0053: conv.r8
 		IL_0054: ldstr "convertHtmlToMarkdown"
 		IL_0059: ldc.i4.0
 		IL_005a: ldc.i4.1
-		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown>(!!0, float64, string, bool, bool)
+		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0060: stloc.s 9
 		IL_0062: ldloc.0
 		IL_0063: ldloc.s 9
@@ -2642,13 +2642,13 @@
 		IL_0078: ldc.i4.0
 		IL_0079: ldelem.ref
 		IL_007a: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-		IL_007f: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject_FunctionDeclaration_71696E19_main::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope)
+		IL_007f: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope)
 		IL_0084: ldc.i4.0
 		IL_0085: conv.r8
 		IL_0086: ldstr "main"
 		IL_008b: ldc.i4.0
 		IL_008c: ldc.i4.1
-		IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject_FunctionDeclaration_71696E19_main>(!!0, float64, string, bool, bool)
+		IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0092: stloc.1
 		IL_0093: nop
 		IL_0094: ldarg.1
@@ -2807,7 +2807,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2821,7 +2821,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2832,7 +2832,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2843,7 +2843,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2858,7 +2858,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Packages.turndown.index/TurndownService::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2874,7 +2874,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Packages.turndown.index/TurndownService::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2892,9 +2892,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2946,7 +2946,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8739CC51_addRule
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2960,7 +2960,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2971,7 +2971,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2982,7 +2982,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3003,7 +3003,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Packages.turndown.index/addRule::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3025,7 +3025,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Packages.turndown.index/addRule::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3043,9 +3043,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_8739CC51_addRule
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3107,7 +3107,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C20E11E7_turndown
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3121,7 +3121,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3132,7 +3132,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3143,7 +3143,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3161,7 +3161,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Packages.turndown.index/turndown::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3180,7 +3180,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Packages.turndown.index/turndown::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3198,9 +3198,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C20E11E7_turndown
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3294,11 +3294,11 @@
 		.maxstack 8
 		.locals init (
 			[0] class Packages.turndown.index/Scope,
-			[1] class Packages.turndown.index/TurndownService/FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService,
+			[1] class Packages.turndown.index/TurndownService/FunctionObject,
 			[2] object[],
 			[3] object,
-			[4] class Packages.turndown.index/addRule/FunctionObject_FunctionExpression_8739CC51_addRule,
-			[5] class Packages.turndown.index/turndown/FunctionObject_FunctionExpression_C20E11E7_turndown
+			[4] class Packages.turndown.index/addRule/FunctionObject,
+			[5] class Packages.turndown.index/turndown/FunctionObject
 		)
 
 		IL_0000: newobj instance void Packages.turndown.index/Scope::.ctor()
@@ -3310,13 +3310,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Packages.turndown.index/TurndownService/FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::.ctor()
+		IL_0011: newobj instance void Packages.turndown.index/TurndownService/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "TurndownService"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Packages.turndown.index/TurndownService/FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Packages.turndown.index/TurndownService/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -3331,13 +3331,13 @@
 		IL_003b: ldloc.0
 		IL_003c: stelem.ref
 		IL_003d: stloc.2
-		IL_003e: newobj instance void Packages.turndown.index/addRule/FunctionObject_FunctionExpression_8739CC51_addRule::.ctor()
+		IL_003e: newobj instance void Packages.turndown.index/addRule/FunctionObject::.ctor()
 		IL_0043: ldc.i4.2
 		IL_0044: conv.r8
 		IL_0045: ldstr "addRule"
 		IL_004a: ldc.i4.1
 		IL_004b: ldc.i4.1
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Packages.turndown.index/addRule/FunctionObject_FunctionExpression_8739CC51_addRule>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Packages.turndown.index/addRule/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0051: stloc.s 4
 		IL_0053: ldloc.3
 		IL_0054: ldstr "addRule"
@@ -3356,13 +3356,13 @@
 		IL_0076: ldloc.0
 		IL_0077: stelem.ref
 		IL_0078: stloc.2
-		IL_0079: newobj instance void Packages.turndown.index/turndown/FunctionObject_FunctionExpression_C20E11E7_turndown::.ctor()
+		IL_0079: newobj instance void Packages.turndown.index/turndown/FunctionObject::.ctor()
 		IL_007e: ldc.i4.1
 		IL_007f: conv.r8
 		IL_0080: ldstr "turndown"
 		IL_0085: ldc.i4.1
 		IL_0086: ldc.i4.1
-		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Packages.turndown.index/turndown/FunctionObject_FunctionExpression_C20E11E7_turndown>(!!0, float64, string, bool, bool)
+		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Packages.turndown.index/turndown/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_008c: stloc.s 5
 		IL_008e: ldloc.3
 		IL_008f: ldstr "turndown"

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -258,7 +258,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -278,9 +278,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -291,7 +291,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -302,7 +302,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -315,14 +315,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -336,14 +336,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -361,9 +361,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -738,7 +738,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -758,9 +758,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -771,7 +771,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -782,7 +782,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -795,14 +795,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -816,14 +816,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -841,9 +841,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1346,7 +1346,7 @@
 
 		} // end of class Scope_ForOf_L72C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1366,9 +1366,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1379,7 +1379,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1390,7 +1390,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1403,7 +1403,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -1413,7 +1413,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1427,7 +1427,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -1437,7 +1437,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1455,9 +1455,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1819,7 +1819,7 @@
 
 		} // end of class Scope_ForOf_L87C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1839,9 +1839,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1852,7 +1852,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1863,7 +1863,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1876,7 +1876,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -1886,7 +1886,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1900,7 +1900,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -1910,7 +1910,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1928,9 +1928,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2135,7 +2135,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_60187D86_findProjectRoot
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2155,9 +2155,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2168,7 +2168,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2179,7 +2179,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2192,14 +2192,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2213,14 +2213,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2238,9 +2238,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_60187D86_findProjectRoot
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2456,7 +2456,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2476,9 +2476,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2489,7 +2489,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2500,7 +2500,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2513,7 +2513,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2523,7 +2523,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2537,7 +2537,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2547,7 +2547,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2565,9 +2565,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2666,7 +2666,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2686,9 +2686,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2699,7 +2699,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2710,7 +2710,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2723,14 +2723,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2744,14 +2744,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2769,9 +2769,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3048,7 +3048,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_62C762B7_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3068,9 +3068,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject_FunctionDeclaration_62C762B7_main::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3081,7 +3081,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3092,7 +3092,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3105,11 +3105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject_FunctionDeclaration_62C762B7_main::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3123,11 +3123,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject_FunctionDeclaration_62C762B7_main::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject::_environment0_Compile_Scripts_DecompileGeneratorTest
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3145,9 +3145,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_62C762B7_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3934,16 +3934,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_DecompileGeneratorTest/Scope,
-			[1] class Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject_FunctionDeclaration_60187D86_findProjectRoot,
-			[2] class Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject_FunctionDeclaration_62C762B7_main,
+			[1] class Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject,
+			[2] class Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject,
 			[3] object[],
-			[4] class Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName/FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName,
-			[5] class Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory,
-			[6] class Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots,
-			[7] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot,
-			[8] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly,
-			[9] class Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath,
-			[10] class Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy,
+			[4] class Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName/FunctionObject,
+			[5] class Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject,
+			[6] class Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject,
+			[7] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject,
+			[8] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject,
+			[9] class Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject,
+			[10] class Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject,
 			[11] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule,
 			[12] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[13] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
@@ -3960,13 +3960,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName/FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::.ctor()
+		IL_0011: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "getAssemblyFileBaseName"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName/FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.s 4
 		IL_0026: ldloc.0
 		IL_0027: ldloc.s 4
@@ -3982,13 +3982,13 @@
 		IL_003a: ldc.i4.0
 		IL_003b: ldelem.ref
 		IL_003c: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_0041: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_0041: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_0046: ldc.i4.1
 		IL_0047: conv.r8
 		IL_0048: ldstr "normalizeCategory"
 		IL_004d: ldc.i4.0
 		IL_004e: ldc.i4.1
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory>(!!0, float64, string, bool, bool)
+		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0054: stloc.s 5
 		IL_0056: ldloc.0
 		IL_0057: ldloc.s 5
@@ -4004,13 +4004,13 @@
 		IL_006a: ldc.i4.0
 		IL_006b: ldelem.ref
 		IL_006c: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_0071: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_0071: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_0076: ldc.i4.1
 		IL_0077: conv.r8
 		IL_0078: ldstr "getCandidateCategoryRoots"
 		IL_007d: ldc.i4.0
 		IL_007e: ldc.i4.1
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0084: stloc.s 6
 		IL_0086: ldloc.0
 		IL_0087: ldloc.s 6
@@ -4026,13 +4026,13 @@
 		IL_009a: ldc.i4.0
 		IL_009b: ldelem.ref
 		IL_009c: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_00a1: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_00a1: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_00a6: ldc.i4.2
 		IL_00a7: conv.r8
 		IL_00a8: ldstr "tryFindLatestGeneratedAssemblyInRoot"
 		IL_00ad: ldc.i4.0
 		IL_00ae: ldc.i4.1
-		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot>(!!0, float64, string, bool, bool)
+		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00b4: stloc.s 7
 		IL_00b6: ldloc.0
 		IL_00b7: ldloc.s 7
@@ -4048,13 +4048,13 @@
 		IL_00ca: ldc.i4.0
 		IL_00cb: ldelem.ref
 		IL_00cc: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_00d1: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_00d1: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_00d6: ldc.i4.2
 		IL_00d7: conv.r8
 		IL_00d8: ldstr "tryFindLatestGeneratedAssembly"
 		IL_00dd: ldc.i4.0
 		IL_00de: ldc.i4.1
-		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly>(!!0, float64, string, bool, bool)
+		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00e4: stloc.s 8
 		IL_00e6: ldloc.0
 		IL_00e7: ldloc.s 8
@@ -4070,13 +4070,13 @@
 		IL_00fa: ldc.i4.0
 		IL_00fb: ldelem.ref
 		IL_00fc: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_0101: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_0101: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_0106: ldc.i4.1
 		IL_0107: conv.r8
 		IL_0108: ldstr "findProjectRoot"
 		IL_010d: ldc.i4.0
 		IL_010e: ldc.i4.1
-		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject_FunctionDeclaration_60187D86_findProjectRoot>(!!0, float64, string, bool, bool)
+		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0114: stloc.1
 		IL_0115: ldc.i4.1
 		IL_0116: newarr [System.Runtime]System.Object
@@ -4089,13 +4089,13 @@
 		IL_0121: ldc.i4.0
 		IL_0122: ldelem.ref
 		IL_0123: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_0128: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_0128: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_012d: ldc.i4.2
 		IL_012e: conv.r8
 		IL_012f: ldstr "getGeneratorTestSnapshotPath"
 		IL_0134: ldc.i4.0
 		IL_0135: ldc.i4.1
-		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath>(!!0, float64, string, bool, bool)
+		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_013b: stloc.s 9
 		IL_013d: ldloc.0
 		IL_013e: ldloc.s 9
@@ -4111,13 +4111,13 @@
 		IL_0151: ldc.i4.0
 		IL_0152: ldelem.ref
 		IL_0153: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_0158: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_0158: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_015d: ldc.i4.1
 		IL_015e: conv.r8
 		IL_015f: ldstr "openInIlSpy"
 		IL_0164: ldc.i4.0
 		IL_0165: ldc.i4.1
-		IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy>(!!0, float64, string, bool, bool)
+		IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_016b: stloc.s 10
 		IL_016d: ldloc.0
 		IL_016e: ldloc.s 10
@@ -4133,13 +4133,13 @@
 		IL_0181: ldc.i4.0
 		IL_0182: ldelem.ref
 		IL_0183: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_0188: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject_FunctionDeclaration_62C762B7_main::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_0188: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_018d: ldc.i4.0
 		IL_018e: conv.r8
 		IL_018f: ldstr "main"
 		IL_0194: ldc.i4.0
 		IL_0195: ldc.i4.1
-		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject_FunctionDeclaration_62C762B7_main>(!!0, float64, string, bool, bool)
+		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_019b: stloc.2
 		IL_019c: nop
 		IL_019d: ldarg.1

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5C26764E_run
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -59,12 +59,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject_FunctionDeclaration_5C26764E_run::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject_FunctionDeclaration_5C26764E_run::_transitionalScopes
+				IL_000f: stfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -75,7 +75,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -86,7 +86,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -99,14 +99,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject_FunctionDeclaration_5C26764E_run::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_5C26764E_run
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -148,7 +148,7 @@
 			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject_FunctionDeclaration_5C26764E_run
+			IL_002c: ldtoken Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -510,7 +510,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope,
-			[1] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject_FunctionDeclaration_5C26764E_run,
+			[1] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/ArrowFunction_L8C13/FunctionObject
@@ -534,14 +534,14 @@
 		IL_001f: ldelem.ref
 		IL_0020: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope
 		IL_0025: ldloc.2
-		IL_0026: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject_FunctionDeclaration_5C26764E_run::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope, object[])
+		IL_0026: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope, object[])
 		IL_002b: ldc.i4.0
 		IL_002c: conv.r8
 		IL_002d: ldstr "run"
 		IL_0032: ldc.i4.0
 		IL_0033: ldc.i4.1
-		IL_0034: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject_FunctionDeclaration_5C26764E_run>(!!0, float64, string, bool, bool)
-		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject_FunctionDeclaration_5C26764E_run>(!!0)
+		IL_0034: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject>(!!0)
 		IL_003e: stloc.1
 		IL_003f: nop
 		IL_0040: nop
@@ -626,7 +626,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DA704280_normalize
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -640,7 +640,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -651,7 +651,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -662,7 +662,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -683,7 +683,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -705,7 +705,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -723,9 +723,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DA704280_normalize
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1026,7 +1026,7 @@
 
 		} // end of class Scope_For_L30C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0C11330D_parseArgs
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1046,9 +1046,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1059,7 +1059,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1070,7 +1070,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1083,14 +1083,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1104,14 +1104,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1129,9 +1129,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0C11330D_parseArgs
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2936,7 +2936,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A95D6710_fetchText
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2956,9 +2956,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2969,7 +2969,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2980,7 +2980,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2993,7 +2993,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -3003,7 +3003,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3017,7 +3017,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -3027,7 +3027,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3045,9 +3045,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A95D6710_fetchText
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3150,7 +3150,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3164,7 +3164,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3175,7 +3175,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3186,7 +3186,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3204,7 +3204,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3223,7 +3223,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3241,9 +3241,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3367,7 +3367,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3387,9 +3387,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3400,7 +3400,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3411,7 +3411,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3424,7 +3424,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -3434,7 +3434,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3448,7 +3448,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -3458,7 +3458,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3476,9 +3476,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3935,7 +3935,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DFE1081E_extractElementById
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3955,9 +3955,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3968,7 +3968,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3979,7 +3979,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3992,7 +3992,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -4002,7 +4002,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4016,7 +4016,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -4026,7 +4026,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4044,9 +4044,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DFE1081E_extractElementById
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4463,7 +4463,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4483,9 +4483,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4496,7 +4496,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4507,7 +4507,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4520,7 +4520,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -4530,7 +4530,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4544,7 +4544,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -4554,7 +4554,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4572,9 +4572,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4806,7 +4806,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -4820,7 +4820,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4831,7 +4831,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4842,7 +4842,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4866,7 +4866,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4891,7 +4891,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4909,9 +4909,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5178,7 +5178,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -5200,12 +5200,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
+				IL_000f: stfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5216,7 +5216,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5227,7 +5227,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -5240,14 +5240,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5319,7 +5319,7 @@
 			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
+			IL_002c: ldtoken Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -6729,16 +6729,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope,
-			[1] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli,
+			[1] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject,
 			[2] object[],
-			[3] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject_FunctionDeclaration_DA704280_normalize,
-			[4] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs,
-			[5] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText,
-			[6] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp,
-			[7] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt,
-			[8] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById,
-			[9] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml,
-			[10] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml,
+			[3] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject,
+			[4] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject,
+			[5] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject,
+			[6] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject,
+			[7] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject,
+			[8] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject,
+			[9] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject,
+			[10] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject,
 			[11] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[12] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[13] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule,
@@ -6756,13 +6756,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject_FunctionDeclaration_DA704280_normalize::.ctor()
+		IL_0011: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "normalize"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject_FunctionDeclaration_DA704280_normalize>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.3
 		IL_0025: ldloc.0
 		IL_0026: ldloc.3
@@ -6778,13 +6778,13 @@
 		IL_0038: ldc.i4.0
 		IL_0039: ldelem.ref
 		IL_003a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_003f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_003f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_0044: ldc.i4.1
 		IL_0045: conv.r8
 		IL_0046: ldstr "parseArgs"
 		IL_004b: ldc.i4.0
 		IL_004c: ldc.i4.1
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs>(!!0, float64, string, bool, bool)
+		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0052: stloc.s 4
 		IL_0054: ldloc.0
 		IL_0055: ldloc.s 4
@@ -6800,13 +6800,13 @@
 		IL_0068: ldc.i4.0
 		IL_0069: ldelem.ref
 		IL_006a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_006f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_006f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_0074: ldc.i4.1
 		IL_0075: conv.r8
 		IL_0076: ldstr "fetchText"
 		IL_007b: ldc.i4.0
 		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.s 5
 		IL_0084: ldloc.0
 		IL_0085: ldloc.s 5
@@ -6818,13 +6818,13 @@
 		IL_0094: ldloc.0
 		IL_0095: stelem.ref
 		IL_0096: stloc.2
-		IL_0097: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::.ctor()
+		IL_0097: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject::.ctor()
 		IL_009c: ldc.i4.1
 		IL_009d: conv.r8
 		IL_009e: ldstr "escapeRegExp"
 		IL_00a3: ldc.i4.0
 		IL_00a4: ldc.i4.1
-		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp>(!!0, float64, string, bool, bool)
+		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00aa: stloc.s 6
 		IL_00ac: ldloc.0
 		IL_00ad: ldloc.s 6
@@ -6840,13 +6840,13 @@
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldelem.ref
 		IL_00c2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_00c7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_00c7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_00cc: ldc.i4.2
 		IL_00cd: conv.r8
 		IL_00ce: ldstr "findTagNameAt"
 		IL_00d3: ldc.i4.0
 		IL_00d4: ldc.i4.1
-		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt>(!!0, float64, string, bool, bool)
+		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00da: stloc.s 7
 		IL_00dc: ldloc.0
 		IL_00dd: ldloc.s 7
@@ -6862,13 +6862,13 @@
 		IL_00f0: ldc.i4.0
 		IL_00f1: ldelem.ref
 		IL_00f2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_00f7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_00f7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_00fc: ldc.i4.2
 		IL_00fd: conv.r8
 		IL_00fe: ldstr "extractElementById"
 		IL_0103: ldc.i4.0
 		IL_0104: ldc.i4.1
-		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById>(!!0, float64, string, bool, bool)
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_010a: stloc.s 8
 		IL_010c: ldloc.0
 		IL_010d: ldloc.s 8
@@ -6884,13 +6884,13 @@
 		IL_0120: ldc.i4.0
 		IL_0121: ldelem.ref
 		IL_0122: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_0127: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_0127: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_012c: ldc.i4.2
 		IL_012d: conv.r8
 		IL_012e: ldstr "resolveSectionLinkFromMultipageIndexHtml"
 		IL_0133: ldc.i4.0
 		IL_0134: ldc.i4.1
-		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml>(!!0, float64, string, bool, bool)
+		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_013a: stloc.s 9
 		IL_013c: ldloc.0
 		IL_013d: ldloc.s 9
@@ -6902,13 +6902,13 @@
 		IL_014c: ldloc.0
 		IL_014d: stelem.ref
 		IL_014e: stloc.2
-		IL_014f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::.ctor()
+		IL_014f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject::.ctor()
 		IL_0154: ldc.i4.3
 		IL_0155: conv.r8
 		IL_0156: ldstr "wrapAsStandaloneHtml"
 		IL_015b: ldc.i4.0
 		IL_015c: ldc.i4.1
-		IL_015d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml>(!!0, float64, string, bool, bool)
+		IL_015d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0162: stloc.s 10
 		IL_0164: ldloc.0
 		IL_0165: ldloc.s 10
@@ -6925,14 +6925,14 @@
 		IL_0179: ldelem.ref
 		IL_017a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
 		IL_017f: ldloc.2
-		IL_0180: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object[])
+		IL_0180: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object[])
 		IL_0185: ldc.i4.0
 		IL_0186: conv.r8
 		IL_0187: ldstr "runHarnessCli"
 		IL_018c: ldc.i4.0
 		IL_018d: ldc.i4.1
-		IL_018e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli>(!!0, float64, string, bool, bool)
-		IL_0193: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli>(!!0)
+		IL_018e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0193: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject>(!!0)
 		IL_0198: stloc.1
 		IL_0199: nop
 		IL_019a: ldarg.1

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_319FFFE4_run
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -59,12 +59,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject_FunctionDeclaration_319FFFE4_run::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject_FunctionDeclaration_319FFFE4_run::_transitionalScopes
+				IL_000f: stfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -75,7 +75,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -86,7 +86,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -99,14 +99,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject_FunctionDeclaration_319FFFE4_run::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_319FFFE4_run
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -148,7 +148,7 @@
 			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject_FunctionDeclaration_319FFFE4_run
+			IL_002c: ldtoken Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -510,7 +510,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope,
-			[1] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject_FunctionDeclaration_319FFFE4_run,
+			[1] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject,
 			[2] object[],
 			[3] object,
 			[4] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/ArrowFunction_L8C13/FunctionObject
@@ -534,14 +534,14 @@
 		IL_001f: ldelem.ref
 		IL_0020: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope
 		IL_0025: ldloc.2
-		IL_0026: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject_FunctionDeclaration_319FFFE4_run::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope, object[])
+		IL_0026: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope, object[])
 		IL_002b: ldc.i4.0
 		IL_002c: conv.r8
 		IL_002d: ldstr "run"
 		IL_0032: ldc.i4.0
 		IL_0033: ldc.i4.1
-		IL_0034: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject_FunctionDeclaration_319FFFE4_run>(!!0, float64, string, bool, bool)
-		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject_FunctionDeclaration_319FFFE4_run>(!!0)
+		IL_0034: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject>(!!0)
 		IL_003e: stloc.1
 		IL_003f: nop
 		IL_0040: nop
@@ -626,7 +626,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DA704280_normalize
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -640,7 +640,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -651,7 +651,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -662,7 +662,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -683,7 +683,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -705,7 +705,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -723,9 +723,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DA704280_normalize
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1026,7 +1026,7 @@
 
 		} // end of class Scope_For_L30C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0C11330D_parseArgs
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1046,9 +1046,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1059,7 +1059,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1070,7 +1070,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1083,14 +1083,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1104,14 +1104,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1129,9 +1129,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0C11330D_parseArgs
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2936,7 +2936,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A95D6710_fetchText
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2956,9 +2956,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2969,7 +2969,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2980,7 +2980,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2993,7 +2993,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -3003,7 +3003,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3017,7 +3017,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -3027,7 +3027,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3045,9 +3045,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A95D6710_fetchText
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3150,7 +3150,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3164,7 +3164,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3175,7 +3175,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3186,7 +3186,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3204,7 +3204,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3223,7 +3223,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3241,9 +3241,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3367,7 +3367,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3387,9 +3387,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3400,7 +3400,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3411,7 +3411,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3424,7 +3424,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -3434,7 +3434,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3448,7 +3448,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -3458,7 +3458,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3476,9 +3476,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3935,7 +3935,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DFE1081E_extractElementById
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3955,9 +3955,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3968,7 +3968,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3979,7 +3979,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3992,7 +3992,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -4002,7 +4002,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4016,7 +4016,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -4026,7 +4026,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4044,9 +4044,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DFE1081E_extractElementById
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4463,7 +4463,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4483,9 +4483,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4496,7 +4496,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4507,7 +4507,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4520,7 +4520,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -4530,7 +4530,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4544,7 +4544,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -4554,7 +4554,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4572,9 +4572,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4806,7 +4806,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -4820,7 +4820,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4831,7 +4831,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4842,7 +4842,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4866,7 +4866,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4891,7 +4891,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4909,9 +4909,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5178,7 +5178,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -5200,12 +5200,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
+				IL_000f: stfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -5216,7 +5216,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -5227,7 +5227,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -5240,14 +5240,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -5319,7 +5319,7 @@
 			IL_0020: ldftn object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
+			IL_002c: ldtoken Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -6729,16 +6729,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope,
-			[1] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli,
+			[1] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject,
 			[2] object[],
-			[3] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject_FunctionDeclaration_DA704280_normalize,
-			[4] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs,
-			[5] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText,
-			[6] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp,
-			[7] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt,
-			[8] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById,
-			[9] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml,
-			[10] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml,
+			[3] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject,
+			[4] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject,
+			[5] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject,
+			[6] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject,
+			[7] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject,
+			[8] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject,
+			[9] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject,
+			[10] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject,
 			[11] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[12] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[13] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule,
@@ -6756,13 +6756,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject_FunctionDeclaration_DA704280_normalize::.ctor()
+		IL_0011: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "normalize"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject_FunctionDeclaration_DA704280_normalize>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.3
 		IL_0025: ldloc.0
 		IL_0026: ldloc.3
@@ -6778,13 +6778,13 @@
 		IL_0038: ldc.i4.0
 		IL_0039: ldelem.ref
 		IL_003a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_003f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_003f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_0044: ldc.i4.1
 		IL_0045: conv.r8
 		IL_0046: ldstr "parseArgs"
 		IL_004b: ldc.i4.0
 		IL_004c: ldc.i4.1
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs>(!!0, float64, string, bool, bool)
+		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0052: stloc.s 4
 		IL_0054: ldloc.0
 		IL_0055: ldloc.s 4
@@ -6800,13 +6800,13 @@
 		IL_0068: ldc.i4.0
 		IL_0069: ldelem.ref
 		IL_006a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_006f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_006f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_0074: ldc.i4.1
 		IL_0075: conv.r8
 		IL_0076: ldstr "fetchText"
 		IL_007b: ldc.i4.0
 		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.s 5
 		IL_0084: ldloc.0
 		IL_0085: ldloc.s 5
@@ -6818,13 +6818,13 @@
 		IL_0094: ldloc.0
 		IL_0095: stelem.ref
 		IL_0096: stloc.2
-		IL_0097: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::.ctor()
+		IL_0097: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject::.ctor()
 		IL_009c: ldc.i4.1
 		IL_009d: conv.r8
 		IL_009e: ldstr "escapeRegExp"
 		IL_00a3: ldc.i4.0
 		IL_00a4: ldc.i4.1
-		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp>(!!0, float64, string, bool, bool)
+		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00aa: stloc.s 6
 		IL_00ac: ldloc.0
 		IL_00ad: ldloc.s 6
@@ -6840,13 +6840,13 @@
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldelem.ref
 		IL_00c2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_00c7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_00c7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_00cc: ldc.i4.2
 		IL_00cd: conv.r8
 		IL_00ce: ldstr "findTagNameAt"
 		IL_00d3: ldc.i4.0
 		IL_00d4: ldc.i4.1
-		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt>(!!0, float64, string, bool, bool)
+		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00da: stloc.s 7
 		IL_00dc: ldloc.0
 		IL_00dd: ldloc.s 7
@@ -6862,13 +6862,13 @@
 		IL_00f0: ldc.i4.0
 		IL_00f1: ldelem.ref
 		IL_00f2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_00f7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_00f7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_00fc: ldc.i4.2
 		IL_00fd: conv.r8
 		IL_00fe: ldstr "extractElementById"
 		IL_0103: ldc.i4.0
 		IL_0104: ldc.i4.1
-		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById>(!!0, float64, string, bool, bool)
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_010a: stloc.s 8
 		IL_010c: ldloc.0
 		IL_010d: ldloc.s 8
@@ -6884,13 +6884,13 @@
 		IL_0120: ldc.i4.0
 		IL_0121: ldelem.ref
 		IL_0122: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_0127: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_0127: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_012c: ldc.i4.2
 		IL_012d: conv.r8
 		IL_012e: ldstr "resolveSectionLinkFromMultipageIndexHtml"
 		IL_0133: ldc.i4.0
 		IL_0134: ldc.i4.1
-		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml>(!!0, float64, string, bool, bool)
+		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_013a: stloc.s 9
 		IL_013c: ldloc.0
 		IL_013d: ldloc.s 9
@@ -6902,13 +6902,13 @@
 		IL_014c: ldloc.0
 		IL_014d: stelem.ref
 		IL_014e: stloc.2
-		IL_014f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::.ctor()
+		IL_014f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject::.ctor()
 		IL_0154: ldc.i4.3
 		IL_0155: conv.r8
 		IL_0156: ldstr "wrapAsStandaloneHtml"
 		IL_015b: ldc.i4.0
 		IL_015c: ldc.i4.1
-		IL_015d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml>(!!0, float64, string, bool, bool)
+		IL_015d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0162: stloc.s 10
 		IL_0164: ldloc.0
 		IL_0165: ldloc.s 10
@@ -6925,14 +6925,14 @@
 		IL_0179: ldelem.ref
 		IL_017a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
 		IL_017f: ldloc.2
-		IL_0180: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object[])
+		IL_0180: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object[])
 		IL_0185: ldc.i4.0
 		IL_0186: conv.r8
 		IL_0187: ldstr "runHarnessCli"
 		IL_018c: ldc.i4.0
 		IL_018d: ldc.i4.1
-		IL_018e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli>(!!0, float64, string, bool, bool)
-		IL_0193: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli>(!!0)
+		IL_018e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0193: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject>(!!0)
 		IL_0198: stloc.1
 		IL_0199: nop
 		IL_019a: ldarg.1

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1C7E821E_readJson
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject_FunctionDeclaration_1C7E821E_readJson::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject_FunctionDeclaration_1C7E821E_readJson::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/readJson::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject_FunctionDeclaration_1C7E821E_readJson::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/readJson::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_1C7E821E_readJson
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -197,7 +197,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_57160465_asArray
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -211,7 +211,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -222,7 +222,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -233,7 +233,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -251,7 +251,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/asArray::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -270,7 +270,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Scripts_GenerateNodeSupportMd/asArray::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -288,9 +288,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_57160465_asArray
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -367,7 +367,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -381,7 +381,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -392,7 +392,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -403,7 +403,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -421,7 +421,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -440,7 +440,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -458,9 +458,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -527,7 +527,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C98BDC38_link
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -541,7 +541,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -552,7 +552,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -563,7 +563,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -584,7 +584,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Compile_Scripts_GenerateNodeSupportMd/link::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -606,7 +606,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Compile_Scripts_GenerateNodeSupportMd/link::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -624,9 +624,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C98BDC38_link
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -724,7 +724,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -744,9 +744,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -757,7 +757,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -768,7 +768,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -781,14 +781,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -802,14 +802,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -827,9 +827,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1153,7 +1153,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1173,9 +1173,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1186,7 +1186,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1197,7 +1197,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1210,14 +1210,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1231,14 +1231,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1256,9 +1256,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1424,7 +1424,7 @@
 
 		} // end of class Scope_ForOf_L50C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C787672B_renderApisTable
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1444,9 +1444,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject_FunctionDeclaration_C787672B_renderApisTable::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1457,7 +1457,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1468,7 +1468,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1481,14 +1481,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject_FunctionDeclaration_C787672B_renderApisTable::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1502,14 +1502,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject_FunctionDeclaration_C787672B_renderApisTable::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1527,9 +1527,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C787672B_renderApisTable
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1916,7 +1916,7 @@
 
 		} // end of class Scope_ForOf_L58C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1936,9 +1936,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1949,7 +1949,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1960,7 +1960,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1973,14 +1973,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1994,14 +1994,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2019,9 +2019,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2517,7 +2517,7 @@
 
 		} // end of class Scope_ForOf_L74C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_99982A69_renderModules
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2537,9 +2537,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject_FunctionDeclaration_99982A69_renderModules::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2550,7 +2550,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2561,7 +2561,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2574,14 +2574,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject_FunctionDeclaration_99982A69_renderModules::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2595,14 +2595,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject_FunctionDeclaration_99982A69_renderModules::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2620,9 +2620,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_99982A69_renderModules
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3130,7 +3130,7 @@
 
 		} // end of class Scope_ForOf_L101C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3150,9 +3150,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3163,7 +3163,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3174,7 +3174,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3187,14 +3187,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3208,14 +3208,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3233,9 +3233,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3733,7 +3733,7 @@
 
 		} // end of class Scope_ForOf_L131C7
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_62338119_renderLimitations
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -3747,7 +3747,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3758,7 +3758,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3769,7 +3769,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3787,7 +3787,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3806,7 +3806,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3824,9 +3824,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_62338119_renderLimitations
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4008,7 +4008,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_16D03725_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -4028,9 +4028,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject_FunctionDeclaration_16D03725_main::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_16D03725_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4041,7 +4041,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_16D03725_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4052,7 +4052,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_16D03725_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -4065,11 +4065,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject_FunctionDeclaration_16D03725_main::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Compile_Scripts_GenerateNodeSupportMd/main::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_16D03725_main::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -4083,11 +4083,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject_FunctionDeclaration_16D03725_main::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject::_environment0_Compile_Scripts_GenerateNodeSupportMd
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Compile_Scripts_GenerateNodeSupportMd/main::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_16D03725_main::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -4105,9 +4105,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_16D03725_main::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_16D03725_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4412,19 +4412,19 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope,
-			[1] class Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject_FunctionDeclaration_16D03725_main,
+			[1] class Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject,
 			[2] object[],
-			[3] class Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject_FunctionDeclaration_1C7E821E_readJson,
-			[4] class Modules.Compile_Scripts_GenerateNodeSupportMd/asArray/FunctionObject_FunctionDeclaration_57160465_asArray,
-			[5] class Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode/FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode,
-			[6] class Modules.Compile_Scripts_GenerateNodeSupportMd/link/FunctionObject_FunctionDeclaration_C98BDC38_link,
-			[7] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader,
-			[8] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation,
-			[9] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject_FunctionDeclaration_C787672B_renderApisTable,
-			[10] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests,
-			[11] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject_FunctionDeclaration_99982A69_renderModules,
-			[12] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals,
-			[13] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations/FunctionObject_FunctionDeclaration_62338119_renderLimitations,
+			[3] class Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject,
+			[4] class Modules.Compile_Scripts_GenerateNodeSupportMd/asArray/FunctionObject,
+			[5] class Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode/FunctionObject,
+			[6] class Modules.Compile_Scripts_GenerateNodeSupportMd/link/FunctionObject,
+			[7] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject,
+			[8] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject,
+			[9] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject,
+			[10] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject,
+			[11] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject,
+			[12] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject,
+			[13] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations/FunctionObject,
 			[14] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[15] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
 		)
@@ -4445,13 +4445,13 @@
 		IL_001a: ldc.i4.0
 		IL_001b: ldelem.ref
 		IL_001c: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_0021: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject_FunctionDeclaration_1C7E821E_readJson::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_0021: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_0026: ldc.i4.1
 		IL_0027: conv.r8
 		IL_0028: ldstr "readJson"
 		IL_002d: ldc.i4.0
 		IL_002e: ldc.i4.1
-		IL_002f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject_FunctionDeclaration_1C7E821E_readJson>(!!0, float64, string, bool, bool)
+		IL_002f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0034: stloc.3
 		IL_0035: ldloc.0
 		IL_0036: ldloc.3
@@ -4463,13 +4463,13 @@
 		IL_0044: ldloc.0
 		IL_0045: stelem.ref
 		IL_0046: stloc.2
-		IL_0047: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/asArray/FunctionObject_FunctionDeclaration_57160465_asArray::.ctor()
+		IL_0047: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/asArray/FunctionObject::.ctor()
 		IL_004c: ldc.i4.1
 		IL_004d: conv.r8
 		IL_004e: ldstr "asArray"
 		IL_0053: ldc.i4.0
 		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/asArray/FunctionObject_FunctionDeclaration_57160465_asArray>(!!0, float64, string, bool, bool)
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/asArray/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005a: stloc.s 4
 		IL_005c: ldloc.0
 		IL_005d: ldloc.s 4
@@ -4481,13 +4481,13 @@
 		IL_006c: ldloc.0
 		IL_006d: stelem.ref
 		IL_006e: stloc.2
-		IL_006f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode/FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::.ctor()
+		IL_006f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode/FunctionObject::.ctor()
 		IL_0074: ldc.i4.1
 		IL_0075: conv.r8
 		IL_0076: ldstr "fmtCode"
 		IL_007b: ldc.i4.0
 		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode/FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.s 5
 		IL_0084: ldloc.0
 		IL_0085: ldloc.s 5
@@ -4499,13 +4499,13 @@
 		IL_0094: ldloc.0
 		IL_0095: stelem.ref
 		IL_0096: stloc.2
-		IL_0097: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/link/FunctionObject_FunctionDeclaration_C98BDC38_link::.ctor()
+		IL_0097: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/link/FunctionObject::.ctor()
 		IL_009c: ldc.i4.2
 		IL_009d: conv.r8
 		IL_009e: ldstr "link"
 		IL_00a3: ldc.i4.0
 		IL_00a4: ldc.i4.1
-		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/link/FunctionObject_FunctionDeclaration_C98BDC38_link>(!!0, float64, string, bool, bool)
+		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/link/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00aa: stloc.s 6
 		IL_00ac: ldloc.0
 		IL_00ad: ldloc.s 6
@@ -4521,13 +4521,13 @@
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldelem.ref
 		IL_00c2: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_00c7: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_00c7: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_00cc: ldc.i4.1
 		IL_00cd: conv.r8
 		IL_00ce: ldstr "renderHeader"
 		IL_00d3: ldc.i4.0
 		IL_00d4: ldc.i4.1
-		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader>(!!0, float64, string, bool, bool)
+		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00da: stloc.s 7
 		IL_00dc: ldloc.0
 		IL_00dd: ldloc.s 7
@@ -4543,13 +4543,13 @@
 		IL_00f0: ldc.i4.0
 		IL_00f1: ldelem.ref
 		IL_00f2: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_00f7: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_00f7: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_00fc: ldc.i4.1
 		IL_00fd: conv.r8
 		IL_00fe: ldstr "renderImplementation"
 		IL_0103: ldc.i4.0
 		IL_0104: ldc.i4.1
-		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation>(!!0, float64, string, bool, bool)
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_010a: stloc.s 8
 		IL_010c: ldloc.0
 		IL_010d: ldloc.s 8
@@ -4565,13 +4565,13 @@
 		IL_0120: ldc.i4.0
 		IL_0121: ldelem.ref
 		IL_0122: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_0127: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject_FunctionDeclaration_C787672B_renderApisTable::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_0127: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_012c: ldc.i4.1
 		IL_012d: conv.r8
 		IL_012e: ldstr "renderApisTable"
 		IL_0133: ldc.i4.0
 		IL_0134: ldc.i4.1
-		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject_FunctionDeclaration_C787672B_renderApisTable>(!!0, float64, string, bool, bool)
+		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_013a: stloc.s 9
 		IL_013c: ldloc.0
 		IL_013d: ldloc.s 9
@@ -4587,13 +4587,13 @@
 		IL_0150: ldc.i4.0
 		IL_0151: ldelem.ref
 		IL_0152: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_0157: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_0157: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_015c: ldc.i4.1
 		IL_015d: conv.r8
 		IL_015e: ldstr "renderApiTests"
 		IL_0163: ldc.i4.0
 		IL_0164: ldc.i4.1
-		IL_0165: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests>(!!0, float64, string, bool, bool)
+		IL_0165: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_016a: stloc.s 10
 		IL_016c: ldloc.0
 		IL_016d: ldloc.s 10
@@ -4609,13 +4609,13 @@
 		IL_0180: ldc.i4.0
 		IL_0181: ldelem.ref
 		IL_0182: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_0187: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject_FunctionDeclaration_99982A69_renderModules::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_0187: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_018c: ldc.i4.1
 		IL_018d: conv.r8
 		IL_018e: ldstr "renderModules"
 		IL_0193: ldc.i4.0
 		IL_0194: ldc.i4.1
-		IL_0195: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject_FunctionDeclaration_99982A69_renderModules>(!!0, float64, string, bool, bool)
+		IL_0195: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_019a: stloc.s 11
 		IL_019c: ldloc.0
 		IL_019d: ldloc.s 11
@@ -4631,13 +4631,13 @@
 		IL_01b0: ldc.i4.0
 		IL_01b1: ldelem.ref
 		IL_01b2: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_01b7: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_01b7: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_01bc: ldc.i4.1
 		IL_01bd: conv.r8
 		IL_01be: ldstr "renderGlobals"
 		IL_01c3: ldc.i4.0
 		IL_01c4: ldc.i4.1
-		IL_01c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals>(!!0, float64, string, bool, bool)
+		IL_01c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01ca: stloc.s 12
 		IL_01cc: ldloc.0
 		IL_01cd: ldloc.s 12
@@ -4649,13 +4649,13 @@
 		IL_01dc: ldloc.0
 		IL_01dd: stelem.ref
 		IL_01de: stloc.2
-		IL_01df: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations/FunctionObject_FunctionDeclaration_62338119_renderLimitations::.ctor()
+		IL_01df: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations/FunctionObject::.ctor()
 		IL_01e4: ldc.i4.1
 		IL_01e5: conv.r8
 		IL_01e6: ldstr "renderLimitations"
 		IL_01eb: ldc.i4.0
 		IL_01ec: ldc.i4.1
-		IL_01ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations/FunctionObject_FunctionDeclaration_62338119_renderLimitations>(!!0, float64, string, bool, bool)
+		IL_01ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01f2: stloc.s 13
 		IL_01f4: ldloc.0
 		IL_01f5: ldloc.s 13
@@ -4671,13 +4671,13 @@
 		IL_0208: ldc.i4.0
 		IL_0209: ldelem.ref
 		IL_020a: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_020f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject_FunctionDeclaration_16D03725_main::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_020f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_0214: ldc.i4.0
 		IL_0215: conv.r8
 		IL_0216: ldstr "main"
 		IL_021b: ldc.i4.0
 		IL_021c: ldc.i4.1
-		IL_021d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject_FunctionDeclaration_16D03725_main>(!!0, float64, string, bool, bool)
+		IL_021d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0222: stloc.1
 		IL_0223: nop
 		IL_0224: ldarg.1

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_ParseInt_Spec.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_ParseInt_Spec.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2983DD78_L142C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_2983DD78_L142C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -178,7 +178,7 @@
 			[2] float64,
 			[3] object,
 			[4] object[],
-			[5] class Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33/FunctionObject_FunctionExpression_2983DD78_L142C34,
+			[5] class Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
@@ -962,13 +962,13 @@
 		IL_08b8: ldloc.0
 		IL_08b9: stelem.ref
 		IL_08ba: stloc.s 4
-		IL_08bc: newobj instance void Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33/FunctionObject_FunctionExpression_2983DD78_L142C34::.ctor()
+		IL_08bc: newobj instance void Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33/FunctionObject::.ctor()
 		IL_08c1: ldc.i4.0
 		IL_08c2: conv.r8
 		IL_08c3: ldstr ""
 		IL_08c8: ldc.i4.0
 		IL_08c9: ldc.i4.1
-		IL_08ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33/FunctionObject_FunctionExpression_2983DD78_L142C34>(!!0, float64, string, bool, bool)
+		IL_08ca: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_08cf: stloc.s 5
 		IL_08d1: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_08d6: dup

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_861DC683_L6C18
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -58,15 +58,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18::_environment0_Iterator_Helper_Cleanup
+					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject::_environment0_Iterator_Helper_Cleanup
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18::_environment1_makeIterable
+					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject::_environment1_makeIterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18::_transitionalScopes
+					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -77,7 +77,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -88,7 +88,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -101,13 +101,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_861DC683_L6C18
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -161,7 +161,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_72A92B04_L13C25
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -187,18 +187,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25::_environment0_Iterator_Helper_Cleanup
+						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject::_environment0_Iterator_Helper_Cleanup
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25::_environment1_makeIterable
+						IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject::_environment1_makeIterable
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25::_environment2_FunctionExpression_L10C29
+						IL_0016: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject::_environment2_FunctionExpression_L10C29
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25::_transitionalScopes
+						IL_001e: stfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -209,7 +209,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -220,7 +220,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -233,13 +233,13 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::CallCore
+					} // end of method FunctionObject::CallCore
 
-				} // end of class FunctionObject_FunctionExpression_72A92B04_L13C25
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -346,7 +346,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C0155B76_L17C27
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -372,18 +372,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::_environment0_Iterator_Helper_Cleanup
+						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject::_environment0_Iterator_Helper_Cleanup
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::_environment1_makeIterable
+						IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject::_environment1_makeIterable
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::_environment2_FunctionExpression_L10C29
+						IL_0016: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject::_environment2_FunctionExpression_L10C29
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::_transitionalScopes
+						IL_001e: stfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -394,7 +394,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -405,7 +405,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -418,13 +418,13 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::CallCore
+					} // end of method FunctionObject::CallCore
 
-				} // end of class FunctionObject_FunctionExpression_C0155B76_L17C27
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -499,7 +499,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BF3F222A_L10C30
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -523,15 +523,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::_environment0_Iterator_Helper_Cleanup
+					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject::_environment0_Iterator_Helper_Cleanup
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::_environment1_makeIterable
+					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject::_environment1_makeIterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::_transitionalScopes
+					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -542,7 +542,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -553,7 +553,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -566,13 +566,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_BF3F222A_L10C30
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -592,8 +592,8 @@
 					[0] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope,
 					[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 					[2] object[],
-					[3] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25,
-					[4] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27
+					[3] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject,
+					[4] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope::.ctor()
@@ -636,14 +636,14 @@
 				IL_0049: ldelem.ref
 				IL_004a: castclass Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope
 				IL_004f: ldloc.2
-				IL_0050: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope, object[])
+				IL_0050: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope, object[])
 				IL_0055: ldc.i4.0
 				IL_0056: conv.r8
 				IL_0057: ldstr ""
 				IL_005c: ldc.i4.0
 				IL_005d: ldc.i4.1
-				IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25>(!!0, float64, string, bool, bool)
-				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25>(!!0)
+				IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject>(!!0)
 				IL_0068: stloc.3
 				IL_0069: ldloc.1
 				IL_006a: ldstr "next"
@@ -682,14 +682,14 @@
 				IL_009f: ldelem.ref
 				IL_00a0: castclass Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope
 				IL_00a5: ldloc.2
-				IL_00a6: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope, object[])
+				IL_00a6: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope, object[])
 				IL_00ab: ldc.i4.0
 				IL_00ac: conv.r8
 				IL_00ad: ldstr ""
 				IL_00b2: ldc.i4.0
 				IL_00b3: ldc.i4.1
-				IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27>(!!0, float64, string, bool, bool)
-				IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27>(!!0)
+				IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject>(!!0)
 				IL_00be: stloc.s 4
 				IL_00c0: ldloc.1
 				IL_00c1: ldstr "return"
@@ -730,7 +730,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8333AF96_makeIterable
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -750,9 +750,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject_FunctionDeclaration_8333AF96_makeIterable::_environment0_Iterator_Helper_Cleanup
+				IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject::_environment0_Iterator_Helper_Cleanup
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -763,7 +763,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -774,7 +774,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -787,14 +787,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject_FunctionDeclaration_8333AF96_makeIterable::_environment0_Iterator_Helper_Cleanup
+				IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject::_environment0_Iterator_Helper_Cleanup
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -808,14 +808,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject_FunctionDeclaration_8333AF96_makeIterable::_environment0_Iterator_Helper_Cleanup
+				IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject::_environment0_Iterator_Helper_Cleanup
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -833,9 +833,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8333AF96_makeIterable
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -858,7 +858,7 @@
 				[0] class Modules.Iterator_Helper_Cleanup/makeIterable/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[2] object[],
-				[3] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18,
+				[3] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject,
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
@@ -894,14 +894,14 @@
 			IL_0040: ldelem.ref
 			IL_0041: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
 			IL_0046: ldloc.2
-			IL_0047: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, object[])
+			IL_0047: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, object[])
 			IL_004c: ldc.i4.0
 			IL_004d: conv.r8
 			IL_004e: ldstr ""
 			IL_0053: ldc.i4.0
 			IL_0054: ldc.i4.1
-			IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18>(!!0, float64, string, bool, bool)
-			IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18>(!!0)
+			IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject>(!!0)
 			IL_005f: stloc.3
 			IL_0060: ldloc.1
 			IL_0061: ldstr "getClosed"
@@ -935,14 +935,14 @@
 			IL_009d: ldelem.ref
 			IL_009e: castclass Modules.Iterator_Helper_Cleanup/makeIterable/Scope
 			IL_00a3: ldloc.2
-			IL_00a4: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, object[])
+			IL_00a4: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/makeIterable/Scope, object[])
 			IL_00a9: ldc.i4.0
 			IL_00aa: conv.r8
 			IL_00ab: ldstr ""
 			IL_00b0: ldc.i4.0
 			IL_00b1: ldc.i4.1
-			IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30>(!!0, float64, string, bool, bool)
-			IL_00b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30>(!!0)
+			IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject>(!!0)
 			IL_00bc: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 			IL_00c1: pop
 			IL_00c2: ldloc.1
@@ -1371,7 +1371,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_97DA0A87_L64C17
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -1397,18 +1397,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17::_environment0_Iterator_Helper_Cleanup
+						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject::_environment0_Iterator_Helper_Cleanup
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17::_environment1_ArrowFunction_L60C47
+						IL_000f: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject::_environment1_ArrowFunction_L60C47
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17::_environment2_FunctionExpression_flatHelper
+						IL_0016: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject::_environment2_FunctionExpression_flatHelper
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17::_transitionalScopes
+						IL_001e: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -1419,7 +1419,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -1430,7 +1430,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1443,13 +1443,13 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::CallCore
+					} // end of method FunctionObject::CallCore
 
-				} // end of class FunctionObject_FunctionExpression_97DA0A87_L64C17
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1542,7 +1542,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BEE289C4_L72C19
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -1568,18 +1568,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::_environment0_Iterator_Helper_Cleanup
+						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject::_environment0_Iterator_Helper_Cleanup
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::_environment1_ArrowFunction_L60C47
+						IL_000f: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject::_environment1_ArrowFunction_L60C47
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::_environment2_FunctionExpression_flatHelper
+						IL_0016: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject::_environment2_FunctionExpression_flatHelper
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::_transitionalScopes
+						IL_001e: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -1590,7 +1590,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -1601,7 +1601,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1614,13 +1614,13 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::CallCore
+					} // end of method FunctionObject::CallCore
 
-				} // end of class FunctionObject_FunctionExpression_BEE289C4_L72C19
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1695,7 +1695,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EFA19121_L61C22
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1719,15 +1719,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22::_environment0_Iterator_Helper_Cleanup
+					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject::_environment0_Iterator_Helper_Cleanup
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22::_environment1_ArrowFunction_L60C47
+					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject::_environment1_ArrowFunction_L60C47
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22::_transitionalScopes
+					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1738,7 +1738,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1749,7 +1749,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1762,13 +1762,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_EFA19121_L61C22
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1788,8 +1788,8 @@
 					[0] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope,
 					[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 					[2] object[],
-					[3] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17,
-					[4] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19
+					[3] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject,
+					[4] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope::.ctor()
@@ -1832,14 +1832,14 @@
 				IL_0041: ldelem.ref
 				IL_0042: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope
 				IL_0047: ldloc.2
-				IL_0048: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope, object[])
+				IL_0048: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope, object[])
 				IL_004d: ldc.i4.0
 				IL_004e: conv.r8
 				IL_004f: ldstr ""
 				IL_0054: ldc.i4.0
 				IL_0055: ldc.i4.1
-				IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17>(!!0, float64, string, bool, bool)
-				IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17>(!!0)
+				IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject>(!!0)
 				IL_0060: stloc.3
 				IL_0061: ldloc.1
 				IL_0062: ldstr "next"
@@ -1878,14 +1878,14 @@
 				IL_0097: ldelem.ref
 				IL_0098: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope
 				IL_009d: ldloc.2
-				IL_009e: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope, object[])
+				IL_009e: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope, object[])
 				IL_00a3: ldc.i4.0
 				IL_00a4: conv.r8
 				IL_00a5: ldstr ""
 				IL_00aa: ldc.i4.0
 				IL_00ab: ldc.i4.1
-				IL_00ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19>(!!0, float64, string, bool, bool)
-				IL_00b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19>(!!0)
+				IL_00ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_00b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject>(!!0)
 				IL_00b6: stloc.s 4
 				IL_00b8: ldloc.1
 				IL_00b9: ldstr "return"
@@ -2048,14 +2048,14 @@
 			IL_0039: ldelem.ref
 			IL_003a: castclass Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope
 			IL_003f: ldloc.3
-			IL_0040: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope, object[])
+			IL_0040: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope, object[])
 			IL_0045: ldc.i4.0
 			IL_0046: conv.r8
 			IL_0047: ldstr ""
 			IL_004c: ldc.i4.0
 			IL_004d: ldc.i4.1
-			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22>(!!0, float64, string, bool, bool)
-			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22>(!!0)
+			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject>(!!0)
 			IL_0058: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 			IL_005d: pop
 			IL_005e: ldloc.2
@@ -2239,7 +2239,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_649156E0_L99C17
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -2263,15 +2263,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17::_environment0_Iterator_Helper_Cleanup
+					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject::_environment0_Iterator_Helper_Cleanup
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17::_environment1_FunctionExpression_flatThrowHelper
+					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject::_environment1_FunctionExpression_flatThrowHelper
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17::_transitionalScopes
+					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -2282,7 +2282,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -2293,7 +2293,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -2306,13 +2306,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_649156E0_L99C17
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -2396,7 +2396,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B177656C_L107C19
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -2420,15 +2420,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19::_environment0_Iterator_Helper_Cleanup
+					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject::_environment0_Iterator_Helper_Cleanup
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19::_environment1_FunctionExpression_flatThrowHelper
+					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject::_environment1_FunctionExpression_flatThrowHelper
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19::_transitionalScopes
+					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -2439,7 +2439,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -2450,7 +2450,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -2463,13 +2463,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_B177656C_L107C19
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -2544,7 +2544,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_665FA710_L96C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2564,9 +2564,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22::_environment0_Iterator_Helper_Cleanup
+				IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject::_environment0_Iterator_Helper_Cleanup
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2577,7 +2577,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2588,7 +2588,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2601,13 +2601,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22::_environment0_Iterator_Helper_Cleanup
+				IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject::_environment0_Iterator_Helper_Cleanup
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_665FA710_L96C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2629,8 +2629,8 @@
 				[0] class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[2] object[],
-				[3] class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17,
-				[4] class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19
+				[3] class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject,
+				[4] class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope::.ctor()
@@ -2661,14 +2661,14 @@
 			IL_0031: ldelem.ref
 			IL_0032: castclass Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope
 			IL_0037: ldloc.2
-			IL_0038: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope, object[])
+			IL_0038: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope, object[])
 			IL_003d: ldc.i4.0
 			IL_003e: conv.r8
 			IL_003f: ldstr ""
 			IL_0044: ldc.i4.0
 			IL_0045: ldc.i4.1
-			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17>(!!0, float64, string, bool, bool)
-			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17>(!!0)
+			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject>(!!0)
 			IL_0050: stloc.3
 			IL_0051: ldloc.1
 			IL_0052: ldstr "next"
@@ -2695,14 +2695,14 @@
 			IL_0077: ldelem.ref
 			IL_0078: castclass Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope
 			IL_007d: ldloc.2
-			IL_007e: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope, object[])
+			IL_007e: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope, object[])
 			IL_0083: ldc.i4.0
 			IL_0084: conv.r8
 			IL_0085: ldstr ""
 			IL_008a: ldc.i4.0
 			IL_008b: ldc.i4.1
-			IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19>(!!0, float64, string, bool, bool)
-			IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19>(!!0)
+			IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject>(!!0)
 			IL_0096: stloc.s 4
 			IL_0098: ldloc.1
 			IL_0099: ldstr "return"
@@ -2746,7 +2746,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F596D986_L116C17
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Methods
@@ -2760,7 +2760,7 @@
 						IL_0000: ldarg.0
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -2771,7 +2771,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -2782,7 +2782,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -2797,9 +2797,9 @@
 						IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_0005: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper::__js_call__(object)
 						IL_000a: ret
-					} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::CallCore
+					} // end of method FunctionObject::CallCore
 
-				} // end of class FunctionObject_FunctionExpression_F596D986_L116C17
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -2862,7 +2862,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C2293FF7_L119C19
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -2884,12 +2884,12 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19::_environment0_Iterator_Helper_Cleanup
+						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject::_environment0_Iterator_Helper_Cleanup
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19::_transitionalScopes
+						IL_000f: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject::_transitionalScopes
 						IL_0014: ret
-					} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -2900,7 +2900,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -2911,7 +2911,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -2924,13 +2924,13 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::CallCore
+					} // end of method FunctionObject::CallCore
 
-				} // end of class FunctionObject_FunctionExpression_C2293FF7_L119C19
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -2998,7 +2998,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_44F841E1_L114C22
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -3020,12 +3020,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22::_environment0_Iterator_Helper_Cleanup
+					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject::_environment0_Iterator_Helper_Cleanup
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22::_transitionalScopes
+					IL_000f: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -3036,7 +3036,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -3047,7 +3047,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -3060,13 +3060,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_44F841E1_L114C22
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -3086,8 +3086,8 @@
 					[0] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/Scope,
 					[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 					[2] object[],
-					[3] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_F596D986_L116C17,
-					[4] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19
+					[3] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject,
+					[4] class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/Scope::.ctor()
@@ -3103,14 +3103,14 @@
 				IL_0016: ldelem.ref
 				IL_0017: stelem.ref
 				IL_0018: stloc.2
-				IL_0019: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_F596D986_L116C17::.ctor()
+				IL_0019: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject::.ctor()
 				IL_001e: ldc.i4.0
 				IL_001f: conv.r8
 				IL_0020: ldstr ""
 				IL_0025: ldc.i4.0
 				IL_0026: ldc.i4.1
-				IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_F596D986_L116C17>(!!0, float64, string, bool, bool)
-				IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_F596D986_L116C17>(!!0)
+				IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject>(!!0)
 				IL_0031: stloc.3
 				IL_0032: ldloc.1
 				IL_0033: ldstr "next"
@@ -3141,14 +3141,14 @@
 				IL_0058: ldelem.ref
 				IL_0059: castclass Modules.Iterator_Helper_Cleanup/Scope
 				IL_005e: ldloc.2
-				IL_005f: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, object[])
+				IL_005f: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, object[])
 				IL_0064: ldc.i4.0
 				IL_0065: conv.r8
 				IL_0066: ldstr ""
 				IL_006b: ldc.i4.0
 				IL_006c: ldc.i4.1
-				IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19>(!!0, float64, string, bool, bool)
-				IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19>(!!0)
+				IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject>(!!0, float64, string, bool, bool)
+				IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject>(!!0)
 				IL_0077: stloc.s 4
 				IL_0079: ldloc.1
 				IL_007a: ldstr "return"
@@ -3304,14 +3304,14 @@
 			IL_002a: ldelem.ref
 			IL_002b: castclass Modules.Iterator_Helper_Cleanup/Scope
 			IL_0030: ldloc.3
-			IL_0031: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, object[])
+			IL_0031: newobj instance void Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope, object[])
 			IL_0036: ldc.i4.0
 			IL_0037: conv.r8
 			IL_0038: ldstr ""
 			IL_003d: ldc.i4.0
 			IL_003e: ldc.i4.1
-			IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22>(!!0, float64, string, bool, bool)
-			IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22>(!!0)
+			IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject>(!!0)
 			IL_0049: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 			IL_004e: pop
 			IL_004f: ldloc.2
@@ -3528,7 +3528,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Iterator_Helper_Cleanup/Scope,
-			[1] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject_FunctionDeclaration_8333AF96_makeIterable,
+			[1] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -3581,13 +3581,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_001b: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject_FunctionDeclaration_8333AF96_makeIterable::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
+		IL_001b: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "makeIterable"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject_FunctionDeclaration_8333AF96_makeIterable>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop
@@ -4112,14 +4112,14 @@
 		IL_0641: ldc.i4.0
 		IL_0642: ldelem.ref
 		IL_0643: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_0648: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
+		IL_0648: newobj instance void Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
 		IL_064d: ldc.i4.0
 		IL_064e: conv.r8
 		IL_064f: ldstr ""
 		IL_0654: ldc.i4.0
 		IL_0655: ldc.i4.1
-		IL_0656: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22>(!!0, float64, string, bool, bool)
-		IL_065b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22>(!!0)
+		IL_0656: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_065b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject>(!!0)
 		IL_0660: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_0665: pop
 		IL_0666: ldloc.s 29

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Next_Return.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Next_Return.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CB0EEF83_L8C17
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -58,15 +58,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17::_environment0_Iterator_Helper_Next_Return
+					IL_0008: stfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_environment0_Iterator_Helper_Next_Return
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17::_environment1_FunctionExpression_iterable
+					IL_000f: stfld class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_environment1_FunctionExpression_iterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17::_transitionalScopes
+					IL_0016: stfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -77,7 +77,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -88,7 +88,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -101,13 +101,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_CB0EEF83_L8C17
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -203,7 +203,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C90FF228_L12C19
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -227,15 +227,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19::_environment0_Iterator_Helper_Next_Return
+					IL_0008: stfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject::_environment0_Iterator_Helper_Next_Return
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19::_environment1_FunctionExpression_iterable
+					IL_000f: stfld class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject::_environment1_FunctionExpression_iterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19::_transitionalScopes
+					IL_0016: stfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -246,7 +246,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -257,7 +257,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -270,13 +270,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_C90FF228_L12C19
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -355,7 +355,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_86652434_L5C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -375,9 +375,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22::_environment0_Iterator_Helper_Next_Return
+				IL_0008: stfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject::_environment0_Iterator_Helper_Next_Return
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_86652434_L5C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -388,7 +388,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_86652434_L5C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -399,7 +399,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_86652434_L5C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -412,13 +412,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22::_environment0_Iterator_Helper_Next_Return
+				IL_0001: ldfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject::_environment0_Iterator_Helper_Next_Return
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable::__js_call__(class Modules.Iterator_Helper_Next_Return/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_86652434_L5C22::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_86652434_L5C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -440,8 +440,8 @@
 				[0] class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[2] object[],
-				[3] class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17,
-				[4] class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19
+				[3] class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject,
+				[4] class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope::.ctor()
@@ -472,14 +472,14 @@
 			IL_0039: ldelem.ref
 			IL_003a: castclass Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope
 			IL_003f: ldloc.2
-			IL_0040: newobj instance void Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17::.ctor(class Modules.Iterator_Helper_Next_Return/Scope, class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope, object[])
+			IL_0040: newobj instance void Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::.ctor(class Modules.Iterator_Helper_Next_Return/Scope, class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope, object[])
 			IL_0045: ldc.i4.0
 			IL_0046: conv.r8
 			IL_0047: ldstr ""
 			IL_004c: ldc.i4.0
 			IL_004d: ldc.i4.1
-			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17>(!!0, float64, string, bool, bool)
-			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17>(!!0)
+			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject>(!!0)
 			IL_0058: stloc.3
 			IL_0059: ldloc.1
 			IL_005a: ldstr "next"
@@ -506,14 +506,14 @@
 			IL_007f: ldelem.ref
 			IL_0080: castclass Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope
 			IL_0085: ldloc.2
-			IL_0086: newobj instance void Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19::.ctor(class Modules.Iterator_Helper_Next_Return/Scope, class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope, object[])
+			IL_0086: newobj instance void Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject::.ctor(class Modules.Iterator_Helper_Next_Return/Scope, class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope, object[])
 			IL_008b: ldc.i4.0
 			IL_008c: conv.r8
 			IL_008d: ldstr ""
 			IL_0092: ldc.i4.0
 			IL_0093: ldc.i4.1
-			IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19>(!!0, float64, string, bool, bool)
-			IL_0099: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19>(!!0)
+			IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0099: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject>(!!0)
 			IL_009e: stloc.s 4
 			IL_00a0: ldloc.1
 			IL_00a1: ldstr "return"
@@ -724,14 +724,14 @@
 		IL_0040: ldc.i4.0
 		IL_0041: ldelem.ref
 		IL_0042: castclass Modules.Iterator_Helper_Next_Return/Scope
-		IL_0047: newobj instance void Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22::.ctor(class Modules.Iterator_Helper_Next_Return/Scope)
+		IL_0047: newobj instance void Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject::.ctor(class Modules.Iterator_Helper_Next_Return/Scope)
 		IL_004c: ldc.i4.0
 		IL_004d: conv.r8
 		IL_004e: ldstr ""
 		IL_0053: ldc.i4.0
 		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22>(!!0, float64, string, bool, bool)
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22>(!!0)
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject>(!!0)
 		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_0064: pop
 		IL_0065: ldloc.s 8

--- a/tests/Jroc.Tests/JSON/Snapshots/GeneratorTests.JSON_Parse_Reviver_Holder.verified.txt
+++ b/tests/Jroc.Tests/JSON/Snapshots/GeneratorTests.JSON_Parse_Reviver_Holder.verified.txt
@@ -108,7 +108,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7D62481C_L5C5
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -122,7 +122,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -133,7 +133,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -144,7 +144,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -165,7 +165,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -187,7 +187,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -205,9 +205,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7D62481C_L5C5
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -522,7 +522,7 @@
 			[0] class Modules.JSON_Parse_Reviver_Holder/Scope,
 			[1] object,
 			[2] object[],
-			[3] class Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result/FunctionObject_FunctionExpression_7D62481C_L5C5,
+			[3] class Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] object,
 			[6] class Modules.JSON_Parse_Reviver_Holder/ArrowFunction_L24C29/FunctionObject
@@ -539,13 +539,13 @@
 		IL_0014: ldloc.0
 		IL_0015: stelem.ref
 		IL_0016: stloc.2
-		IL_0017: newobj instance void Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result/FunctionObject_FunctionExpression_7D62481C_L5C5::.ctor()
+		IL_0017: newobj instance void Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result/FunctionObject::.ctor()
 		IL_001c: ldc.i4.2
 		IL_001d: conv.r8
 		IL_001e: ldstr ""
 		IL_0023: ldc.i4.1
 		IL_0024: ldc.i4.1
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result/FunctionObject_FunctionExpression_7D62481C_L5C5>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002a: stloc.3
 		IL_002b: ldstr "{\"a\":1,\"nested\":{\"b\":2},\"remove\":3,\"arr\":[4,5]}"
 		IL_0030: ldloc.3

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
@@ -55,7 +55,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E1161D0D_L13C17
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -79,15 +79,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17::_environment0_Map_Constructor_Iterable
+					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_environment0_Map_Constructor_Iterable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17::_environment1_FunctionExpression_iterable
+					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_environment1_FunctionExpression_iterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17::_transitionalScopes
+					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -98,7 +98,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -109,7 +109,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -122,13 +122,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_E1161D0D_L13C17
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -262,7 +262,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A18A3F87_L4C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -282,9 +282,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22::_environment0_Map_Constructor_Iterable
+				IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject::_environment0_Map_Constructor_Iterable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -295,7 +295,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -306,7 +306,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -319,13 +319,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22::_environment0_Map_Constructor_Iterable
+				IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject::_environment0_Map_Constructor_Iterable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_iterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_A18A3F87_L4C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -348,7 +348,7 @@
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[3] object[],
-				[4] class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17
+				[4] class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope::.ctor()
@@ -415,14 +415,14 @@
 			IL_00b9: ldelem.ref
 			IL_00ba: castclass Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope
 			IL_00bf: ldloc.3
-			IL_00c0: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope, object[])
+			IL_00c0: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope, object[])
 			IL_00c5: ldc.i4.0
 			IL_00c6: conv.r8
 			IL_00c7: ldstr ""
 			IL_00cc: ldc.i4.0
 			IL_00cd: ldc.i4.1
-			IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17>(!!0, float64, string, bool, bool)
-			IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17>(!!0)
+			IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject>(!!0)
 			IL_00d8: stloc.s 4
 			IL_00da: ldloc.2
 			IL_00db: ldstr "next"
@@ -483,7 +483,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_99568244_L39C17
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -507,15 +507,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17::_environment0_Map_Constructor_Iterable
+					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject::_environment0_Map_Constructor_Iterable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17::_environment1_FunctionExpression_closableIterable
+					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject::_environment1_FunctionExpression_closableIterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17::_transitionalScopes
+					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_99568244_L39C17::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -526,7 +526,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_99568244_L39C17::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -537,7 +537,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_99568244_L39C17::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -550,13 +550,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_99568244_L39C17::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_99568244_L39C17
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -685,7 +685,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D3F48DAC_L46C19
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -709,15 +709,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19::_environment0_Map_Constructor_Iterable
+					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject::_environment0_Map_Constructor_Iterable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19::_environment1_FunctionExpression_closableIterable
+					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject::_environment1_FunctionExpression_closableIterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19::_transitionalScopes
+					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -728,7 +728,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -739,7 +739,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -752,13 +752,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_D3F48DAC_L46C19
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -820,7 +820,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_17108703_L31C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -840,9 +840,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22::_environment0_Map_Constructor_Iterable
+				IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject::_environment0_Map_Constructor_Iterable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_17108703_L31C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -853,7 +853,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_17108703_L31C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -864,7 +864,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_17108703_L31C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -877,13 +877,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22::_environment0_Map_Constructor_Iterable
+				IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject::_environment0_Map_Constructor_Iterable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_17108703_L31C22::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_17108703_L31C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -906,8 +906,8 @@
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[3] object[],
-				[4] class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17,
-				[5] class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19
+				[4] class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject,
+				[5] class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope::.ctor()
@@ -964,14 +964,14 @@
 			IL_0093: ldelem.ref
 			IL_0094: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
 			IL_0099: ldloc.3
-			IL_009a: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope, object[])
+			IL_009a: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope, object[])
 			IL_009f: ldc.i4.0
 			IL_00a0: conv.r8
 			IL_00a1: ldstr ""
 			IL_00a6: ldc.i4.0
 			IL_00a7: ldc.i4.1
-			IL_00a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17>(!!0, float64, string, bool, bool)
-			IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17>(!!0)
+			IL_00a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject>(!!0)
 			IL_00b2: stloc.s 4
 			IL_00b4: ldloc.2
 			IL_00b5: ldstr "next"
@@ -998,14 +998,14 @@
 			IL_00db: ldelem.ref
 			IL_00dc: castclass Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope
 			IL_00e1: ldloc.3
-			IL_00e2: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope, object[])
+			IL_00e2: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope, object[])
 			IL_00e7: ldc.i4.0
 			IL_00e8: conv.r8
 			IL_00e9: ldstr ""
 			IL_00ee: ldc.i4.0
 			IL_00ef: ldc.i4.1
-			IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19>(!!0, float64, string, bool, bool)
-			IL_00f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19>(!!0)
+			IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject>(!!0)
 			IL_00fa: stloc.s 5
 			IL_00fc: ldloc.2
 			IL_00fd: ldstr "return"
@@ -1066,7 +1066,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A2D37BB5_L70C17
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1090,15 +1090,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17::_environment0_Map_Constructor_Iterable
+					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject::_environment0_Map_Constructor_Iterable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17::_environment1_FunctionExpression_invalidIterable
+					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject::_environment1_FunctionExpression_invalidIterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17::_transitionalScopes
+					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1109,7 +1109,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1120,7 +1120,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1133,13 +1133,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_A2D37BB5_L70C17
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1229,7 +1229,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_471A5FC3_L78C19
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1253,15 +1253,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19::_environment0_Map_Constructor_Iterable
+					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject::_environment0_Map_Constructor_Iterable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19::_environment1_FunctionExpression_invalidIterable
+					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject::_environment1_FunctionExpression_invalidIterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19::_transitionalScopes
+					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1272,7 +1272,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1283,7 +1283,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1296,13 +1296,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_471A5FC3_L78C19
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1362,7 +1362,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EEAD530B_L66C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1382,9 +1382,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22::_environment0_Map_Constructor_Iterable
+				IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject::_environment0_Map_Constructor_Iterable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1395,7 +1395,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1406,7 +1406,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1419,13 +1419,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22::_environment0_Map_Constructor_Iterable
+				IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject::_environment0_Map_Constructor_Iterable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_EEAD530B_L66C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1447,8 +1447,8 @@
 				[0] class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[2] object[],
-				[3] class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17,
-				[4] class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19
+				[3] class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject,
+				[4] class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope::.ctor()
@@ -1479,14 +1479,14 @@
 			IL_0031: ldelem.ref
 			IL_0032: castclass Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope
 			IL_0037: ldloc.2
-			IL_0038: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope, object[])
+			IL_0038: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope, object[])
 			IL_003d: ldc.i4.0
 			IL_003e: conv.r8
 			IL_003f: ldstr ""
 			IL_0044: ldc.i4.0
 			IL_0045: ldc.i4.1
-			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17>(!!0, float64, string, bool, bool)
-			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17>(!!0)
+			IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject>(!!0)
 			IL_0050: stloc.3
 			IL_0051: ldloc.1
 			IL_0052: ldstr "next"
@@ -1513,14 +1513,14 @@
 			IL_0077: ldelem.ref
 			IL_0078: castclass Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope
 			IL_007d: ldloc.2
-			IL_007e: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope, object[])
+			IL_007e: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject::.ctor(class Modules.Map_Constructor_Iterable/Scope, class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope, object[])
 			IL_0083: ldc.i4.0
 			IL_0084: conv.r8
 			IL_0085: ldstr ""
 			IL_008a: ldc.i4.0
 			IL_008b: ldc.i4.1
-			IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19>(!!0, float64, string, bool, bool)
-			IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19>(!!0)
+			IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject>(!!0)
 			IL_0096: stloc.s 4
 			IL_0098: ldloc.1
 			IL_0099: ldstr "return"
@@ -1662,14 +1662,14 @@
 		IL_002c: ldc.i4.0
 		IL_002d: ldelem.ref
 		IL_002e: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_0033: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
+		IL_0033: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject::.ctor(class Modules.Map_Constructor_Iterable/Scope)
 		IL_0038: ldc.i4.0
 		IL_0039: conv.r8
 		IL_003a: ldstr ""
 		IL_003f: ldc.i4.0
 		IL_0040: ldc.i4.1
-		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22>(!!0, float64, string, bool, bool)
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22>(!!0)
+		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject>(!!0)
 		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_0050: pop
 		IL_0051: ldloc.s 12
@@ -1731,14 +1731,14 @@
 		IL_00f0: ldc.i4.0
 		IL_00f1: ldelem.ref
 		IL_00f2: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_00f7: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
+		IL_00f7: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject::.ctor(class Modules.Map_Constructor_Iterable/Scope)
 		IL_00fc: ldc.i4.0
 		IL_00fd: conv.r8
 		IL_00fe: ldstr ""
 		IL_0103: ldc.i4.0
 		IL_0104: ldc.i4.1
-		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22>(!!0, float64, string, bool, bool)
-		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22>(!!0)
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_010a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject>(!!0)
 		IL_010f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_0114: pop
 		IL_0115: ldloc.s 12
@@ -1829,14 +1829,14 @@
 		IL_020c: ldc.i4.0
 		IL_020d: ldelem.ref
 		IL_020e: castclass Modules.Map_Constructor_Iterable/Scope
-		IL_0213: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22::.ctor(class Modules.Map_Constructor_Iterable/Scope)
+		IL_0213: newobj instance void Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject::.ctor(class Modules.Map_Constructor_Iterable/Scope)
 		IL_0218: ldc.i4.0
 		IL_0219: conv.r8
 		IL_021a: ldstr ""
 		IL_021f: ldc.i4.0
 		IL_0220: ldc.i4.1
-		IL_0221: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22>(!!0, float64, string, bool, bool)
-		IL_0226: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22>(!!0)
+		IL_0221: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0226: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject>(!!0)
 		IL_022b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_0230: pop
 		IL_0231: ldloc.s 12

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_ForEach_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_ForEach_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1DD06151_L11C13
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Map_ForEach_Basic/Scope Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject_FunctionExpression_1DD06151_L11C13::_environment0_Map_ForEach_Basic
+				IL_0008: stfld class Modules.Map_ForEach_Basic/Scope Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject::_environment0_Map_ForEach_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Map_ForEach_Basic/Scope Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject_FunctionExpression_1DD06151_L11C13::_environment0_Map_ForEach_Basic
+				IL_0001: ldfld class Modules.Map_ForEach_Basic/Scope Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject::_environment0_Map_ForEach_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -100,7 +100,7 @@
 				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0020: call object Modules.Map_ForEach_Basic/FunctionExpression_L11C12::__js_call__(class Modules.Map_ForEach_Basic/Scope, object, object, object, object)
 				IL_0025: ret
-			} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -114,7 +114,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Map_ForEach_Basic/Scope Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject_FunctionExpression_1DD06151_L11C13::_environment0_Map_ForEach_Basic
+				IL_0001: ldfld class Modules.Map_ForEach_Basic/Scope Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject::_environment0_Map_ForEach_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -127,7 +127,7 @@
 				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001c: call object Modules.Map_ForEach_Basic/FunctionExpression_L11C12::__js_call__(class Modules.Map_ForEach_Basic/Scope, object, object, object, object)
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -145,9 +145,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1DD06151_L11C13
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -278,7 +278,7 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Map,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject_FunctionExpression_1DD06151_L11C13,
+			[6] class Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] object
 		)
@@ -342,13 +342,13 @@
 		IL_00a7: ldc.i4.0
 		IL_00a8: ldelem.ref
 		IL_00a9: castclass Modules.Map_ForEach_Basic/Scope
-		IL_00ae: newobj instance void Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject_FunctionExpression_1DD06151_L11C13::.ctor(class Modules.Map_ForEach_Basic/Scope)
+		IL_00ae: newobj instance void Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject::.ctor(class Modules.Map_ForEach_Basic/Scope)
 		IL_00b3: ldc.i4.3
 		IL_00b4: conv.r8
 		IL_00b5: ldstr ""
 		IL_00ba: ldc.i4.1
 		IL_00bb: ldc.i4.1
-		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject_FunctionExpression_1DD06151_L11C13>(!!0, float64, string, bool, bool)
+		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c1: stloc.s 6
 		IL_00c3: ldloc.s 4
 		IL_00c5: ldstr "forEach"

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_AliasReplacement_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_AliasReplacement_Dispatch.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BAC020DF_L2C17
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -96,7 +96,7 @@
 				IL_0005: call float64 Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -113,7 +113,7 @@
 				IL_0001: call float64 Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -131,9 +131,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_BAC020DF_L2C17
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -192,7 +192,7 @@
 			[0] class Modules.Math_AliasReplacement_Dispatch/Scope,
 			[1] object,
 			[2] object[],
-			[3] class Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16/FunctionObject_FunctionExpression_BAC020DF_L2C17,
+			[3] class Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] float64,
 			[6] object,
@@ -211,14 +211,14 @@
 		IL_0019: ldloc.0
 		IL_001a: stelem.ref
 		IL_001b: stloc.2
-		IL_001c: newobj instance void Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16/FunctionObject_FunctionExpression_BAC020DF_L2C17::.ctor()
+		IL_001c: newobj instance void Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16/FunctionObject::.ctor()
 		IL_0021: ldc.i4.0
 		IL_0022: conv.r8
 		IL_0023: ldstr ""
 		IL_0028: ldc.i4.0
 		IL_0029: ldc.i4.0
-		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16/FunctionObject_FunctionExpression_BAC020DF_L2C17>(!!0, float64, string, bool, bool)
-		IL_002f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16/FunctionObject_FunctionExpression_BAC020DF_L2C17>(!!0)
+		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16/FunctionObject>(!!0)
 		IL_0034: stloc.3
 		IL_0035: ldloc.1
 		IL_0036: ldstr "abs"

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_DefinePropertyReplacement_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_DefinePropertyReplacement_Dispatch.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A40CA478_L2C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -96,7 +96,7 @@
 				IL_0005: call float64 Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -113,7 +113,7 @@
 				IL_0001: call float64 Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -131,9 +131,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A40CA478_L2C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -192,7 +192,7 @@
 			[0] class Modules.Math_DefinePropertyReplacement_Dispatch/Scope,
 			[1] object,
 			[2] object[],
-			[3] class Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9/FunctionObject_FunctionExpression_A40CA478_L2C10,
+			[3] class Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -209,14 +209,14 @@
 		IL_0019: ldloc.0
 		IL_001a: stelem.ref
 		IL_001b: stloc.2
-		IL_001c: newobj instance void Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9/FunctionObject_FunctionExpression_A40CA478_L2C10::.ctor()
+		IL_001c: newobj instance void Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9/FunctionObject::.ctor()
 		IL_0021: ldc.i4.0
 		IL_0022: conv.r8
 		IL_0023: ldstr ""
 		IL_0028: ldc.i4.0
 		IL_0029: ldc.i4.0
-		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9/FunctionObject_FunctionExpression_A40CA478_L2C10>(!!0, float64, string, bool, bool)
-		IL_002f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9/FunctionObject_FunctionExpression_A40CA478_L2C10>(!!0)
+		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9/FunctionObject>(!!0)
 		IL_0034: stloc.3
 		IL_0035: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_003a: dup

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Fround_SignedZero.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Fround_SignedZero.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F210FF6C_toStr
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.Math_Fround_SignedZero/toStr::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.Math_Fround_SignedZero/toStr::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F210FF6C_toStr
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -239,7 +239,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_Fround_SignedZero/Scope,
-			[1] class Modules.Math_Fround_SignedZero/toStr/FunctionObject_FunctionDeclaration_F210FF6C_toStr,
+			[1] class Modules.Math_Fround_SignedZero/toStr/FunctionObject,
 			[2] float64,
 			[3] float64,
 			[4] object[],
@@ -258,13 +258,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void Modules.Math_Fround_SignedZero/toStr/FunctionObject_FunctionDeclaration_F210FF6C_toStr::.ctor()
+		IL_0012: newobj instance void Modules.Math_Fround_SignedZero/toStr/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "toStr"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_Fround_SignedZero/toStr/FunctionObject_FunctionDeclaration_F210FF6C_toStr>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_Fround_SignedZero/toStr/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldc.r8 1.337

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_GlobalThisReplacement_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_GlobalThisReplacement_Dispatch.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_22FAF068_L1C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -96,7 +96,7 @@
 				IL_0005: call float64 Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -113,7 +113,7 @@
 				IL_0001: call float64 Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -131,9 +131,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_22FAF068_L1C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -192,7 +192,7 @@
 			[0] class Modules.Math_GlobalThisReplacement_Dispatch/Scope,
 			[1] object,
 			[2] object[],
-			[3] class Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24/FunctionObject_FunctionExpression_22FAF068_L1C25,
+			[3] class Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24/FunctionObject,
 			[4] object
 		)
 
@@ -216,14 +216,14 @@
 		IL_0041: ldloc.0
 		IL_0042: stelem.ref
 		IL_0043: stloc.2
-		IL_0044: newobj instance void Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24/FunctionObject_FunctionExpression_22FAF068_L1C25::.ctor()
+		IL_0044: newobj instance void Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24/FunctionObject::.ctor()
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr ""
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.0
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24/FunctionObject_FunctionExpression_22FAF068_L1C25>(!!0, float64, string, bool, bool)
-		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24/FunctionObject_FunctionExpression_22FAF068_L1C25>(!!0)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24/FunctionObject>(!!0)
 		IL_005c: stloc.3
 		IL_005d: ldloc.1
 		IL_005e: ldstr "round"

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Imul_Clz32_Basics.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Imul_Clz32_Basics.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9EEB60C5_toStr
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.Math_Imul_Clz32_Basics/toStr::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.Math_Imul_Clz32_Basics/toStr::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9EEB60C5_toStr
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -239,7 +239,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_Imul_Clz32_Basics/Scope,
-			[1] class Modules.Math_Imul_Clz32_Basics/toStr/FunctionObject_FunctionDeclaration_9EEB60C5_toStr,
+			[1] class Modules.Math_Imul_Clz32_Basics/toStr/FunctionObject,
 			[2] float64,
 			[3] float64,
 			[4] float64,
@@ -264,13 +264,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 8
-		IL_0012: newobj instance void Modules.Math_Imul_Clz32_Basics/toStr/FunctionObject_FunctionDeclaration_9EEB60C5_toStr::.ctor()
+		IL_0012: newobj instance void Modules.Math_Imul_Clz32_Basics/toStr/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "toStr"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_Imul_Clz32_Basics/toStr/FunctionObject_FunctionDeclaration_9EEB60C5_toStr>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_Imul_Clz32_Basics/toStr/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldc.r8 2

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Round_Trunc_NegativeHalves.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Round_Trunc_NegativeHalves.verified.txt
@@ -250,7 +250,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_48B435D9_toStr
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -264,7 +264,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -275,7 +275,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -286,7 +286,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -304,7 +304,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Math_Round_Trunc_NegativeHalves/toStr::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -323,7 +323,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Math_Round_Trunc_NegativeHalves/toStr::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -341,9 +341,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_48B435D9_toStr
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -462,7 +462,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_Round_Trunc_NegativeHalves/Scope,
-			[1] class Modules.Math_Round_Trunc_NegativeHalves/toStr/FunctionObject_FunctionDeclaration_48B435D9_toStr,
+			[1] class Modules.Math_Round_Trunc_NegativeHalves/toStr/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -483,13 +483,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
-		IL_0012: newobj instance void Modules.Math_Round_Trunc_NegativeHalves/toStr/FunctionObject_FunctionDeclaration_48B435D9_toStr::.ctor()
+		IL_0012: newobj instance void Modules.Math_Round_Trunc_NegativeHalves/toStr/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "toStr"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_Round_Trunc_NegativeHalves/toStr/FunctionObject_FunctionDeclaration_48B435D9_toStr>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_Round_Trunc_NegativeHalves/toStr/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldc.i4.8

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_ShadowedAndReplaced_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_ShadowedAndReplaced_Dispatch.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_33643B44_L3C10
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -48,7 +48,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -59,7 +59,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -70,7 +70,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -84,7 +84,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -100,7 +100,7 @@
 					IL_0005: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math::__js_call__(object)
 					IL_000a: box [System.Runtime]System.Double
 					IL_000f: ret
-				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -117,7 +117,7 @@
 					IL_0001: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math::__js_call__(object)
 					IL_0006: box [System.Runtime]System.Double
 					IL_000b: ret
-				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -135,9 +135,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_33643B44_L3C10
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -182,7 +182,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1F283315_L4C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -196,7 +196,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -207,7 +207,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -218,7 +218,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -232,7 +232,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -248,7 +248,7 @@
 					IL_0005: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11::__js_call__(object)
 					IL_000a: box [System.Runtime]System.Double
 					IL_000f: ret
-				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -265,7 +265,7 @@
 					IL_0001: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11::__js_call__(object)
 					IL_0006: box [System.Runtime]System.Double
 					IL_000b: ret
-				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -283,9 +283,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_1F283315_L4C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -326,7 +326,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8AAEF358_L1C2
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -346,9 +346,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Math_ShadowedAndReplaced_Dispatch/Scope Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2::_environment0_Math_ShadowedAndReplaced_Dispatch
+				IL_0008: stfld class Modules.Math_ShadowedAndReplaced_Dispatch/Scope Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject::_environment0_Math_ShadowedAndReplaced_Dispatch
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -359,7 +359,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -370,7 +370,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -384,7 +384,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -397,11 +397,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Math_ShadowedAndReplaced_Dispatch/Scope Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2::_environment0_Math_ShadowedAndReplaced_Dispatch
+				IL_0001: ldfld class Modules.Math_ShadowedAndReplaced_Dispatch/Scope Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject::_environment0_Math_ShadowedAndReplaced_Dispatch
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1::__js_call__(class Modules.Math_ShadowedAndReplaced_Dispatch/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -415,11 +415,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Math_ShadowedAndReplaced_Dispatch/Scope Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2::_environment0_Math_ShadowedAndReplaced_Dispatch
+				IL_0001: ldfld class Modules.Math_ShadowedAndReplaced_Dispatch/Scope Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject::_environment0_Math_ShadowedAndReplaced_Dispatch
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1::__js_call__(class Modules.Math_ShadowedAndReplaced_Dispatch/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -437,9 +437,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_8AAEF358_L1C2
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -461,8 +461,8 @@
 				[0] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/Scope,
 				[1] class Modules.Math_ShadowedAndReplaced_Dispatch/ObjectLiterals/L2C16_Math,
 				[2] object[],
-				[3] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math/FunctionObject_FunctionExpression_33643B44_L3C10,
-				[4] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11/FunctionObject_FunctionExpression_1F283315_L4C12,
+				[3] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math/FunctionObject,
+				[4] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11/FunctionObject,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[6] float64,
 				[7] object,
@@ -479,14 +479,14 @@
 			IL_000e: ldarg.0
 			IL_000f: stelem.ref
 			IL_0010: stloc.2
-			IL_0011: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math/FunctionObject_FunctionExpression_33643B44_L3C10::.ctor()
+			IL_0011: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math/FunctionObject::.ctor()
 			IL_0016: ldc.i4.0
 			IL_0017: conv.r8
 			IL_0018: ldstr ""
 			IL_001d: ldc.i4.0
 			IL_001e: ldc.i4.0
-			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math/FunctionObject_FunctionExpression_33643B44_L3C10>(!!0, float64, string, bool, bool)
-			IL_0024: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math/FunctionObject_FunctionExpression_33643B44_L3C10>(!!0)
+			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0024: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math/FunctionObject>(!!0)
 			IL_0029: stloc.3
 			IL_002a: ldc.i4.1
 			IL_002b: newarr [System.Runtime]System.Object
@@ -495,14 +495,14 @@
 			IL_0032: ldarg.0
 			IL_0033: stelem.ref
 			IL_0034: stloc.2
-			IL_0035: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11/FunctionObject_FunctionExpression_1F283315_L4C12::.ctor()
+			IL_0035: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11/FunctionObject::.ctor()
 			IL_003a: ldc.i4.0
 			IL_003b: conv.r8
 			IL_003c: ldstr ""
 			IL_0041: ldc.i4.0
 			IL_0042: ldc.i4.0
-			IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11/FunctionObject_FunctionExpression_1F283315_L4C12>(!!0, float64, string, bool, bool)
-			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11/FunctionObject_FunctionExpression_1F283315_L4C12>(!!0)
+			IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11/FunctionObject>(!!0)
 			IL_004d: stloc.s 4
 			IL_004f: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/ObjectLiterals/L2C16_Math::.ctor()
 			IL_0054: stloc.1
@@ -576,7 +576,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E8504F2A_L11C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -590,7 +590,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -601,7 +601,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -612,7 +612,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -626,7 +626,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -642,7 +642,7 @@
 				IL_0005: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -659,7 +659,7 @@
 				IL_0001: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -677,9 +677,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E8504F2A_L11C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -860,9 +860,9 @@
 		.locals init (
 			[0] class Modules.Math_ShadowedAndReplaced_Dispatch/Scope,
 			[1] object[],
-			[2] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2,
+			[2] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject,
 			[3] object,
-			[4] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11/FunctionObject_FunctionExpression_E8504F2A_L11C12,
+			[4] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11/FunctionObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[6] float64,
 			[7] object
@@ -881,14 +881,14 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Math_ShadowedAndReplaced_Dispatch/Scope
-		IL_0019: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2::.ctor(class Modules.Math_ShadowedAndReplaced_Dispatch/Scope)
+		IL_0019: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject::.ctor(class Modules.Math_ShadowedAndReplaced_Dispatch/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr ""
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.0
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2>(!!0, float64, string, bool, bool)
-		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2>(!!0)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject>(!!0)
 		IL_0031: stloc.2
 		IL_0032: ldloc.2
 		IL_0033: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -904,14 +904,14 @@
 		IL_0051: ldloc.0
 		IL_0052: stelem.ref
 		IL_0053: stloc.1
-		IL_0054: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11/FunctionObject_FunctionExpression_E8504F2A_L11C12::.ctor()
+		IL_0054: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11/FunctionObject::.ctor()
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr ""
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.0
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11/FunctionObject_FunctionExpression_E8504F2A_L11C12>(!!0, float64, string, bool, bool)
-		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11/FunctionObject_FunctionExpression_E8504F2A_L11C12>(!!0)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11/FunctionObject>(!!0)
 		IL_006c: stloc.s 4
 		IL_006e: ldloc.3
 		IL_006f: ldstr "abs"

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Sign_ZeroVariants.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Sign_ZeroVariants.verified.txt
@@ -140,7 +140,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5635EB9B_toStr
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -154,7 +154,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -165,7 +165,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -176,7 +176,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -194,7 +194,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Math_Sign_ZeroVariants/toStr::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -213,7 +213,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Math_Sign_ZeroVariants/toStr::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -231,9 +231,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5635EB9B_toStr
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -352,7 +352,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_Sign_ZeroVariants/Scope,
-			[1] class Modules.Math_Sign_ZeroVariants/toStr/FunctionObject_FunctionDeclaration_5635EB9B_toStr,
+			[1] class Modules.Math_Sign_ZeroVariants/toStr/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] object[],
@@ -371,13 +371,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void Modules.Math_Sign_ZeroVariants/toStr/FunctionObject_FunctionDeclaration_5635EB9B_toStr::.ctor()
+		IL_0012: newobj instance void Modules.Math_Sign_ZeroVariants/toStr/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "toStr"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_Sign_ZeroVariants/toStr/FunctionObject_FunctionDeclaration_5635EB9B_toStr>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_Sign_ZeroVariants/toStr/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldc.i4.7

--- a/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncLocalStorage.verified.txt
+++ b/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncLocalStorage.verified.txt
@@ -308,7 +308,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_41014B8D_L14C37
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -328,9 +328,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result/FunctionObject_FunctionExpression_41014B8D_L14C37::_environment0_Require_AsyncHooks_AsyncLocalStorage
+				IL_0008: stfld class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result/FunctionObject::_environment0_Require_AsyncHooks_AsyncLocalStorage
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_41014B8D_L14C37::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -341,7 +341,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_41014B8D_L14C37::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -352,7 +352,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_41014B8D_L14C37::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -365,14 +365,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result/FunctionObject_FunctionExpression_41014B8D_L14C37::_environment0_Require_AsyncHooks_AsyncLocalStorage
+				IL_0001: ldfld class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result/FunctionObject::_environment0_Require_AsyncHooks_AsyncLocalStorage
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result::__js_call__(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_41014B8D_L14C37::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -386,14 +386,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result/FunctionObject_FunctionExpression_41014B8D_L14C37::_environment0_Require_AsyncHooks_AsyncLocalStorage
+				IL_0001: ldfld class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result/FunctionObject::_environment0_Require_AsyncHooks_AsyncLocalStorage
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result::__js_call__(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_41014B8D_L14C37::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -411,9 +411,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_41014B8D_L14C37::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_41014B8D_L14C37
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1298,7 +1298,7 @@
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[7] object[],
 			[8] class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L10C24/FunctionObject,
-			[9] class Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result/FunctionObject_FunctionExpression_41014B8D_L14C37,
+			[9] class Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result/FunctionObject,
 			[10] class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L25C51/FunctionObject,
 			[11] class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L27C38/FunctionObject,
 			[12] class Modules.Require_AsyncHooks_AsyncLocalStorage/ArrowFunction_L28C25/FunctionObject,
@@ -1438,13 +1438,13 @@
 		IL_016b: ldc.i4.0
 		IL_016c: ldelem.ref
 		IL_016d: castclass Modules.Require_AsyncHooks_AsyncLocalStorage/Scope
-		IL_0172: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result/FunctionObject_FunctionExpression_41014B8D_L14C37::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope)
+		IL_0172: newobj instance void Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncLocalStorage/Scope)
 		IL_0177: ldc.i4.1
 		IL_0178: conv.r8
 		IL_0179: ldstr ""
 		IL_017e: ldc.i4.0
 		IL_017f: ldc.i4.1
-		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result/FunctionObject_FunctionExpression_41014B8D_L14C37>(!!0, float64, string, bool, bool)
+		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncLocalStorage/FunctionExpression_result/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0185: stloc.s 9
 		IL_0187: ldloc.s 4
 		IL_0189: ldstr "run"

--- a/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncResource.verified.txt
+++ b/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncResource.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_17947914_L9C41
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_AsyncHooks_AsyncResource/Scope Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result/FunctionObject_FunctionExpression_17947914_L9C41::_environment0_Require_AsyncHooks_AsyncResource
+				IL_0008: stfld class Modules.Require_AsyncHooks_AsyncResource/Scope Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result/FunctionObject::_environment0_Require_AsyncHooks_AsyncResource
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_17947914_L9C41::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_17947914_L9C41::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_17947914_L9C41::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_AsyncHooks_AsyncResource/Scope Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result/FunctionObject_FunctionExpression_17947914_L9C41::_environment0_Require_AsyncHooks_AsyncResource
+				IL_0001: ldfld class Modules.Require_AsyncHooks_AsyncResource/Scope Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result/FunctionObject::_environment0_Require_AsyncHooks_AsyncResource
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -97,7 +97,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result::__js_call__(class Modules.Require_AsyncHooks_AsyncResource/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_17947914_L9C41::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -111,7 +111,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_AsyncHooks_AsyncResource/Scope Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result/FunctionObject_FunctionExpression_17947914_L9C41::_environment0_Require_AsyncHooks_AsyncResource
+				IL_0001: ldfld class Modules.Require_AsyncHooks_AsyncResource/Scope Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result/FunctionObject::_environment0_Require_AsyncHooks_AsyncResource
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -121,7 +121,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result::__js_call__(class Modules.Require_AsyncHooks_AsyncResource/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_17947914_L9C41::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -139,9 +139,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_17947914_L9C41::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_17947914_L9C41
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -313,7 +313,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2E1A76AF_L19C29
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -327,7 +327,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_2E1A76AF_L19C29::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -338,7 +338,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2E1A76AF_L19C29::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -349,7 +349,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2E1A76AF_L19C29::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -367,7 +367,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_bound::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_2E1A76AF_L19C29::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -386,7 +386,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_bound::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2E1A76AF_L19C29::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -404,9 +404,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2E1A76AF_L19C29::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_2E1A76AF_L19C29
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -465,7 +465,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8E652FD3_L23C51
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -479,7 +479,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8E652FD3_L23C51::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -490,7 +490,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8E652FD3_L23C51::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -501,7 +501,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8E652FD3_L23C51::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -516,7 +516,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_staticBound::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_8E652FD3_L23C51::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -532,7 +532,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_staticBound::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8E652FD3_L23C51::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -550,9 +550,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8E652FD3_L23C51::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_8E652FD3_L23C51
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -798,14 +798,14 @@
 			[11] object,
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[13] object[],
-			[14] class Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result/FunctionObject_FunctionExpression_17947914_L9C41,
+			[14] class Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result/FunctionObject,
 			[15] object,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[17] bool,
 			[18] object,
 			[19] string,
-			[20] class Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_bound/FunctionObject_FunctionExpression_2E1A76AF_L19C29,
-			[21] class Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_staticBound/FunctionObject_FunctionExpression_8E652FD3_L23C51,
+			[20] class Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_bound/FunctionObject,
+			[21] class Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_staticBound/FunctionObject,
 			[22] class Modules.Require_AsyncHooks_AsyncResource/ArrowFunction_L28C30/FunctionObject
 		)
 
@@ -894,13 +894,13 @@
 		IL_00f0: ldc.i4.0
 		IL_00f1: ldelem.ref
 		IL_00f2: castclass Modules.Require_AsyncHooks_AsyncResource/Scope
-		IL_00f7: newobj instance void Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result/FunctionObject_FunctionExpression_17947914_L9C41::.ctor(class Modules.Require_AsyncHooks_AsyncResource/Scope)
+		IL_00f7: newobj instance void Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncResource/Scope)
 		IL_00fc: ldc.i4.2
 		IL_00fd: conv.r8
 		IL_00fe: ldstr ""
 		IL_0103: ldc.i4.1
 		IL_0104: ldc.i4.1
-		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result/FunctionObject_FunctionExpression_17947914_L9C41>(!!0, float64, string, bool, bool)
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_result/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_010a: stloc.s 14
 		IL_010c: ldloc.0
 		IL_010d: ldfld object Modules.Require_AsyncHooks_AsyncResource/Scope::receiver
@@ -978,13 +978,13 @@
 		IL_01f0: ldloc.0
 		IL_01f1: stelem.ref
 		IL_01f2: stloc.s 13
-		IL_01f4: newobj instance void Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_bound/FunctionObject_FunctionExpression_2E1A76AF_L19C29::.ctor()
+		IL_01f4: newobj instance void Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_bound/FunctionObject::.ctor()
 		IL_01f9: ldc.i4.1
 		IL_01fa: conv.r8
 		IL_01fb: ldstr ""
 		IL_0200: ldc.i4.1
 		IL_0201: ldc.i4.1
-		IL_0202: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_bound/FunctionObject_FunctionExpression_2E1A76AF_L19C29>(!!0, float64, string, bool, bool)
+		IL_0202: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_bound/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0207: stloc.s 20
 		IL_0209: ldloc.0
 		IL_020a: ldfld object Modules.Require_AsyncHooks_AsyncResource/Scope::receiver
@@ -1038,13 +1038,13 @@
 		IL_029f: ldloc.0
 		IL_02a0: stelem.ref
 		IL_02a1: stloc.s 13
-		IL_02a3: newobj instance void Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_staticBound/FunctionObject_FunctionExpression_8E652FD3_L23C51::.ctor()
+		IL_02a3: newobj instance void Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_staticBound/FunctionObject::.ctor()
 		IL_02a8: ldc.i4.0
 		IL_02a9: conv.r8
 		IL_02aa: ldstr ""
 		IL_02af: ldc.i4.1
 		IL_02b0: ldc.i4.1
-		IL_02b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_staticBound/FunctionObject_FunctionExpression_8E652FD3_L23C51>(!!0, float64, string, bool, bool)
+		IL_02b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncResource/FunctionExpression_staticBound/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02b6: stloc.s 21
 		IL_02b8: ldloc.0
 		IL_02b9: ldfld object Modules.Require_AsyncHooks_AsyncResource/Scope::receiver

--- a/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncResource_Subclass.verified.txt
+++ b/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_AsyncResource_Subclass.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_61CB150A_L16C40
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_AsyncHooks_AsyncResource_Subclass/Scope Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject_FunctionExpression_61CB150A_L16C40::_environment0_Require_AsyncHooks_AsyncResource_Subclass
+				IL_0008: stfld class Modules.Require_AsyncHooks_AsyncResource_Subclass/Scope Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject::_environment0_Require_AsyncHooks_AsyncResource_Subclass
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_61CB150A_L16C40::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_61CB150A_L16C40::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_61CB150A_L16C40::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_AsyncHooks_AsyncResource_Subclass/Scope Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject_FunctionExpression_61CB150A_L16C40::_environment0_Require_AsyncHooks_AsyncResource_Subclass
+				IL_0001: ldfld class Modules.Require_AsyncHooks_AsyncResource_Subclass/Scope Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject::_environment0_Require_AsyncHooks_AsyncResource_Subclass
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -97,7 +97,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler::__js_call__(class Modules.Require_AsyncHooks_AsyncResource_Subclass/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_61CB150A_L16C40::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -111,7 +111,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_AsyncHooks_AsyncResource_Subclass/Scope Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject_FunctionExpression_61CB150A_L16C40::_environment0_Require_AsyncHooks_AsyncResource_Subclass
+				IL_0001: ldfld class Modules.Require_AsyncHooks_AsyncResource_Subclass/Scope Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject::_environment0_Require_AsyncHooks_AsyncResource_Subclass
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -121,7 +121,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler::__js_call__(class Modules.Require_AsyncHooks_AsyncResource_Subclass/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_61CB150A_L16C40::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -139,9 +139,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_61CB150A_L16C40::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_61CB150A_L16C40
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -566,7 +566,7 @@
 			[5] object[],
 			[6] class Modules.Require_AsyncHooks_AsyncResource_Subclass/UndiciStyleHandler/FunctionObject_ClassConstructor_56E834DB_UndiciStyleHandler,
 			[7] object[],
-			[8] class Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject_FunctionExpression_61CB150A_L16C40,
+			[8] class Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[10] bool,
 			[11] object,
@@ -674,13 +674,13 @@
 		IL_00f6: ldc.i4.0
 		IL_00f7: ldelem.ref
 		IL_00f8: castclass Modules.Require_AsyncHooks_AsyncResource_Subclass/Scope
-		IL_00fd: newobj instance void Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject_FunctionExpression_61CB150A_L16C40::.ctor(class Modules.Require_AsyncHooks_AsyncResource_Subclass/Scope)
+		IL_00fd: newobj instance void Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject::.ctor(class Modules.Require_AsyncHooks_AsyncResource_Subclass/Scope)
 		IL_0102: ldc.i4.2
 		IL_0103: conv.r8
 		IL_0104: ldstr ""
 		IL_0109: ldc.i4.1
 		IL_010a: ldc.i4.1
-		IL_010b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject_FunctionExpression_61CB150A_L16C40>(!!0, float64, string, bool, bool)
+		IL_010b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_AsyncResource_Subclass/FunctionExpression_handler/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0110: stloc.s 8
 		IL_0112: ldloc.s 5
 		IL_0114: ldc.i4.1

--- a/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_CreateHook.verified.txt
+++ b/tests/Jroc.Tests/Node/AsyncHooks/Snapshots/GeneratorTests.Require_AsyncHooks_CreateHook.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_10C9CAFC_L11C9
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook/FunctionObject_FunctionExpression_10C9CAFC_L11C9::_environment0_Require_AsyncHooks_CreateHook
+				IL_0008: stfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook/FunctionObject::_environment0_Require_AsyncHooks_CreateHook
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_10C9CAFC_L11C9::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_10C9CAFC_L11C9::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_10C9CAFC_L11C9::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook/FunctionObject_FunctionExpression_10C9CAFC_L11C9::_environment0_Require_AsyncHooks_CreateHook
+				IL_0001: ldfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook/FunctionObject::_environment0_Require_AsyncHooks_CreateHook
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -103,9 +103,9 @@
 				IL_0022: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0027: call object Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook::__js_call__(class Modules.Require_AsyncHooks_CreateHook/Scope, object, object, object, object, object)
 				IL_002c: ret
-			} // end of method FunctionObject_FunctionExpression_10C9CAFC_L11C9::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_10C9CAFC_L11C9
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -193,7 +193,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EB74E156_L14C11
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -213,9 +213,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10/FunctionObject_FunctionExpression_EB74E156_L14C11::_environment0_Require_AsyncHooks_CreateHook
+				IL_0008: stfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10/FunctionObject::_environment0_Require_AsyncHooks_CreateHook
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EB74E156_L14C11::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -226,7 +226,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EB74E156_L14C11::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -237,7 +237,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EB74E156_L14C11::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -250,13 +250,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10/FunctionObject_FunctionExpression_EB74E156_L14C11::_environment0_Require_AsyncHooks_CreateHook
+				IL_0001: ldfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10/FunctionObject::_environment0_Require_AsyncHooks_CreateHook
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10::__js_call__(class Modules.Require_AsyncHooks_CreateHook/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_EB74E156_L14C11::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_EB74E156_L14C11
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -314,7 +314,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8E69C61E_L17C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -334,9 +334,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9/FunctionObject_FunctionExpression_8E69C61E_L17C10::_environment0_Require_AsyncHooks_CreateHook
+				IL_0008: stfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9/FunctionObject::_environment0_Require_AsyncHooks_CreateHook
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8E69C61E_L17C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -347,7 +347,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8E69C61E_L17C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -358,7 +358,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8E69C61E_L17C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -371,13 +371,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9/FunctionObject_FunctionExpression_8E69C61E_L17C10::_environment0_Require_AsyncHooks_CreateHook
+				IL_0001: ldfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9/FunctionObject::_environment0_Require_AsyncHooks_CreateHook
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9::__js_call__(class Modules.Require_AsyncHooks_CreateHook/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_8E69C61E_L17C10::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_8E69C61E_L17C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -435,7 +435,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_87A5C75A_L20C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -455,9 +455,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11/FunctionObject_FunctionExpression_87A5C75A_L20C12::_environment0_Require_AsyncHooks_CreateHook
+				IL_0008: stfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11/FunctionObject::_environment0_Require_AsyncHooks_CreateHook
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_87A5C75A_L20C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -468,7 +468,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_87A5C75A_L20C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -479,7 +479,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_87A5C75A_L20C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -492,13 +492,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11/FunctionObject_FunctionExpression_87A5C75A_L20C12::_environment0_Require_AsyncHooks_CreateHook
+				IL_0001: ldfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11/FunctionObject::_environment0_Require_AsyncHooks_CreateHook
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11::__js_call__(class Modules.Require_AsyncHooks_CreateHook/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_87A5C75A_L20C12::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_87A5C75A_L20C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -556,7 +556,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BFA942C8_L23C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -576,9 +576,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18/FunctionObject_FunctionExpression_BFA942C8_L23C19::_environment0_Require_AsyncHooks_CreateHook
+				IL_0008: stfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18/FunctionObject::_environment0_Require_AsyncHooks_CreateHook
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BFA942C8_L23C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -589,7 +589,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BFA942C8_L23C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -600,7 +600,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BFA942C8_L23C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -613,13 +613,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18/FunctionObject_FunctionExpression_BFA942C8_L23C19::_environment0_Require_AsyncHooks_CreateHook
+				IL_0001: ldfld class Modules.Require_AsyncHooks_CreateHook/Scope Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18/FunctionObject::_environment0_Require_AsyncHooks_CreateHook
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18::__js_call__(class Modules.Require_AsyncHooks_CreateHook/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_BFA942C8_L23C19::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_BFA942C8_L23C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1151,11 +1151,11 @@
 			[5] object[],
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[7] object[],
-			[8] class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook/FunctionObject_FunctionExpression_10C9CAFC_L11C9,
-			[9] class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10/FunctionObject_FunctionExpression_EB74E156_L14C11,
-			[10] class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9/FunctionObject_FunctionExpression_8E69C61E_L17C10,
-			[11] class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11/FunctionObject_FunctionExpression_87A5C75A_L20C12,
-			[12] class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18/FunctionObject_FunctionExpression_BFA942C8_L23C19,
+			[8] class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook/FunctionObject,
+			[9] class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10/FunctionObject,
+			[10] class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9/FunctionObject,
+			[11] class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11/FunctionObject,
+			[12] class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18/FunctionObject,
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[14] object,
 			[15] bool,
@@ -1223,14 +1223,14 @@
 		IL_0092: ldc.i4.0
 		IL_0093: ldelem.ref
 		IL_0094: castclass Modules.Require_AsyncHooks_CreateHook/Scope
-		IL_0099: newobj instance void Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook/FunctionObject_FunctionExpression_10C9CAFC_L11C9::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
+		IL_0099: newobj instance void Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook/FunctionObject::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
 		IL_009e: ldc.i4.4
 		IL_009f: conv.r8
 		IL_00a0: ldstr ""
 		IL_00a5: ldc.i4.0
 		IL_00a6: ldc.i4.1
-		IL_00a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook/FunctionObject_FunctionExpression_10C9CAFC_L11C9>(!!0, float64, string, bool, bool)
-		IL_00ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook/FunctionObject_FunctionExpression_10C9CAFC_L11C9>(!!0)
+		IL_00a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00ac: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook/FunctionObject>(!!0)
 		IL_00b1: stloc.s 8
 		IL_00b3: ldloc.s 6
 		IL_00b5: ldstr "init"
@@ -1248,14 +1248,14 @@
 		IL_00d0: ldc.i4.0
 		IL_00d1: ldelem.ref
 		IL_00d2: castclass Modules.Require_AsyncHooks_CreateHook/Scope
-		IL_00d7: newobj instance void Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10/FunctionObject_FunctionExpression_EB74E156_L14C11::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
+		IL_00d7: newobj instance void Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10/FunctionObject::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
 		IL_00dc: ldc.i4.0
 		IL_00dd: conv.r8
 		IL_00de: ldstr ""
 		IL_00e3: ldc.i4.0
 		IL_00e4: ldc.i4.1
-		IL_00e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10/FunctionObject_FunctionExpression_EB74E156_L14C11>(!!0, float64, string, bool, bool)
-		IL_00ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10/FunctionObject_FunctionExpression_EB74E156_L14C11>(!!0)
+		IL_00e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L14C10/FunctionObject>(!!0)
 		IL_00ef: stloc.s 9
 		IL_00f1: ldloc.s 6
 		IL_00f3: ldstr "before"
@@ -1273,14 +1273,14 @@
 		IL_010e: ldc.i4.0
 		IL_010f: ldelem.ref
 		IL_0110: castclass Modules.Require_AsyncHooks_CreateHook/Scope
-		IL_0115: newobj instance void Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9/FunctionObject_FunctionExpression_8E69C61E_L17C10::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
+		IL_0115: newobj instance void Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9/FunctionObject::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
 		IL_011a: ldc.i4.0
 		IL_011b: conv.r8
 		IL_011c: ldstr ""
 		IL_0121: ldc.i4.0
 		IL_0122: ldc.i4.1
-		IL_0123: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9/FunctionObject_FunctionExpression_8E69C61E_L17C10>(!!0, float64, string, bool, bool)
-		IL_0128: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9/FunctionObject_FunctionExpression_8E69C61E_L17C10>(!!0)
+		IL_0123: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0128: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L17C9/FunctionObject>(!!0)
 		IL_012d: stloc.s 10
 		IL_012f: ldloc.s 6
 		IL_0131: ldstr "after"
@@ -1298,14 +1298,14 @@
 		IL_014c: ldc.i4.0
 		IL_014d: ldelem.ref
 		IL_014e: castclass Modules.Require_AsyncHooks_CreateHook/Scope
-		IL_0153: newobj instance void Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11/FunctionObject_FunctionExpression_87A5C75A_L20C12::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
+		IL_0153: newobj instance void Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11/FunctionObject::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
 		IL_0158: ldc.i4.0
 		IL_0159: conv.r8
 		IL_015a: ldstr ""
 		IL_015f: ldc.i4.0
 		IL_0160: ldc.i4.1
-		IL_0161: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11/FunctionObject_FunctionExpression_87A5C75A_L20C12>(!!0, float64, string, bool, bool)
-		IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11/FunctionObject_FunctionExpression_87A5C75A_L20C12>(!!0)
+		IL_0161: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L20C11/FunctionObject>(!!0)
 		IL_016b: stloc.s 11
 		IL_016d: ldloc.s 6
 		IL_016f: ldstr "destroy"
@@ -1323,14 +1323,14 @@
 		IL_018a: ldc.i4.0
 		IL_018b: ldelem.ref
 		IL_018c: castclass Modules.Require_AsyncHooks_CreateHook/Scope
-		IL_0191: newobj instance void Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18/FunctionObject_FunctionExpression_BFA942C8_L23C19::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
+		IL_0191: newobj instance void Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18/FunctionObject::.ctor(class Modules.Require_AsyncHooks_CreateHook/Scope)
 		IL_0196: ldc.i4.0
 		IL_0197: conv.r8
 		IL_0198: ldstr ""
 		IL_019d: ldc.i4.0
 		IL_019e: ldc.i4.1
-		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18/FunctionObject_FunctionExpression_BFA942C8_L23C19>(!!0, float64, string, bool, bool)
-		IL_01a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18/FunctionObject_FunctionExpression_BFA942C8_L23C19>(!!0)
+		IL_019f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_AsyncHooks_CreateHook/FunctionExpression_hook_L23C18/FunctionObject>(!!0)
 		IL_01a9: stloc.s 12
 		IL_01ab: ldloc.s 6
 		IL_01ad: ldstr "promiseResolve"

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Exec_Callback_Function_Objects.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Exec_Callback_Function_Objects.verified.txt
@@ -38,7 +38,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1A937B49_generatorCallback
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -58,9 +58,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject_FunctionExpression_1A937B49_generatorCallback::_transitionalScopes
+				IL_0008: stfld object[] Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1A937B49_generatorCallback::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -71,7 +71,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1A937B49_generatorCallback::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -82,7 +82,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1A937B49_generatorCallback::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -95,15 +95,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject_FunctionExpression_1A937B49_generatorCallback::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionExpression_1A937B49_generatorCallback::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_1A937B49_generatorCallback
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -144,7 +144,7 @@
 			IL_001f: ldftn object Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject_FunctionExpression_1A937B49_generatorCallback
+			IL_002b: ldtoken Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -259,7 +259,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FD97D584_asyncCallback
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -279,9 +279,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback/FunctionObject_FunctionExpression_FD97D584_asyncCallback::_transitionalScopes
+				IL_0008: stfld object[] Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FD97D584_asyncCallback::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -292,7 +292,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FD97D584_asyncCallback::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -303,7 +303,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FD97D584_asyncCallback::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -316,7 +316,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback/FunctionObject_FunctionExpression_FD97D584_asyncCallback::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -330,9 +330,9 @@
 				IL_0020: call object Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback::__js_call__(object[], object, object, object, object)
 				IL_0025: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_002a: ret
-			} // end of method FunctionObject_FunctionExpression_FD97D584_asyncCallback::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionExpression_FD97D584_asyncCallback
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -462,10 +462,10 @@
 			[5] object,
 			[6] bool,
 			[7] object[],
-			[8] class Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject_FunctionExpression_1A937B49_generatorCallback,
+			[8] class Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[10] string,
-			[11] class Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback/FunctionObject_FunctionExpression_FD97D584_asyncCallback
+			[11] class Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Require_ChildProcess_Exec_Callback_Function_Objects/Scope::.ctor()
@@ -504,15 +504,15 @@
 		IL_005a: stelem.ref
 		IL_005b: stloc.s 7
 		IL_005d: ldloc.s 7
-		IL_005f: newobj instance void Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject_FunctionExpression_1A937B49_generatorCallback::.ctor(object[])
+		IL_005f: newobj instance void Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject::.ctor(object[])
 		IL_0064: ldc.i4.0
 		IL_0065: conv.r8
 		IL_0066: ldstr "generatorCallback"
 		IL_006b: ldc.i4.1
 		IL_006c: ldc.i4.1
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject_FunctionExpression_1A937B49_generatorCallback>(!!0, float64, string, bool, bool)
+		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0072: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_0077: castclass Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject_FunctionExpression_1A937B49_generatorCallback
+		IL_0077: castclass Modules.Require_ChildProcess_Exec_Callback_Function_Objects/generatorCallback/FunctionObject
 		IL_007c: stloc.s 8
 		IL_007e: ldloc.1
 		IL_007f: ldstr "exec"
@@ -545,14 +545,14 @@
 		IL_00cd: stelem.ref
 		IL_00ce: stloc.s 7
 		IL_00d0: ldloc.s 7
-		IL_00d2: newobj instance void Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback/FunctionObject_FunctionExpression_FD97D584_asyncCallback::.ctor(object[])
+		IL_00d2: newobj instance void Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback/FunctionObject::.ctor(object[])
 		IL_00d7: ldc.i4.3
 		IL_00d8: conv.r8
 		IL_00d9: ldstr "asyncCallback"
 		IL_00de: ldc.i4.1
 		IL_00df: ldc.i4.1
-		IL_00e0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback/FunctionObject_FunctionExpression_FD97D584_asyncCallback>(!!0, float64, string, bool, bool)
-		IL_00e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback/FunctionObject_FunctionExpression_FD97D584_asyncCallback>(!!0)
+		IL_00e0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_ChildProcess_Exec_Callback_Function_Objects/asyncCallback/FunctionObject>(!!0)
 		IL_00ea: stloc.s 11
 		IL_00ec: ldloc.1
 		IL_00ed: ldstr "exec"

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
@@ -723,7 +723,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -743,9 +743,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::_environment0_Require_ChildProcess_Fork_Silent
+				IL_0008: stfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject::_environment0_Require_ChildProcess_Fork_Silent
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -756,7 +756,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -767,7 +767,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -780,11 +780,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::_environment0_Require_ChildProcess_Fork_Silent
+				IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject::_environment0_Require_ChildProcess_Fork_Silent
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -798,11 +798,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::_environment0_Require_ChildProcess_Fork_Silent
+				IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject::_environment0_Require_ChildProcess_Fork_Silent
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -820,9 +820,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1450,7 +1450,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1470,9 +1470,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::_environment0_Require_ChildProcess_Fork_Silent
+				IL_0008: stfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject::_environment0_Require_ChildProcess_Fork_Silent
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1483,7 +1483,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1494,7 +1494,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1507,11 +1507,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::_environment0_Require_ChildProcess_Fork_Silent
+				IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject::_environment0_Require_ChildProcess_Fork_Silent
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1525,11 +1525,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::_environment0_Require_ChildProcess_Fork_Silent
+				IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject::_environment0_Require_ChildProcess_Fork_Silent
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1547,9 +1547,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1807,9 +1807,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_Silent/Scope,
-			[1] class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue,
+			[1] class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject,
 			[2] object[],
-			[3] class Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse,
+			[3] class Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject,
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule
 		)
 
@@ -1826,13 +1826,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-		IL_0019: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope)
+		IL_0019: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "runSilentTrue"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: ldc.i4.1
 		IL_002e: newarr [System.Runtime]System.Object
@@ -1845,13 +1845,13 @@
 		IL_0039: ldc.i4.0
 		IL_003a: ldelem.ref
 		IL_003b: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-		IL_0040: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope)
+		IL_0040: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope)
 		IL_0045: ldc.i4.0
 		IL_0046: conv.r8
 		IL_0047: ldstr "runSilentFalse"
 		IL_004c: ldc.i4.0
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse>(!!0, float64, string, bool, bool)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0053: stloc.3
 		IL_0054: ldloc.0
 		IL_0055: ldloc.3

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_ComputedGlobalPropertyReplacement.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_ComputedGlobalPropertyReplacement.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BD585917_L3C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/Scope Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_BD585917_L3C8::_environment0_Console_GlobalLog_ComputedGlobalPropertyReplacement
+				IL_0008: stfld class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/Scope Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject::_environment0_Console_GlobalLog_ComputedGlobalPropertyReplacement
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BD585917_L3C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BD585917_L3C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BD585917_L3C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -88,7 +88,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_BD585917_L3C8::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -101,16 +101,16 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/Scope Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_BD585917_L3C8::_environment0_Console_GlobalLog_ComputedGlobalPropertyReplacement
+				IL_0001: ldfld class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/Scope Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject::_environment0_Console_GlobalLog_ComputedGlobalPropertyReplacement
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7::__js_call__(class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_BD585917_L3C8::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_BD585917_L3C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -190,7 +190,7 @@
 			[1] object,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
-			[4] class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_BD585917_L3C8
+			[4] class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/Scope::.ctor()
@@ -223,15 +223,15 @@
 		IL_0053: ldc.i4.0
 		IL_0054: ldelem.ref
 		IL_0055: castclass Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/Scope
-		IL_005a: newobj instance void Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_BD585917_L3C8::.ctor(class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/Scope)
+		IL_005a: newobj instance void Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject::.ctor(class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/Scope)
 		IL_005f: ldc.i4.1
 		IL_0060: conv.r8
 		IL_0061: ldstr ""
 		IL_0066: ldc.i4.0
 		IL_0067: ldc.i4.0
-		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_BD585917_L3C8>(!!0, float64, string, bool, bool)
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_BD585917_L3C8>(!!0)
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_BD585917_L3C8>(!!0)
+		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject>(!!0)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_ComputedGlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject>(!!0)
 		IL_0077: stloc.s 4
 		IL_0079: ldloc.2
 		IL_007a: ldstr "log"

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_DescriptorReplacement.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_DescriptorReplacement.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D2A375B9_L4C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Console_GlobalLog_DescriptorReplacement/Scope Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject_FunctionExpression_D2A375B9_L4C12::_environment0_Console_GlobalLog_DescriptorReplacement
+				IL_0008: stfld class Modules.Console_GlobalLog_DescriptorReplacement/Scope Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject::_environment0_Console_GlobalLog_DescriptorReplacement
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D2A375B9_L4C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D2A375B9_L4C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D2A375B9_L4C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -88,7 +88,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D2A375B9_L4C12::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -101,16 +101,16 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Console_GlobalLog_DescriptorReplacement/Scope Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject_FunctionExpression_D2A375B9_L4C12::_environment0_Console_GlobalLog_DescriptorReplacement
+				IL_0001: ldfld class Modules.Console_GlobalLog_DescriptorReplacement/Scope Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject::_environment0_Console_GlobalLog_DescriptorReplacement
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11::__js_call__(class Modules.Console_GlobalLog_DescriptorReplacement/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_D2A375B9_L4C12::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_D2A375B9_L4C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -190,7 +190,7 @@
 			[1] object,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
-			[4] class Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject_FunctionExpression_D2A375B9_L4C12
+			[4] class Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Console_GlobalLog_DescriptorReplacement/Scope::.ctor()
@@ -223,15 +223,15 @@
 		IL_0053: ldc.i4.0
 		IL_0054: ldelem.ref
 		IL_0055: castclass Modules.Console_GlobalLog_DescriptorReplacement/Scope
-		IL_005a: newobj instance void Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject_FunctionExpression_D2A375B9_L4C12::.ctor(class Modules.Console_GlobalLog_DescriptorReplacement/Scope)
+		IL_005a: newobj instance void Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject::.ctor(class Modules.Console_GlobalLog_DescriptorReplacement/Scope)
 		IL_005f: ldc.i4.1
 		IL_0060: conv.r8
 		IL_0061: ldstr ""
 		IL_0066: ldc.i4.0
 		IL_0067: ldc.i4.0
-		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject_FunctionExpression_D2A375B9_L4C12>(!!0, float64, string, bool, bool)
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject_FunctionExpression_D2A375B9_L4C12>(!!0)
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject_FunctionExpression_D2A375B9_L4C12>(!!0)
+		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject>(!!0)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_DescriptorReplacement/FunctionExpression_L4C11/FunctionObject>(!!0)
 		IL_0077: stloc.s 4
 		IL_0079: ldloc.2
 		IL_007a: ldstr "log"

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_GlobalPropertyReplacement.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_GlobalPropertyReplacement.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_47874DFA_L3C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Console_GlobalLog_GlobalPropertyReplacement/Scope Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_47874DFA_L3C8::_environment0_Console_GlobalLog_GlobalPropertyReplacement
+				IL_0008: stfld class Modules.Console_GlobalLog_GlobalPropertyReplacement/Scope Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject::_environment0_Console_GlobalLog_GlobalPropertyReplacement
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_47874DFA_L3C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_47874DFA_L3C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_47874DFA_L3C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -88,7 +88,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_47874DFA_L3C8::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -101,16 +101,16 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Console_GlobalLog_GlobalPropertyReplacement/Scope Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_47874DFA_L3C8::_environment0_Console_GlobalLog_GlobalPropertyReplacement
+				IL_0001: ldfld class Modules.Console_GlobalLog_GlobalPropertyReplacement/Scope Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject::_environment0_Console_GlobalLog_GlobalPropertyReplacement
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7::__js_call__(class Modules.Console_GlobalLog_GlobalPropertyReplacement/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_47874DFA_L3C8::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_47874DFA_L3C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -190,7 +190,7 @@
 			[1] object,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
-			[4] class Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_47874DFA_L3C8
+			[4] class Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Console_GlobalLog_GlobalPropertyReplacement/Scope::.ctor()
@@ -223,15 +223,15 @@
 		IL_0053: ldc.i4.0
 		IL_0054: ldelem.ref
 		IL_0055: castclass Modules.Console_GlobalLog_GlobalPropertyReplacement/Scope
-		IL_005a: newobj instance void Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_47874DFA_L3C8::.ctor(class Modules.Console_GlobalLog_GlobalPropertyReplacement/Scope)
+		IL_005a: newobj instance void Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject::.ctor(class Modules.Console_GlobalLog_GlobalPropertyReplacement/Scope)
 		IL_005f: ldc.i4.1
 		IL_0060: conv.r8
 		IL_0061: ldstr ""
 		IL_0066: ldc.i4.0
 		IL_0067: ldc.i4.0
-		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_47874DFA_L3C8>(!!0, float64, string, bool, bool)
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_47874DFA_L3C8>(!!0)
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject_FunctionExpression_47874DFA_L3C8>(!!0)
+		IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject>(!!0)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_GlobalPropertyReplacement/FunctionExpression_L3C7/FunctionObject>(!!0)
 		IL_0077: stloc.s 4
 		IL_0079: ldloc.2
 		IL_007a: ldstr "log"

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_GlobalThisAliasReplacement.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_GlobalThisAliasReplacement.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_64F88AA8_L4C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Console_GlobalLog_GlobalThisAliasReplacement/Scope Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject_FunctionExpression_64F88AA8_L4C8::_environment0_Console_GlobalLog_GlobalThisAliasReplacement
+				IL_0008: stfld class Modules.Console_GlobalLog_GlobalThisAliasReplacement/Scope Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject::_environment0_Console_GlobalLog_GlobalThisAliasReplacement
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_64F88AA8_L4C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_64F88AA8_L4C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_64F88AA8_L4C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -88,7 +88,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_64F88AA8_L4C8::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -101,16 +101,16 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Console_GlobalLog_GlobalThisAliasReplacement/Scope Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject_FunctionExpression_64F88AA8_L4C8::_environment0_Console_GlobalLog_GlobalThisAliasReplacement
+				IL_0001: ldfld class Modules.Console_GlobalLog_GlobalThisAliasReplacement/Scope Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject::_environment0_Console_GlobalLog_GlobalThisAliasReplacement
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7::__js_call__(class Modules.Console_GlobalLog_GlobalThisAliasReplacement/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_64F88AA8_L4C8::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_64F88AA8_L4C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -191,7 +191,7 @@
 			[2] object,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object[],
-			[5] class Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject_FunctionExpression_64F88AA8_L4C8
+			[5] class Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Console_GlobalLog_GlobalThisAliasReplacement/Scope::.ctor()
@@ -224,15 +224,15 @@
 		IL_0055: ldc.i4.0
 		IL_0056: ldelem.ref
 		IL_0057: castclass Modules.Console_GlobalLog_GlobalThisAliasReplacement/Scope
-		IL_005c: newobj instance void Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject_FunctionExpression_64F88AA8_L4C8::.ctor(class Modules.Console_GlobalLog_GlobalThisAliasReplacement/Scope)
+		IL_005c: newobj instance void Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject::.ctor(class Modules.Console_GlobalLog_GlobalThisAliasReplacement/Scope)
 		IL_0061: ldc.i4.1
 		IL_0062: conv.r8
 		IL_0063: ldstr ""
 		IL_0068: ldc.i4.0
 		IL_0069: ldc.i4.0
-		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject_FunctionExpression_64F88AA8_L4C8>(!!0, float64, string, bool, bool)
-		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject_FunctionExpression_64F88AA8_L4C8>(!!0)
-		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject_FunctionExpression_64F88AA8_L4C8>(!!0)
+		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject>(!!0)
+		IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_GlobalThisAliasReplacement/FunctionExpression_L4C7/FunctionObject>(!!0)
 		IL_0079: stloc.s 5
 		IL_007b: ldloc.3
 		IL_007c: ldstr "log"

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_LocalBindingShadowing.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_GlobalLog_LocalBindingShadowing.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C90D3773_L2C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_C90D3773_L2C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C90D3773_L2C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C90D3773_L2C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_C90D3773_L2C8::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -98,9 +98,9 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_C90D3773_L2C8::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_C90D3773_L2C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -176,7 +176,7 @@
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
-			[4] class Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject_FunctionExpression_C90D3773_L2C8
+			[4] class Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Console_GlobalLog_LocalBindingShadowing/Scope::.ctor()
@@ -190,15 +190,15 @@
 		IL_0014: ldloc.0
 		IL_0015: stelem.ref
 		IL_0016: stloc.3
-		IL_0017: newobj instance void Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject_FunctionExpression_C90D3773_L2C8::.ctor()
+		IL_0017: newobj instance void Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject::.ctor()
 		IL_001c: ldc.i4.1
 		IL_001d: conv.r8
 		IL_001e: ldstr ""
 		IL_0023: ldc.i4.0
 		IL_0024: ldc.i4.0
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject_FunctionExpression_C90D3773_L2C8>(!!0, float64, string, bool, bool)
-		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject_FunctionExpression_C90D3773_L2C8>(!!0)
-		IL_002f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject_FunctionExpression_C90D3773_L2C8>(!!0)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject>(!!0)
+		IL_002f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_GlobalLog_LocalBindingShadowing/FunctionExpression_console/FunctionObject>(!!0)
 		IL_0034: stloc.s 4
 		IL_0036: ldloc.2
 		IL_0037: ldstr "log"

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_Undici_Transform_Table.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_Undici_Transform_Table.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B23CAF09_L7C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -90,9 +90,9 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Console_Undici_Transform_Table/FunctionExpression_output::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_B23CAF09_L7C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -172,7 +172,7 @@
 			[6] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IConsoleModule,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[8] object[],
-			[9] class Modules.Console_Undici_Transform_Table/FunctionExpression_output/FunctionObject_FunctionExpression_B23CAF09_L7C12,
+			[9] class Modules.Console_Undici_Transform_Table/FunctionExpression_output/FunctionObject,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[12] object
@@ -230,14 +230,14 @@
 		IL_0092: ldloc.0
 		IL_0093: stelem.ref
 		IL_0094: stloc.s 8
-		IL_0096: newobj instance void Modules.Console_Undici_Transform_Table/FunctionExpression_output/FunctionObject_FunctionExpression_B23CAF09_L7C12::.ctor()
+		IL_0096: newobj instance void Modules.Console_Undici_Transform_Table/FunctionExpression_output/FunctionObject::.ctor()
 		IL_009b: ldc.i4.3
 		IL_009c: conv.r8
 		IL_009d: ldstr ""
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_Undici_Transform_Table/FunctionExpression_output/FunctionObject_FunctionExpression_B23CAF09_L7C12>(!!0, float64, string, bool, bool)
-		IL_00a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_Undici_Transform_Table/FunctionExpression_output/FunctionObject_FunctionExpression_B23CAF09_L7C12>(!!0)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Console_Undici_Transform_Table/FunctionExpression_output/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Console_Undici_Transform_Table/FunctionExpression_output/FunctionObject>(!!0)
 		IL_00ae: stloc.s 9
 		IL_00b0: ldloc.s 7
 		IL_00b2: ldstr "transform"

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B38D6CE6_logError
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -84,7 +84,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -106,7 +106,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -128,7 +128,7 @@
 				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0018: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -151,7 +151,7 @@
 				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0014: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -169,9 +169,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B38D6CE6_logError
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2744,7 +2744,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -2764,9 +2764,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::_transitionalScopes
+				IL_0008: stfld object[] Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2777,7 +2777,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2788,7 +2788,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -2801,7 +2801,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2812,9 +2812,9 @@
 				IL_0019: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
 				IL_001e: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2860,7 +2860,7 @@
 			IL_0020: ldftn object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc2::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError
+			IL_002c: ldtoken Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.2
 			IL_0037: newarr [System.Runtime]System.Object
@@ -4655,7 +4655,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -4677,12 +4677,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_Crypto_ErrorPaths/Scope Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::_environment0_Require_Crypto_ErrorPaths
+				IL_0008: stfld class Modules.Require_Crypto_ErrorPaths/Scope Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject::_environment0_Require_Crypto_ErrorPaths
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::_transitionalScopes
+				IL_000f: stfld object[] Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -4693,7 +4693,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -4704,7 +4704,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -4717,14 +4717,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -4780,7 +4780,7 @@
 			IL_0020: ldftn object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors
+			IL_002c: ldtoken Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -6609,10 +6609,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_ErrorPaths/Scope,
-			[1] class Modules.Require_Crypto_ErrorPaths/logError/FunctionObject_FunctionDeclaration_B38D6CE6_logError,
-			[2] class Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors,
+			[1] class Modules.Require_Crypto_ErrorPaths/logError/FunctionObject,
+			[2] class Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject,
 			[3] object[],
-			[4] class Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError,
+			[4] class Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject,
 			[5] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
 			[6] object[],
 			[7] class Modules.Require_Crypto_ErrorPaths/ArrowFunction_L16C28/FunctionObject,
@@ -6648,13 +6648,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Require_Crypto_ErrorPaths/logError/FunctionObject_FunctionDeclaration_B38D6CE6_logError::.ctor()
+		IL_0011: newobj instance void Modules.Require_Crypto_ErrorPaths/logError/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "logError"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/logError/FunctionObject_FunctionDeclaration_B38D6CE6_logError>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/logError/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: ldc.i4.1
 		IL_0026: newarr [System.Runtime]System.Object
@@ -6664,14 +6664,14 @@
 		IL_002e: stelem.ref
 		IL_002f: stloc.3
 		IL_0030: ldloc.3
-		IL_0031: newobj instance void Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::.ctor(object[])
+		IL_0031: newobj instance void Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject::.ctor(object[])
 		IL_0036: ldc.i4.2
 		IL_0037: conv.r8
 		IL_0038: ldstr "logPromiseError"
 		IL_003d: ldc.i4.0
 		IL_003e: ldc.i4.1
-		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError>(!!0, float64, string, bool, bool)
-		IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError>(!!0)
+		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0044: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject>(!!0)
 		IL_0049: stloc.s 4
 		IL_004b: ldloc.0
 		IL_004c: ldloc.s 4
@@ -6688,14 +6688,14 @@
 		IL_0060: ldelem.ref
 		IL_0061: castclass Modules.Require_Crypto_ErrorPaths/Scope
 		IL_0066: ldloc.3
-		IL_0067: newobj instance void Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope, object[])
+		IL_0067: newobj instance void Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject::.ctor(class Modules.Require_Crypto_ErrorPaths/Scope, object[])
 		IL_006c: ldc.i4.0
 		IL_006d: conv.r8
 		IL_006e: ldstr "runWebCryptoErrors"
 		IL_0073: ldc.i4.0
 		IL_0074: ldc.i4.1
-		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors>(!!0, float64, string, bool, bool)
-		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors>(!!0)
+		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject>(!!0)
 		IL_007f: stloc.2
 		IL_0080: nop
 		IL_0081: ldarg.1

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
@@ -55,7 +55,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_02C500D8_run
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -77,12 +77,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_Crypto_WebCrypto_Subtle/Scope Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject_FunctionDeclaration_02C500D8_run::_environment0_Require_Crypto_WebCrypto_Subtle
+				IL_0008: stfld class Modules.Require_Crypto_WebCrypto_Subtle/Scope Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject::_environment0_Require_Crypto_WebCrypto_Subtle
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject_FunctionDeclaration_02C500D8_run::_transitionalScopes
+				IL_000f: stfld object[] Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -93,7 +93,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -104,7 +104,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -117,14 +117,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject_FunctionDeclaration_02C500D8_run::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Require_Crypto_WebCrypto_Subtle/run::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_02C500D8_run
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -178,7 +178,7 @@
 			IL_0020: ldftn object Modules.Require_Crypto_WebCrypto_Subtle/run::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject_FunctionDeclaration_02C500D8_run
+			IL_002c: ldtoken Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1506,7 +1506,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_WebCrypto_Subtle/Scope,
-			[1] class Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject_FunctionDeclaration_02C500D8_run,
+			[1] class Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ICryptoModule,
 			[4] object,
@@ -1527,14 +1527,14 @@
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Require_Crypto_WebCrypto_Subtle/Scope
 		IL_0019: ldloc.2
-		IL_001a: newobj instance void Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject_FunctionDeclaration_02C500D8_run::.ctor(class Modules.Require_Crypto_WebCrypto_Subtle/Scope, object[])
+		IL_001a: newobj instance void Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject::.ctor(class Modules.Require_Crypto_WebCrypto_Subtle/Scope, object[])
 		IL_001f: ldc.i4.0
 		IL_0020: conv.r8
 		IL_0021: ldstr "run"
 		IL_0026: ldc.i4.0
 		IL_0027: ldc.i4.1
-		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject_FunctionDeclaration_02C500D8_run>(!!0, float64, string, bool, bool)
-		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject_FunctionDeclaration_02C500D8_run>(!!0)
+		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject>(!!0)
 		IL_0032: stloc.1
 		IL_0033: nop
 		IL_0034: ldarg.1

--- a/tests/Jroc.Tests/Node/DiagnosticsChannel/Snapshots/GeneratorTests.Require_DiagnosticsChannel.verified.txt
+++ b/tests/Jroc.Tests/Node/DiagnosticsChannel/Snapshots/GeneratorTests.Require_DiagnosticsChannel.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_62405A1D_listener
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_DiagnosticsChannel/Scope Modules.Require_DiagnosticsChannel/listener/FunctionObject_FunctionDeclaration_62405A1D_listener::_environment0_Require_DiagnosticsChannel
+				IL_0008: stfld class Modules.Require_DiagnosticsChannel/Scope Modules.Require_DiagnosticsChannel/listener/FunctionObject::_environment0_Require_DiagnosticsChannel
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_62405A1D_listener::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_62405A1D_listener::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_62405A1D_listener::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_DiagnosticsChannel/Scope Modules.Require_DiagnosticsChannel/listener/FunctionObject_FunctionDeclaration_62405A1D_listener::_environment0_Require_DiagnosticsChannel
+				IL_0001: ldfld class Modules.Require_DiagnosticsChannel/Scope Modules.Require_DiagnosticsChannel/listener/FunctionObject::_environment0_Require_DiagnosticsChannel
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -97,7 +97,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Require_DiagnosticsChannel/listener::__js_call__(class Modules.Require_DiagnosticsChannel/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_62405A1D_listener::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -111,7 +111,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_DiagnosticsChannel/Scope Modules.Require_DiagnosticsChannel/listener/FunctionObject_FunctionDeclaration_62405A1D_listener::_environment0_Require_DiagnosticsChannel
+				IL_0001: ldfld class Modules.Require_DiagnosticsChannel/Scope Modules.Require_DiagnosticsChannel/listener/FunctionObject::_environment0_Require_DiagnosticsChannel
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -121,7 +121,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Require_DiagnosticsChannel/listener::__js_call__(class Modules.Require_DiagnosticsChannel/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_62405A1D_listener::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -139,9 +139,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_62405A1D_listener::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_62405A1D_listener
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -253,7 +253,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_DiagnosticsChannel/Scope,
-			[1] class Modules.Require_DiagnosticsChannel/listener/FunctionObject_FunctionDeclaration_62405A1D_listener,
+			[1] class Modules.Require_DiagnosticsChannel/listener/FunctionObject,
 			[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IDiagnosticsChannelModule,
 			[3] object,
 			[4] object,
@@ -281,13 +281,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Require_DiagnosticsChannel/Scope
-		IL_001b: newobj instance void Modules.Require_DiagnosticsChannel/listener/FunctionObject_FunctionDeclaration_62405A1D_listener::.ctor(class Modules.Require_DiagnosticsChannel/Scope)
+		IL_001b: newobj instance void Modules.Require_DiagnosticsChannel/listener/FunctionObject::.ctor(class Modules.Require_DiagnosticsChannel/Scope)
 		IL_0020: ldc.i4.2
 		IL_0021: conv.r8
 		IL_0022: ldstr "listener"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_DiagnosticsChannel/listener/FunctionObject_FunctionDeclaration_62405A1D_listener>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_DiagnosticsChannel/listener/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: ldarg.1

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
@@ -101,7 +101,7 @@
 
 		} // end of class Scope_ForOf_L14C13
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -123,12 +123,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::_environment0_Events_AsyncHelpers_On_Once
+				IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject::_environment0_Events_AsyncHelpers_On_Once
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::_transitionalScopes
+				IL_000f: stfld object[] Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -139,7 +139,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -150,7 +150,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -163,14 +163,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Events_AsyncHelpers_On_Once/runOnBreak::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -223,7 +223,7 @@
 			IL_0020: ldftn object Modules.Events_AsyncHelpers_On_Once/runOnBreak::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak
+			IL_002c: ldtoken Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1403,7 +1403,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -1425,12 +1425,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::_environment0_Events_AsyncHelpers_On_Once
+				IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject::_environment0_Events_AsyncHelpers_On_Once
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::_transitionalScopes
+				IL_000f: stfld object[] Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1441,7 +1441,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1452,7 +1452,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -1465,14 +1465,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1517,7 +1517,7 @@
 			IL_0020: ldftn object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject
+			IL_002c: ldtoken Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1748,7 +1748,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -1770,12 +1770,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::_environment0_Events_AsyncHelpers_On_Once
+				IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject::_environment0_Events_AsyncHelpers_On_Once
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::_transitionalScopes
+				IL_000f: stfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1786,7 +1786,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1797,7 +1797,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -1810,14 +1810,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Events_AsyncHelpers_On_Once/runOnceResolve::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1862,7 +1862,7 @@
 			IL_0020: ldftn object Modules.Events_AsyncHelpers_On_Once/runOnceResolve::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve
+			IL_002c: ldtoken Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -2117,7 +2117,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D30260CA_runOnceReject
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -2139,12 +2139,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::_environment0_Events_AsyncHelpers_On_Once
+				IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject::_environment0_Events_AsyncHelpers_On_Once
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::_transitionalScopes
+				IL_000f: stfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2155,7 +2155,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2166,7 +2166,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -2179,14 +2179,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Events_AsyncHelpers_On_Once/runOnceReject::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_D30260CA_runOnceReject
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2231,7 +2231,7 @@
 			IL_0020: ldftn object Modules.Events_AsyncHelpers_On_Once/runOnceReject::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject_FunctionDeclaration_D30260CA_runOnceReject
+			IL_002c: ldtoken Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -2579,10 +2579,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_AsyncHelpers_On_Once/Scope,
-			[1] class Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak,
-			[2] class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject,
-			[3] class Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve,
-			[4] class Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject_FunctionDeclaration_D30260CA_runOnceReject,
+			[1] class Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject,
+			[2] class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject,
+			[3] class Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject,
+			[4] class Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject,
 			[5] object[],
 			[6] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule,
 			[7] object,
@@ -2603,14 +2603,14 @@
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Events_AsyncHelpers_On_Once/Scope
 		IL_001b: ldloc.s 5
-		IL_001d: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::.ctor(class Modules.Events_AsyncHelpers_On_Once/Scope, object[])
+		IL_001d: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject::.ctor(class Modules.Events_AsyncHelpers_On_Once/Scope, object[])
 		IL_0022: ldc.i4.0
 		IL_0023: conv.r8
 		IL_0024: ldstr "runOnBreak"
 		IL_0029: ldc.i4.0
 		IL_002a: ldc.i4.1
-		IL_002b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak>(!!0, float64, string, bool, bool)
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak>(!!0)
+		IL_002b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject>(!!0)
 		IL_0035: stloc.1
 		IL_0036: ldc.i4.1
 		IL_0037: newarr [System.Runtime]System.Object
@@ -2624,14 +2624,14 @@
 		IL_0045: ldelem.ref
 		IL_0046: castclass Modules.Events_AsyncHelpers_On_Once/Scope
 		IL_004b: ldloc.s 5
-		IL_004d: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::.ctor(class Modules.Events_AsyncHelpers_On_Once/Scope, object[])
+		IL_004d: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject::.ctor(class Modules.Events_AsyncHelpers_On_Once/Scope, object[])
 		IL_0052: ldc.i4.0
 		IL_0053: conv.r8
 		IL_0054: ldstr "runOnErrorReject"
 		IL_0059: ldc.i4.0
 		IL_005a: ldc.i4.1
-		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject>(!!0, float64, string, bool, bool)
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject>(!!0)
+		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject>(!!0)
 		IL_0065: stloc.2
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -2645,14 +2645,14 @@
 		IL_0075: ldelem.ref
 		IL_0076: castclass Modules.Events_AsyncHelpers_On_Once/Scope
 		IL_007b: ldloc.s 5
-		IL_007d: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::.ctor(class Modules.Events_AsyncHelpers_On_Once/Scope, object[])
+		IL_007d: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject::.ctor(class Modules.Events_AsyncHelpers_On_Once/Scope, object[])
 		IL_0082: ldc.i4.0
 		IL_0083: conv.r8
 		IL_0084: ldstr "runOnceResolve"
 		IL_0089: ldc.i4.0
 		IL_008a: ldc.i4.1
-		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve>(!!0, float64, string, bool, bool)
-		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve>(!!0)
+		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject>(!!0)
 		IL_0095: stloc.3
 		IL_0096: ldc.i4.1
 		IL_0097: newarr [System.Runtime]System.Object
@@ -2666,14 +2666,14 @@
 		IL_00a5: ldelem.ref
 		IL_00a6: castclass Modules.Events_AsyncHelpers_On_Once/Scope
 		IL_00ab: ldloc.s 5
-		IL_00ad: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::.ctor(class Modules.Events_AsyncHelpers_On_Once/Scope, object[])
+		IL_00ad: newobj instance void Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject::.ctor(class Modules.Events_AsyncHelpers_On_Once/Scope, object[])
 		IL_00b2: ldc.i4.0
 		IL_00b3: conv.r8
 		IL_00b4: ldstr "runOnceReject"
 		IL_00b9: ldc.i4.0
 		IL_00ba: ldc.i4.1
-		IL_00bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject_FunctionDeclaration_D30260CA_runOnceReject>(!!0, float64, string, bool, bool)
-		IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject_FunctionDeclaration_D30260CA_runOnceReject>(!!0)
+		IL_00bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject>(!!0)
 		IL_00c5: stloc.s 4
 		IL_00c7: nop
 		IL_00c8: ldarg.1

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_Callback_Identity_And_Function_Objects.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_Callback_Identity_And_Function_Objects.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E69118AE_listener
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/listener/FunctionObject_FunctionDeclaration_E69118AE_listener::_environment0_Events_Callback_Identity_And_Function_Objects
+				IL_0008: stfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/listener/FunctionObject::_environment0_Events_Callback_Identity_And_Function_Objects
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E69118AE_listener::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E69118AE_listener::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E69118AE_listener::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/listener/FunctionObject_FunctionDeclaration_E69118AE_listener::_environment0_Events_Callback_Identity_And_Function_Objects
+				IL_0001: ldfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/listener/FunctionObject::_environment0_Events_Callback_Identity_And_Function_Objects
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Events_Callback_Identity_And_Function_Objects/listener::__js_call__(class Modules.Events_Callback_Identity_And_Function_Objects/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_E69118AE_listener::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/listener/FunctionObject_FunctionDeclaration_E69118AE_listener::_environment0_Events_Callback_Identity_And_Function_Objects
+				IL_0001: ldfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/listener/FunctionObject::_environment0_Events_Callback_Identity_And_Function_Objects
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Events_Callback_Identity_And_Function_Objects/listener::__js_call__(class Modules.Events_Callback_Identity_And_Function_Objects/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_E69118AE_listener::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E69118AE_listener::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E69118AE_listener
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -198,7 +198,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A21CC4DC_rawListener
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -218,9 +218,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/rawListener/FunctionObject_FunctionDeclaration_A21CC4DC_rawListener::_environment0_Events_Callback_Identity_And_Function_Objects
+				IL_0008: stfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/rawListener/FunctionObject::_environment0_Events_Callback_Identity_And_Function_Objects
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A21CC4DC_rawListener::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -231,7 +231,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A21CC4DC_rawListener::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -242,7 +242,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A21CC4DC_rawListener::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -255,14 +255,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/rawListener/FunctionObject_FunctionDeclaration_A21CC4DC_rawListener::_environment0_Events_Callback_Identity_And_Function_Objects
+				IL_0001: ldfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/rawListener/FunctionObject::_environment0_Events_Callback_Identity_And_Function_Objects
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Events_Callback_Identity_And_Function_Objects/rawListener::__js_call__(class Modules.Events_Callback_Identity_And_Function_Objects/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_A21CC4DC_rawListener::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -276,14 +276,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/rawListener/FunctionObject_FunctionDeclaration_A21CC4DC_rawListener::_environment0_Events_Callback_Identity_And_Function_Objects
+				IL_0001: ldfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/rawListener/FunctionObject::_environment0_Events_Callback_Identity_And_Function_Objects
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Events_Callback_Identity_And_Function_Objects/rawListener::__js_call__(class Modules.Events_Callback_Identity_And_Function_Objects/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_A21CC4DC_rawListener::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -301,9 +301,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A21CC4DC_rawListener::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A21CC4DC_rawListener
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -376,7 +376,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -396,9 +396,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener/FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener::_environment0_Events_Callback_Identity_And_Function_Objects
+				IL_0008: stfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener/FunctionObject::_environment0_Events_Callback_Identity_And_Function_Objects
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -409,7 +409,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -420,7 +420,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -433,11 +433,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener/FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener::_environment0_Events_Callback_Identity_And_Function_Objects
+				IL_0001: ldfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener/FunctionObject::_environment0_Events_Callback_Identity_And_Function_Objects
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener::__js_call__(class Modules.Events_Callback_Identity_And_Function_Objects/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -451,11 +451,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener/FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener::_environment0_Events_Callback_Identity_And_Function_Objects
+				IL_0001: ldfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener/FunctionObject::_environment0_Events_Callback_Identity_And_Function_Objects
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener::__js_call__(class Modules.Events_Callback_Identity_And_Function_Objects/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -473,9 +473,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -537,7 +537,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_946B536A_asyncListener
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -559,12 +559,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject_FunctionDeclaration_946B536A_asyncListener::_environment0_Events_Callback_Identity_And_Function_Objects
+				IL_0008: stfld class Modules.Events_Callback_Identity_And_Function_Objects/Scope Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject::_environment0_Events_Callback_Identity_And_Function_Objects
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject_FunctionDeclaration_946B536A_asyncListener::_transitionalScopes
+				IL_000f: stfld object[] Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_946B536A_asyncListener::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -575,7 +575,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_946B536A_asyncListener::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -586,7 +586,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_946B536A_asyncListener::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -599,7 +599,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject_FunctionDeclaration_946B536A_asyncListener::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -607,9 +607,9 @@
 				IL_0012: call object Modules.Events_Callback_Identity_And_Function_Objects/asyncListener::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_946B536A_asyncListener::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_946B536A_asyncListener
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -684,7 +684,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_990D8A6F_generatorListener
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -704,9 +704,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject_FunctionDeclaration_990D8A6F_generatorListener::_transitionalScopes
+				IL_0008: stfld object[] Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_990D8A6F_generatorListener::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -717,7 +717,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_990D8A6F_generatorListener::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -728,7 +728,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_990D8A6F_generatorListener::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -741,7 +741,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject_FunctionDeclaration_990D8A6F_generatorListener::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -750,9 +750,9 @@
 				IL_0017: ldarg.0
 				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_990D8A6F_generatorListener::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_990D8A6F_generatorListener
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -794,7 +794,7 @@
 			IL_001f: ldftn object Modules.Events_Callback_Identity_And_Function_Objects/generatorListener::__js_call__(object[], object, object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject_FunctionDeclaration_990D8A6F_generatorListener
+			IL_002b: ldtoken Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.1
 			IL_0036: newarr [System.Runtime]System.Object
@@ -988,11 +988,11 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_Callback_Identity_And_Function_Objects/Scope,
-			[1] class Modules.Events_Callback_Identity_And_Function_Objects/listener/FunctionObject_FunctionDeclaration_E69118AE_listener,
-			[2] class Modules.Events_Callback_Identity_And_Function_Objects/rawListener/FunctionObject_FunctionDeclaration_A21CC4DC_rawListener,
-			[3] class Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener/FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener,
-			[4] class Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject_FunctionDeclaration_946B536A_asyncListener,
-			[5] class Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject_FunctionDeclaration_990D8A6F_generatorListener,
+			[1] class Modules.Events_Callback_Identity_And_Function_Objects/listener/FunctionObject,
+			[2] class Modules.Events_Callback_Identity_And_Function_Objects/rawListener/FunctionObject,
+			[3] class Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener/FunctionObject,
+			[4] class Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject,
+			[5] class Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject,
 			[6] object,
 			[7] object,
 			[8] object,
@@ -1026,13 +1026,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Events_Callback_Identity_And_Function_Objects/Scope
-		IL_001b: newobj instance void Modules.Events_Callback_Identity_And_Function_Objects/listener/FunctionObject_FunctionDeclaration_E69118AE_listener::.ctor(class Modules.Events_Callback_Identity_And_Function_Objects/Scope)
+		IL_001b: newobj instance void Modules.Events_Callback_Identity_And_Function_Objects/listener/FunctionObject::.ctor(class Modules.Events_Callback_Identity_And_Function_Objects/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "listener"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_Callback_Identity_And_Function_Objects/listener/FunctionObject_FunctionDeclaration_E69118AE_listener>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_Callback_Identity_And_Function_Objects/listener/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: ldc.i4.1
 		IL_0030: newarr [System.Runtime]System.Object
@@ -1045,13 +1045,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.Events_Callback_Identity_And_Function_Objects/Scope
-		IL_0044: newobj instance void Modules.Events_Callback_Identity_And_Function_Objects/rawListener/FunctionObject_FunctionDeclaration_A21CC4DC_rawListener::.ctor(class Modules.Events_Callback_Identity_And_Function_Objects/Scope)
+		IL_0044: newobj instance void Modules.Events_Callback_Identity_And_Function_Objects/rawListener/FunctionObject::.ctor(class Modules.Events_Callback_Identity_And_Function_Objects/Scope)
 		IL_0049: ldc.i4.1
 		IL_004a: conv.r8
 		IL_004b: ldstr "rawListener"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_Callback_Identity_And_Function_Objects/rawListener/FunctionObject_FunctionDeclaration_A21CC4DC_rawListener>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_Callback_Identity_And_Function_Objects/rawListener/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.2
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object
@@ -1064,13 +1064,13 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.Events_Callback_Identity_And_Function_Objects/Scope
-		IL_006d: newobj instance void Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener/FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener::.ctor(class Modules.Events_Callback_Identity_And_Function_Objects/Scope)
+		IL_006d: newobj instance void Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener/FunctionObject::.ctor(class Modules.Events_Callback_Identity_And_Function_Objects/Scope)
 		IL_0072: ldc.i4.0
 		IL_0073: conv.r8
 		IL_0074: ldstr "duplicateOnceListener"
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener/FunctionObject_FunctionDeclaration_51C1C16A_duplicateOnceListener>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_Callback_Identity_And_Function_Objects/duplicateOnceListener/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.3
 		IL_0081: ldc.i4.1
 		IL_0082: newarr [System.Runtime]System.Object
@@ -1084,14 +1084,14 @@
 		IL_0090: ldelem.ref
 		IL_0091: castclass Modules.Events_Callback_Identity_And_Function_Objects/Scope
 		IL_0096: ldloc.s 13
-		IL_0098: newobj instance void Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject_FunctionDeclaration_946B536A_asyncListener::.ctor(class Modules.Events_Callback_Identity_And_Function_Objects/Scope, object[])
+		IL_0098: newobj instance void Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject::.ctor(class Modules.Events_Callback_Identity_And_Function_Objects/Scope, object[])
 		IL_009d: ldc.i4.1
 		IL_009e: conv.r8
 		IL_009f: ldstr "asyncListener"
 		IL_00a4: ldc.i4.0
 		IL_00a5: ldc.i4.1
-		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject_FunctionDeclaration_946B536A_asyncListener>(!!0, float64, string, bool, bool)
-		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject_FunctionDeclaration_946B536A_asyncListener>(!!0)
+		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Events_Callback_Identity_And_Function_Objects/asyncListener/FunctionObject>(!!0)
 		IL_00b0: stloc.s 4
 		IL_00b2: ldc.i4.1
 		IL_00b3: newarr [System.Runtime]System.Object
@@ -1101,15 +1101,15 @@
 		IL_00bb: stelem.ref
 		IL_00bc: stloc.s 13
 		IL_00be: ldloc.s 13
-		IL_00c0: newobj instance void Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject_FunctionDeclaration_990D8A6F_generatorListener::.ctor(object[])
+		IL_00c0: newobj instance void Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject::.ctor(object[])
 		IL_00c5: ldc.i4.1
 		IL_00c6: conv.r8
 		IL_00c7: ldstr "generatorListener"
 		IL_00cc: ldc.i4.1
 		IL_00cd: ldc.i4.1
-		IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject_FunctionDeclaration_990D8A6F_generatorListener>(!!0, float64, string, bool, bool)
+		IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d3: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_00d8: castclass Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject_FunctionDeclaration_990D8A6F_generatorListener
+		IL_00d8: castclass Modules.Events_Callback_Identity_And_Function_Objects/generatorListener/FunctionObject
 		IL_00dd: stloc.s 5
 		IL_00df: nop
 		IL_00e0: ldarg.1

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Complete.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Complete.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AAE3580A_L9C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_AAE3580A_L9C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -162,7 +162,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8B3472AC_L10C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -176,7 +176,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -187,7 +187,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -198,7 +198,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -213,7 +213,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -229,7 +229,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -247,9 +247,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_8B3472AC_L10C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -294,7 +294,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B4812E11_listener1
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -308,7 +308,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -319,7 +319,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -330,7 +330,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -345,7 +345,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Events_EventEmitter_Complete/listener1::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -361,7 +361,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Events_EventEmitter_Complete/listener1::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -379,9 +379,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B4812E11_listener1
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -426,7 +426,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B1812958_listener2
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -440,7 +440,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -451,7 +451,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -462,7 +462,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -477,7 +477,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Events_EventEmitter_Complete/listener2::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -493,7 +493,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Events_EventEmitter_Complete/listener2::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -511,9 +511,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B1812958_listener2
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -558,7 +558,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A32A464C_L27C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -578,9 +578,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject_FunctionExpression_A32A464C_L27C22::_environment0_Events_EventEmitter_Complete
+				IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject::_environment0_Events_EventEmitter_Complete
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -591,7 +591,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -602,7 +602,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -615,11 +615,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject_FunctionExpression_A32A464C_L27C22::_environment0_Events_EventEmitter_Complete
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject::_environment0_Events_EventEmitter_Complete
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -633,11 +633,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject_FunctionExpression_A32A464C_L27C22::_environment0_Events_EventEmitter_Complete
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject::_environment0_Events_EventEmitter_Complete
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -655,9 +655,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A32A464C_L27C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -719,7 +719,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_12958C6C_L30C35
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -739,9 +739,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject_FunctionExpression_12958C6C_L30C35::_environment0_Events_EventEmitter_Complete
+				IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject::_environment0_Events_EventEmitter_Complete
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -752,7 +752,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -763,7 +763,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -776,11 +776,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject_FunctionExpression_12958C6C_L30C35::_environment0_Events_EventEmitter_Complete
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject::_environment0_Events_EventEmitter_Complete
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -794,11 +794,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject_FunctionExpression_12958C6C_L30C35::_environment0_Events_EventEmitter_Complete
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject::_environment0_Events_EventEmitter_Complete
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -816,9 +816,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_12958C6C_L30C35
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -880,7 +880,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_906D07E0_L39C21
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -900,9 +900,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject_FunctionExpression_906D07E0_L39C21::_environment0_Events_EventEmitter_Complete
+				IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject::_environment0_Events_EventEmitter_Complete
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -913,7 +913,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -924,7 +924,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -937,11 +937,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject_FunctionExpression_906D07E0_L39C21::_environment0_Events_EventEmitter_Complete
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject::_environment0_Events_EventEmitter_Complete
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -955,11 +955,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject_FunctionExpression_906D07E0_L39C21::_environment0_Events_EventEmitter_Complete
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject::_environment0_Events_EventEmitter_Complete
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -977,9 +977,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_906D07E0_L39C21
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1041,7 +1041,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_662FFF80_L42C38
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1061,9 +1061,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject_FunctionExpression_662FFF80_L42C38::_environment0_Events_EventEmitter_Complete
+				IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject::_environment0_Events_EventEmitter_Complete
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1074,7 +1074,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1085,7 +1085,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1098,11 +1098,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject_FunctionExpression_662FFF80_L42C38::_environment0_Events_EventEmitter_Complete
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject::_environment0_Events_EventEmitter_Complete
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1116,11 +1116,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject_FunctionExpression_662FFF80_L42C38::_environment0_Events_EventEmitter_Complete
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject::_environment0_Events_EventEmitter_Complete
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1138,9 +1138,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_662FFF80_L42C38
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1202,7 +1202,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EFF25745_L60C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1216,7 +1216,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1227,7 +1227,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1238,7 +1238,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1253,7 +1253,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1269,7 +1269,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1287,9 +1287,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_EFF25745_L60C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1334,7 +1334,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_00D9E772_L61C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1348,7 +1348,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1359,7 +1359,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1370,7 +1370,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1385,7 +1385,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1401,7 +1401,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1419,9 +1419,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_00D9E772_L61C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1466,7 +1466,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_36454590_L68C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1480,7 +1480,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_36454590_L68C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1491,7 +1491,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_36454590_L68C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1502,7 +1502,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_36454590_L68C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1517,7 +1517,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_result::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_36454590_L68C12::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1533,7 +1533,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_result::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_36454590_L68C12::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1551,9 +1551,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_36454590_L68C12::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_36454590_L68C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1598,7 +1598,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_504662DB_L69C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1612,7 +1612,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1623,7 +1623,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1634,7 +1634,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1649,7 +1649,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1665,7 +1665,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1683,9 +1683,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_504662DB_L69C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1730,7 +1730,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D817B431_L78C21
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1744,7 +1744,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1755,7 +1755,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1766,7 +1766,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1781,7 +1781,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1797,7 +1797,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1815,9 +1815,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D817B431_L78C21
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1889,8 +1889,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_Complete/Scope,
-			[1] class Modules.Events_EventEmitter_Complete/listener1/FunctionObject_FunctionDeclaration_B4812E11_listener1,
-			[2] class Modules.Events_EventEmitter_Complete/listener2/FunctionObject_FunctionDeclaration_B1812958_listener2,
+			[1] class Modules.Events_EventEmitter_Complete/listener1/FunctionObject,
+			[2] class Modules.Events_EventEmitter_Complete/listener2/FunctionObject,
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule,
 			[4] object,
 			[5] object,
@@ -1910,19 +1910,19 @@
 			[19] object[],
 			[20] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[21] object,
-			[22] class Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19/FunctionObject_FunctionExpression_AAE3580A_L9C20,
-			[23] class Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19/FunctionObject_FunctionExpression_8B3472AC_L10C20,
-			[24] class Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject_FunctionExpression_A32A464C_L27C22,
-			[25] class Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject_FunctionExpression_12958C6C_L30C35,
-			[26] class Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject_FunctionExpression_906D07E0_L39C21,
-			[27] class Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject_FunctionExpression_662FFF80_L42C38,
-			[28] class Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject_FunctionExpression_EFF25745_L60C20,
-			[29] class Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject_FunctionExpression_00D9E772_L61C22,
-			[30] class Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject_FunctionExpression_36454590_L68C12,
-			[31] class Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject_FunctionExpression_504662DB_L69C25,
+			[22] class Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19/FunctionObject,
+			[23] class Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19/FunctionObject,
+			[24] class Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject,
+			[25] class Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject,
+			[26] class Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject,
+			[27] class Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject,
+			[28] class Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject,
+			[29] class Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject,
+			[30] class Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject,
+			[31] class Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject,
 			[32] bool,
 			[33] object,
-			[34] class Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject_FunctionExpression_D817B431_L78C21
+			[34] class Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Events_EventEmitter_Complete/Scope::.ctor()
@@ -1934,13 +1934,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 19
-		IL_0012: newobj instance void Modules.Events_EventEmitter_Complete/listener1/FunctionObject_FunctionDeclaration_B4812E11_listener1::.ctor()
+		IL_0012: newobj instance void Modules.Events_EventEmitter_Complete/listener1/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "listener1"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/listener1/FunctionObject_FunctionDeclaration_B4812E11_listener1>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/listener1/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1949,13 +1949,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 19
-		IL_0032: newobj instance void Modules.Events_EventEmitter_Complete/listener2/FunctionObject_FunctionDeclaration_B1812958_listener2::.ctor()
+		IL_0032: newobj instance void Modules.Events_EventEmitter_Complete/listener2/FunctionObject::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "listener2"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/listener2/FunctionObject_FunctionDeclaration_B1812958_listener2>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/listener2/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: nop
 		IL_0047: ldarg.1
@@ -1994,13 +1994,13 @@
 		IL_00a8: ldloc.0
 		IL_00a9: stelem.ref
 		IL_00aa: stloc.s 19
-		IL_00ac: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19/FunctionObject_FunctionExpression_AAE3580A_L9C20::.ctor()
+		IL_00ac: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19/FunctionObject::.ctor()
 		IL_00b1: ldc.i4.0
 		IL_00b2: conv.r8
 		IL_00b3: ldstr ""
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldc.i4.1
-		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19/FunctionObject_FunctionExpression_AAE3580A_L9C20>(!!0, float64, string, bool, bool)
+		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00bf: stloc.s 22
 		IL_00c1: ldloc.s 21
 		IL_00c3: ldstr "on"
@@ -2018,13 +2018,13 @@
 		IL_00e6: ldloc.0
 		IL_00e7: stelem.ref
 		IL_00e8: stloc.s 19
-		IL_00ea: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19/FunctionObject_FunctionExpression_8B3472AC_L10C20::.ctor()
+		IL_00ea: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19/FunctionObject::.ctor()
 		IL_00ef: ldc.i4.0
 		IL_00f0: conv.r8
 		IL_00f1: ldstr ""
 		IL_00f6: ldc.i4.0
 		IL_00f7: ldc.i4.1
-		IL_00f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19/FunctionObject_FunctionExpression_8B3472AC_L10C20>(!!0, float64, string, bool, bool)
+		IL_00f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00fd: stloc.s 23
 		IL_00ff: ldloc.s 21
 		IL_0101: ldstr "on"
@@ -2120,13 +2120,13 @@
 		IL_021b: ldc.i4.0
 		IL_021c: ldelem.ref
 		IL_021d: castclass Modules.Events_EventEmitter_Complete/Scope
-		IL_0222: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject_FunctionExpression_A32A464C_L27C22::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
+		IL_0222: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
 		IL_0227: ldc.i4.0
 		IL_0228: conv.r8
 		IL_0229: ldstr ""
 		IL_022e: ldc.i4.0
 		IL_022f: ldc.i4.1
-		IL_0230: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject_FunctionExpression_A32A464C_L27C22>(!!0, float64, string, bool, bool)
+		IL_0230: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0235: stloc.s 24
 		IL_0237: ldloc.s 21
 		IL_0239: ldstr "on"
@@ -2148,13 +2148,13 @@
 		IL_0262: ldc.i4.0
 		IL_0263: ldelem.ref
 		IL_0264: castclass Modules.Events_EventEmitter_Complete/Scope
-		IL_0269: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject_FunctionExpression_12958C6C_L30C35::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
+		IL_0269: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
 		IL_026e: ldc.i4.0
 		IL_026f: conv.r8
 		IL_0270: ldstr ""
 		IL_0275: ldc.i4.0
 		IL_0276: ldc.i4.1
-		IL_0277: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject_FunctionExpression_12958C6C_L30C35>(!!0, float64, string, bool, bool)
+		IL_0277: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_027c: stloc.s 25
 		IL_027e: ldloc.s 21
 		IL_0280: ldstr "prependListener"
@@ -2198,13 +2198,13 @@
 		IL_02ee: ldc.i4.0
 		IL_02ef: ldelem.ref
 		IL_02f0: castclass Modules.Events_EventEmitter_Complete/Scope
-		IL_02f5: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject_FunctionExpression_906D07E0_L39C21::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
+		IL_02f5: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
 		IL_02fa: ldc.i4.0
 		IL_02fb: conv.r8
 		IL_02fc: ldstr ""
 		IL_0301: ldc.i4.0
 		IL_0302: ldc.i4.1
-		IL_0303: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject_FunctionExpression_906D07E0_L39C21>(!!0, float64, string, bool, bool)
+		IL_0303: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0308: stloc.s 26
 		IL_030a: ldloc.s 21
 		IL_030c: ldstr "on"
@@ -2226,13 +2226,13 @@
 		IL_0335: ldc.i4.0
 		IL_0336: ldelem.ref
 		IL_0337: castclass Modules.Events_EventEmitter_Complete/Scope
-		IL_033c: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject_FunctionExpression_662FFF80_L42C38::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
+		IL_033c: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
 		IL_0341: ldc.i4.0
 		IL_0342: conv.r8
 		IL_0343: ldstr ""
 		IL_0348: ldc.i4.0
 		IL_0349: ldc.i4.1
-		IL_034a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject_FunctionExpression_662FFF80_L42C38>(!!0, float64, string, bool, bool)
+		IL_034a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_034f: stloc.s 27
 		IL_0351: ldloc.s 21
 		IL_0353: ldstr "prependOnceListener"
@@ -2335,13 +2335,13 @@
 		IL_0496: ldloc.0
 		IL_0497: stelem.ref
 		IL_0498: stloc.s 19
-		IL_049a: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject_FunctionExpression_EFF25745_L60C20::.ctor()
+		IL_049a: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject::.ctor()
 		IL_049f: ldc.i4.0
 		IL_04a0: conv.r8
 		IL_04a1: ldstr ""
 		IL_04a6: ldc.i4.0
 		IL_04a7: ldc.i4.1
-		IL_04a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject_FunctionExpression_EFF25745_L60C20>(!!0, float64, string, bool, bool)
+		IL_04a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_04ad: stloc.s 28
 		IL_04af: ldloc.s 21
 		IL_04b1: ldstr "on"
@@ -2359,13 +2359,13 @@
 		IL_04d4: ldloc.0
 		IL_04d5: stelem.ref
 		IL_04d6: stloc.s 19
-		IL_04d8: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject_FunctionExpression_00D9E772_L61C22::.ctor()
+		IL_04d8: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject::.ctor()
 		IL_04dd: ldc.i4.0
 		IL_04de: conv.r8
 		IL_04df: ldstr ""
 		IL_04e4: ldc.i4.0
 		IL_04e5: ldc.i4.1
-		IL_04e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject_FunctionExpression_00D9E772_L61C22>(!!0, float64, string, bool, bool)
+		IL_04e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_04eb: stloc.s 29
 		IL_04ed: ldloc.s 21
 		IL_04ef: ldstr "once"
@@ -2403,13 +2403,13 @@
 		IL_0553: ldloc.0
 		IL_0554: stelem.ref
 		IL_0555: stloc.s 19
-		IL_0557: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject_FunctionExpression_36454590_L68C12::.ctor()
+		IL_0557: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject::.ctor()
 		IL_055c: ldc.i4.0
 		IL_055d: conv.r8
 		IL_055e: ldstr ""
 		IL_0563: ldc.i4.0
 		IL_0564: ldc.i4.1
-		IL_0565: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject_FunctionExpression_36454590_L68C12>(!!0, float64, string, bool, bool)
+		IL_0565: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_056a: stloc.s 30
 		IL_056c: ldloc.s 21
 		IL_056e: ldstr "on"
@@ -2427,13 +2427,13 @@
 		IL_0592: ldloc.0
 		IL_0593: stelem.ref
 		IL_0594: stloc.s 19
-		IL_0596: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject_FunctionExpression_504662DB_L69C25::.ctor()
+		IL_0596: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject::.ctor()
 		IL_059b: ldc.i4.0
 		IL_059c: conv.r8
 		IL_059d: ldstr ""
 		IL_05a2: ldc.i4.0
 		IL_05a3: ldc.i4.1
-		IL_05a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject_FunctionExpression_504662DB_L69C25>(!!0, float64, string, bool, bool)
+		IL_05a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_05a9: stloc.s 31
 		IL_05ab: ldloc.s 21
 		IL_05ad: ldstr "prependListener"
@@ -2506,13 +2506,13 @@
 		IL_068a: ldloc.0
 		IL_068b: stelem.ref
 		IL_068c: stloc.s 19
-		IL_068e: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject_FunctionExpression_D817B431_L78C21::.ctor()
+		IL_068e: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject::.ctor()
 		IL_0693: ldc.i4.0
 		IL_0694: conv.r8
 		IL_0695: ldstr ""
 		IL_069a: ldc.i4.0
 		IL_069b: ldc.i4.1
-		IL_069c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject_FunctionExpression_D817B431_L78C21>(!!0, float64, string, bool, bool)
+		IL_069c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_06a1: stloc.s 34
 		IL_06a3: ldloc.s 21
 		IL_06a5: ldstr "on"

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Emit_Args.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Emit_Args.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0BA33AEA_L10C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject_FunctionExpression_0BA33AEA_L10C19::_environment0_Events_EventEmitter_Emit_Args
+				IL_0008: stfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject::_environment0_Events_EventEmitter_Emit_Args
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject_FunctionExpression_0BA33AEA_L10C19::_environment0_Events_EventEmitter_Emit_Args
+				IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject::_environment0_Events_EventEmitter_Emit_Args
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -97,7 +97,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18::__js_call__(class Modules.Events_EventEmitter_Emit_Args/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -111,7 +111,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject_FunctionExpression_0BA33AEA_L10C19::_environment0_Events_EventEmitter_Emit_Args
+				IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject::_environment0_Events_EventEmitter_Emit_Args
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -121,7 +121,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18::__js_call__(class Modules.Events_EventEmitter_Emit_Args/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -139,9 +139,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_0BA33AEA_L10C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -201,7 +201,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9BAF52F7_L14C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -221,9 +221,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject_FunctionExpression_9BAF52F7_L14C23::_environment0_Events_EventEmitter_Emit_Args
+				IL_0008: stfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject::_environment0_Events_EventEmitter_Emit_Args
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -234,7 +234,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -245,7 +245,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -258,7 +258,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject_FunctionExpression_9BAF52F7_L14C23::_environment0_Events_EventEmitter_Emit_Args
+				IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject::_environment0_Events_EventEmitter_Emit_Args
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -271,7 +271,7 @@
 				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0020: call object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22::__js_call__(class Modules.Events_EventEmitter_Emit_Args/Scope, object, object, object, object)
 				IL_0025: ret
-			} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -285,7 +285,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject_FunctionExpression_9BAF52F7_L14C23::_environment0_Events_EventEmitter_Emit_Args
+				IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject::_environment0_Events_EventEmitter_Emit_Args
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -298,7 +298,7 @@
 				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001c: call object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22::__js_call__(class Modules.Events_EventEmitter_Emit_Args/Scope, object, object, object, object)
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -316,9 +316,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_9BAF52F7_L14C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -414,8 +414,8 @@
 			[3] object,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject_FunctionExpression_0BA33AEA_L10C19,
-			[7] class Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject_FunctionExpression_9BAF52F7_L14C23,
+			[6] class Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject,
+			[7] class Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
 
@@ -455,13 +455,13 @@
 		IL_0060: ldc.i4.0
 		IL_0061: ldelem.ref
 		IL_0062: castclass Modules.Events_EventEmitter_Emit_Args/Scope
-		IL_0067: newobj instance void Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject_FunctionExpression_0BA33AEA_L10C19::.ctor(class Modules.Events_EventEmitter_Emit_Args/Scope)
+		IL_0067: newobj instance void Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject::.ctor(class Modules.Events_EventEmitter_Emit_Args/Scope)
 		IL_006c: ldc.i4.2
 		IL_006d: conv.r8
 		IL_006e: ldstr ""
 		IL_0073: ldc.i4.0
 		IL_0074: ldc.i4.1
-		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject_FunctionExpression_0BA33AEA_L10C19>(!!0, float64, string, bool, bool)
+		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007a: stloc.s 6
 		IL_007c: ldloc.s 4
 		IL_007e: ldstr "on"
@@ -483,13 +483,13 @@
 		IL_00a6: ldc.i4.0
 		IL_00a7: ldelem.ref
 		IL_00a8: castclass Modules.Events_EventEmitter_Emit_Args/Scope
-		IL_00ad: newobj instance void Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject_FunctionExpression_9BAF52F7_L14C23::.ctor(class Modules.Events_EventEmitter_Emit_Args/Scope)
+		IL_00ad: newobj instance void Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject::.ctor(class Modules.Events_EventEmitter_Emit_Args/Scope)
 		IL_00b2: ldc.i4.3
 		IL_00b3: conv.r8
 		IL_00b4: ldstr ""
 		IL_00b9: ldc.i4.0
 		IL_00ba: ldc.i4.1
-		IL_00bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject_FunctionExpression_9BAF52F7_L14C23>(!!0, float64, string, bool, bool)
+		IL_00bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c0: stloc.s 7
 		IL_00c2: ldloc.s 4
 		IL_00c4: ldstr "on"

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_ErrorMonitor.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_ErrorMonitor.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DA01CEF5_L7C33
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_DA01CEF5_L7C33
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -188,7 +188,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2AF8E8BC_L10C21
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -202,7 +202,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -213,7 +213,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -224,7 +224,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -242,7 +242,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -261,7 +261,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -279,9 +279,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_2AF8E8BC_L10C21
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -346,7 +346,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A8471C41_L17C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -360,7 +360,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -371,7 +371,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -382,7 +382,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -400,7 +400,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -419,7 +419,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -437,9 +437,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A8471C41_L17C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -562,10 +562,10 @@
 			[9] object,
 			[10] object,
 			[11] object[],
-			[12] class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32/FunctionObject_FunctionExpression_DA01CEF5_L7C33,
-			[13] class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20/FunctionObject_FunctionExpression_2AF8E8BC_L10C21,
+			[12] class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32/FunctionObject,
+			[13] class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20/FunctionObject,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.Error,
-			[15] class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33/FunctionObject_FunctionExpression_A8471C41_L17C34,
+			[15] class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33/FunctionObject,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
 
@@ -596,13 +596,13 @@
 		IL_003a: ldloc.0
 		IL_003b: stelem.ref
 		IL_003c: stloc.s 11
-		IL_003e: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32/FunctionObject_FunctionExpression_DA01CEF5_L7C33::.ctor()
+		IL_003e: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32/FunctionObject::.ctor()
 		IL_0043: ldc.i4.1
 		IL_0044: conv.r8
 		IL_0045: ldstr ""
 		IL_004a: ldc.i4.0
 		IL_004b: ldc.i4.1
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32/FunctionObject_FunctionExpression_DA01CEF5_L7C33>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0051: stloc.s 12
 		IL_0053: ldloc.s 9
 		IL_0055: ldstr "on"
@@ -620,13 +620,13 @@
 		IL_0074: ldloc.0
 		IL_0075: stelem.ref
 		IL_0076: stloc.s 11
-		IL_0078: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20/FunctionObject_FunctionExpression_2AF8E8BC_L10C21::.ctor()
+		IL_0078: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20/FunctionObject::.ctor()
 		IL_007d: ldc.i4.1
 		IL_007e: conv.r8
 		IL_007f: ldstr ""
 		IL_0084: ldc.i4.0
 		IL_0085: ldc.i4.1
-		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20/FunctionObject_FunctionExpression_2AF8E8BC_L10C21>(!!0, float64, string, bool, bool)
+		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_008b: stloc.s 13
 		IL_008d: ldloc.s 10
 		IL_008f: ldstr "on"
@@ -663,13 +663,13 @@
 		IL_00eb: ldloc.0
 		IL_00ec: stelem.ref
 		IL_00ed: stloc.s 11
-		IL_00ef: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33/FunctionObject_FunctionExpression_A8471C41_L17C34::.ctor()
+		IL_00ef: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33/FunctionObject::.ctor()
 		IL_00f4: ldc.i4.1
 		IL_00f5: conv.r8
 		IL_00f6: ldstr ""
 		IL_00fb: ldc.i4.0
 		IL_00fc: ldc.i4.1
-		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33/FunctionObject_FunctionExpression_A8471C41_L17C34>(!!0, float64, string, bool, bool)
+		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0102: stloc.s 15
 		IL_0104: ldloc.s 10
 		IL_0106: ldstr "on"

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_On_Off_Once.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_On_Off_Once.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E40C4F21_onData
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject_FunctionDeclaration_E40C4F21_onData::_environment0_Events_EventEmitter_On_Off_Once
+				IL_0008: stfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject::_environment0_Events_EventEmitter_On_Off_Once
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject_FunctionDeclaration_E40C4F21_onData::_environment0_Events_EventEmitter_On_Off_Once
+				IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject::_environment0_Events_EventEmitter_On_Off_Once
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Events_EventEmitter_On_Off_Once/onData::__js_call__(class Modules.Events_EventEmitter_On_Off_Once/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject_FunctionDeclaration_E40C4F21_onData::_environment0_Events_EventEmitter_On_Off_Once
+				IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject::_environment0_Events_EventEmitter_On_Off_Once
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Events_EventEmitter_On_Off_Once/onData::__js_call__(class Modules.Events_EventEmitter_On_Off_Once/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E40C4F21_onData
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -191,7 +191,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BB5FB80E_L23C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -211,9 +211,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject_FunctionExpression_BB5FB80E_L23C22::_environment0_Events_EventEmitter_On_Off_Once
+				IL_0008: stfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject::_environment0_Events_EventEmitter_On_Off_Once
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -224,7 +224,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -235,7 +235,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -248,11 +248,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject_FunctionExpression_BB5FB80E_L23C22::_environment0_Events_EventEmitter_On_Off_Once
+				IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject::_environment0_Events_EventEmitter_On_Off_Once
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21::__js_call__(class Modules.Events_EventEmitter_On_Off_Once/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -266,11 +266,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject_FunctionExpression_BB5FB80E_L23C22::_environment0_Events_EventEmitter_On_Off_Once
+				IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject::_environment0_Events_EventEmitter_On_Off_Once
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21::__js_call__(class Modules.Events_EventEmitter_On_Off_Once/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -288,9 +288,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_BB5FB80E_L23C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -352,7 +352,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E84513BE_L31C21
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -366,7 +366,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -377,7 +377,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -388,7 +388,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -403,7 +403,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -419,7 +419,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -437,9 +437,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E84513BE_L31C21
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -484,7 +484,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D268090E_L32C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -498,7 +498,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -509,7 +509,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -520,7 +520,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -535,7 +535,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -551,7 +551,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -569,9 +569,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D268090E_L32C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -639,16 +639,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_On_Off_Once/Scope,
-			[1] class Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject_FunctionDeclaration_E40C4F21_onData,
+			[1] class Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject,
 			[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule,
 			[3] object,
 			[4] object,
 			[5] object[],
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[7] object,
-			[8] class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject_FunctionExpression_BB5FB80E_L23C22,
-			[9] class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject_FunctionExpression_E84513BE_L31C21,
-			[10] class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject_FunctionExpression_D268090E_L32C20
+			[8] class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject,
+			[9] class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject,
+			[10] class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Events_EventEmitter_On_Off_Once/Scope::.ctor()
@@ -664,13 +664,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Events_EventEmitter_On_Off_Once/Scope
-		IL_001b: newobj instance void Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject_FunctionDeclaration_E40C4F21_onData::.ctor(class Modules.Events_EventEmitter_On_Off_Once/Scope)
+		IL_001b: newobj instance void Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject::.ctor(class Modules.Events_EventEmitter_On_Off_Once/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "onData"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject_FunctionDeclaration_E40C4F21_onData>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: ldarg.1
@@ -787,13 +787,13 @@
 		IL_0192: ldc.i4.0
 		IL_0193: ldelem.ref
 		IL_0194: castclass Modules.Events_EventEmitter_On_Off_Once/Scope
-		IL_0199: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject_FunctionExpression_BB5FB80E_L23C22::.ctor(class Modules.Events_EventEmitter_On_Off_Once/Scope)
+		IL_0199: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject::.ctor(class Modules.Events_EventEmitter_On_Off_Once/Scope)
 		IL_019e: ldc.i4.0
 		IL_019f: conv.r8
 		IL_01a0: ldstr ""
 		IL_01a5: ldc.i4.0
 		IL_01a6: ldc.i4.1
-		IL_01a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject_FunctionExpression_BB5FB80E_L23C22>(!!0, float64, string, bool, bool)
+		IL_01a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01ac: stloc.s 8
 		IL_01ae: ldloc.s 7
 		IL_01b0: ldstr "once"
@@ -856,13 +856,13 @@
 		IL_0267: ldloc.0
 		IL_0268: stelem.ref
 		IL_0269: stloc.s 5
-		IL_026b: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject_FunctionExpression_E84513BE_L31C21::.ctor()
+		IL_026b: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject::.ctor()
 		IL_0270: ldc.i4.0
 		IL_0271: conv.r8
 		IL_0272: ldstr ""
 		IL_0277: ldc.i4.0
 		IL_0278: ldc.i4.1
-		IL_0279: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject_FunctionExpression_E84513BE_L31C21>(!!0, float64, string, bool, bool)
+		IL_0279: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_027e: stloc.s 9
 		IL_0280: ldloc.s 7
 		IL_0282: ldstr "on"
@@ -880,13 +880,13 @@
 		IL_02a5: ldloc.0
 		IL_02a6: stelem.ref
 		IL_02a7: stloc.s 5
-		IL_02a9: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject_FunctionExpression_D268090E_L32C20::.ctor()
+		IL_02a9: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject::.ctor()
 		IL_02ae: ldc.i4.0
 		IL_02af: conv.r8
 		IL_02b0: ldstr ""
 		IL_02b5: ldc.i4.0
 		IL_02b6: ldc.i4.1
-		IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject_FunctionExpression_D268090E_L32C20>(!!0, float64, string, bool, bool)
+		IL_02b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02bc: stloc.s 10
 		IL_02be: ldloc.s 7
 		IL_02c0: ldstr "on"

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Agent_KeepAlive_Reuses_Connection.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Agent_KeepAlive_Reuses_Connection.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AD8A01FB_L9C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject_FunctionExpression_AD8A01FB_L9C34::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject_FunctionExpression_AD8A01FB_L9C34::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -97,7 +97,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -111,7 +111,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject_FunctionExpression_AD8A01FB_L9C34::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -121,7 +121,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -139,9 +139,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_AD8A01FB_L9C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -228,7 +228,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2B9E525E_L15C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -248,9 +248,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject_FunctionExpression_2B9E525E_L15C25::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -261,7 +261,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -272,7 +272,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -285,11 +285,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject_FunctionExpression_2B9E525E_L15C25::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -303,11 +303,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject_FunctionExpression_2B9E525E_L15C25::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -325,9 +325,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_2B9E525E_L15C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -397,7 +397,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_83707BD8_L34C22
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -423,18 +423,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+						IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::_environment1_FunctionExpression_L19C30
+						IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject::_environment1_FunctionExpression_L19C30
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::_environment2_FunctionExpression_L29C4
+						IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject::_environment2_FunctionExpression_L29C4
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::_transitionalScopes
+						IL_001e: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -445,7 +445,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -456,7 +456,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -469,14 +469,14 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: ldarg.2
 						IL_000c: ldc.i4.0
 						IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 						IL_0012: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21::__js_call__(object[], object, object)
 						IL_0017: ret
-					} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -490,14 +490,14 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: ldarg.2
 						IL_0008: ldc.i4.0
 						IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 						IL_000e: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21::__js_call__(object[], object, object)
 						IL_0013: ret
-					} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -515,9 +515,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_83707BD8_L34C22
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -592,7 +592,7 @@
 
 						} // end of class Scope
 
-						.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_609C8B8A_L53C32
+						.class nested public auto ansi sealed beforefieldinit FunctionObject
 							extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 						{
 							// Fields
@@ -620,21 +620,21 @@
 								IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 								IL_0006: ldarg.0
 								IL_0007: ldarg.1
-								IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+								IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 								IL_000d: ldarg.0
 								IL_000e: ldarg.2
-								IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_environment1_FunctionExpression_L19C30
+								IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject::_environment1_FunctionExpression_L19C30
 								IL_0014: ldarg.0
 								IL_0015: ldarg.3
-								IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_environment2_FunctionExpression_L29C4
+								IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject::_environment2_FunctionExpression_L29C4
 								IL_001b: ldarg.0
 								IL_001c: ldarg.s capture3
-								IL_001e: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_environment4_FunctionExpression_L48C10
+								IL_001e: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject::_environment4_FunctionExpression_L48C10
 								IL_0023: ldarg.0
 								IL_0024: ldarg.s capture4
-								IL_0026: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_transitionalScopes
+								IL_0026: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject::_transitionalScopes
 								IL_002b: ret
-							} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::.ctor
+							} // end of method FunctionObject::.ctor
 
 							.method public hidebysig specialname virtual 
 								instance bool get_IsConstructor () cil managed 
@@ -645,7 +645,7 @@
 
 								IL_0000: ldc.i4.1
 								IL_0001: ret
-							} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::get_IsConstructor
+							} // end of method FunctionObject::get_IsConstructor
 
 							.method public hidebysig specialname virtual 
 								instance bool get_RequiresInvocationContext () cil managed 
@@ -656,7 +656,7 @@
 
 								IL_0000: ldc.i4.0
 								IL_0001: ret
-							} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::get_RequiresInvocationContext
+							} // end of method FunctionObject::get_RequiresInvocationContext
 
 							.method family hidebysig virtual 
 								instance object CallCore (
@@ -669,14 +669,14 @@
 								.maxstack 8
 
 								IL_0000: ldarg.0
-								IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_transitionalScopes
+								IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject::_transitionalScopes
 								IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 								IL_000b: ldarg.2
 								IL_000c: ldc.i4.0
 								IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 								IL_0012: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31::__js_call__(object[], object, object)
 								IL_0017: ret
-							} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::CallCore
+							} // end of method FunctionObject::CallCore
 
 							.method family hidebysig virtual 
 								instance object ConstructBodyCore (
@@ -690,14 +690,14 @@
 								.maxstack 8
 
 								IL_0000: ldarg.0
-								IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_transitionalScopes
+								IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject::_transitionalScopes
 								IL_0006: ldarg.3
 								IL_0007: ldarg.2
 								IL_0008: ldc.i4.0
 								IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 								IL_000e: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31::__js_call__(object[], object, object)
 								IL_0013: ret
-							} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::ConstructBodyCore
+							} // end of method FunctionObject::ConstructBodyCore
 
 							.method family hidebysig virtual 
 								instance object ConstructCore (
@@ -715,9 +715,9 @@
 								IL_0007: ldarg.2
 								IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 								IL_000d: ret
-							} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::ConstructCore
+							} // end of method FunctionObject::ConstructCore
 
-						} // end of class FunctionObject_FunctionExpression_609C8B8A_L53C32
+						} // end of class FunctionObject
 
 
 						// Methods
@@ -788,7 +788,7 @@
 
 							} // end of class Scope
 
-							.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_71E42388_L61C28
+							.class nested public auto ansi sealed beforefieldinit FunctionObject
 								extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 							{
 								// Methods
@@ -802,7 +802,7 @@
 									IL_0000: ldarg.0
 									IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 									IL_0006: ret
-								} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::.ctor
+								} // end of method FunctionObject::.ctor
 
 								.method public hidebysig specialname virtual 
 									instance bool get_IsConstructor () cil managed 
@@ -813,7 +813,7 @@
 
 									IL_0000: ldc.i4.1
 									IL_0001: ret
-								} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::get_IsConstructor
+								} // end of method FunctionObject::get_IsConstructor
 
 								.method public hidebysig specialname virtual 
 									instance bool get_RequiresInvocationContext () cil managed 
@@ -824,7 +824,7 @@
 
 									IL_0000: ldc.i4.0
 									IL_0001: ret
-								} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::get_RequiresInvocationContext
+								} // end of method FunctionObject::get_RequiresInvocationContext
 
 								.method family hidebysig virtual 
 									instance object CallCore (
@@ -839,7 +839,7 @@
 									IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 									IL_0005: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27::__js_call__(object)
 									IL_000a: ret
-								} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::CallCore
+								} // end of method FunctionObject::CallCore
 
 								.method family hidebysig virtual 
 									instance object ConstructBodyCore (
@@ -855,7 +855,7 @@
 									IL_0000: ldarg.3
 									IL_0001: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27::__js_call__(object)
 									IL_0006: ret
-								} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::ConstructBodyCore
+								} // end of method FunctionObject::ConstructBodyCore
 
 								.method family hidebysig virtual 
 									instance object ConstructCore (
@@ -873,9 +873,9 @@
 									IL_0007: ldarg.2
 									IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 									IL_000d: ret
-								} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::ConstructCore
+								} // end of method FunctionObject::ConstructCore
 
-							} // end of class FunctionObject_FunctionExpression_71E42388_L61C28
+							} // end of class FunctionObject
 
 
 							// Methods
@@ -925,7 +925,7 @@
 
 						} // end of class Scope
 
-						.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CD92AD5B_L57C31
+						.class nested public auto ansi sealed beforefieldinit FunctionObject
 							extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 						{
 							// Fields
@@ -953,21 +953,21 @@
 								IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 								IL_0006: ldarg.0
 								IL_0007: ldarg.1
-								IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+								IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 								IL_000d: ldarg.0
 								IL_000e: ldarg.2
-								IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_environment1_FunctionExpression_L19C30
+								IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject::_environment1_FunctionExpression_L19C30
 								IL_0014: ldarg.0
 								IL_0015: ldarg.3
-								IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_environment2_FunctionExpression_L29C4
+								IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject::_environment2_FunctionExpression_L29C4
 								IL_001b: ldarg.0
 								IL_001c: ldarg.s capture3
-								IL_001e: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_environment4_FunctionExpression_L48C10
+								IL_001e: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject::_environment4_FunctionExpression_L48C10
 								IL_0023: ldarg.0
 								IL_0024: ldarg.s capture4
-								IL_0026: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_transitionalScopes
+								IL_0026: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject::_transitionalScopes
 								IL_002b: ret
-							} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::.ctor
+							} // end of method FunctionObject::.ctor
 
 							.method public hidebysig specialname virtual 
 								instance bool get_IsConstructor () cil managed 
@@ -978,7 +978,7 @@
 
 								IL_0000: ldc.i4.1
 								IL_0001: ret
-							} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::get_IsConstructor
+							} // end of method FunctionObject::get_IsConstructor
 
 							.method public hidebysig specialname virtual 
 								instance bool get_RequiresInvocationContext () cil managed 
@@ -989,7 +989,7 @@
 
 								IL_0000: ldc.i4.0
 								IL_0001: ret
-							} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::get_RequiresInvocationContext
+							} // end of method FunctionObject::get_RequiresInvocationContext
 
 							.method family hidebysig virtual 
 								instance object CallCore (
@@ -1002,11 +1002,11 @@
 								.maxstack 8
 
 								IL_0000: ldarg.0
-								IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_transitionalScopes
+								IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject::_transitionalScopes
 								IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 								IL_000b: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30::__js_call__(object[], object)
 								IL_0010: ret
-							} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::CallCore
+							} // end of method FunctionObject::CallCore
 
 							.method family hidebysig virtual 
 								instance object ConstructBodyCore (
@@ -1020,11 +1020,11 @@
 								.maxstack 8
 
 								IL_0000: ldarg.0
-								IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_transitionalScopes
+								IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject::_transitionalScopes
 								IL_0006: ldarg.3
 								IL_0007: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30::__js_call__(object[], object)
 								IL_000c: ret
-							} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::ConstructBodyCore
+							} // end of method FunctionObject::ConstructBodyCore
 
 							.method family hidebysig virtual 
 								instance object ConstructCore (
@@ -1042,9 +1042,9 @@
 								IL_0007: ldarg.2
 								IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 								IL_000d: ret
-							} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::ConstructCore
+							} // end of method FunctionObject::ConstructCore
 
-						} // end of class FunctionObject_FunctionExpression_CD92AD5B_L57C31
+						} // end of class FunctionObject
 
 
 						// Methods
@@ -1066,7 +1066,7 @@
 								[2] object,
 								[3] object,
 								[4] object[],
-								[5] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27/FunctionObject_FunctionExpression_71E42388_L61C28
+								[5] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27/FunctionObject
 							)
 
 							IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/Scope::.ctor()
@@ -1128,13 +1128,13 @@
 							IL_0090: ldelem.ref
 							IL_0091: stelem.ref
 							IL_0092: stloc.s 4
-							IL_0094: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27/FunctionObject_FunctionExpression_71E42388_L61C28::.ctor()
+							IL_0094: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27/FunctionObject::.ctor()
 							IL_0099: ldc.i4.0
 							IL_009a: conv.r8
 							IL_009b: ldstr ""
 							IL_00a0: ldc.i4.0
 							IL_00a1: ldc.i4.1
-							IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27/FunctionObject_FunctionExpression_71E42388_L61C28>(!!0, float64, string, bool, bool)
+							IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27/FunctionObject>(!!0, float64, string, bool, bool)
 							IL_00a7: stloc.s 5
 							IL_00a9: ldloc.2
 							IL_00aa: ldstr "close"
@@ -1173,7 +1173,7 @@
 
 					} // end of class Scope
 
-					.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D91593AD_L48C11
+					.class nested public auto ansi sealed beforefieldinit FunctionObject
 						extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 					{
 						// Fields
@@ -1199,18 +1199,18 @@
 							IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 							IL_0006: ldarg.0
 							IL_0007: ldarg.1
-							IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+							IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 							IL_000d: ldarg.0
 							IL_000e: ldarg.2
-							IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::_environment1_FunctionExpression_L19C30
+							IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject::_environment1_FunctionExpression_L19C30
 							IL_0014: ldarg.0
 							IL_0015: ldarg.3
-							IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::_environment2_FunctionExpression_L29C4
+							IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject::_environment2_FunctionExpression_L29C4
 							IL_001b: ldarg.0
 							IL_001c: ldarg.s capture3
-							IL_001e: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::_transitionalScopes
+							IL_001e: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject::_transitionalScopes
 							IL_0023: ret
-						} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::.ctor
+						} // end of method FunctionObject::.ctor
 
 						.method public hidebysig specialname virtual 
 							instance bool get_IsConstructor () cil managed 
@@ -1221,7 +1221,7 @@
 
 							IL_0000: ldc.i4.1
 							IL_0001: ret
-						} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::get_IsConstructor
+						} // end of method FunctionObject::get_IsConstructor
 
 						.method public hidebysig specialname virtual 
 							instance bool get_RequiresInvocationContext () cil managed 
@@ -1232,7 +1232,7 @@
 
 							IL_0000: ldc.i4.0
 							IL_0001: ret
-						} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::get_RequiresInvocationContext
+						} // end of method FunctionObject::get_RequiresInvocationContext
 
 						.method family hidebysig virtual 
 							instance object CallCore (
@@ -1245,14 +1245,14 @@
 							.maxstack 8
 
 							IL_0000: ldarg.0
-							IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::_transitionalScopes
+							IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject::_transitionalScopes
 							IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 							IL_000b: ldarg.2
 							IL_000c: ldc.i4.0
 							IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 							IL_0012: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10::__js_call__(object[], object, object)
 							IL_0017: ret
-						} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::CallCore
+						} // end of method FunctionObject::CallCore
 
 						.method family hidebysig virtual 
 							instance object ConstructBodyCore (
@@ -1266,14 +1266,14 @@
 							.maxstack 8
 
 							IL_0000: ldarg.0
-							IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::_transitionalScopes
+							IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject::_transitionalScopes
 							IL_0006: ldarg.3
 							IL_0007: ldarg.2
 							IL_0008: ldc.i4.0
 							IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 							IL_000e: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10::__js_call__(object[], object, object)
 							IL_0013: ret
-						} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::ConstructBodyCore
+						} // end of method FunctionObject::ConstructBodyCore
 
 						.method family hidebysig virtual 
 							instance object ConstructCore (
@@ -1291,9 +1291,9 @@
 							IL_0007: ldarg.2
 							IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 							IL_000d: ret
-						} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::ConstructCore
+						} // end of method FunctionObject::ConstructCore
 
-					} // end of class FunctionObject_FunctionExpression_D91593AD_L48C11
+					} // end of class FunctionObject
 
 
 					// Methods
@@ -1316,8 +1316,8 @@
 							[2] object,
 							[3] object,
 							[4] object[],
-							[5] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32,
-							[6] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31
+							[5] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject,
+							[6] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject
 						)
 
 						IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope::.ctor()
@@ -1400,13 +1400,13 @@
 						IL_00a2: ldelem.ref
 						IL_00a3: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
 						IL_00a8: ldloc.s 4
-						IL_00aa: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope, object[])
+						IL_00aa: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope, object[])
 						IL_00af: ldc.i4.1
 						IL_00b0: conv.r8
 						IL_00b1: ldstr ""
 						IL_00b6: ldc.i4.0
 						IL_00b7: ldc.i4.1
-						IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32>(!!0, float64, string, bool, bool)
+						IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject>(!!0, float64, string, bool, bool)
 						IL_00bd: stloc.s 5
 						IL_00bf: ldloc.2
 						IL_00c0: ldstr "on"
@@ -1465,13 +1465,13 @@
 						IL_011b: ldelem.ref
 						IL_011c: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
 						IL_0121: ldloc.s 4
-						IL_0123: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope, object[])
+						IL_0123: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope, object[])
 						IL_0128: ldc.i4.0
 						IL_0129: conv.r8
 						IL_012a: ldstr ""
 						IL_012f: ldc.i4.0
 						IL_0130: ldc.i4.1
-						IL_0131: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31>(!!0, float64, string, bool, bool)
+						IL_0131: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject>(!!0, float64, string, bool, bool)
 						IL_0136: stloc.s 6
 						IL_0138: ldloc.2
 						IL_0139: ldstr "on"
@@ -1504,7 +1504,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D1A28085_L38C21
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -1530,18 +1530,18 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+						IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::_environment1_FunctionExpression_L19C30
+						IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject::_environment1_FunctionExpression_L19C30
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::_environment2_FunctionExpression_L29C4
+						IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject::_environment2_FunctionExpression_L29C4
 						IL_001b: ldarg.0
 						IL_001c: ldarg.s capture3
-						IL_001e: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::_transitionalScopes
+						IL_001e: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject::_transitionalScopes
 						IL_0023: ret
-					} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -1552,7 +1552,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -1563,7 +1563,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1576,11 +1576,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1594,11 +1594,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1616,9 +1616,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_D1A28085_L38C21
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1644,7 +1644,7 @@
 						[6] object,
 						[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 						[8] object[],
-						[9] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11
+						[9] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject
 					)
 
 					IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/Scope::.ctor()
@@ -1749,13 +1749,13 @@
 					IL_00ed: ldelem.ref
 					IL_00ee: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
 					IL_00f3: ldloc.s 8
-					IL_00f5: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
+					IL_00f5: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
 					IL_00fa: ldc.i4.1
 					IL_00fb: conv.r8
 					IL_00fc: ldstr ""
 					IL_0101: ldc.i4.0
 					IL_0102: ldc.i4.1
-					IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11>(!!0, float64, string, bool, bool)
+					IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject>(!!0, float64, string, bool, bool)
 					IL_0108: stloc.s 9
 					IL_010a: ldloc.s 4
 					IL_010c: ldstr "get"
@@ -1795,7 +1795,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_40997E85_L29C5
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1819,15 +1819,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+					IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5::_environment1_FunctionExpression_L19C30
+					IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject::_environment1_FunctionExpression_L19C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5::_transitionalScopes
+					IL_0016: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1838,7 +1838,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1849,7 +1849,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1862,14 +1862,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1883,14 +1883,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1908,9 +1908,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_40997E85_L29C5
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1933,8 +1933,8 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22,
-					[6] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21
+					[5] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject,
+					[6] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope::.ctor()
@@ -2001,13 +2001,13 @@
 				IL_008d: ldelem.ref
 				IL_008e: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
 				IL_0093: ldloc.s 4
-				IL_0095: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
+				IL_0095: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
 				IL_009a: ldc.i4.1
 				IL_009b: conv.r8
 				IL_009c: ldstr ""
 				IL_00a1: ldc.i4.0
 				IL_00a2: ldc.i4.1
-				IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22>(!!0, float64, string, bool, bool)
+				IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_00a8: stloc.s 5
 				IL_00aa: ldloc.2
 				IL_00ab: ldstr "on"
@@ -2050,13 +2050,13 @@
 				IL_00f1: ldelem.ref
 				IL_00f2: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
 				IL_00f7: ldloc.s 4
-				IL_00f9: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
+				IL_00f9: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
 				IL_00fe: ldc.i4.0
 				IL_00ff: conv.r8
 				IL_0100: ldstr ""
 				IL_0105: ldc.i4.0
 				IL_0106: ldc.i4.1
-				IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21>(!!0, float64, string, bool, bool)
+				IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_010c: stloc.s 6
 				IL_010e: ldloc.2
 				IL_010f: ldstr "on"
@@ -2096,7 +2096,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B82FA783_L19C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2116,9 +2116,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject_FunctionExpression_B82FA783_L19C31::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2129,7 +2129,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2140,7 +2140,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2153,11 +2153,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject_FunctionExpression_B82FA783_L19C31::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2171,11 +2171,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject_FunctionExpression_B82FA783_L19C31::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject::_environment0_Http_Agent_KeepAlive_Reuses_Connection
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2193,9 +2193,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_B82FA783_L19C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2221,7 +2221,7 @@
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[6] object[],
-				[7] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5
+				[7] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::.ctor()
@@ -2289,13 +2289,13 @@
 			IL_00ac: ldelem.ref
 			IL_00ad: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
 			IL_00b2: ldloc.s 6
-			IL_00b4: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, object[])
+			IL_00b4: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, object[])
 			IL_00b9: ldc.i4.1
 			IL_00ba: conv.r8
 			IL_00bb: ldstr ""
 			IL_00c0: ldc.i4.0
 			IL_00c1: ldc.i4.1
-			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5>(!!0, float64, string, bool, bool)
+			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00c7: stloc.s 7
 			IL_00c9: ldloc.2
 			IL_00ca: ldstr "get"
@@ -2364,9 +2364,9 @@
 			[2] object,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object[],
-			[5] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject_FunctionExpression_AD8A01FB_L9C34,
-			[6] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject_FunctionExpression_2B9E525E_L15C25,
-			[7] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject_FunctionExpression_B82FA783_L19C31
+			[5] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject,
+			[6] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject,
+			[7] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::.ctor()
@@ -2421,13 +2421,13 @@
 		IL_0087: ldc.i4.0
 		IL_0088: ldelem.ref
 		IL_0089: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-		IL_008e: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject_FunctionExpression_AD8A01FB_L9C34::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope)
+		IL_008e: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope)
 		IL_0093: ldc.i4.2
 		IL_0094: conv.r8
 		IL_0095: ldstr ""
 		IL_009a: ldc.i4.0
 		IL_009b: ldc.i4.1
-		IL_009c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject_FunctionExpression_AD8A01FB_L9C34>(!!0, float64, string, bool, bool)
+		IL_009c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a1: stloc.s 5
 		IL_00a3: ldloc.1
 		IL_00a4: ldloc.s 5
@@ -2451,13 +2451,13 @@
 		IL_00cd: ldc.i4.0
 		IL_00ce: ldelem.ref
 		IL_00cf: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-		IL_00d4: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject_FunctionExpression_2B9E525E_L15C25::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope)
+		IL_00d4: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope)
 		IL_00d9: ldc.i4.0
 		IL_00da: conv.r8
 		IL_00db: ldstr ""
 		IL_00e0: ldc.i4.0
 		IL_00e1: ldc.i4.1
-		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject_FunctionExpression_2B9E525E_L15C25>(!!0, float64, string, bool, bool)
+		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00e7: stloc.s 6
 		IL_00e9: ldloc.2
 		IL_00ea: ldstr "on"
@@ -2480,13 +2480,13 @@
 		IL_0116: ldc.i4.0
 		IL_0117: ldelem.ref
 		IL_0118: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-		IL_011d: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject_FunctionExpression_B82FA783_L19C31::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope)
+		IL_011d: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope)
 		IL_0122: ldc.i4.0
 		IL_0123: conv.r8
 		IL_0124: ldstr ""
 		IL_0129: ldc.i4.0
 		IL_012a: ldc.i4.1
-		IL_012b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject_FunctionExpression_B82FA783_L19C31>(!!0, float64, string, bool, bool)
+		IL_012b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0130: stloc.s 7
 		IL_0132: ldloc.2
 		IL_0133: ldstr "listen"

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0CFE5DC0_L5C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_0CFE5DC0_L5C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -281,7 +281,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C8F0E4C7_L25C20
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -305,15 +305,15 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_environment0_Http_CreateServer_Get_Loopback
+						IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject::_environment0_Http_CreateServer_Get_Loopback
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_environment2_FunctionExpression_L19C76
+						IL_000f: stfld class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject::_environment2_FunctionExpression_L19C76
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_transitionalScopes
+						IL_0016: stfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject::_transitionalScopes
 						IL_001b: ret
-					} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -324,7 +324,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -335,7 +335,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -348,14 +348,14 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: ldarg.2
 						IL_000c: ldc.i4.0
 						IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 						IL_0012: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19::__js_call__(object[], object, object)
 						IL_0017: ret
-					} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -369,14 +369,14 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: ldarg.2
 						IL_0008: ldc.i4.0
 						IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 						IL_000e: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19::__js_call__(object[], object, object)
 						IL_0013: ret
-					} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -394,9 +394,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_C8F0E4C7_L25C20
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -467,7 +467,7 @@
 
 					} // end of class Scope
 
-					.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8F7EC3DF_L31C20
+					.class nested public auto ansi sealed beforefieldinit FunctionObject
 						extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 					{
 						// Methods
@@ -481,7 +481,7 @@
 							IL_0000: ldarg.0
 							IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 							IL_0006: ret
-						} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::.ctor
+						} // end of method FunctionObject::.ctor
 
 						.method public hidebysig specialname virtual 
 							instance bool get_IsConstructor () cil managed 
@@ -492,7 +492,7 @@
 
 							IL_0000: ldc.i4.1
 							IL_0001: ret
-						} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::get_IsConstructor
+						} // end of method FunctionObject::get_IsConstructor
 
 						.method public hidebysig specialname virtual 
 							instance bool get_RequiresInvocationContext () cil managed 
@@ -503,7 +503,7 @@
 
 							IL_0000: ldc.i4.0
 							IL_0001: ret
-						} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::get_RequiresInvocationContext
+						} // end of method FunctionObject::get_RequiresInvocationContext
 
 						.method family hidebysig virtual 
 							instance object CallCore (
@@ -518,7 +518,7 @@
 							IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 							IL_0005: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19::__js_call__(object)
 							IL_000a: ret
-						} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::CallCore
+						} // end of method FunctionObject::CallCore
 
 						.method family hidebysig virtual 
 							instance object ConstructBodyCore (
@@ -534,7 +534,7 @@
 							IL_0000: ldarg.3
 							IL_0001: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19::__js_call__(object)
 							IL_0006: ret
-						} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::ConstructBodyCore
+						} // end of method FunctionObject::ConstructBodyCore
 
 						.method family hidebysig virtual 
 							instance object ConstructCore (
@@ -552,9 +552,9 @@
 							IL_0007: ldarg.2
 							IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 							IL_000d: ret
-						} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::ConstructCore
+						} // end of method FunctionObject::ConstructCore
 
-					} // end of class FunctionObject_FunctionExpression_8F7EC3DF_L31C20
+					} // end of class FunctionObject
 
 
 					// Methods
@@ -604,7 +604,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_20E9685B_L29C19
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -628,15 +628,15 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19::_environment0_Http_CreateServer_Get_Loopback
+						IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject::_environment0_Http_CreateServer_Get_Loopback
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19::_environment2_FunctionExpression_L19C76
+						IL_000f: stfld class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject::_environment2_FunctionExpression_L19C76
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19::_transitionalScopes
+						IL_0016: stfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject::_transitionalScopes
 						IL_001b: ret
-					} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -647,7 +647,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -658,7 +658,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -671,11 +671,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -689,11 +689,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -711,9 +711,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_20E9685B_L29C19
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -735,7 +735,7 @@
 						[2] object,
 						[3] object,
 						[4] object[],
-						[5] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19/FunctionObject_FunctionExpression_8F7EC3DF_L31C20
+						[5] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19/FunctionObject
 					)
 
 					IL_0000: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/Scope::.ctor()
@@ -772,13 +772,13 @@
 					IL_004b: ldelem.ref
 					IL_004c: stelem.ref
 					IL_004d: stloc.s 4
-					IL_004f: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19/FunctionObject_FunctionExpression_8F7EC3DF_L31C20::.ctor()
+					IL_004f: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19/FunctionObject::.ctor()
 					IL_0054: ldc.i4.0
 					IL_0055: conv.r8
 					IL_0056: ldstr ""
 					IL_005b: ldc.i4.0
 					IL_005c: ldc.i4.1
-					IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19/FunctionObject_FunctionExpression_8F7EC3DF_L31C20>(!!0, float64, string, bool, bool)
+					IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19/FunctionObject>(!!0, float64, string, bool, bool)
 					IL_0062: stloc.s 5
 					IL_0064: ldloc.2
 					IL_0065: ldstr "close"
@@ -817,7 +817,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D2B33758_L19C77
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -839,12 +839,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77::_environment0_Http_CreateServer_Get_Loopback
+					IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject::_environment0_Http_CreateServer_Get_Loopback
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77::_transitionalScopes
+					IL_000f: stfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -855,7 +855,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -866,7 +866,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -879,14 +879,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -900,14 +900,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -925,9 +925,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_D2B33758_L19C77
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -950,8 +950,8 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20,
-					[6] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19
+					[5] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject,
+					[6] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope::.ctor()
@@ -1028,13 +1028,13 @@
 				IL_00aa: ldelem.ref
 				IL_00ab: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
 				IL_00b0: ldloc.s 4
-				IL_00b2: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope, object[])
+				IL_00b2: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope, object[])
 				IL_00b7: ldc.i4.1
 				IL_00b8: conv.r8
 				IL_00b9: ldstr ""
 				IL_00be: ldc.i4.0
 				IL_00bf: ldc.i4.1
-				IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20>(!!0, float64, string, bool, bool)
+				IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_00c5: stloc.s 5
 				IL_00c7: ldloc.2
 				IL_00c8: ldstr "on"
@@ -1073,13 +1073,13 @@
 				IL_0105: ldelem.ref
 				IL_0106: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
 				IL_010b: ldloc.s 4
-				IL_010d: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope, object[])
+				IL_010d: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope, object[])
 				IL_0112: ldc.i4.0
 				IL_0113: conv.r8
 				IL_0114: ldstr ""
 				IL_0119: ldc.i4.0
 				IL_011a: ldc.i4.1
-				IL_011b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19>(!!0, float64, string, bool, bool)
+				IL_011b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0120: stloc.s 6
 				IL_0122: ldloc.2
 				IL_0123: ldstr "on"
@@ -1112,7 +1112,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C45B3F96_L15C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1132,9 +1132,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject_FunctionExpression_C45B3F96_L15C31::_environment0_Http_CreateServer_Get_Loopback
+				IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject::_environment0_Http_CreateServer_Get_Loopback
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1145,7 +1145,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1156,7 +1156,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1169,11 +1169,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject_FunctionExpression_C45B3F96_L15C31::_environment0_Http_CreateServer_Get_Loopback
+				IL_0001: ldfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject::_environment0_Http_CreateServer_Get_Loopback
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30::__js_call__(class Modules.Http_CreateServer_Get_Loopback/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1187,11 +1187,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject_FunctionExpression_C45B3F96_L15C31::_environment0_Http_CreateServer_Get_Loopback
+				IL_0001: ldfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject::_environment0_Http_CreateServer_Get_Loopback
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30::__js_call__(class Modules.Http_CreateServer_Get_Loopback/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1209,9 +1209,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C45B3F96_L15C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1239,7 +1239,7 @@
 				[6] object,
 				[7] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 				[8] object[],
-				[9] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77
+				[9] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/Scope::.ctor()
@@ -1327,13 +1327,13 @@
 			IL_00eb: ldelem.ref
 			IL_00ec: castclass Modules.Http_CreateServer_Get_Loopback/Scope
 			IL_00f1: ldloc.s 8
-			IL_00f3: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, object[])
+			IL_00f3: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, object[])
 			IL_00f8: ldc.i4.1
 			IL_00f9: conv.r8
 			IL_00fa: ldstr ""
 			IL_00ff: ldc.i4.0
 			IL_0100: ldc.i4.1
-			IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77>(!!0, float64, string, bool, bool)
+			IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0106: stloc.s 9
 			IL_0108: ldloc.s 7
 			IL_010a: ldstr "get"
@@ -1393,9 +1393,9 @@
 			[0] class Modules.Http_CreateServer_Get_Loopback/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[2] object[],
-			[3] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server/FunctionObject_FunctionExpression_0CFE5DC0_L5C34,
+			[3] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server/FunctionObject,
 			[4] object,
-			[5] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject_FunctionExpression_C45B3F96_L15C31
+			[5] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Http_CreateServer_Get_Loopback/Scope::.ctor()
@@ -1418,13 +1418,13 @@
 		IL_0029: ldloc.0
 		IL_002a: stelem.ref
 		IL_002b: stloc.2
-		IL_002c: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server/FunctionObject_FunctionExpression_0CFE5DC0_L5C34::.ctor()
+		IL_002c: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server/FunctionObject::.ctor()
 		IL_0031: ldc.i4.2
 		IL_0032: conv.r8
 		IL_0033: ldstr ""
 		IL_0038: ldc.i4.0
 		IL_0039: ldc.i4.1
-		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server/FunctionObject_FunctionExpression_0CFE5DC0_L5C34>(!!0, float64, string, bool, bool)
+		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_003f: stloc.3
 		IL_0040: ldloc.1
 		IL_0041: ldloc.3
@@ -1448,13 +1448,13 @@
 		IL_006a: ldc.i4.0
 		IL_006b: ldelem.ref
 		IL_006c: castclass Modules.Http_CreateServer_Get_Loopback/Scope
-		IL_0071: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject_FunctionExpression_C45B3F96_L15C31::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope)
+		IL_0071: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope)
 		IL_0076: ldc.i4.0
 		IL_0077: conv.r8
 		IL_0078: ldstr ""
 		IL_007d: ldc.i4.0
 		IL_007e: ldc.i4.1
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject_FunctionExpression_C45B3F96_L15C31>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0084: stloc.s 5
 		IL_0086: ldloc.s 4
 		IL_0088: ldstr "listen"

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_05E6B498_L9C18
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -58,15 +58,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18::_environment0_Http_Request_Post_Basic
+					IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment0_Http_Request_Post_Basic
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18::_environment1_FunctionExpression_server
+					IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment1_FunctionExpression_server
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18::_transitionalScopes
+					IL_0016: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -77,7 +77,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -88,7 +88,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -101,14 +101,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -122,14 +122,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -147,9 +147,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_05E6B498_L9C18
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -216,7 +216,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9539117E_L13C17
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -240,15 +240,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17::_environment0_Http_Request_Post_Basic
+					IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject::_environment0_Http_Request_Post_Basic
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17::_environment1_FunctionExpression_server
+					IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject::_environment1_FunctionExpression_server
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17::_transitionalScopes
+					IL_0016: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -259,7 +259,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -270,7 +270,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -283,11 +283,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -301,11 +301,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -323,9 +323,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_9539117E_L13C17
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -525,7 +525,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A159A473_L5C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -545,9 +545,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_A159A473_L5C34::_environment0_Http_Request_Post_Basic
+				IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject::_environment0_Http_Request_Post_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -558,7 +558,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -569,7 +569,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -582,7 +582,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_A159A473_L5C34::_environment0_Http_Request_Post_Basic
+				IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject::_environment0_Http_Request_Post_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -592,7 +592,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Http_Request_Post_Basic/FunctionExpression_server::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -606,7 +606,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_A159A473_L5C34::_environment0_Http_Request_Post_Basic
+				IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject::_environment0_Http_Request_Post_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -616,7 +616,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Http_Request_Post_Basic/FunctionExpression_server::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -634,9 +634,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A159A473_L5C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -660,8 +660,8 @@
 				[0] class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope,
 				[1] object,
 				[2] object[],
-				[3] class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18,
-				[4] class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17
+				[3] class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject,
+				[4] class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::.ctor()
@@ -706,13 +706,13 @@
 			IL_005f: ldelem.ref
 			IL_0060: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
 			IL_0065: ldloc.2
-			IL_0066: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope, object[])
+			IL_0066: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope, object[])
 			IL_006b: ldc.i4.1
 			IL_006c: conv.r8
 			IL_006d: ldstr ""
 			IL_0072: ldc.i4.0
 			IL_0073: ldc.i4.1
-			IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18>(!!0, float64, string, bool, bool)
+			IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0079: stloc.3
 			IL_007a: ldloc.1
 			IL_007b: ldstr "on"
@@ -744,13 +744,13 @@
 			IL_00b1: ldelem.ref
 			IL_00b2: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
 			IL_00b7: ldloc.2
-			IL_00b8: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope, object[])
+			IL_00b8: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope, object[])
 			IL_00bd: ldc.i4.0
 			IL_00be: conv.r8
 			IL_00bf: ldstr ""
 			IL_00c4: ldc.i4.0
 			IL_00c5: ldc.i4.1
-			IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17>(!!0, float64, string, bool, bool)
+			IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00cb: stloc.s 4
 			IL_00cd: ldloc.1
 			IL_00ce: ldstr "on"
@@ -795,7 +795,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_198EBA5C_L47C22
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -819,15 +819,15 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22::_environment0_Http_Request_Post_Basic
+						IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::_environment0_Http_Request_Post_Basic
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22::_environment2_FunctionExpression_req
+						IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::_environment2_FunctionExpression_req
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22::_transitionalScopes
+						IL_0016: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::_transitionalScopes
 						IL_001b: ret
-					} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -838,7 +838,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -849,7 +849,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -862,14 +862,14 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: ldarg.2
 						IL_000c: ldc.i4.0
 						IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 						IL_0012: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req::__js_call__(object[], object, object)
 						IL_0017: ret
-					} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -883,14 +883,14 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: ldarg.2
 						IL_0008: ldc.i4.0
 						IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 						IL_000e: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req::__js_call__(object[], object, object)
 						IL_0013: ret
-					} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -908,9 +908,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_198EBA5C_L47C22
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -981,7 +981,7 @@
 
 					} // end of class Scope
 
-					.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1E4A6C5B_L53C22
+					.class nested public auto ansi sealed beforefieldinit FunctionObject
 						extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 					{
 						// Methods
@@ -995,7 +995,7 @@
 							IL_0000: ldarg.0
 							IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 							IL_0006: ret
-						} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::.ctor
+						} // end of method FunctionObject::.ctor
 
 						.method public hidebysig specialname virtual 
 							instance bool get_IsConstructor () cil managed 
@@ -1006,7 +1006,7 @@
 
 							IL_0000: ldc.i4.1
 							IL_0001: ret
-						} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::get_IsConstructor
+						} // end of method FunctionObject::get_IsConstructor
 
 						.method public hidebysig specialname virtual 
 							instance bool get_RequiresInvocationContext () cil managed 
@@ -1017,7 +1017,7 @@
 
 							IL_0000: ldc.i4.0
 							IL_0001: ret
-						} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::get_RequiresInvocationContext
+						} // end of method FunctionObject::get_RequiresInvocationContext
 
 						.method family hidebysig virtual 
 							instance object CallCore (
@@ -1032,7 +1032,7 @@
 							IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 							IL_0005: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req::__js_call__(object)
 							IL_000a: ret
-						} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::CallCore
+						} // end of method FunctionObject::CallCore
 
 						.method family hidebysig virtual 
 							instance object ConstructBodyCore (
@@ -1048,7 +1048,7 @@
 							IL_0000: ldarg.3
 							IL_0001: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req::__js_call__(object)
 							IL_0006: ret
-						} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::ConstructBodyCore
+						} // end of method FunctionObject::ConstructBodyCore
 
 						.method family hidebysig virtual 
 							instance object ConstructCore (
@@ -1066,9 +1066,9 @@
 							IL_0007: ldarg.2
 							IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 							IL_000d: ret
-						} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::ConstructCore
+						} // end of method FunctionObject::ConstructCore
 
-					} // end of class FunctionObject_FunctionExpression_1E4A6C5B_L53C22
+					} // end of class FunctionObject
 
 
 					// Methods
@@ -1118,7 +1118,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F5C71F38_L51C21
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -1142,15 +1142,15 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21::_environment0_Http_Request_Post_Basic
+						IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject::_environment0_Http_Request_Post_Basic
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21::_environment2_FunctionExpression_req
+						IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject::_environment2_FunctionExpression_req
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21::_transitionalScopes
+						IL_0016: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject::_transitionalScopes
 						IL_001b: ret
-					} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -1161,7 +1161,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -1172,7 +1172,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1185,11 +1185,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1203,11 +1203,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1225,9 +1225,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_F5C71F38_L51C21
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1249,7 +1249,7 @@
 						[2] object,
 						[3] object,
 						[4] object[],
-						[5] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req/FunctionObject_FunctionExpression_1E4A6C5B_L53C22
+						[5] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req/FunctionObject
 					)
 
 					IL_0000: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/Scope::.ctor()
@@ -1286,13 +1286,13 @@
 					IL_004b: ldelem.ref
 					IL_004c: stelem.ref
 					IL_004d: stloc.s 4
-					IL_004f: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req/FunctionObject_FunctionExpression_1E4A6C5B_L53C22::.ctor()
+					IL_004f: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req/FunctionObject::.ctor()
 					IL_0054: ldc.i4.0
 					IL_0055: conv.r8
 					IL_0056: ldstr ""
 					IL_005b: ldc.i4.0
 					IL_005c: ldc.i4.1
-					IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req/FunctionObject_FunctionExpression_1E4A6C5B_L53C22>(!!0, float64, string, bool, bool)
+					IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req/FunctionObject>(!!0, float64, string, bool, bool)
 					IL_0062: stloc.s 5
 					IL_0064: ldloc.2
 					IL_0065: ldstr "close"
@@ -1332,7 +1332,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_15D5C424_L40C5
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1354,12 +1354,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5::_environment0_Http_Request_Post_Basic
+					IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject::_environment0_Http_Request_Post_Basic
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5::_transitionalScopes
+					IL_000f: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1370,7 +1370,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1381,7 +1381,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1394,14 +1394,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1415,14 +1415,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1440,9 +1440,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_15D5C424_L40C5
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1465,8 +1465,8 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22,
-					[6] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21
+					[5] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject,
+					[6] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope::.ctor()
@@ -1561,13 +1561,13 @@
 				IL_00dc: ldelem.ref
 				IL_00dd: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
 				IL_00e2: ldloc.s 4
-				IL_00e4: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope, object[])
+				IL_00e4: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope, object[])
 				IL_00e9: ldc.i4.1
 				IL_00ea: conv.r8
 				IL_00eb: ldstr ""
 				IL_00f0: ldc.i4.0
 				IL_00f1: ldc.i4.1
-				IL_00f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22>(!!0, float64, string, bool, bool)
+				IL_00f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_00f7: stloc.s 5
 				IL_00f9: ldloc.2
 				IL_00fa: ldstr "on"
@@ -1606,13 +1606,13 @@
 				IL_0137: ldelem.ref
 				IL_0138: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
 				IL_013d: ldloc.s 4
-				IL_013f: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope, object[])
+				IL_013f: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope, object[])
 				IL_0144: ldc.i4.0
 				IL_0145: conv.r8
 				IL_0146: ldstr ""
 				IL_014b: ldc.i4.0
 				IL_014c: ldc.i4.1
-				IL_014d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21>(!!0, float64, string, bool, bool)
+				IL_014d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0152: stloc.s 6
 				IL_0154: ldloc.2
 				IL_0155: ldstr "on"
@@ -1645,7 +1645,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_13DD647B_L28C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1665,9 +1665,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject_FunctionExpression_13DD647B_L28C31::_environment0_Http_Request_Post_Basic
+				IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject::_environment0_Http_Request_Post_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1678,7 +1678,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1689,7 +1689,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1702,11 +1702,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject_FunctionExpression_13DD647B_L28C31::_environment0_Http_Request_Post_Basic
+				IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject::_environment0_Http_Request_Post_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1720,11 +1720,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject_FunctionExpression_13DD647B_L28C31::_environment0_Http_Request_Post_Basic
+				IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject::_environment0_Http_Request_Post_Basic
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1742,9 +1742,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_13DD647B_L28C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1770,7 +1770,7 @@
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[6] object[],
-				[7] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5
+				[7] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/Scope::.ctor()
@@ -1835,13 +1835,13 @@
 			IL_00b2: ldelem.ref
 			IL_00b3: castclass Modules.Http_Request_Post_Basic/Scope
 			IL_00b8: ldloc.s 6
-			IL_00ba: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5::.ctor(class Modules.Http_Request_Post_Basic/Scope, object[])
+			IL_00ba: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope, object[])
 			IL_00bf: ldc.i4.1
 			IL_00c0: conv.r8
 			IL_00c1: ldstr ""
 			IL_00c6: ldc.i4.0
 			IL_00c7: ldc.i4.1
-			IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5>(!!0, float64, string, bool, bool)
+			IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00cd: stloc.s 7
 			IL_00cf: ldstr "request"
 			IL_00d4: ldloc.s 5
@@ -1912,9 +1912,9 @@
 			[0] class Modules.Http_Request_Post_Basic/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[2] object[],
-			[3] class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_A159A473_L5C34,
+			[3] class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject,
 			[4] object,
-			[5] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject_FunctionExpression_13DD647B_L28C31
+			[5] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Http_Request_Post_Basic/Scope::.ctor()
@@ -1941,13 +1941,13 @@
 		IL_002d: ldc.i4.0
 		IL_002e: ldelem.ref
 		IL_002f: castclass Modules.Http_Request_Post_Basic/Scope
-		IL_0034: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_A159A473_L5C34::.ctor(class Modules.Http_Request_Post_Basic/Scope)
+		IL_0034: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope)
 		IL_0039: ldc.i4.2
 		IL_003a: conv.r8
 		IL_003b: ldstr ""
 		IL_0040: ldc.i4.0
 		IL_0041: ldc.i4.1
-		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_A159A473_L5C34>(!!0, float64, string, bool, bool)
+		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0047: stloc.3
 		IL_0048: ldloc.1
 		IL_0049: ldloc.3
@@ -1971,13 +1971,13 @@
 		IL_0072: ldc.i4.0
 		IL_0073: ldelem.ref
 		IL_0074: castclass Modules.Http_Request_Post_Basic/Scope
-		IL_0079: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject_FunctionExpression_13DD647B_L28C31::.ctor(class Modules.Http_Request_Post_Basic/Scope)
+		IL_0079: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject::.ctor(class Modules.Http_Request_Post_Basic/Scope)
 		IL_007e: ldc.i4.0
 		IL_007f: conv.r8
 		IL_0080: ldstr ""
 		IL_0085: ldc.i4.0
 		IL_0086: ldc.i4.1
-		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject_FunctionExpression_13DD647B_L28C31>(!!0, float64, string, bool, bool)
+		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_008c: stloc.s 5
 		IL_008e: ldloc.s 4
 		IL_0090: ldstr "listen"

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Streaming_Chunked_RequestBody.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Streaming_Chunked_RequestBody.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_076D9C75_L13C18
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -58,15 +58,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18::_environment0_Http_Request_Streaming_Chunked_RequestBody
+					IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment0_Http_Request_Streaming_Chunked_RequestBody
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18::_environment1_FunctionExpression_server
+					IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment1_FunctionExpression_server
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18::_transitionalScopes
+					IL_0016: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -77,7 +77,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -88,7 +88,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -101,14 +101,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -122,14 +122,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -147,9 +147,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_076D9C75_L13C18
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -257,7 +257,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7DCB19C2_L19C17
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -281,15 +281,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17::_environment0_Http_Request_Streaming_Chunked_RequestBody
+					IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject::_environment0_Http_Request_Streaming_Chunked_RequestBody
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17::_environment1_FunctionExpression_server
+					IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject::_environment1_FunctionExpression_server
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17::_transitionalScopes
+					IL_0016: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -300,7 +300,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -311,7 +311,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -324,11 +324,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -342,11 +342,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -364,9 +364,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_7DCB19C2_L19C17
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -466,7 +466,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2B2BC7DD_L5C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -486,9 +486,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject_FunctionExpression_2B2BC7DD_L5C34::_environment0_Http_Request_Streaming_Chunked_RequestBody
+				IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject::_environment0_Http_Request_Streaming_Chunked_RequestBody
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -499,7 +499,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -510,7 +510,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -523,7 +523,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject_FunctionExpression_2B2BC7DD_L5C34::_environment0_Http_Request_Streaming_Chunked_RequestBody
+				IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject::_environment0_Http_Request_Streaming_Chunked_RequestBody
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -533,7 +533,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -547,7 +547,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject_FunctionExpression_2B2BC7DD_L5C34::_environment0_Http_Request_Streaming_Chunked_RequestBody
+				IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject::_environment0_Http_Request_Streaming_Chunked_RequestBody
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -557,7 +557,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -575,9 +575,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_2B2BC7DD_L5C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -603,8 +603,8 @@
 				[2] object,
 				[3] object,
 				[4] object[],
-				[5] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18,
-				[6] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17
+				[5] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject,
+				[6] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::.ctor()
@@ -666,13 +666,13 @@
 			IL_0097: ldelem.ref
 			IL_0098: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
 			IL_009d: ldloc.s 4
-			IL_009f: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope, object[])
+			IL_009f: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope, object[])
 			IL_00a4: ldc.i4.1
 			IL_00a5: conv.r8
 			IL_00a6: ldstr ""
 			IL_00ab: ldc.i4.0
 			IL_00ac: ldc.i4.1
-			IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18>(!!0, float64, string, bool, bool)
+			IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00b2: stloc.s 5
 			IL_00b4: ldloc.2
 			IL_00b5: ldstr "on"
@@ -703,13 +703,13 @@
 			IL_00ea: ldelem.ref
 			IL_00eb: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
 			IL_00f0: ldloc.s 4
-			IL_00f2: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope, object[])
+			IL_00f2: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope, object[])
 			IL_00f7: ldc.i4.0
 			IL_00f8: conv.r8
 			IL_00f9: ldstr ""
 			IL_00fe: ldc.i4.0
 			IL_00ff: ldc.i4.1
-			IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17>(!!0, float64, string, bool, bool)
+			IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0105: stloc.s 6
 			IL_0107: ldloc.2
 			IL_0108: ldstr "on"
@@ -754,7 +754,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FBD7FA11_L42C22
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -778,15 +778,15 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22::_environment0_Http_Request_Streaming_Chunked_RequestBody
+						IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::_environment0_Http_Request_Streaming_Chunked_RequestBody
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22::_environment2_FunctionExpression_req
+						IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::_environment2_FunctionExpression_req
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22::_transitionalScopes
+						IL_0016: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::_transitionalScopes
 						IL_001b: ret
-					} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -797,7 +797,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -808,7 +808,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -821,14 +821,14 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: ldarg.2
 						IL_000c: ldc.i4.0
 						IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 						IL_0012: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req::__js_call__(object[], object, object)
 						IL_0017: ret
-					} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -842,14 +842,14 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: ldarg.2
 						IL_0008: ldc.i4.0
 						IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 						IL_000e: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req::__js_call__(object[], object, object)
 						IL_0013: ret
-					} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -867,9 +867,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_FBD7FA11_L42C22
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -940,7 +940,7 @@
 
 					} // end of class Scope
 
-					.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BB2FB49F_L48C22
+					.class nested public auto ansi sealed beforefieldinit FunctionObject
 						extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 					{
 						// Methods
@@ -954,7 +954,7 @@
 							IL_0000: ldarg.0
 							IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 							IL_0006: ret
-						} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::.ctor
+						} // end of method FunctionObject::.ctor
 
 						.method public hidebysig specialname virtual 
 							instance bool get_IsConstructor () cil managed 
@@ -965,7 +965,7 @@
 
 							IL_0000: ldc.i4.1
 							IL_0001: ret
-						} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::get_IsConstructor
+						} // end of method FunctionObject::get_IsConstructor
 
 						.method public hidebysig specialname virtual 
 							instance bool get_RequiresInvocationContext () cil managed 
@@ -976,7 +976,7 @@
 
 							IL_0000: ldc.i4.0
 							IL_0001: ret
-						} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::get_RequiresInvocationContext
+						} // end of method FunctionObject::get_RequiresInvocationContext
 
 						.method family hidebysig virtual 
 							instance object CallCore (
@@ -991,7 +991,7 @@
 							IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 							IL_0005: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req::__js_call__(object)
 							IL_000a: ret
-						} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::CallCore
+						} // end of method FunctionObject::CallCore
 
 						.method family hidebysig virtual 
 							instance object ConstructBodyCore (
@@ -1007,7 +1007,7 @@
 							IL_0000: ldarg.3
 							IL_0001: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req::__js_call__(object)
 							IL_0006: ret
-						} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::ConstructBodyCore
+						} // end of method FunctionObject::ConstructBodyCore
 
 						.method family hidebysig virtual 
 							instance object ConstructCore (
@@ -1025,9 +1025,9 @@
 							IL_0007: ldarg.2
 							IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 							IL_000d: ret
-						} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::ConstructCore
+						} // end of method FunctionObject::ConstructCore
 
-					} // end of class FunctionObject_FunctionExpression_BB2FB49F_L48C22
+					} // end of class FunctionObject
 
 
 					// Methods
@@ -1077,7 +1077,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_66CE18BC_L46C21
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -1101,15 +1101,15 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21::_environment0_Http_Request_Streaming_Chunked_RequestBody
+						IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject::_environment0_Http_Request_Streaming_Chunked_RequestBody
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21::_environment2_FunctionExpression_req
+						IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject::_environment2_FunctionExpression_req
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21::_transitionalScopes
+						IL_0016: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject::_transitionalScopes
 						IL_001b: ret
-					} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -1120,7 +1120,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -1131,7 +1131,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1144,11 +1144,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1162,11 +1162,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1184,9 +1184,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_66CE18BC_L46C21
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1208,7 +1208,7 @@
 						[2] object,
 						[3] object,
 						[4] object[],
-						[5] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req/FunctionObject_FunctionExpression_BB2FB49F_L48C22
+						[5] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req/FunctionObject
 					)
 
 					IL_0000: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/Scope::.ctor()
@@ -1245,13 +1245,13 @@
 					IL_004b: ldelem.ref
 					IL_004c: stelem.ref
 					IL_004d: stloc.s 4
-					IL_004f: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req/FunctionObject_FunctionExpression_BB2FB49F_L48C22::.ctor()
+					IL_004f: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req/FunctionObject::.ctor()
 					IL_0054: ldc.i4.0
 					IL_0055: conv.r8
 					IL_0056: ldstr ""
 					IL_005b: ldc.i4.0
 					IL_005c: ldc.i4.1
-					IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req/FunctionObject_FunctionExpression_BB2FB49F_L48C22>(!!0, float64, string, bool, bool)
+					IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req/FunctionObject>(!!0, float64, string, bool, bool)
 					IL_0062: stloc.s 5
 					IL_0064: ldloc.2
 					IL_0065: ldstr "close"
@@ -1291,7 +1291,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2B333867_L38C5
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1313,12 +1313,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5::_environment0_Http_Request_Streaming_Chunked_RequestBody
+					IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject::_environment0_Http_Request_Streaming_Chunked_RequestBody
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5::_transitionalScopes
+					IL_000f: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1329,7 +1329,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1340,7 +1340,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1353,14 +1353,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1374,14 +1374,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1399,9 +1399,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_2B333867_L38C5
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1422,8 +1422,8 @@
 					[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope,
 					[1] object,
 					[2] object[],
-					[3] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22,
-					[4] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21
+					[3] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject,
+					[4] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope::.ctor()
@@ -1468,13 +1468,13 @@
 				IL_004f: ldelem.ref
 				IL_0050: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
 				IL_0055: ldloc.2
-				IL_0056: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope, object[])
+				IL_0056: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope, object[])
 				IL_005b: ldc.i4.1
 				IL_005c: conv.r8
 				IL_005d: ldstr ""
 				IL_0062: ldc.i4.0
 				IL_0063: ldc.i4.1
-				IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22>(!!0, float64, string, bool, bool)
+				IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0069: stloc.3
 				IL_006a: ldloc.1
 				IL_006b: ldstr "on"
@@ -1513,13 +1513,13 @@
 				IL_00a4: ldelem.ref
 				IL_00a5: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
 				IL_00aa: ldloc.2
-				IL_00ab: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope, object[])
+				IL_00ab: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope, object[])
 				IL_00b0: ldc.i4.0
 				IL_00b1: conv.r8
 				IL_00b2: ldstr ""
 				IL_00b7: ldc.i4.0
 				IL_00b8: ldc.i4.1
-				IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21>(!!0, float64, string, bool, bool)
+				IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_00be: stloc.s 4
 				IL_00c0: ldloc.1
 				IL_00c1: ldstr "on"
@@ -1552,7 +1552,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A86A20EB_L26C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1572,9 +1572,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject_FunctionExpression_A86A20EB_L26C31::_environment0_Http_Request_Streaming_Chunked_RequestBody
+				IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject::_environment0_Http_Request_Streaming_Chunked_RequestBody
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1585,7 +1585,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1596,7 +1596,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1609,11 +1609,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject_FunctionExpression_A86A20EB_L26C31::_environment0_Http_Request_Streaming_Chunked_RequestBody
+				IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject::_environment0_Http_Request_Streaming_Chunked_RequestBody
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1627,11 +1627,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject_FunctionExpression_A86A20EB_L26C31::_environment0_Http_Request_Streaming_Chunked_RequestBody
+				IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject::_environment0_Http_Request_Streaming_Chunked_RequestBody
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1649,9 +1649,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A86A20EB_L26C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1677,7 +1677,7 @@
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[6] object[],
-				[7] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5
+				[7] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/Scope::.ctor()
@@ -1742,13 +1742,13 @@
 			IL_00b2: ldelem.ref
 			IL_00b3: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
 			IL_00b8: ldloc.s 6
-			IL_00ba: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object[])
+			IL_00ba: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object[])
 			IL_00bf: ldc.i4.1
 			IL_00c0: conv.r8
 			IL_00c1: ldstr ""
 			IL_00c6: ldc.i4.0
 			IL_00c7: ldc.i4.1
-			IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5>(!!0, float64, string, bool, bool)
+			IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00cd: stloc.s 7
 			IL_00cf: ldstr "request"
 			IL_00d4: ldloc.s 5
@@ -1819,9 +1819,9 @@
 			[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[2] object[],
-			[3] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject_FunctionExpression_2B2BC7DD_L5C34,
+			[3] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject,
 			[4] object,
-			[5] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject_FunctionExpression_A86A20EB_L26C31
+			[5] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::.ctor()
@@ -1848,13 +1848,13 @@
 		IL_002d: ldc.i4.0
 		IL_002e: ldelem.ref
 		IL_002f: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-		IL_0034: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject_FunctionExpression_2B2BC7DD_L5C34::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope)
+		IL_0034: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope)
 		IL_0039: ldc.i4.2
 		IL_003a: conv.r8
 		IL_003b: ldstr ""
 		IL_0040: ldc.i4.0
 		IL_0041: ldc.i4.1
-		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject_FunctionExpression_2B2BC7DD_L5C34>(!!0, float64, string, bool, bool)
+		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0047: stloc.3
 		IL_0048: ldloc.1
 		IL_0049: ldloc.3
@@ -1878,13 +1878,13 @@
 		IL_0072: ldc.i4.0
 		IL_0073: ldelem.ref
 		IL_0074: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-		IL_0079: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject_FunctionExpression_A86A20EB_L26C31::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope)
+		IL_0079: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope)
 		IL_007e: ldc.i4.0
 		IL_007f: conv.r8
 		IL_0080: ldstr ""
 		IL_0085: ldc.i4.0
 		IL_0086: ldc.i4.1
-		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject_FunctionExpression_A86A20EB_L26C31>(!!0, float64, string, bool, bool)
+		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_008c: stloc.s 5
 		IL_008e: ldloc.s 4
 		IL_0090: ldstr "listen"

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Response_Streaming_Chunked_ResponseBody.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Response_Streaming_Chunked_ResponseBody.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C2820861_L5C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C2820861_L5C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -203,7 +203,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FBD0BEEC_L26C22
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -227,15 +227,15 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_environment0_Http_Response_Streaming_Chunked_ResponseBody
+						IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject::_environment0_Http_Response_Streaming_Chunked_ResponseBody
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_environment2_FunctionExpression_L20C4
+						IL_000f: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject::_environment2_FunctionExpression_L20C4
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_transitionalScopes
+						IL_0016: stfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject::_transitionalScopes
 						IL_001b: ret
-					} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -246,7 +246,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -257,7 +257,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -270,14 +270,14 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: ldarg.2
 						IL_000c: ldc.i4.0
 						IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 						IL_0012: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21::__js_call__(object[], object, object)
 						IL_0017: ret
-					} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -291,14 +291,14 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: ldarg.2
 						IL_0008: ldc.i4.0
 						IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 						IL_000e: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21::__js_call__(object[], object, object)
 						IL_0013: ret
-					} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -316,9 +316,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_FBD0BEEC_L26C22
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -430,7 +430,7 @@
 
 					} // end of class Scope
 
-					.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2125F824_L35C22
+					.class nested public auto ansi sealed beforefieldinit FunctionObject
 						extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 					{
 						// Methods
@@ -444,7 +444,7 @@
 							IL_0000: ldarg.0
 							IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 							IL_0006: ret
-						} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::.ctor
+						} // end of method FunctionObject::.ctor
 
 						.method public hidebysig specialname virtual 
 							instance bool get_IsConstructor () cil managed 
@@ -455,7 +455,7 @@
 
 							IL_0000: ldc.i4.1
 							IL_0001: ret
-						} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::get_IsConstructor
+						} // end of method FunctionObject::get_IsConstructor
 
 						.method public hidebysig specialname virtual 
 							instance bool get_RequiresInvocationContext () cil managed 
@@ -466,7 +466,7 @@
 
 							IL_0000: ldc.i4.0
 							IL_0001: ret
-						} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::get_RequiresInvocationContext
+						} // end of method FunctionObject::get_RequiresInvocationContext
 
 						.method family hidebysig virtual 
 							instance object CallCore (
@@ -481,7 +481,7 @@
 							IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 							IL_0005: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21::__js_call__(object)
 							IL_000a: ret
-						} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::CallCore
+						} // end of method FunctionObject::CallCore
 
 						.method family hidebysig virtual 
 							instance object ConstructBodyCore (
@@ -497,7 +497,7 @@
 							IL_0000: ldarg.3
 							IL_0001: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21::__js_call__(object)
 							IL_0006: ret
-						} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::ConstructBodyCore
+						} // end of method FunctionObject::ConstructBodyCore
 
 						.method family hidebysig virtual 
 							instance object ConstructCore (
@@ -515,9 +515,9 @@
 							IL_0007: ldarg.2
 							IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 							IL_000d: ret
-						} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::ConstructCore
+						} // end of method FunctionObject::ConstructCore
 
-					} // end of class FunctionObject_FunctionExpression_2125F824_L35C22
+					} // end of class FunctionObject
 
 
 					// Methods
@@ -567,7 +567,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2CB77A36_L32C21
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -591,15 +591,15 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21::_environment0_Http_Response_Streaming_Chunked_ResponseBody
+						IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject::_environment0_Http_Response_Streaming_Chunked_ResponseBody
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21::_environment2_FunctionExpression_L20C4
+						IL_000f: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject::_environment2_FunctionExpression_L20C4
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21::_transitionalScopes
+						IL_0016: stfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject::_transitionalScopes
 						IL_001b: ret
-					} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -610,7 +610,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -621,7 +621,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -634,11 +634,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -652,11 +652,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -674,9 +674,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_2CB77A36_L32C21
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -698,7 +698,7 @@
 						[2] object,
 						[3] object,
 						[4] object[],
-						[5] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21/FunctionObject_FunctionExpression_2125F824_L35C22
+						[5] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21/FunctionObject
 					)
 
 					IL_0000: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/Scope::.ctor()
@@ -751,13 +751,13 @@
 					IL_0073: ldelem.ref
 					IL_0074: stelem.ref
 					IL_0075: stloc.s 4
-					IL_0077: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21/FunctionObject_FunctionExpression_2125F824_L35C22::.ctor()
+					IL_0077: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21/FunctionObject::.ctor()
 					IL_007c: ldc.i4.0
 					IL_007d: conv.r8
 					IL_007e: ldstr ""
 					IL_0083: ldc.i4.0
 					IL_0084: ldc.i4.1
-					IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21/FunctionObject_FunctionExpression_2125F824_L35C22>(!!0, float64, string, bool, bool)
+					IL_0085: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21/FunctionObject>(!!0, float64, string, bool, bool)
 					IL_008a: stloc.s 5
 					IL_008c: ldloc.2
 					IL_008d: ldstr "close"
@@ -798,7 +798,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8640535C_L20C5
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -820,12 +820,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5::_environment0_Http_Response_Streaming_Chunked_ResponseBody
+					IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject::_environment0_Http_Response_Streaming_Chunked_ResponseBody
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5::_transitionalScopes
+					IL_000f: stfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -836,7 +836,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -847,7 +847,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -860,14 +860,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -881,14 +881,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -906,9 +906,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_8640535C_L20C5
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -931,8 +931,8 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22,
-					[6] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21
+					[5] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject,
+					[6] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::.ctor()
@@ -999,13 +999,13 @@
 				IL_0098: ldelem.ref
 				IL_0099: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
 				IL_009e: ldloc.s 4
-				IL_00a0: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope, object[])
+				IL_00a0: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope, object[])
 				IL_00a5: ldc.i4.1
 				IL_00a6: conv.r8
 				IL_00a7: ldstr ""
 				IL_00ac: ldc.i4.0
 				IL_00ad: ldc.i4.1
-				IL_00ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22>(!!0, float64, string, bool, bool)
+				IL_00ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_00b3: stloc.s 5
 				IL_00b5: ldloc.2
 				IL_00b6: ldstr "on"
@@ -1044,13 +1044,13 @@
 				IL_00f3: ldelem.ref
 				IL_00f4: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
 				IL_00f9: ldloc.s 4
-				IL_00fb: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope, object[])
+				IL_00fb: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope, object[])
 				IL_0100: ldc.i4.0
 				IL_0101: conv.r8
 				IL_0102: ldstr ""
 				IL_0107: ldc.i4.0
 				IL_0108: ldc.i4.1
-				IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21>(!!0, float64, string, bool, bool)
+				IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_010e: stloc.s 6
 				IL_0110: ldloc.2
 				IL_0111: ldstr "on"
@@ -1083,7 +1083,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6069C9D9_L11C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1103,9 +1103,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject_FunctionExpression_6069C9D9_L11C31::_environment0_Http_Response_Streaming_Chunked_ResponseBody
+				IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject::_environment0_Http_Response_Streaming_Chunked_ResponseBody
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1116,7 +1116,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1127,7 +1127,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1140,11 +1140,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject_FunctionExpression_6069C9D9_L11C31::_environment0_Http_Response_Streaming_Chunked_ResponseBody
+				IL_0001: ldfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject::_environment0_Http_Response_Streaming_Chunked_ResponseBody
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30::__js_call__(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1158,11 +1158,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject_FunctionExpression_6069C9D9_L11C31::_environment0_Http_Response_Streaming_Chunked_ResponseBody
+				IL_0001: ldfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject::_environment0_Http_Response_Streaming_Chunked_ResponseBody
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30::__js_call__(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1180,9 +1180,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_6069C9D9_L11C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1208,7 +1208,7 @@
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[6] object[],
-				[7] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5
+				[7] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/Scope::.ctor()
@@ -1260,13 +1260,13 @@
 			IL_007f: ldelem.ref
 			IL_0080: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
 			IL_0085: ldloc.s 6
-			IL_0087: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object[])
+			IL_0087: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object[])
 			IL_008c: ldc.i4.1
 			IL_008d: conv.r8
 			IL_008e: ldstr ""
 			IL_0093: ldc.i4.0
 			IL_0094: ldc.i4.1
-			IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5>(!!0, float64, string, bool, bool)
+			IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_009a: stloc.s 7
 			IL_009c: ldloc.2
 			IL_009d: ldstr "get"
@@ -1326,9 +1326,9 @@
 			[0] class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[2] object[],
-			[3] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server/FunctionObject_FunctionExpression_C2820861_L5C34,
+			[3] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server/FunctionObject,
 			[4] object,
-			[5] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject_FunctionExpression_6069C9D9_L11C31
+			[5] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::.ctor()
@@ -1351,13 +1351,13 @@
 		IL_0029: ldloc.0
 		IL_002a: stelem.ref
 		IL_002b: stloc.2
-		IL_002c: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server/FunctionObject_FunctionExpression_C2820861_L5C34::.ctor()
+		IL_002c: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server/FunctionObject::.ctor()
 		IL_0031: ldc.i4.2
 		IL_0032: conv.r8
 		IL_0033: ldstr ""
 		IL_0038: ldc.i4.0
 		IL_0039: ldc.i4.1
-		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server/FunctionObject_FunctionExpression_C2820861_L5C34>(!!0, float64, string, bool, bool)
+		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_003f: stloc.3
 		IL_0040: ldloc.1
 		IL_0041: ldloc.3
@@ -1381,13 +1381,13 @@
 		IL_006a: ldc.i4.0
 		IL_006b: ldelem.ref
 		IL_006c: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
-		IL_0071: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject_FunctionExpression_6069C9D9_L11C31::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope)
+		IL_0071: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope)
 		IL_0076: ldc.i4.0
 		IL_0077: conv.r8
 		IL_0078: ldstr ""
 		IL_007d: ldc.i4.0
 		IL_007e: ldc.i4.1
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject_FunctionExpression_6069C9D9_L11C31>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0084: stloc.s 5
 		IL_0086: ldloc.s 4
 		IL_0088: ldstr "listen"

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8ADFF83F_L9C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -58,15 +58,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21::_environment1_FunctionExpression_server
+					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment1_FunctionExpression_server
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -77,7 +77,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -88,7 +88,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -101,14 +101,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -122,14 +122,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -147,9 +147,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_8ADFF83F_L9C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -227,7 +227,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C3680A0B_L15C16
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -251,15 +251,15 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+						IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16::_environment1_FunctionExpression_server
+						IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject::_environment1_FunctionExpression_server
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16::_transitionalScopes
+						IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject::_transitionalScopes
 						IL_001b: ret
-					} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -270,7 +270,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -281,7 +281,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -294,11 +294,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -312,11 +312,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -334,9 +334,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_C3680A0B_L15C16
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -427,7 +427,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C3CAD785_L13C20
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -451,15 +451,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20::_environment1_FunctionExpression_server
+					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject::_environment1_FunctionExpression_server
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -470,7 +470,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -481,7 +481,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -494,11 +494,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -512,11 +512,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -534,9 +534,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_C3CAD785_L13C20
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -558,7 +558,7 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16
+					[5] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/Scope::.ctor()
@@ -607,13 +607,13 @@
 				IL_0052: ldelem.ref
 				IL_0053: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
 				IL_0058: ldloc.s 4
-				IL_005a: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope, object[])
+				IL_005a: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope, object[])
 				IL_005f: ldc.i4.0
 				IL_0060: conv.r8
 				IL_0061: ldstr ""
 				IL_0066: ldc.i4.0
 				IL_0067: ldc.i4.1
-				IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16>(!!0, float64, string, bool, bool)
+				IL_0068: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_006d: stloc.s 5
 				IL_006f: ldloc.s 5
 				IL_0071: ldc.r8 0.0
@@ -656,7 +656,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BC7FD036_L5C58
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -676,9 +676,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject_FunctionExpression_BC7FD036_L5C58::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -689,7 +689,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -700,7 +700,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -713,14 +713,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject_FunctionExpression_BC7FD036_L5C58::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -734,14 +734,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject_FunctionExpression_BC7FD036_L5C58::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -759,9 +759,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_BC7FD036_L5C58
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -786,8 +786,8 @@
 				[2] object,
 				[3] object,
 				[4] object[],
-				[5] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21,
-				[6] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20
+				[5] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject,
+				[6] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::.ctor()
@@ -837,13 +837,13 @@
 			IL_006b: ldelem.ref
 			IL_006c: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
 			IL_0071: ldloc.s 4
-			IL_0073: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope, object[])
+			IL_0073: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope, object[])
 			IL_0078: ldc.i4.1
 			IL_0079: conv.r8
 			IL_007a: ldstr ""
 			IL_007f: ldc.i4.0
 			IL_0080: ldc.i4.1
-			IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21>(!!0, float64, string, bool, bool)
+			IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0086: stloc.s 5
 			IL_0088: ldloc.2
 			IL_0089: ldstr "on"
@@ -875,13 +875,13 @@
 			IL_00c3: ldelem.ref
 			IL_00c4: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
 			IL_00c9: ldloc.s 4
-			IL_00cb: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope, object[])
+			IL_00cb: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope, object[])
 			IL_00d0: ldc.i4.0
 			IL_00d1: conv.r8
 			IL_00d2: ldstr ""
 			IL_00d7: ldc.i4.0
 			IL_00d8: ldc.i4.1
-			IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20>(!!0, float64, string, bool, bool)
+			IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00de: stloc.s 6
 			IL_00e0: ldloc.2
 			IL_00e1: ldstr "on"
@@ -922,7 +922,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F2056A7A_L24C55
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -946,15 +946,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55::_environment1_FunctionExpression_L22C30
+					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject::_environment1_FunctionExpression_L22C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -965,7 +965,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -976,7 +976,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -989,11 +989,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1007,11 +1007,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1029,9 +1029,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_F2056A7A_L24C55
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1089,7 +1089,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E3FCF0A6_L30C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1113,15 +1113,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_environment1_FunctionExpression_L22C30
+					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject::_environment1_FunctionExpression_L22C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1132,7 +1132,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1143,7 +1143,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1156,14 +1156,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1177,14 +1177,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1202,9 +1202,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_E3FCF0A6_L30C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1275,7 +1275,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F2F79B12_L36C18
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Methods
@@ -1289,7 +1289,7 @@
 						IL_0000: ldarg.0
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -1300,7 +1300,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -1311,7 +1311,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1326,7 +1326,7 @@
 						IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_0005: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17::__js_call__(object)
 						IL_000a: ret
-					} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1342,7 +1342,7 @@
 						IL_0000: ldarg.3
 						IL_0001: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17::__js_call__(object)
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1360,9 +1360,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_F2F79B12_L36C18
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1412,7 +1412,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_03FCDB35_L34C20
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1436,15 +1436,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20::_environment1_FunctionExpression_L22C30
+					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject::_environment1_FunctionExpression_L22C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1455,7 +1455,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1466,7 +1466,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1479,11 +1479,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1497,11 +1497,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1519,9 +1519,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_03FCDB35_L34C20
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1543,7 +1543,7 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17/FunctionObject_FunctionExpression_F2F79B12_L36C18
+					[5] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/Scope::.ctor()
@@ -1580,13 +1580,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: stelem.ref
 				IL_004d: stloc.s 4
-				IL_004f: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17/FunctionObject_FunctionExpression_F2F79B12_L36C18::.ctor()
+				IL_004f: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17/FunctionObject::.ctor()
 				IL_0054: ldc.i4.0
 				IL_0055: conv.r8
 				IL_0056: ldstr ""
 				IL_005b: ldc.i4.0
 				IL_005c: ldc.i4.1
-				IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17/FunctionObject_FunctionExpression_F2F79B12_L36C18>(!!0, float64, string, bool, bool)
+				IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0062: stloc.s 5
 				IL_0064: ldloc.2
 				IL_0065: ldstr "close"
@@ -1630,7 +1630,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0BE9B9C0_L22C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1650,9 +1650,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject_FunctionExpression_0BE9B9C0_L22C31::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1663,7 +1663,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1674,7 +1674,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1687,11 +1687,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject_FunctionExpression_0BE9B9C0_L22C31::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1705,11 +1705,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject_FunctionExpression_0BE9B9C0_L22C31::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1727,9 +1727,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_0BE9B9C0_L22C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1753,9 +1753,9 @@
 				[2] object,
 				[3] object,
 				[4] object[],
-				[5] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55,
-				[6] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21,
-				[7] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20
+				[5] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject,
+				[6] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject,
+				[7] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::.ctor()
@@ -1796,13 +1796,13 @@
 			IL_0056: ldelem.ref
 			IL_0057: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
 			IL_005c: ldloc.s 4
-			IL_005e: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
+			IL_005e: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
 			IL_0063: ldc.i4.0
 			IL_0064: conv.r8
 			IL_0065: ldstr ""
 			IL_006a: ldc.i4.0
 			IL_006b: ldc.i4.1
-			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55>(!!0, float64, string, bool, bool)
+			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0071: stloc.s 5
 			IL_0073: ldstr "connect"
 			IL_0078: ldloc.2
@@ -1851,13 +1851,13 @@
 			IL_00eb: ldelem.ref
 			IL_00ec: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
 			IL_00f1: ldloc.s 4
-			IL_00f3: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
+			IL_00f3: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
 			IL_00f8: ldc.i4.1
 			IL_00f9: conv.r8
 			IL_00fa: ldstr ""
 			IL_00ff: ldc.i4.0
 			IL_0100: ldc.i4.1
-			IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21>(!!0, float64, string, bool, bool)
+			IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0106: stloc.s 6
 			IL_0108: ldloc.3
 			IL_0109: ldstr "on"
@@ -1891,13 +1891,13 @@
 			IL_014d: ldelem.ref
 			IL_014e: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
 			IL_0153: ldloc.s 4
-			IL_0155: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
+			IL_0155: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
 			IL_015a: ldc.i4.0
 			IL_015b: conv.r8
 			IL_015c: ldstr ""
 			IL_0161: ldc.i4.0
 			IL_0162: ldc.i4.1
-			IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20>(!!0, float64, string, bool, bool)
+			IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0168: stloc.s 7
 			IL_016a: ldloc.3
 			IL_016b: ldstr "on"
@@ -1958,9 +1958,9 @@
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
-			[4] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject_FunctionExpression_BC7FD036_L5C58,
+			[4] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject,
 			[5] object,
-			[6] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject_FunctionExpression_0BE9B9C0_L22C31
+			[6] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::.ctor()
@@ -1992,13 +1992,13 @@
 		IL_003e: ldc.i4.0
 		IL_003f: ldelem.ref
 		IL_0040: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
-		IL_0045: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject_FunctionExpression_BC7FD036_L5C58::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope)
+		IL_0045: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope)
 		IL_004a: ldc.i4.1
 		IL_004b: conv.r8
 		IL_004c: ldstr ""
 		IL_0051: ldc.i4.0
 		IL_0052: ldc.i4.1
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject_FunctionExpression_BC7FD036_L5C58>(!!0, float64, string, bool, bool)
+		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0058: stloc.s 4
 		IL_005a: ldstr "createServer"
 		IL_005f: ldloc.2
@@ -2023,13 +2023,13 @@
 		IL_008a: ldc.i4.0
 		IL_008b: ldelem.ref
 		IL_008c: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
-		IL_0091: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject_FunctionExpression_0BE9B9C0_L22C31::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope)
+		IL_0091: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope)
 		IL_0096: ldc.i4.0
 		IL_0097: conv.r8
 		IL_0098: ldstr ""
 		IL_009d: ldc.i4.0
 		IL_009e: ldc.i4.1
-		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject_FunctionExpression_0BE9B9C0_L22C31>(!!0, float64, string, bool, bool)
+		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a4: stloc.s 6
 		IL_00a6: ldloc.s 5
 		IL_00a8: ldstr "listen"

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_47F27A5E_L8C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -58,15 +58,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21::_environment0_Net_CreateServer_Connect_Basic
+					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment0_Net_CreateServer_Connect_Basic
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21::_environment1_FunctionExpression_server
+					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment1_FunctionExpression_server
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -77,7 +77,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -88,7 +88,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -101,14 +101,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -122,14 +122,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -147,9 +147,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_47F27A5E_L8C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -223,7 +223,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_91246900_L12C20
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -247,15 +247,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20::_environment0_Net_CreateServer_Connect_Basic
+					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject::_environment0_Net_CreateServer_Connect_Basic
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20::_environment1_FunctionExpression_server
+					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject::_environment1_FunctionExpression_server
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_91246900_L12C20::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -266,7 +266,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_91246900_L12C20::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -277,7 +277,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_91246900_L12C20::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -290,11 +290,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_91246900_L12C20::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -308,11 +308,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_91246900_L12C20::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -330,9 +330,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_91246900_L12C20::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_91246900_L12C20
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -439,7 +439,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E00EA35D_L5C33
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -459,9 +459,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_E00EA35D_L5C33::_environment0_Net_CreateServer_Connect_Basic
+				IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject::_environment0_Net_CreateServer_Connect_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -472,7 +472,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -483,7 +483,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -496,14 +496,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_E00EA35D_L5C33::_environment0_Net_CreateServer_Connect_Basic
+				IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject::_environment0_Net_CreateServer_Connect_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -517,14 +517,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_E00EA35D_L5C33::_environment0_Net_CreateServer_Connect_Basic
+				IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject::_environment0_Net_CreateServer_Connect_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -542,9 +542,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E00EA35D_L5C33
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -567,8 +567,8 @@
 				[0] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope,
 				[1] object,
 				[2] object[],
-				[3] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21,
-				[4] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20
+				[3] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject,
+				[4] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::.ctor()
@@ -603,13 +603,13 @@
 			IL_003d: ldelem.ref
 			IL_003e: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
 			IL_0043: ldloc.2
-			IL_0044: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope, object[])
+			IL_0044: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope, object[])
 			IL_0049: ldc.i4.1
 			IL_004a: conv.r8
 			IL_004b: ldstr ""
 			IL_0050: ldc.i4.0
 			IL_0051: ldc.i4.1
-			IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21>(!!0, float64, string, bool, bool)
+			IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0057: stloc.3
 			IL_0058: ldloc.1
 			IL_0059: ldstr "on"
@@ -641,13 +641,13 @@
 			IL_008f: ldelem.ref
 			IL_0090: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
 			IL_0095: ldloc.2
-			IL_0096: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope, object[])
+			IL_0096: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope, object[])
 			IL_009b: ldc.i4.0
 			IL_009c: conv.r8
 			IL_009d: ldstr ""
 			IL_00a2: ldc.i4.0
 			IL_00a3: ldc.i4.1
-			IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20>(!!0, float64, string, bool, bool)
+			IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00a9: stloc.s 4
 			IL_00ab: ldloc.1
 			IL_00ac: ldstr "on"
@@ -688,7 +688,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FCCB5C27_L23C55
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -712,15 +712,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55::_environment0_Net_CreateServer_Connect_Basic
+					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject::_environment0_Net_CreateServer_Connect_Basic
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55::_environment1_FunctionExpression_L19C30
+					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject::_environment1_FunctionExpression_L19C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -731,7 +731,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -742,7 +742,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -755,11 +755,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -773,11 +773,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -795,9 +795,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_FCCB5C27_L23C55
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -855,7 +855,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AAF4393B_L28C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -879,15 +879,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21::_environment0_Net_CreateServer_Connect_Basic
+					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject::_environment0_Net_CreateServer_Connect_Basic
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21::_environment1_FunctionExpression_L19C30
+					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject::_environment1_FunctionExpression_L19C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -898,7 +898,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -909,7 +909,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -922,14 +922,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -943,14 +943,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -968,9 +968,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_AAF4393B_L28C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1048,7 +1048,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3A83E61C_L34C18
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Methods
@@ -1062,7 +1062,7 @@
 						IL_0000: ldarg.0
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -1073,7 +1073,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -1084,7 +1084,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1099,7 +1099,7 @@
 						IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_0005: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17::__js_call__(object)
 						IL_000a: ret
-					} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1115,7 +1115,7 @@
 						IL_0000: ldarg.3
 						IL_0001: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17::__js_call__(object)
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1133,9 +1133,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_3A83E61C_L34C18
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1185,7 +1185,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F3DE6889_L32C20
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1209,15 +1209,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20::_environment0_Net_CreateServer_Connect_Basic
+					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject::_environment0_Net_CreateServer_Connect_Basic
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20::_environment1_FunctionExpression_L19C30
+					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject::_environment1_FunctionExpression_L19C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1228,7 +1228,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1239,7 +1239,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1252,11 +1252,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1270,11 +1270,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1292,9 +1292,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_F3DE6889_L32C20
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1316,7 +1316,7 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17/FunctionObject_FunctionExpression_3A83E61C_L34C18
+					[5] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/Scope::.ctor()
@@ -1353,13 +1353,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: stelem.ref
 				IL_004d: stloc.s 4
-				IL_004f: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17/FunctionObject_FunctionExpression_3A83E61C_L34C18::.ctor()
+				IL_004f: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17/FunctionObject::.ctor()
 				IL_0054: ldc.i4.0
 				IL_0055: conv.r8
 				IL_0056: ldstr ""
 				IL_005b: ldc.i4.0
 				IL_005c: ldc.i4.1
-				IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17/FunctionObject_FunctionExpression_3A83E61C_L34C18>(!!0, float64, string, bool, bool)
+				IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0062: stloc.s 5
 				IL_0064: ldloc.2
 				IL_0065: ldstr "close"
@@ -1403,7 +1403,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7DD89A92_L19C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1423,9 +1423,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject_FunctionExpression_7DD89A92_L19C31::_environment0_Net_CreateServer_Connect_Basic
+				IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject::_environment0_Net_CreateServer_Connect_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1436,7 +1436,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1447,7 +1447,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1460,11 +1460,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject_FunctionExpression_7DD89A92_L19C31::_environment0_Net_CreateServer_Connect_Basic
+				IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject::_environment0_Net_CreateServer_Connect_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1478,11 +1478,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject_FunctionExpression_7DD89A92_L19C31::_environment0_Net_CreateServer_Connect_Basic
+				IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject::_environment0_Net_CreateServer_Connect_Basic
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1500,9 +1500,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7DD89A92_L19C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1530,9 +1530,9 @@
 				[6] object,
 				[7] object,
 				[8] object[],
-				[9] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55,
-				[10] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21,
-				[11] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20
+				[9] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject,
+				[10] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject,
+				[11] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::.ctor()
@@ -1619,13 +1619,13 @@
 			IL_00e4: ldelem.ref
 			IL_00e5: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
 			IL_00ea: ldloc.s 8
-			IL_00ec: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope, object[])
+			IL_00ec: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope, object[])
 			IL_00f1: ldc.i4.0
 			IL_00f2: conv.r8
 			IL_00f3: ldstr ""
 			IL_00f8: ldc.i4.0
 			IL_00f9: ldc.i4.1
-			IL_00fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55>(!!0, float64, string, bool, bool)
+			IL_00fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00ff: stloc.s 9
 			IL_0101: ldstr "connect"
 			IL_0106: ldloc.3
@@ -1665,13 +1665,13 @@
 			IL_0158: ldelem.ref
 			IL_0159: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
 			IL_015e: ldloc.s 8
-			IL_0160: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope, object[])
+			IL_0160: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope, object[])
 			IL_0165: ldc.i4.1
 			IL_0166: conv.r8
 			IL_0167: ldstr ""
 			IL_016c: ldc.i4.0
 			IL_016d: ldc.i4.1
-			IL_016e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21>(!!0, float64, string, bool, bool)
+			IL_016e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0173: stloc.s 10
 			IL_0175: ldloc.s 7
 			IL_0177: ldstr "on"
@@ -1705,13 +1705,13 @@
 			IL_01bc: ldelem.ref
 			IL_01bd: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
 			IL_01c2: ldloc.s 8
-			IL_01c4: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope, object[])
+			IL_01c4: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope, object[])
 			IL_01c9: ldc.i4.0
 			IL_01ca: conv.r8
 			IL_01cb: ldstr ""
 			IL_01d0: ldc.i4.0
 			IL_01d1: ldc.i4.1
-			IL_01d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20>(!!0, float64, string, bool, bool)
+			IL_01d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_01d7: stloc.s 11
 			IL_01d9: ldloc.s 7
 			IL_01db: ldstr "on"
@@ -1771,9 +1771,9 @@
 			[0] class Modules.Net_CreateServer_Connect_Basic/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule,
 			[2] object[],
-			[3] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_E00EA35D_L5C33,
+			[3] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject,
 			[4] object,
-			[5] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject_FunctionExpression_7DD89A92_L19C31
+			[5] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Net_CreateServer_Connect_Basic/Scope::.ctor()
@@ -1799,13 +1799,13 @@
 		IL_002c: ldc.i4.0
 		IL_002d: ldelem.ref
 		IL_002e: castclass Modules.Net_CreateServer_Connect_Basic/Scope
-		IL_0033: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_E00EA35D_L5C33::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope)
+		IL_0033: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope)
 		IL_0038: ldc.i4.1
 		IL_0039: conv.r8
 		IL_003a: ldstr ""
 		IL_003f: ldc.i4.0
 		IL_0040: ldc.i4.1
-		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_E00EA35D_L5C33>(!!0, float64, string, bool, bool)
+		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0046: stloc.3
 		IL_0047: ldstr "createServer"
 		IL_004c: ldloc.3
@@ -1829,13 +1829,13 @@
 		IL_0075: ldc.i4.0
 		IL_0076: ldelem.ref
 		IL_0077: castclass Modules.Net_CreateServer_Connect_Basic/Scope
-		IL_007c: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject_FunctionExpression_7DD89A92_L19C31::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope)
+		IL_007c: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope)
 		IL_0081: ldc.i4.0
 		IL_0082: conv.r8
 		IL_0083: ldstr ""
 		IL_0088: ldc.i4.0
 		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject_FunctionExpression_7DD89A92_L19C31>(!!0, float64, string, bool, bool)
+		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_008f: stloc.s 5
 		IL_0091: ldloc.s 4
 		IL_0093: ldstr "listen"

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Binary_Data_Defaults_To_Buffer.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Binary_Data_Defaults_To_Buffer.verified.txt
@@ -55,7 +55,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AA8D4FE4_L9C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -79,15 +79,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+					IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_environment1_FunctionExpression_server
+					IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment1_FunctionExpression_server
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -98,7 +98,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -109,7 +109,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -122,14 +122,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -143,14 +143,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -168,9 +168,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_AA8D4FE4_L9C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -426,7 +426,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2A91282E_L5C33
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -446,9 +446,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject_FunctionExpression_2A91282E_L5C33::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -459,7 +459,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -470,7 +470,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -483,14 +483,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject_FunctionExpression_2A91282E_L5C33::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -504,14 +504,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject_FunctionExpression_2A91282E_L5C33::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -529,9 +529,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_2A91282E_L5C33
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -555,7 +555,7 @@
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[2] object,
 				[3] object[],
-				[4] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21
+				[4] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::.ctor()
@@ -597,13 +597,13 @@
 			IL_004c: ldelem.ref
 			IL_004d: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
 			IL_0052: ldloc.3
-			IL_0053: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope, object[])
+			IL_0053: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope, object[])
 			IL_0058: ldc.i4.1
 			IL_0059: conv.r8
 			IL_005a: ldstr ""
 			IL_005f: ldc.i4.0
 			IL_0060: ldc.i4.1
-			IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21>(!!0, float64, string, bool, bool)
+			IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0066: stloc.s 4
 			IL_0068: ldloc.2
 			IL_0069: ldstr "on"
@@ -644,7 +644,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_945BE1B3_L25C55
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -668,15 +668,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+					IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55::_environment1_FunctionExpression_L23C30
+					IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject::_environment1_FunctionExpression_L23C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -687,7 +687,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -698,7 +698,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -711,11 +711,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -729,11 +729,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -751,9 +751,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_945BE1B3_L25C55
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -830,7 +830,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_895CF472_L30C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -854,15 +854,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+					IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21::_environment1_FunctionExpression_L23C30
+					IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject::_environment1_FunctionExpression_L23C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -873,7 +873,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -884,7 +884,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -897,14 +897,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -918,14 +918,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -943,9 +943,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_895CF472_L30C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1037,7 +1037,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_56792F9B_L39C18
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Methods
@@ -1051,7 +1051,7 @@
 						IL_0000: ldarg.0
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -1062,7 +1062,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -1073,7 +1073,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1088,7 +1088,7 @@
 						IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_0005: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17::__js_call__(object)
 						IL_000a: ret
-					} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1104,7 +1104,7 @@
 						IL_0000: ldarg.3
 						IL_0001: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17::__js_call__(object)
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1122,9 +1122,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_56792F9B_L39C18
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1174,7 +1174,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CB9F1FB7_L36C20
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1198,15 +1198,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+					IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_environment1_FunctionExpression_L23C30
+					IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject::_environment1_FunctionExpression_L23C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1217,7 +1217,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1228,7 +1228,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1241,11 +1241,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1259,11 +1259,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1281,9 +1281,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_CB9F1FB7_L36C20
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1308,7 +1308,7 @@
 					[5] object,
 					[6] object,
 					[7] object[],
-					[8] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17/FunctionObject_FunctionExpression_56792F9B_L39C18
+					[8] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/Scope::.ctor()
@@ -1399,13 +1399,13 @@
 				IL_0106: ldelem.ref
 				IL_0107: stelem.ref
 				IL_0108: stloc.s 7
-				IL_010a: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17/FunctionObject_FunctionExpression_56792F9B_L39C18::.ctor()
+				IL_010a: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17/FunctionObject::.ctor()
 				IL_010f: ldc.i4.0
 				IL_0110: conv.r8
 				IL_0111: ldstr ""
 				IL_0116: ldc.i4.0
 				IL_0117: ldc.i4.1
-				IL_0118: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17/FunctionObject_FunctionExpression_56792F9B_L39C18>(!!0, float64, string, bool, bool)
+				IL_0118: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_011d: stloc.s 8
 				IL_011f: ldloc.s 6
 				IL_0121: ldstr "close"
@@ -1449,7 +1449,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_990FE208_L23C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1469,9 +1469,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject_FunctionExpression_990FE208_L23C31::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1482,7 +1482,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1493,7 +1493,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1506,11 +1506,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject_FunctionExpression_990FE208_L23C31::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1524,11 +1524,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject_FunctionExpression_990FE208_L23C31::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1546,9 +1546,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_990FE208_L23C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1572,10 +1572,10 @@
 				[2] object,
 				[3] object,
 				[4] object[],
-				[5] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55,
+				[5] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject,
 				[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[7] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21,
-				[8] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20
+				[7] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject,
+				[8] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::.ctor()
@@ -1616,13 +1616,13 @@
 			IL_0056: ldelem.ref
 			IL_0057: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
 			IL_005c: ldloc.s 4
-			IL_005e: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope, object[])
+			IL_005e: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope, object[])
 			IL_0063: ldc.i4.0
 			IL_0064: conv.r8
 			IL_0065: ldstr ""
 			IL_006a: ldc.i4.0
 			IL_006b: ldc.i4.1
-			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55>(!!0, float64, string, bool, bool)
+			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0071: stloc.s 5
 			IL_0073: ldstr "connect"
 			IL_0078: ldloc.2
@@ -1665,13 +1665,13 @@
 			IL_00cb: ldelem.ref
 			IL_00cc: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
 			IL_00d1: ldloc.s 4
-			IL_00d3: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope, object[])
+			IL_00d3: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope, object[])
 			IL_00d8: ldc.i4.1
 			IL_00d9: conv.r8
 			IL_00da: ldstr ""
 			IL_00df: ldc.i4.0
 			IL_00e0: ldc.i4.1
-			IL_00e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21>(!!0, float64, string, bool, bool)
+			IL_00e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00e6: stloc.s 7
 			IL_00e8: ldloc.3
 			IL_00e9: ldstr "on"
@@ -1705,13 +1705,13 @@
 			IL_012d: ldelem.ref
 			IL_012e: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
 			IL_0133: ldloc.s 4
-			IL_0135: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope, object[])
+			IL_0135: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope, object[])
 			IL_013a: ldc.i4.0
 			IL_013b: conv.r8
 			IL_013c: ldstr ""
 			IL_0141: ldc.i4.0
 			IL_0142: ldc.i4.1
-			IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20>(!!0, float64, string, bool, bool)
+			IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0148: stloc.s 8
 			IL_014a: ldloc.3
 			IL_014b: ldstr "on"
@@ -1771,9 +1771,9 @@
 			[0] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule,
 			[2] object[],
-			[3] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject_FunctionExpression_2A91282E_L5C33,
+			[3] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject,
 			[4] object,
-			[5] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject_FunctionExpression_990FE208_L23C31
+			[5] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::.ctor()
@@ -1799,13 +1799,13 @@
 		IL_002c: ldc.i4.0
 		IL_002d: ldelem.ref
 		IL_002e: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
-		IL_0033: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject_FunctionExpression_2A91282E_L5C33::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope)
+		IL_0033: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope)
 		IL_0038: ldc.i4.1
 		IL_0039: conv.r8
 		IL_003a: ldstr ""
 		IL_003f: ldc.i4.0
 		IL_0040: ldc.i4.1
-		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject_FunctionExpression_2A91282E_L5C33>(!!0, float64, string, bool, bool)
+		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0046: stloc.3
 		IL_0047: ldstr "createServer"
 		IL_004c: ldloc.3
@@ -1829,13 +1829,13 @@
 		IL_0075: ldc.i4.0
 		IL_0076: ldelem.ref
 		IL_0077: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
-		IL_007c: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject_FunctionExpression_990FE208_L23C31::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope)
+		IL_007c: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope)
 		IL_0081: ldc.i4.0
 		IL_0082: conv.r8
 		IL_0083: ldstr ""
 		IL_0088: ldc.i4.0
 		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject_FunctionExpression_990FE208_L23C31>(!!0, float64, string, bool, bool)
+		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_008f: stloc.s 5
 		IL_0091: ldloc.s 4
 		IL_0093: ldstr "listen"

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EA8659D0_L11C33
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject_FunctionExpression_EA8659D0_L11C33::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject_FunctionExpression_EA8659D0_L11C33::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject_FunctionExpression_EA8659D0_L11C33::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_EA8659D0_L11C33
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -261,7 +261,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_ED8227CA_L18C55
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -285,15 +285,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+					IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55::_environment1_FunctionExpression_L16C30
+					IL_000f: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject::_environment1_FunctionExpression_L16C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -304,7 +304,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -315,7 +315,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -328,11 +328,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -346,11 +346,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -368,9 +368,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_ED8227CA_L18C55
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -565,7 +565,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3897B4EB_L30C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -589,15 +589,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+					IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21::_environment1_FunctionExpression_L16C30
+					IL_000f: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject::_environment1_FunctionExpression_L16C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -608,7 +608,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -619,7 +619,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -632,14 +632,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -653,14 +653,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -678,9 +678,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_3897B4EB_L30C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -744,7 +744,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E9FDE408_L40C18
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Methods
@@ -758,7 +758,7 @@
 						IL_0000: ldarg.0
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -769,7 +769,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -780,7 +780,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -795,7 +795,7 @@
 						IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_0005: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17::__js_call__(object)
 						IL_000a: ret
-					} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -811,7 +811,7 @@
 						IL_0000: ldarg.3
 						IL_0001: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17::__js_call__(object)
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -829,9 +829,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_E9FDE408_L40C18
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -881,7 +881,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_49A25974_L34C20
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -905,15 +905,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+					IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20::_environment1_FunctionExpression_L16C30
+					IL_000f: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject::_environment1_FunctionExpression_L16C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -924,7 +924,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -935,7 +935,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -948,11 +948,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -966,11 +966,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -988,9 +988,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_49A25974_L34C20
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1011,7 +1011,7 @@
 					[1] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 					[2] object,
 					[3] object[],
-					[4] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17/FunctionObject_FunctionExpression_E9FDE408_L40C18
+					[4] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/Scope::.ctor()
@@ -1092,13 +1092,13 @@
 				IL_00af: ldelem.ref
 				IL_00b0: stelem.ref
 				IL_00b1: stloc.3
-				IL_00b2: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17/FunctionObject_FunctionExpression_E9FDE408_L40C18::.ctor()
+				IL_00b2: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17/FunctionObject::.ctor()
 				IL_00b7: ldc.i4.0
 				IL_00b8: conv.r8
 				IL_00b9: ldstr ""
 				IL_00be: ldc.i4.0
 				IL_00bf: ldc.i4.1
-				IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17/FunctionObject_FunctionExpression_E9FDE408_L40C18>(!!0, float64, string, bool, bool)
+				IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_00c5: stloc.s 4
 				IL_00c7: ldloc.2
 				IL_00c8: ldstr "close"
@@ -1140,7 +1140,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_47229D4D_L16C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1160,9 +1160,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject_FunctionExpression_47229D4D_L16C31::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1173,7 +1173,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1184,7 +1184,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1197,11 +1197,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject_FunctionExpression_47229D4D_L16C31::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1215,11 +1215,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject_FunctionExpression_47229D4D_L16C31::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1237,9 +1237,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_47229D4D_L16C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1263,9 +1263,9 @@
 				[2] object,
 				[3] object,
 				[4] object[],
-				[5] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55,
-				[6] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21,
-				[7] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20
+				[5] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject,
+				[6] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject,
+				[7] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::.ctor()
@@ -1306,13 +1306,13 @@
 			IL_0056: ldelem.ref
 			IL_0057: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
 			IL_005c: ldloc.s 4
-			IL_005e: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
+			IL_005e: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
 			IL_0063: ldc.i4.0
 			IL_0064: conv.r8
 			IL_0065: ldstr ""
 			IL_006a: ldc.i4.0
 			IL_006b: ldc.i4.1
-			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55>(!!0, float64, string, bool, bool)
+			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0071: stloc.s 5
 			IL_0073: ldstr "connect"
 			IL_0078: ldloc.2
@@ -1358,13 +1358,13 @@
 			IL_00e0: ldelem.ref
 			IL_00e1: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
 			IL_00e6: ldloc.s 4
-			IL_00e8: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
+			IL_00e8: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
 			IL_00ed: ldc.i4.1
 			IL_00ee: conv.r8
 			IL_00ef: ldstr ""
 			IL_00f4: ldc.i4.0
 			IL_00f5: ldc.i4.1
-			IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21>(!!0, float64, string, bool, bool)
+			IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00fb: stloc.s 6
 			IL_00fd: ldloc.3
 			IL_00fe: ldstr "on"
@@ -1398,13 +1398,13 @@
 			IL_0142: ldelem.ref
 			IL_0143: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
 			IL_0148: ldloc.s 4
-			IL_014a: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
+			IL_014a: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
 			IL_014f: ldc.i4.0
 			IL_0150: conv.r8
 			IL_0151: ldstr ""
 			IL_0156: ldc.i4.0
 			IL_0157: ldc.i4.1
-			IL_0158: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20>(!!0, float64, string, bool, bool)
+			IL_0158: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_015d: stloc.s 7
 			IL_015f: ldloc.3
 			IL_0160: ldstr "on"
@@ -1482,9 +1482,9 @@
 			[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule,
 			[2] object[],
-			[3] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject_FunctionExpression_EA8659D0_L11C33,
+			[3] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject,
 			[4] object,
-			[5] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject_FunctionExpression_47229D4D_L16C31
+			[5] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::.ctor()
@@ -1530,13 +1530,13 @@
 		IL_0068: ldc.i4.0
 		IL_0069: ldelem.ref
 		IL_006a: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-		IL_006f: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject_FunctionExpression_EA8659D0_L11C33::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope)
+		IL_006f: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope)
 		IL_0074: ldc.i4.1
 		IL_0075: conv.r8
 		IL_0076: ldstr ""
 		IL_007b: ldc.i4.0
 		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject_FunctionExpression_EA8659D0_L11C33>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.3
 		IL_0083: ldstr "createServer"
 		IL_0088: ldloc.3
@@ -1560,13 +1560,13 @@
 		IL_00b1: ldc.i4.0
 		IL_00b2: ldelem.ref
 		IL_00b3: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-		IL_00b8: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject_FunctionExpression_47229D4D_L16C31::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope)
+		IL_00b8: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope)
 		IL_00bd: ldc.i4.0
 		IL_00be: conv.r8
 		IL_00bf: ldstr ""
 		IL_00c4: ldc.i4.0
 		IL_00c5: ldc.i4.1
-		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject_FunctionExpression_47229D4D_L16C31>(!!0, float64, string, bool, bool)
+		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00cb: stloc.s 5
 		IL_00cd: ldloc.s 4
 		IL_00cf: ldstr "listen"

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_SetEncoding_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_SetEncoding_Utf8.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2D181329_L9C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -58,15 +58,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21::_environment0_Net_Socket_SetEncoding_Utf8
+					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_SetEncoding_Utf8
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21::_environment1_FunctionExpression_server
+					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment1_FunctionExpression_server
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -77,7 +77,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -88,7 +88,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -101,14 +101,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -122,14 +122,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -147,9 +147,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_2D181329_L9C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -237,7 +237,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FAB9795C_L14C20
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -261,15 +261,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20::_environment0_Net_Socket_SetEncoding_Utf8
+					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject::_environment0_Net_Socket_SetEncoding_Utf8
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20::_environment1_FunctionExpression_server
+					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject::_environment1_FunctionExpression_server
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -280,7 +280,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -291,7 +291,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -304,11 +304,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -322,11 +322,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -344,9 +344,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_FAB9795C_L14C20
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -441,7 +441,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C02347C7_L5C33
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -461,9 +461,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject_FunctionExpression_C02347C7_L5C33::_environment0_Net_Socket_SetEncoding_Utf8
+				IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_SetEncoding_Utf8
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -474,7 +474,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -485,7 +485,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -498,14 +498,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject_FunctionExpression_C02347C7_L5C33::_environment0_Net_Socket_SetEncoding_Utf8
+				IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_SetEncoding_Utf8
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -519,14 +519,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject_FunctionExpression_C02347C7_L5C33::_environment0_Net_Socket_SetEncoding_Utf8
+				IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_SetEncoding_Utf8
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -544,9 +544,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C02347C7_L5C33
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -569,8 +569,8 @@
 				[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope,
 				[1] object,
 				[2] object[],
-				[3] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21,
-				[4] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20
+				[3] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject,
+				[4] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::.ctor()
@@ -612,13 +612,13 @@
 			IL_0058: ldelem.ref
 			IL_0059: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
 			IL_005e: ldloc.2
-			IL_005f: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope, object[])
+			IL_005f: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope, object[])
 			IL_0064: ldc.i4.1
 			IL_0065: conv.r8
 			IL_0066: ldstr ""
 			IL_006b: ldc.i4.0
 			IL_006c: ldc.i4.1
-			IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21>(!!0, float64, string, bool, bool)
+			IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0072: stloc.3
 			IL_0073: ldloc.1
 			IL_0074: ldstr "on"
@@ -650,13 +650,13 @@
 			IL_00aa: ldelem.ref
 			IL_00ab: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
 			IL_00b0: ldloc.2
-			IL_00b1: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope, object[])
+			IL_00b1: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope, object[])
 			IL_00b6: ldc.i4.0
 			IL_00b7: conv.r8
 			IL_00b8: ldstr ""
 			IL_00bd: ldc.i4.0
 			IL_00be: ldc.i4.1
-			IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20>(!!0, float64, string, bool, bool)
+			IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00c4: stloc.s 4
 			IL_00c6: ldloc.1
 			IL_00c7: ldstr "on"
@@ -701,7 +701,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0B722580_L24C16
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Fields
@@ -725,15 +725,15 @@
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ldarg.0
 						IL_0007: ldarg.1
-						IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16::_environment0_Net_Socket_SetEncoding_Utf8
+						IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject::_environment0_Net_Socket_SetEncoding_Utf8
 						IL_000d: ldarg.0
 						IL_000e: ldarg.2
-						IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16::_environment1_FunctionExpression_L20C30
+						IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject::_environment1_FunctionExpression_L20C30
 						IL_0014: ldarg.0
 						IL_0015: ldarg.3
-						IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16::_transitionalScopes
+						IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject::_transitionalScopes
 						IL_001b: ret
-					} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -744,7 +744,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -755,7 +755,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -768,11 +768,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject::_transitionalScopes
 						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client::__js_call__(object[], object)
 						IL_0010: ret
-					} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -786,11 +786,11 @@
 						.maxstack 8
 
 						IL_0000: ldarg.0
-						IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16::_transitionalScopes
+						IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject::_transitionalScopes
 						IL_0006: ldarg.3
 						IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client::__js_call__(object[], object)
 						IL_000c: ret
-					} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -808,9 +808,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_0B722580_L24C16
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -877,7 +877,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4E083AEC_L22C55
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -901,15 +901,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55::_environment0_Net_Socket_SetEncoding_Utf8
+					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject::_environment0_Net_Socket_SetEncoding_Utf8
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55::_environment1_FunctionExpression_L20C30
+					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject::_environment1_FunctionExpression_L20C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -920,7 +920,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -931,7 +931,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -944,11 +944,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -962,11 +962,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -984,9 +984,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_4E083AEC_L22C55
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1006,7 +1006,7 @@
 					[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/Scope,
 					[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 					[2] object[],
-					[3] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16
+					[3] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/Scope::.ctor()
@@ -1061,13 +1061,13 @@
 				IL_0079: ldelem.ref
 				IL_007a: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
 				IL_007f: ldloc.2
-				IL_0080: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
+				IL_0080: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
 				IL_0085: ldc.i4.0
 				IL_0086: conv.r8
 				IL_0087: ldstr ""
 				IL_008c: ldc.i4.0
 				IL_008d: ldc.i4.1
-				IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16>(!!0, float64, string, bool, bool)
+				IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0093: stloc.3
 				IL_0094: ldloc.3
 				IL_0095: ldc.r8 0.0
@@ -1105,7 +1105,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_646EC19B_L31C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1129,15 +1129,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21::_environment0_Net_Socket_SetEncoding_Utf8
+					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject::_environment0_Net_Socket_SetEncoding_Utf8
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21::_environment1_FunctionExpression_L20C30
+					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject::_environment1_FunctionExpression_L20C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1148,7 +1148,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1159,7 +1159,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1172,14 +1172,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1193,14 +1193,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1218,9 +1218,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_646EC19B_L31C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1312,7 +1312,7 @@
 
 				} // end of class Scope
 
-				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5C22CABE_L38C18
+				.class nested public auto ansi sealed beforefieldinit FunctionObject
 					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 				{
 					// Methods
@@ -1326,7 +1326,7 @@
 						IL_0000: ldarg.0
 						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::.ctor
+					} // end of method FunctionObject::.ctor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_IsConstructor () cil managed 
@@ -1337,7 +1337,7 @@
 
 						IL_0000: ldc.i4.1
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::get_IsConstructor
+					} // end of method FunctionObject::get_IsConstructor
 
 					.method public hidebysig specialname virtual 
 						instance bool get_RequiresInvocationContext () cil managed 
@@ -1348,7 +1348,7 @@
 
 						IL_0000: ldc.i4.0
 						IL_0001: ret
-					} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::get_RequiresInvocationContext
+					} // end of method FunctionObject::get_RequiresInvocationContext
 
 					.method family hidebysig virtual 
 						instance object CallCore (
@@ -1363,7 +1363,7 @@
 						IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 						IL_0005: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17::__js_call__(object)
 						IL_000a: ret
-					} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::CallCore
+					} // end of method FunctionObject::CallCore
 
 					.method family hidebysig virtual 
 						instance object ConstructBodyCore (
@@ -1379,7 +1379,7 @@
 						IL_0000: ldarg.3
 						IL_0001: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17::__js_call__(object)
 						IL_0006: ret
-					} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::ConstructBodyCore
+					} // end of method FunctionObject::ConstructBodyCore
 
 					.method family hidebysig virtual 
 						instance object ConstructCore (
@@ -1397,9 +1397,9 @@
 						IL_0007: ldarg.2
 						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 						IL_000d: ret
-					} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::ConstructCore
+					} // end of method FunctionObject::ConstructCore
 
-				} // end of class FunctionObject_FunctionExpression_5C22CABE_L38C18
+				} // end of class FunctionObject
 
 
 				// Methods
@@ -1449,7 +1449,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A7C13C0B_L36C20
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1473,15 +1473,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20::_environment0_Net_Socket_SetEncoding_Utf8
+					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject::_environment0_Net_Socket_SetEncoding_Utf8
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20::_environment1_FunctionExpression_L20C30
+					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject::_environment1_FunctionExpression_L20C30
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1492,7 +1492,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1503,7 +1503,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1516,11 +1516,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1534,11 +1534,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1556,9 +1556,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_A7C13C0B_L36C20
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1580,7 +1580,7 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17/FunctionObject_FunctionExpression_5C22CABE_L38C18
+					[5] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17/FunctionObject
 				)
 
 				IL_0000: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/Scope::.ctor()
@@ -1617,13 +1617,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: stelem.ref
 				IL_004d: stloc.s 4
-				IL_004f: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17/FunctionObject_FunctionExpression_5C22CABE_L38C18::.ctor()
+				IL_004f: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17/FunctionObject::.ctor()
 				IL_0054: ldc.i4.0
 				IL_0055: conv.r8
 				IL_0056: ldstr ""
 				IL_005b: ldc.i4.0
 				IL_005c: ldc.i4.1
-				IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17/FunctionObject_FunctionExpression_5C22CABE_L38C18>(!!0, float64, string, bool, bool)
+				IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0062: stloc.s 5
 				IL_0064: ldloc.2
 				IL_0065: ldstr "close"
@@ -1667,7 +1667,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6F6DE3BC_L20C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1687,9 +1687,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject_FunctionExpression_6F6DE3BC_L20C31::_environment0_Net_Socket_SetEncoding_Utf8
+				IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject::_environment0_Net_Socket_SetEncoding_Utf8
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1700,7 +1700,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1711,7 +1711,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1724,11 +1724,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject_FunctionExpression_6F6DE3BC_L20C31::_environment0_Net_Socket_SetEncoding_Utf8
+				IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject::_environment0_Net_Socket_SetEncoding_Utf8
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1742,11 +1742,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject_FunctionExpression_6F6DE3BC_L20C31::_environment0_Net_Socket_SetEncoding_Utf8
+				IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject::_environment0_Net_Socket_SetEncoding_Utf8
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1764,9 +1764,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_6F6DE3BC_L20C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1790,9 +1790,9 @@
 				[2] object,
 				[3] object,
 				[4] object[],
-				[5] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55,
-				[6] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21,
-				[7] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20
+				[5] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject,
+				[6] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject,
+				[7] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::.ctor()
@@ -1833,13 +1833,13 @@
 			IL_0056: ldelem.ref
 			IL_0057: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
 			IL_005c: ldloc.s 4
-			IL_005e: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
+			IL_005e: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
 			IL_0063: ldc.i4.0
 			IL_0064: conv.r8
 			IL_0065: ldstr ""
 			IL_006a: ldc.i4.0
 			IL_006b: ldc.i4.1
-			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55>(!!0, float64, string, bool, bool)
+			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0071: stloc.s 5
 			IL_0073: ldstr "connect"
 			IL_0078: ldloc.2
@@ -1888,13 +1888,13 @@
 			IL_00eb: ldelem.ref
 			IL_00ec: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
 			IL_00f1: ldloc.s 4
-			IL_00f3: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
+			IL_00f3: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
 			IL_00f8: ldc.i4.1
 			IL_00f9: conv.r8
 			IL_00fa: ldstr ""
 			IL_00ff: ldc.i4.0
 			IL_0100: ldc.i4.1
-			IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21>(!!0, float64, string, bool, bool)
+			IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0106: stloc.s 6
 			IL_0108: ldloc.3
 			IL_0109: ldstr "on"
@@ -1928,13 +1928,13 @@
 			IL_014d: ldelem.ref
 			IL_014e: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
 			IL_0153: ldloc.s 4
-			IL_0155: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
+			IL_0155: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
 			IL_015a: ldc.i4.0
 			IL_015b: conv.r8
 			IL_015c: ldstr ""
 			IL_0161: ldc.i4.0
 			IL_0162: ldc.i4.1
-			IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20>(!!0, float64, string, bool, bool)
+			IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0168: stloc.s 7
 			IL_016a: ldloc.3
 			IL_016b: ldstr "on"
@@ -1994,9 +1994,9 @@
 			[0] class Modules.Net_Socket_SetEncoding_Utf8/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule,
 			[2] object[],
-			[3] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject_FunctionExpression_C02347C7_L5C33,
+			[3] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject,
 			[4] object,
-			[5] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject_FunctionExpression_6F6DE3BC_L20C31
+			[5] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/Scope::.ctor()
@@ -2022,13 +2022,13 @@
 		IL_002c: ldc.i4.0
 		IL_002d: ldelem.ref
 		IL_002e: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-		IL_0033: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject_FunctionExpression_C02347C7_L5C33::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope)
+		IL_0033: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope)
 		IL_0038: ldc.i4.1
 		IL_0039: conv.r8
 		IL_003a: ldstr ""
 		IL_003f: ldc.i4.0
 		IL_0040: ldc.i4.1
-		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject_FunctionExpression_C02347C7_L5C33>(!!0, float64, string, bool, bool)
+		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0046: stloc.3
 		IL_0047: ldstr "createServer"
 		IL_004c: ldloc.3
@@ -2052,13 +2052,13 @@
 		IL_0075: ldc.i4.0
 		IL_0076: ldelem.ref
 		IL_0077: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-		IL_007c: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject_FunctionExpression_6F6DE3BC_L20C31::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope)
+		IL_007c: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope)
 		IL_0081: ldc.i4.0
 		IL_0082: conv.r8
 		IL_0083: ldstr ""
 		IL_0088: ldc.i4.0
 		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject_FunctionExpression_6F6DE3BC_L20C31>(!!0, float64, string, bool, bool)
+		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_008f: stloc.s 5
 		IL_0091: ldloc.s 4
 		IL_0093: ldstr "listen"

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Timeout_Allows_Graceful_End.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Timeout_Allows_Graceful_End.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B3953B4D_L6C25
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -58,15 +58,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+					IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_Timeout_Allows_Graceful_End
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25::_environment1_FunctionExpression_server
+					IL_000f: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject::_environment1_FunctionExpression_server
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25::_transitionalScopes
+					IL_0016: stfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -77,7 +77,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -88,7 +88,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -101,11 +101,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -119,11 +119,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -141,9 +141,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_B3953B4D_L6C25
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -228,7 +228,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_76ADA745_L12C22
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -242,7 +242,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -253,7 +253,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -264,7 +264,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -282,7 +282,7 @@
 					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000c: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21::__js_call__(object, object)
 					IL_0011: ret
-				} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -301,7 +301,7 @@
 					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0008: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21::__js_call__(object, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -319,9 +319,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_76ADA745_L12C22
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -384,7 +384,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D224BDC0_L5C33
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -404,9 +404,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject_FunctionExpression_D224BDC0_L5C33::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+				IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_Timeout_Allows_Graceful_End
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -417,7 +417,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -428,7 +428,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -441,14 +441,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject_FunctionExpression_D224BDC0_L5C33::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+				IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_Timeout_Allows_Graceful_End
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -462,14 +462,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject_FunctionExpression_D224BDC0_L5C33::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+				IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject::_environment0_Net_Socket_Timeout_Allows_Graceful_End
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -487,9 +487,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D224BDC0_L5C33
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -512,8 +512,8 @@
 				[0] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope,
 				[1] object,
 				[2] object[],
-				[3] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25,
-				[4] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21/FunctionObject_FunctionExpression_76ADA745_L12C22
+				[3] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject,
+				[4] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope::.ctor()
@@ -545,13 +545,13 @@
 			IL_0032: ldelem.ref
 			IL_0033: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope
 			IL_0038: ldloc.2
-			IL_0039: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope, object[])
+			IL_0039: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope, object[])
 			IL_003e: ldc.i4.0
 			IL_003f: conv.r8
 			IL_0040: ldstr ""
 			IL_0045: ldc.i4.0
 			IL_0046: ldc.i4.1
-			IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25>(!!0, float64, string, bool, bool)
+			IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_004c: stloc.3
 			IL_004d: ldloc.1
 			IL_004e: ldstr "setTimeout"
@@ -571,13 +571,13 @@
 			IL_007c: ldarg.0
 			IL_007d: stelem.ref
 			IL_007e: stloc.2
-			IL_007f: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21/FunctionObject_FunctionExpression_76ADA745_L12C22::.ctor()
+			IL_007f: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21/FunctionObject::.ctor()
 			IL_0084: ldc.i4.1
 			IL_0085: conv.r8
 			IL_0086: ldstr ""
 			IL_008b: ldc.i4.0
 			IL_008c: ldc.i4.1
-			IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21/FunctionObject_FunctionExpression_76ADA745_L12C22>(!!0, float64, string, bool, bool)
+			IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0092: stloc.s 4
 			IL_0094: ldloc.1
 			IL_0095: ldstr "on"
@@ -618,7 +618,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7DA5D9C5_L19C55
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -632,7 +632,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -643,7 +643,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -654,7 +654,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -669,7 +669,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -685,7 +685,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -703,9 +703,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_7DA5D9C5_L19C55
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -759,7 +759,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2AD4A0E6_L24C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -773,7 +773,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -784,7 +784,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -795,7 +795,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -813,7 +813,7 @@
 					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000c: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20::__js_call__(object, object)
 					IL_0011: ret
-				} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -832,7 +832,7 @@
 					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0008: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20::__js_call__(object, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -850,9 +850,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_2AD4A0E6_L24C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -912,7 +912,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9F410EBD_L28C20
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -934,12 +934,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+					IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject::_environment0_Net_Socket_Timeout_Allows_Graceful_End
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20::_transitionalScopes
+					IL_000f: stfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -950,7 +950,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -961,7 +961,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -974,11 +974,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -992,11 +992,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1014,9 +1014,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_9F410EBD_L28C20
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1076,7 +1076,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AACE2D1B_L17C31
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1096,9 +1096,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject_FunctionExpression_AACE2D1B_L17C31::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+				IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject::_environment0_Net_Socket_Timeout_Allows_Graceful_End
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1109,7 +1109,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1120,7 +1120,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1133,11 +1133,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject_FunctionExpression_AACE2D1B_L17C31::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+				IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject::_environment0_Net_Socket_Timeout_Allows_Graceful_End
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1151,11 +1151,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject_FunctionExpression_AACE2D1B_L17C31::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+				IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject::_environment0_Net_Socket_Timeout_Allows_Graceful_End
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1173,9 +1173,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_AACE2D1B_L17C31
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1200,9 +1200,9 @@
 				[3] object,
 				[4] object,
 				[5] object[],
-				[6] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client/FunctionObject_FunctionExpression_7DA5D9C5_L19C55,
-				[7] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject_FunctionExpression_2AD4A0E6_L24C21,
-				[8] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20
+				[6] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client/FunctionObject,
+				[7] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject,
+				[8] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/Scope::.ctor()
@@ -1230,13 +1230,13 @@
 			IL_0043: ldarg.0
 			IL_0044: stelem.ref
 			IL_0045: stloc.s 5
-			IL_0047: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client/FunctionObject_FunctionExpression_7DA5D9C5_L19C55::.ctor()
+			IL_0047: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client/FunctionObject::.ctor()
 			IL_004c: ldc.i4.0
 			IL_004d: conv.r8
 			IL_004e: ldstr ""
 			IL_0053: ldc.i4.0
 			IL_0054: ldc.i4.1
-			IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client/FunctionObject_FunctionExpression_7DA5D9C5_L19C55>(!!0, float64, string, bool, bool)
+			IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_005a: stloc.s 6
 			IL_005c: ldstr "connect"
 			IL_0061: ldloc.3
@@ -1260,13 +1260,13 @@
 			IL_0092: ldarg.0
 			IL_0093: stelem.ref
 			IL_0094: stloc.s 5
-			IL_0096: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject_FunctionExpression_2AD4A0E6_L24C21::.ctor()
+			IL_0096: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject::.ctor()
 			IL_009b: ldc.i4.1
 			IL_009c: conv.r8
 			IL_009d: ldstr ""
 			IL_00a2: ldc.i4.0
 			IL_00a3: ldc.i4.1
-			IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject_FunctionExpression_2AD4A0E6_L24C21>(!!0, float64, string, bool, bool)
+			IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00a9: stloc.s 7
 			IL_00ab: ldloc.s 4
 			IL_00ad: ldstr "on"
@@ -1293,13 +1293,13 @@
 			IL_00da: ldelem.ref
 			IL_00db: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
 			IL_00e0: ldloc.s 5
-			IL_00e2: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object[])
+			IL_00e2: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object[])
 			IL_00e7: ldc.i4.0
 			IL_00e8: conv.r8
 			IL_00e9: ldstr ""
 			IL_00ee: ldc.i4.0
 			IL_00ef: ldc.i4.1
-			IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20>(!!0, float64, string, bool, bool)
+			IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00f5: stloc.s 8
 			IL_00f7: ldloc.s 4
 			IL_00f9: ldstr "on"
@@ -1359,9 +1359,9 @@
 			[0] class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule,
 			[2] object[],
-			[3] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject_FunctionExpression_D224BDC0_L5C33,
+			[3] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject,
 			[4] object,
-			[5] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject_FunctionExpression_AACE2D1B_L17C31
+			[5] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::.ctor()
@@ -1387,13 +1387,13 @@
 		IL_002c: ldc.i4.0
 		IL_002d: ldelem.ref
 		IL_002e: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
-		IL_0033: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject_FunctionExpression_D224BDC0_L5C33::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope)
+		IL_0033: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope)
 		IL_0038: ldc.i4.1
 		IL_0039: conv.r8
 		IL_003a: ldstr ""
 		IL_003f: ldc.i4.0
 		IL_0040: ldc.i4.1
-		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject_FunctionExpression_D224BDC0_L5C33>(!!0, float64, string, bool, bool)
+		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0046: stloc.3
 		IL_0047: ldstr "createServer"
 		IL_004c: ldloc.3
@@ -1417,13 +1417,13 @@
 		IL_0075: ldc.i4.0
 		IL_0076: ldelem.ref
 		IL_0077: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
-		IL_007c: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject_FunctionExpression_AACE2D1B_L17C31::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope)
+		IL_007c: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope)
 		IL_0081: ldc.i4.0
 		IL_0082: conv.r8
 		IL_0083: ldstr ""
 		IL_0088: ldc.i4.0
 		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject_FunctionExpression_AACE2D1B_L17C31>(!!0, float64, string, bool, bool)
+		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_008f: stloc.s 5
 		IL_0091: ldloc.s 4
 		IL_0093: ldstr "listen"

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DefaultParameterOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DefaultParameterOverride.verified.txt
@@ -204,7 +204,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2695CFF7_patchPath
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -224,9 +224,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_Path_DefaultParameterOverride/Scope Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject_FunctionDeclaration_2695CFF7_patchPath::_environment0_Require_Path_DefaultParameterOverride
+				IL_0008: stfld class Modules.Require_Path_DefaultParameterOverride/Scope Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject::_environment0_Require_Path_DefaultParameterOverride
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -237,7 +237,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -248,7 +248,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -261,14 +261,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_Path_DefaultParameterOverride/Scope Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject_FunctionDeclaration_2695CFF7_patchPath::_environment0_Require_Path_DefaultParameterOverride
+				IL_0001: ldfld class Modules.Require_Path_DefaultParameterOverride/Scope Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject::_environment0_Require_Path_DefaultParameterOverride
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Require_Path_DefaultParameterOverride/patchPath::__js_call__(class Modules.Require_Path_DefaultParameterOverride/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -282,14 +282,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_Path_DefaultParameterOverride/Scope Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject_FunctionDeclaration_2695CFF7_patchPath::_environment0_Require_Path_DefaultParameterOverride
+				IL_0001: ldfld class Modules.Require_Path_DefaultParameterOverride/Scope Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject::_environment0_Require_Path_DefaultParameterOverride
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Require_Path_DefaultParameterOverride/patchPath::__js_call__(class Modules.Require_Path_DefaultParameterOverride/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -307,9 +307,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2695CFF7_patchPath
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -416,7 +416,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_DefaultParameterOverride/Scope,
-			[1] class Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject_FunctionDeclaration_2695CFF7_patchPath,
+			[1] class Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -436,13 +436,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Require_Path_DefaultParameterOverride/Scope
-		IL_0019: newobj instance void Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject_FunctionDeclaration_2695CFF7_patchPath::.ctor(class Modules.Require_Path_DefaultParameterOverride/Scope)
+		IL_0019: newobj instance void Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject::.ctor(class Modules.Require_Path_DefaultParameterOverride/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "patchPath"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject_FunctionDeclaration_2695CFF7_patchPath>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldarg.1

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_Path_Join_NestedFunction/Scope Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::_environment0_Require_Path_Join_NestedFunction
+				IL_0008: stfld class Modules.Require_Path_Join_NestedFunction/Scope Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject::_environment0_Require_Path_Join_NestedFunction
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_Path_Join_NestedFunction/Scope Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::_environment0_Require_Path_Join_NestedFunction
+				IL_0001: ldfld class Modules.Require_Path_Join_NestedFunction/Scope Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject::_environment0_Require_Path_Join_NestedFunction
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -99,7 +99,7 @@
 				IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0023: call object Modules.Require_Path_Join_NestedFunction/joinWrapper::__js_call__(class Modules.Require_Path_Join_NestedFunction/Scope, object, string, string)
 				IL_0028: ret
-			} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -113,7 +113,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_Path_Join_NestedFunction/Scope Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::_environment0_Require_Path_Join_NestedFunction
+				IL_0001: ldfld class Modules.Require_Path_Join_NestedFunction/Scope Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject::_environment0_Require_Path_Join_NestedFunction
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -125,7 +125,7 @@
 				IL_001a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_001f: call object Modules.Require_Path_Join_NestedFunction/joinWrapper::__js_call__(class Modules.Require_Path_Join_NestedFunction/Scope, object, string, string)
 				IL_0024: ret
-			} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -143,9 +143,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -236,7 +236,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Join_NestedFunction/Scope,
-			[1] class Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper,
+			[1] class Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
@@ -257,13 +257,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Require_Path_Join_NestedFunction/Scope
-		IL_0019: newobj instance void Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::.ctor(class Modules.Require_Path_Join_NestedFunction/Scope)
+		IL_0019: newobj instance void Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject::.ctor(class Modules.Require_Path_Join_NestedFunction/Scope)
 		IL_001e: ldc.i4.2
 		IL_001f: conv.r8
 		IL_0020: ldstr "joinWrapper"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldarg.1

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_MemberOverrides.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_MemberOverrides.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2DB7A438_normalize
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_Path_MemberOverrides/Scope Modules.Require_Path_MemberOverrides/normalize/FunctionObject_FunctionDeclaration_2DB7A438_normalize::_environment0_Require_Path_MemberOverrides
+				IL_0008: stfld class Modules.Require_Path_MemberOverrides/Scope Modules.Require_Path_MemberOverrides/normalize/FunctionObject::_environment0_Require_Path_MemberOverrides
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_Path_MemberOverrides/Scope Modules.Require_Path_MemberOverrides/normalize/FunctionObject_FunctionDeclaration_2DB7A438_normalize::_environment0_Require_Path_MemberOverrides
+				IL_0001: ldfld class Modules.Require_Path_MemberOverrides/Scope Modules.Require_Path_MemberOverrides/normalize/FunctionObject::_environment0_Require_Path_MemberOverrides
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -95,7 +95,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call object Modules.Require_Path_MemberOverrides/normalize::__js_call__(class Modules.Require_Path_MemberOverrides/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_Path_MemberOverrides/Scope Modules.Require_Path_MemberOverrides/normalize/FunctionObject_FunctionDeclaration_2DB7A438_normalize::_environment0_Require_Path_MemberOverrides
+				IL_0001: ldfld class Modules.Require_Path_MemberOverrides/Scope Modules.Require_Path_MemberOverrides/normalize/FunctionObject::_environment0_Require_Path_MemberOverrides
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -117,7 +117,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call object Modules.Require_Path_MemberOverrides/normalize::__js_call__(class Modules.Require_Path_MemberOverrides/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -135,9 +135,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2DB7A438_normalize
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -448,7 +448,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_MemberOverrides/Scope,
-			[1] class Modules.Require_Path_MemberOverrides/normalize/FunctionObject_FunctionDeclaration_2DB7A438_normalize,
+			[1] class Modules.Require_Path_MemberOverrides/normalize/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] class [System.Runtime]System.Exception,
@@ -480,13 +480,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Require_Path_MemberOverrides/Scope
-		IL_001b: newobj instance void Modules.Require_Path_MemberOverrides/normalize/FunctionObject_FunctionDeclaration_2DB7A438_normalize::.ctor(class Modules.Require_Path_MemberOverrides/Scope)
+		IL_001b: newobj instance void Modules.Require_Path_MemberOverrides/normalize/FunctionObject::.ctor(class Modules.Require_Path_MemberOverrides/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "normalize"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_MemberOverrides/normalize/FunctionObject_FunctionDeclaration_2DB7A438_normalize>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_MemberOverrides/normalize/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: ldarg.1

--- a/tests/Jroc.Tests/Node/Snapshots/GeneratorTests.PerfHooks_DestructuredPerformanceOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Snapshots/GeneratorTests.PerfHooks_DestructuredPerformanceOverride.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_60CA76E0_L5C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -82,9 +82,9 @@
 				IL_0005: call float64 Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_60CA76E0_L5C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -145,7 +145,7 @@
 			[2] object,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object[],
-			[5] class Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7/FunctionObject_FunctionExpression_60CA76E0_L5C8,
+			[5] class Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7/FunctionObject,
 			[6] object,
 			[7] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPerfHooksModule,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console
@@ -167,14 +167,14 @@
 		IL_0021: ldloc.0
 		IL_0022: stelem.ref
 		IL_0023: stloc.s 4
-		IL_0025: newobj instance void Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7/FunctionObject_FunctionExpression_60CA76E0_L5C8::.ctor()
+		IL_0025: newobj instance void Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7/FunctionObject::.ctor()
 		IL_002a: ldc.i4.0
 		IL_002b: conv.r8
 		IL_002c: ldstr ""
 		IL_0031: ldc.i4.0
 		IL_0032: ldc.i4.1
-		IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7/FunctionObject_FunctionExpression_60CA76E0_L5C8>(!!0, float64, string, bool, bool)
-		IL_0038: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7/FunctionObject_FunctionExpression_60CA76E0_L5C8>(!!0)
+		IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0038: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7/FunctionObject>(!!0)
 		IL_003d: stloc.s 5
 		IL_003f: ldloc.3
 		IL_0040: ldstr "now"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Callback_Function_Objects.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Callback_Function_Objects.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FD235BD3_L6C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_FD235BD3_L6C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FD235BD3_L6C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FD235BD3_L6C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Stream_Callback_Function_Objects/FunctionExpression_L6C23::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_FD235BD3_L6C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Stream_Callback_Function_Objects/FunctionExpression_L6C23::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_FD235BD3_L6C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FD235BD3_L6C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_FD235BD3_L6C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -162,7 +162,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C039381D_L7C32
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -182,9 +182,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31/FunctionObject_FunctionExpression_C039381D_L7C32::_transitionalScopes
+				IL_0008: stfld object[] Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C039381D_L7C32::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -195,7 +195,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C039381D_L7C32::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -206,7 +206,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C039381D_L7C32::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -219,7 +219,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31/FunctionObject_FunctionExpression_C039381D_L7C32::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -227,9 +227,9 @@
 				IL_0012: call object Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionExpression_C039381D_L7C32::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionExpression_C039381D_L7C32
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -311,7 +311,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D52B797D_L13C28
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -325,7 +325,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D52B797D_L13C28::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -336,7 +336,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D52B797D_L13C28::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -347,7 +347,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D52B797D_L13C28::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -362,7 +362,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Stream_Callback_Function_Objects/FunctionExpression_L13C27::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_D52B797D_L13C28::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -378,7 +378,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Stream_Callback_Function_Objects/FunctionExpression_L13C27::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D52B797D_L13C28::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -396,9 +396,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D52B797D_L13C28::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D52B797D_L13C28
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -450,7 +450,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9B50BC89_L14C36
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -470,9 +470,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject_FunctionExpression_9B50BC89_L14C36::_transitionalScopes
+				IL_0008: stfld object[] Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9B50BC89_L14C36::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -483,7 +483,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9B50BC89_L14C36::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -494,7 +494,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9B50BC89_L14C36::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -507,7 +507,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject_FunctionExpression_9B50BC89_L14C36::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -516,9 +516,9 @@
 				IL_0017: ldarg.0
 				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionExpression_9B50BC89_L14C36::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_9B50BC89_L14C36
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -560,7 +560,7 @@
 			IL_001f: ldftn object Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35::__js_call__(object[], object, object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject_FunctionExpression_9B50BC89_L14C36
+			IL_002b: ldtoken Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.1
 			IL_0036: newarr [System.Runtime]System.Object
@@ -672,7 +672,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_46DC28CC_L19C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -686,7 +686,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_46DC28CC_L19C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -697,7 +697,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_46DC28CC_L19C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -708,7 +708,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_46DC28CC_L19C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -723,7 +723,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Stream_Callback_Function_Objects/FunctionExpression_L19C13::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_46DC28CC_L19C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -739,7 +739,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Stream_Callback_Function_Objects/FunctionExpression_L19C13::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_46DC28CC_L19C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -757,9 +757,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_46DC28CC_L19C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_46DC28CC_L19C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -830,11 +830,11 @@
 			[3] object,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Stream_Callback_Function_Objects/FunctionExpression_L6C23/FunctionObject_FunctionExpression_FD235BD3_L6C24,
-			[7] class Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31/FunctionObject_FunctionExpression_C039381D_L7C32,
-			[8] class Modules.Stream_Callback_Function_Objects/FunctionExpression_L13C27/FunctionObject_FunctionExpression_D52B797D_L13C28,
-			[9] class Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject_FunctionExpression_9B50BC89_L14C36,
-			[10] class Modules.Stream_Callback_Function_Objects/FunctionExpression_L19C13/FunctionObject_FunctionExpression_46DC28CC_L19C14
+			[6] class Modules.Stream_Callback_Function_Objects/FunctionExpression_L6C23/FunctionObject,
+			[7] class Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31/FunctionObject,
+			[8] class Modules.Stream_Callback_Function_Objects/FunctionExpression_L13C27/FunctionObject,
+			[9] class Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject,
+			[10] class Modules.Stream_Callback_Function_Objects/FunctionExpression_L19C13/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Callback_Function_Objects/Scope::.ctor()
@@ -858,13 +858,13 @@
 		IL_002c: ldloc.0
 		IL_002d: stelem.ref
 		IL_002e: stloc.s 5
-		IL_0030: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L6C23/FunctionObject_FunctionExpression_FD235BD3_L6C24::.ctor()
+		IL_0030: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L6C23/FunctionObject::.ctor()
 		IL_0035: ldc.i4.0
 		IL_0036: conv.r8
 		IL_0037: ldstr ""
 		IL_003c: ldc.i4.0
 		IL_003d: ldc.i4.1
-		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L6C23/FunctionObject_FunctionExpression_FD235BD3_L6C24>(!!0, float64, string, bool, bool)
+		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L6C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0043: stloc.s 6
 		IL_0045: ldloc.2
 		IL_0046: ldstr "_write"
@@ -880,14 +880,14 @@
 		IL_005d: stelem.ref
 		IL_005e: stloc.s 5
 		IL_0060: ldloc.s 5
-		IL_0062: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31/FunctionObject_FunctionExpression_C039381D_L7C32::.ctor(object[])
+		IL_0062: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31/FunctionObject::.ctor(object[])
 		IL_0067: ldc.i4.1
 		IL_0068: conv.r8
 		IL_0069: ldstr ""
 		IL_006e: ldc.i4.0
 		IL_006f: ldc.i4.1
-		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31/FunctionObject_FunctionExpression_C039381D_L7C32>(!!0, float64, string, bool, bool)
-		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31/FunctionObject_FunctionExpression_C039381D_L7C32>(!!0)
+		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L7C31/FunctionObject>(!!0)
 		IL_007a: stloc.s 7
 		IL_007c: ldloc.1
 		IL_007d: ldstr "finished"
@@ -915,13 +915,13 @@
 		IL_00ba: ldloc.0
 		IL_00bb: stelem.ref
 		IL_00bc: stloc.s 5
-		IL_00be: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L13C27/FunctionObject_FunctionExpression_D52B797D_L13C28::.ctor()
+		IL_00be: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L13C27/FunctionObject::.ctor()
 		IL_00c3: ldc.i4.0
 		IL_00c4: conv.r8
 		IL_00c5: ldstr ""
 		IL_00ca: ldc.i4.0
 		IL_00cb: ldc.i4.1
-		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L13C27/FunctionObject_FunctionExpression_D52B797D_L13C28>(!!0, float64, string, bool, bool)
+		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L13C27/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d1: stloc.s 8
 		IL_00d3: ldloc.3
 		IL_00d4: ldstr "_write"
@@ -937,15 +937,15 @@
 		IL_00eb: stelem.ref
 		IL_00ec: stloc.s 5
 		IL_00ee: ldloc.s 5
-		IL_00f0: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject_FunctionExpression_9B50BC89_L14C36::.ctor(object[])
+		IL_00f0: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject::.ctor(object[])
 		IL_00f5: ldc.i4.1
 		IL_00f6: conv.r8
 		IL_00f7: ldstr ""
 		IL_00fc: ldc.i4.1
 		IL_00fd: ldc.i4.1
-		IL_00fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject_FunctionExpression_9B50BC89_L14C36>(!!0, float64, string, bool, bool)
+		IL_00fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0103: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_0108: castclass Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject_FunctionExpression_9B50BC89_L14C36
+		IL_0108: castclass Modules.Stream_Callback_Function_Objects/FunctionExpression_L14C35/FunctionObject
 		IL_010d: stloc.s 9
 		IL_010f: ldloc.1
 		IL_0110: ldstr "finished"
@@ -966,13 +966,13 @@
 		IL_013c: ldloc.0
 		IL_013d: stelem.ref
 		IL_013e: stloc.s 5
-		IL_0140: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L19C13/FunctionObject_FunctionExpression_46DC28CC_L19C14::.ctor()
+		IL_0140: newobj instance void Modules.Stream_Callback_Function_Objects/FunctionExpression_L19C13/FunctionObject::.ctor()
 		IL_0145: ldc.i4.0
 		IL_0146: conv.r8
 		IL_0147: ldstr ""
 		IL_014c: ldc.i4.0
 		IL_014d: ldc.i4.1
-		IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L19C13/FunctionObject_FunctionExpression_46DC28CC_L19C14>(!!0, float64, string, bool, bool)
+		IL_014e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Callback_Function_Objects/FunctionExpression_L19C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0153: stloc.s 10
 		IL_0155: ldloc.s 10
 		IL_0157: ldc.i4.0

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F5E4395D_L6C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F5E4395D_L6C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -162,7 +162,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9F4085BA_L8C27
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -182,9 +182,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Finished_Callback_Basic/Scope Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_9F4085BA_L8C27::_environment0_Stream_Finished_Callback_Basic
+				IL_0008: stfld class Modules.Stream_Finished_Callback_Basic/Scope Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject::_environment0_Stream_Finished_Callback_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -195,7 +195,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -206,7 +206,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -219,14 +219,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Finished_Callback_Basic/Scope Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_9F4085BA_L8C27::_environment0_Stream_Finished_Callback_Basic
+				IL_0001: ldfld class Modules.Stream_Finished_Callback_Basic/Scope Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject::_environment0_Stream_Finished_Callback_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26::__js_call__(class Modules.Stream_Finished_Callback_Basic/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -240,14 +240,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Finished_Callback_Basic/Scope Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_9F4085BA_L8C27::_environment0_Stream_Finished_Callback_Basic
+				IL_0001: ldfld class Modules.Stream_Finished_Callback_Basic/Scope Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject::_environment0_Stream_Finished_Callback_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26::__js_call__(class Modules.Stream_Finished_Callback_Basic/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -265,9 +265,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_9F4085BA_L8C27
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -387,8 +387,8 @@
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 			[2] object,
 			[3] object[],
-			[4] class Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18/FunctionObject_FunctionExpression_F5E4395D_L6C19,
-			[5] class Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_9F4085BA_L8C27,
+			[4] class Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18/FunctionObject,
+			[5] class Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[7] object
 		)
@@ -420,13 +420,13 @@
 		IL_0038: ldloc.0
 		IL_0039: stelem.ref
 		IL_003a: stloc.3
-		IL_003b: newobj instance void Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18/FunctionObject_FunctionExpression_F5E4395D_L6C19::.ctor()
+		IL_003b: newobj instance void Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18/FunctionObject::.ctor()
 		IL_0040: ldc.i4.0
 		IL_0041: conv.r8
 		IL_0042: ldstr ""
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18/FunctionObject_FunctionExpression_F5E4395D_L6C19>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.s 4
 		IL_0050: ldloc.2
 		IL_0051: ldstr "_write"
@@ -448,13 +448,13 @@
 		IL_0072: ldc.i4.0
 		IL_0073: ldelem.ref
 		IL_0074: castclass Modules.Stream_Finished_Callback_Basic/Scope
-		IL_0079: newobj instance void Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_9F4085BA_L8C27::.ctor(class Modules.Stream_Finished_Callback_Basic/Scope)
+		IL_0079: newobj instance void Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject::.ctor(class Modules.Stream_Finished_Callback_Basic/Scope)
 		IL_007e: ldc.i4.1
 		IL_007f: conv.r8
 		IL_0080: ldstr ""
 		IL_0085: ldc.i4.0
 		IL_0086: ldc.i4.1
-		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_9F4085BA_L8C27>(!!0, float64, string, bool, bool)
+		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_008c: stloc.s 5
 		IL_008e: ldloc.1
 		IL_008f: ldstr "finished"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_DestroyError.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_DestroyError.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2D614845_L7C27
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Finished_Callback_DestroyError/Scope Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject_FunctionExpression_2D614845_L7C27::_environment0_Stream_Finished_Callback_DestroyError
+				IL_0008: stfld class Modules.Stream_Finished_Callback_DestroyError/Scope Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject::_environment0_Stream_Finished_Callback_DestroyError
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Finished_Callback_DestroyError/Scope Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject_FunctionExpression_2D614845_L7C27::_environment0_Stream_Finished_Callback_DestroyError
+				IL_0001: ldfld class Modules.Stream_Finished_Callback_DestroyError/Scope Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject::_environment0_Stream_Finished_Callback_DestroyError
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26::__js_call__(class Modules.Stream_Finished_Callback_DestroyError/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Finished_Callback_DestroyError/Scope Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject_FunctionExpression_2D614845_L7C27::_environment0_Stream_Finished_Callback_DestroyError
+				IL_0001: ldfld class Modules.Stream_Finished_Callback_DestroyError/Scope Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject::_environment0_Stream_Finished_Callback_DestroyError
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26::__js_call__(class Modules.Stream_Finished_Callback_DestroyError/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_2D614845_L7C27
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -255,7 +255,7 @@
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 			[2] object,
 			[3] object[],
-			[4] class Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject_FunctionExpression_2D614845_L7C27,
+			[4] class Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Error
 		)
 
@@ -290,13 +290,13 @@
 		IL_003c: ldc.i4.0
 		IL_003d: ldelem.ref
 		IL_003e: castclass Modules.Stream_Finished_Callback_DestroyError/Scope
-		IL_0043: newobj instance void Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject_FunctionExpression_2D614845_L7C27::.ctor(class Modules.Stream_Finished_Callback_DestroyError/Scope)
+		IL_0043: newobj instance void Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject::.ctor(class Modules.Stream_Finished_Callback_DestroyError/Scope)
 		IL_0048: ldc.i4.1
 		IL_0049: conv.r8
 		IL_004a: ldstr ""
 		IL_004f: ldc.i4.0
 		IL_0050: ldc.i4.1
-		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject_FunctionExpression_2D614845_L7C27>(!!0, float64, string, bool, bool)
+		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0056: stloc.s 4
 		IL_0058: ldloc.1
 		IL_0059: ldstr "finished"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A4A90E5B_L8C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -48,7 +48,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -59,7 +59,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -70,7 +70,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -88,7 +88,7 @@
 					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000c: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20::__js_call__(object, object)
 					IL_0011: ret
-				} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -107,7 +107,7 @@
 					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0008: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20::__js_call__(object, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -125,9 +125,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_A4A90E5B_L8C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -169,7 +169,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CEE88488_createWritable
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -189,9 +189,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject_FunctionDeclaration_CEE88488_createWritable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_0008: stfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject::_environment0_Stream_Helper_Signal_Requires_AbortSignal
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -202,7 +202,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -213,7 +213,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -226,11 +226,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject_FunctionDeclaration_CEE88488_createWritable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject::_environment0_Stream_Helper_Signal_Requires_AbortSignal
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -244,11 +244,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject_FunctionDeclaration_CEE88488_createWritable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject::_environment0_Stream_Helper_Signal_Requires_AbortSignal
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -266,9 +266,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CEE88488_createWritable
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -293,7 +293,7 @@
 				[3] object,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[5] object[],
-				[6] class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20/FunctionObject_FunctionExpression_A4A90E5B_L8C21
+				[6] class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/Scope::.ctor()
@@ -322,13 +322,13 @@
 			IL_0039: ldarg.0
 			IL_003a: stelem.ref
 			IL_003b: stloc.s 5
-			IL_003d: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20/FunctionObject_FunctionExpression_A4A90E5B_L8C21::.ctor()
+			IL_003d: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20/FunctionObject::.ctor()
 			IL_0042: ldc.i4.1
 			IL_0043: conv.r8
 			IL_0044: ldstr ""
 			IL_0049: ldc.i4.0
 			IL_004a: ldc.i4.1
-			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20/FunctionObject_FunctionExpression_A4A90E5B_L8C21>(!!0, float64, string, bool, bool)
+			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0050: stloc.s 6
 			IL_0052: ldloc.1
 			IL_0053: ldstr "_write"
@@ -365,7 +365,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ECED33DC_createReadable
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -385,9 +385,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject_FunctionDeclaration_ECED33DC_createReadable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_0008: stfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject::_environment0_Stream_Helper_Signal_Requires_AbortSignal
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -398,7 +398,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -409,7 +409,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -422,11 +422,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject_FunctionDeclaration_ECED33DC_createReadable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject::_environment0_Stream_Helper_Signal_Requires_AbortSignal
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -440,11 +440,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject_FunctionDeclaration_ECED33DC_createReadable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject::_environment0_Stream_Helper_Signal_Requires_AbortSignal
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -462,9 +462,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_ECED33DC_createReadable
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -538,7 +538,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9E17276A_L18C57
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -552,7 +552,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -563,7 +563,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -574,7 +574,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -589,7 +589,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -605,7 +605,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -623,9 +623,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_9E17276A_L18C57
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -670,7 +670,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_68D4A142_L26C73
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -684,7 +684,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -695,7 +695,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -706,7 +706,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -721,7 +721,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -737,7 +737,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -755,9 +755,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_68D4A142_L26C73
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -962,7 +962,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1D6C2B21_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -984,12 +984,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject_FunctionDeclaration_1D6C2B21_main::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_0008: stfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject::_environment0_Stream_Helper_Signal_Requires_AbortSignal
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject_FunctionDeclaration_1D6C2B21_main::_transitionalScopes
+				IL_000f: stfld object[] Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1000,7 +1000,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1011,7 +1011,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -1024,14 +1024,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject_FunctionDeclaration_1D6C2B21_main::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_1D6C2B21_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1064,11 +1064,11 @@
 				[13] object[],
 				[14] object,
 				[15] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[16] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject_FunctionExpression_9E17276A_L18C57,
+				[16] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject,
 				[17] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[18] object,
 				[19] object,
-				[20] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject_FunctionExpression_68D4A142_L26C73,
+				[20] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject,
 				[21] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule
 			)
 
@@ -1091,7 +1091,7 @@
 			IL_0020: ldftn object Modules.Stream_Helper_Signal_Requires_AbortSignal/main::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject_FunctionDeclaration_1D6C2B21_main
+			IL_002c: ldtoken Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1186,7 +1186,7 @@
 			IL_00e2: dup
 			IL_00e3: ldc.i4.s 15
 			IL_00e5: ldelem.ref
-			IL_00e6: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject_FunctionExpression_9E17276A_L18C57
+			IL_00e6: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject
 			IL_00eb: stloc.s 16
 			IL_00ed: dup
 			IL_00ee: ldc.i4.s 16
@@ -1204,7 +1204,7 @@
 			IL_0104: dup
 			IL_0105: ldc.i4.s 19
 			IL_0107: ldelem.ref
-			IL_0108: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject_FunctionExpression_68D4A142_L26C73
+			IL_0108: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject
 			IL_010d: stloc.s 20
 			IL_010f: dup
 			IL_0110: ldc.i4.s 20
@@ -1258,13 +1258,13 @@
 				IL_0190: ldelem.ref
 				IL_0191: stelem.ref
 				IL_0192: stloc.s 13
-				IL_0194: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject_FunctionExpression_9E17276A_L18C57::.ctor()
+				IL_0194: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject::.ctor()
 				IL_0199: ldc.i4.0
 				IL_019a: conv.r8
 				IL_019b: ldstr ""
 				IL_01a0: ldc.i4.0
 				IL_01a1: ldc.i4.1
-				IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject_FunctionExpression_9E17276A_L18C57>(!!0, float64, string, bool, bool)
+				IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_01a7: stloc.s 16
 				IL_01a9: ldloc.s 12
 				IL_01ab: ldstr "finished"
@@ -1404,13 +1404,13 @@
 				IL_02f2: ldelem.ref
 				IL_02f3: stelem.ref
 				IL_02f4: stloc.s 13
-				IL_02f6: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject_FunctionExpression_68D4A142_L26C73::.ctor()
+				IL_02f6: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject::.ctor()
 				IL_02fb: ldc.i4.0
 				IL_02fc: conv.r8
 				IL_02fd: ldstr ""
 				IL_0302: ldc.i4.0
 				IL_0303: ldc.i4.1
-				IL_0304: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject_FunctionExpression_68D4A142_L26C73>(!!0, float64, string, bool, bool)
+				IL_0304: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject>(!!0, float64, string, bool, bool)
 				IL_0309: stloc.s 20
 				IL_030b: ldloc.s 12
 				IL_030d: ldc.i4.4
@@ -2024,10 +2024,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope,
-			[1] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject_FunctionDeclaration_1D6C2B21_main,
+			[1] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject,
 			[2] object[],
-			[3] class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject_FunctionDeclaration_CEE88488_createWritable,
-			[4] class Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject_FunctionDeclaration_ECED33DC_createReadable,
+			[3] class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject,
+			[4] class Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject,
 			[5] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 			[6] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule
 		)
@@ -2045,13 +2045,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-		IL_0019: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject_FunctionDeclaration_CEE88488_createWritable::.ctor(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope)
+		IL_0019: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject::.ctor(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "createWritable"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject_FunctionDeclaration_CEE88488_createWritable>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.3
 		IL_002d: ldloc.0
 		IL_002e: ldloc.3
@@ -2067,13 +2067,13 @@
 		IL_0040: ldc.i4.0
 		IL_0041: ldelem.ref
 		IL_0042: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-		IL_0047: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject_FunctionDeclaration_ECED33DC_createReadable::.ctor(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope)
+		IL_0047: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject::.ctor(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope)
 		IL_004c: ldc.i4.0
 		IL_004d: conv.r8
 		IL_004e: ldstr "createReadable"
 		IL_0053: ldc.i4.0
 		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject_FunctionDeclaration_ECED33DC_createReadable>(!!0, float64, string, bool, bool)
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005a: stloc.s 4
 		IL_005c: ldloc.0
 		IL_005d: ldloc.s 4
@@ -2090,14 +2090,14 @@
 		IL_0071: ldelem.ref
 		IL_0072: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
 		IL_0077: ldloc.2
-		IL_0078: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject_FunctionDeclaration_1D6C2B21_main::.ctor(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object[])
+		IL_0078: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject::.ctor(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object[])
 		IL_007d: ldc.i4.0
 		IL_007e: conv.r8
 		IL_007f: ldstr "main"
 		IL_0084: ldc.i4.0
 		IL_0085: ldc.i4.1
-		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject_FunctionDeclaration_1D6C2B21_main>(!!0, float64, string, bool, bool)
-		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject_FunctionDeclaration_1D6C2B21_main>(!!0)
+		IL_0086: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject>(!!0)
 		IL_0090: stloc.1
 		IL_0091: nop
 		IL_0092: ldarg.1

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_PassThrough_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_PassThrough_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EAEB5E6E_L10C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_EAEB5E6E_L10C19::_environment0_Stream_PassThrough_Basic
+				IL_0008: stfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject::_environment0_Stream_PassThrough_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_EAEB5E6E_L10C19::_environment0_Stream_PassThrough_Basic
+				IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject::_environment0_Stream_PassThrough_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18::__js_call__(class Modules.Stream_PassThrough_Basic/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_EAEB5E6E_L10C19::_environment0_Stream_PassThrough_Basic
+				IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject::_environment0_Stream_PassThrough_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18::__js_call__(class Modules.Stream_PassThrough_Basic/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_EAEB5E6E_L10C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -194,7 +194,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3C59D3C3_L14C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -214,9 +214,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject_FunctionExpression_3C59D3C3_L14C23::_environment0_Stream_PassThrough_Basic
+				IL_0008: stfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject::_environment0_Stream_PassThrough_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -227,7 +227,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -238,7 +238,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -251,11 +251,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject_FunctionExpression_3C59D3C3_L14C23::_environment0_Stream_PassThrough_Basic
+				IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject::_environment0_Stream_PassThrough_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22::__js_call__(class Modules.Stream_PassThrough_Basic/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -269,11 +269,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject_FunctionExpression_3C59D3C3_L14C23::_environment0_Stream_PassThrough_Basic
+				IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject::_environment0_Stream_PassThrough_Basic
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22::__js_call__(class Modules.Stream_PassThrough_Basic/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -291,9 +291,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_3C59D3C3_L14C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -411,8 +411,8 @@
 			[5] object,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[7] object[],
-			[8] class Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_EAEB5E6E_L10C19,
-			[9] class Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject_FunctionExpression_3C59D3C3_L14C23
+			[8] class Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject,
+			[9] class Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Stream_PassThrough_Basic/Scope::.ctor()
@@ -460,13 +460,13 @@
 		IL_0065: ldc.i4.0
 		IL_0066: ldelem.ref
 		IL_0067: castclass Modules.Stream_PassThrough_Basic/Scope
-		IL_006c: newobj instance void Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_EAEB5E6E_L10C19::.ctor(class Modules.Stream_PassThrough_Basic/Scope)
+		IL_006c: newobj instance void Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject::.ctor(class Modules.Stream_PassThrough_Basic/Scope)
 		IL_0071: ldc.i4.1
 		IL_0072: conv.r8
 		IL_0073: ldstr ""
 		IL_0078: ldc.i4.0
 		IL_0079: ldc.i4.1
-		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_EAEB5E6E_L10C19>(!!0, float64, string, bool, bool)
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007f: stloc.s 8
 		IL_0081: ldloc.s 4
 		IL_0083: ldstr "_write"
@@ -488,13 +488,13 @@
 		IL_00a8: ldc.i4.0
 		IL_00a9: ldelem.ref
 		IL_00aa: castclass Modules.Stream_PassThrough_Basic/Scope
-		IL_00af: newobj instance void Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject_FunctionExpression_3C59D3C3_L14C23::.ctor(class Modules.Stream_PassThrough_Basic/Scope)
+		IL_00af: newobj instance void Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject::.ctor(class Modules.Stream_PassThrough_Basic/Scope)
 		IL_00b4: ldc.i4.0
 		IL_00b5: conv.r8
 		IL_00b6: ldstr ""
 		IL_00bb: ldc.i4.0
 		IL_00bc: ldc.i4.1
-		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject_FunctionExpression_3C59D3C3_L14C23>(!!0, float64, string, bool, bool)
+		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c2: stloc.s 9
 		IL_00c4: ldloc.s 5
 		IL_00c6: ldstr "on"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Backpressure_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Backpressure_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_381BECE4_L11C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject_FunctionExpression_381BECE4_L11C19::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0008: stfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject::_environment0_Stream_Pipe_Backpressure_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject_FunctionExpression_381BECE4_L11C19::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject::_environment0_Stream_Pipe_Backpressure_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject_FunctionExpression_381BECE4_L11C19::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject::_environment0_Stream_Pipe_Backpressure_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_381BECE4_L11C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -194,7 +194,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_15BDE42E_L15C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -208,7 +208,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -219,7 +219,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -230,7 +230,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -245,7 +245,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -261,7 +261,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -279,9 +279,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_15BDE42E_L15C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -335,7 +335,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D45C0895_L19C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -355,9 +355,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject_FunctionExpression_D45C0895_L19C23::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0008: stfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject::_environment0_Stream_Pipe_Backpressure_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -368,7 +368,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -379,7 +379,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -392,11 +392,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject_FunctionExpression_D45C0895_L19C23::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject::_environment0_Stream_Pipe_Backpressure_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -410,11 +410,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject_FunctionExpression_D45C0895_L19C23::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject::_environment0_Stream_Pipe_Backpressure_Basic
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -432,9 +432,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D45C0895_L19C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -552,7 +552,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_48135A79_L27C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -572,9 +572,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject_FunctionExpression_48135A79_L27C22::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0008: stfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject::_environment0_Stream_Pipe_Backpressure_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -585,7 +585,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -596,7 +596,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -609,11 +609,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject_FunctionExpression_48135A79_L27C22::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject::_environment0_Stream_Pipe_Backpressure_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -627,11 +627,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject_FunctionExpression_48135A79_L27C22::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject::_environment0_Stream_Pipe_Backpressure_Basic
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -649,9 +649,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_48135A79_L27C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -791,10 +791,10 @@
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object[],
-			[6] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject_FunctionExpression_381BECE4_L11C19,
-			[7] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21/FunctionObject_FunctionExpression_15BDE42E_L15C22,
-			[8] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject_FunctionExpression_D45C0895_L19C23,
-			[9] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject_FunctionExpression_48135A79_L27C22,
+			[6] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject,
+			[7] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21/FunctionObject,
+			[8] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject,
+			[9] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject,
 			[10] string
 		)
 
@@ -845,13 +845,13 @@
 		IL_006c: ldc.i4.0
 		IL_006d: ldelem.ref
 		IL_006e: castclass Modules.Stream_Pipe_Backpressure_Basic/Scope
-		IL_0073: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject_FunctionExpression_381BECE4_L11C19::.ctor(class Modules.Stream_Pipe_Backpressure_Basic/Scope)
+		IL_0073: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject::.ctor(class Modules.Stream_Pipe_Backpressure_Basic/Scope)
 		IL_0078: ldc.i4.1
 		IL_0079: conv.r8
 		IL_007a: ldstr ""
 		IL_007f: ldc.i4.0
 		IL_0080: ldc.i4.1
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject_FunctionExpression_381BECE4_L11C19>(!!0, float64, string, bool, bool)
+		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0086: stloc.s 6
 		IL_0088: ldloc.2
 		IL_0089: ldstr "_write"
@@ -869,13 +869,13 @@
 		IL_00a6: ldloc.0
 		IL_00a7: stelem.ref
 		IL_00a8: stloc.s 5
-		IL_00aa: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21/FunctionObject_FunctionExpression_15BDE42E_L15C22::.ctor()
+		IL_00aa: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21/FunctionObject::.ctor()
 		IL_00af: ldc.i4.0
 		IL_00b0: conv.r8
 		IL_00b1: ldstr ""
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldc.i4.1
-		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21/FunctionObject_FunctionExpression_15BDE42E_L15C22>(!!0, float64, string, bool, bool)
+		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00bd: stloc.s 7
 		IL_00bf: ldloc.3
 		IL_00c0: ldstr "on"
@@ -897,13 +897,13 @@
 		IL_00e7: ldc.i4.0
 		IL_00e8: ldelem.ref
 		IL_00e9: castclass Modules.Stream_Pipe_Backpressure_Basic/Scope
-		IL_00ee: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject_FunctionExpression_D45C0895_L19C23::.ctor(class Modules.Stream_Pipe_Backpressure_Basic/Scope)
+		IL_00ee: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject::.ctor(class Modules.Stream_Pipe_Backpressure_Basic/Scope)
 		IL_00f3: ldc.i4.0
 		IL_00f4: conv.r8
 		IL_00f5: ldstr ""
 		IL_00fa: ldc.i4.0
 		IL_00fb: ldc.i4.1
-		IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject_FunctionExpression_D45C0895_L19C23>(!!0, float64, string, bool, bool)
+		IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0101: stloc.s 8
 		IL_0103: ldloc.3
 		IL_0104: ldstr "on"
@@ -944,13 +944,13 @@
 		IL_0170: ldc.i4.0
 		IL_0171: ldelem.ref
 		IL_0172: castclass Modules.Stream_Pipe_Backpressure_Basic/Scope
-		IL_0177: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject_FunctionExpression_48135A79_L27C22::.ctor(class Modules.Stream_Pipe_Backpressure_Basic/Scope)
+		IL_0177: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject::.ctor(class Modules.Stream_Pipe_Backpressure_Basic/Scope)
 		IL_017c: ldc.i4.0
 		IL_017d: conv.r8
 		IL_017e: ldstr ""
 		IL_0183: ldc.i4.0
 		IL_0184: ldc.i4.1
-		IL_0185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject_FunctionExpression_48135A79_L27C22>(!!0, float64, string, bool, bool)
+		IL_0185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_018a: stloc.s 9
 		IL_018c: ldloc.3
 		IL_018d: ldstr "on"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D9C40067_L13C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Pipe_Basic/Scope Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject_FunctionExpression_D9C40067_L13C19::_environment0_Stream_Pipe_Basic
+				IL_0008: stfld class Modules.Stream_Pipe_Basic/Scope Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject::_environment0_Stream_Pipe_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipe_Basic/Scope Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject_FunctionExpression_D9C40067_L13C19::_environment0_Stream_Pipe_Basic
+				IL_0001: ldfld class Modules.Stream_Pipe_Basic/Scope Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject::_environment0_Stream_Pipe_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Pipe_Basic/FunctionExpression_L13C18::__js_call__(class Modules.Stream_Pipe_Basic/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipe_Basic/Scope Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject_FunctionExpression_D9C40067_L13C19::_environment0_Stream_Pipe_Basic
+				IL_0001: ldfld class Modules.Stream_Pipe_Basic/Scope Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject::_environment0_Stream_Pipe_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Pipe_Basic/FunctionExpression_L13C18::__js_call__(class Modules.Stream_Pipe_Basic/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D9C40067_L13C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -262,7 +262,7 @@
 			[6] float64,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[8] object[],
-			[9] class Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject_FunctionExpression_D9C40067_L13C19,
+			[9] class Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[11] object,
 			[12] float64,
@@ -309,13 +309,13 @@
 		IL_0051: ldc.i4.0
 		IL_0052: ldelem.ref
 		IL_0053: castclass Modules.Stream_Pipe_Basic/Scope
-		IL_0058: newobj instance void Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject_FunctionExpression_D9C40067_L13C19::.ctor(class Modules.Stream_Pipe_Basic/Scope)
+		IL_0058: newobj instance void Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject::.ctor(class Modules.Stream_Pipe_Basic/Scope)
 		IL_005d: ldc.i4.1
 		IL_005e: conv.r8
 		IL_005f: ldstr ""
 		IL_0064: ldc.i4.0
 		IL_0065: ldc.i4.1
-		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject_FunctionExpression_D9C40067_L13C19>(!!0, float64, string, bool, bool)
+		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006b: stloc.s 9
 		IL_006d: ldloc.s 5
 		IL_006f: ldstr "_write"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FE7C800A_L10C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_FE7C800A_L10C19::_environment0_Stream_Pipeline_Basic
+				IL_0008: stfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject::_environment0_Stream_Pipeline_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_FE7C800A_L10C19::_environment0_Stream_Pipeline_Basic
+				IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject::_environment0_Stream_Pipeline_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_FE7C800A_L10C19::_environment0_Stream_Pipeline_Basic
+				IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject::_environment0_Stream_Pipeline_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_FE7C800A_L10C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -194,7 +194,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7FCBC395_L14C43
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -214,9 +214,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject_FunctionExpression_7FCBC395_L14C43::_environment0_Stream_Pipeline_Basic
+				IL_0008: stfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject::_environment0_Stream_Pipeline_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -227,7 +227,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -238,7 +238,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -251,14 +251,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject_FunctionExpression_7FCBC395_L14C43::_environment0_Stream_Pipeline_Basic
+				IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject::_environment0_Stream_Pipeline_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -272,14 +272,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject_FunctionExpression_7FCBC395_L14C43::_environment0_Stream_Pipeline_Basic
+				IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject::_environment0_Stream_Pipeline_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -297,9 +297,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7FCBC395_L14C43
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -445,8 +445,8 @@
 			[4] object,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[6] object[],
-			[7] class Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_FE7C800A_L10C19,
-			[8] class Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject_FunctionExpression_7FCBC395_L14C43
+			[7] class Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject,
+			[8] class Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Pipeline_Basic/Scope::.ctor()
@@ -497,13 +497,13 @@
 		IL_006d: ldc.i4.0
 		IL_006e: ldelem.ref
 		IL_006f: castclass Modules.Stream_Pipeline_Basic/Scope
-		IL_0074: newobj instance void Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_FE7C800A_L10C19::.ctor(class Modules.Stream_Pipeline_Basic/Scope)
+		IL_0074: newobj instance void Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject::.ctor(class Modules.Stream_Pipeline_Basic/Scope)
 		IL_0079: ldc.i4.1
 		IL_007a: conv.r8
 		IL_007b: ldstr ""
 		IL_0080: ldc.i4.0
 		IL_0081: ldc.i4.1
-		IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_FE7C800A_L10C19>(!!0, float64, string, bool, bool)
+		IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0087: stloc.s 7
 		IL_0089: ldloc.3
 		IL_008a: ldstr "_write"
@@ -525,13 +525,13 @@
 		IL_00ae: ldc.i4.0
 		IL_00af: ldelem.ref
 		IL_00b0: castclass Modules.Stream_Pipeline_Basic/Scope
-		IL_00b5: newobj instance void Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject_FunctionExpression_7FCBC395_L14C43::.ctor(class Modules.Stream_Pipeline_Basic/Scope)
+		IL_00b5: newobj instance void Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject::.ctor(class Modules.Stream_Pipeline_Basic/Scope)
 		IL_00ba: ldc.i4.1
 		IL_00bb: conv.r8
 		IL_00bc: ldstr ""
 		IL_00c1: ldc.i4.0
 		IL_00c2: ldc.i4.1
-		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject_FunctionExpression_7FCBC395_L14C43>(!!0, float64, string, bool, bool)
+		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c8: stloc.s 8
 		IL_00ca: ldloc.1
 		IL_00cb: ldc.i4.4

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3399A9B0_L9C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Stream_Pipeline_Error/FunctionExpression_L9C23::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Stream_Pipeline_Error/FunctionExpression_L9C23::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_3399A9B0_L9C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -180,7 +180,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5E6E3F19_L13C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -194,7 +194,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -205,7 +205,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -216,7 +216,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -231,7 +231,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Stream_Pipeline_Error/FunctionExpression_L13C18::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -247,7 +247,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Stream_Pipeline_Error/FunctionExpression_L13C18::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -265,9 +265,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5E6E3F19_L13C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -312,7 +312,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_06BB7F59_L15C48
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -332,9 +332,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Pipeline_Error/Scope Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject_FunctionExpression_06BB7F59_L15C48::_environment0_Stream_Pipeline_Error
+				IL_0008: stfld class Modules.Stream_Pipeline_Error/Scope Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject::_environment0_Stream_Pipeline_Error
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -345,7 +345,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -356,7 +356,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -369,14 +369,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipeline_Error/Scope Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject_FunctionExpression_06BB7F59_L15C48::_environment0_Stream_Pipeline_Error
+				IL_0001: ldfld class Modules.Stream_Pipeline_Error/Scope Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject::_environment0_Stream_Pipeline_Error
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Pipeline_Error/FunctionExpression_L15C47::__js_call__(class Modules.Stream_Pipeline_Error/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -390,14 +390,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipeline_Error/Scope Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject_FunctionExpression_06BB7F59_L15C48::_environment0_Stream_Pipeline_Error
+				IL_0001: ldfld class Modules.Stream_Pipeline_Error/Scope Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject::_environment0_Stream_Pipeline_Error
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Pipeline_Error/FunctionExpression_L15C47::__js_call__(class Modules.Stream_Pipeline_Error/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -415,9 +415,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_06BB7F59_L15C48
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -572,11 +572,11 @@
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 			[2] object,
 			[3] object[],
-			[4] class Modules.Stream_Pipeline_Error/FunctionExpression_L9C23/FunctionObject_FunctionExpression_3399A9B0_L9C24,
-			[5] class Modules.Stream_Pipeline_Error/FunctionExpression_L13C18/FunctionObject_FunctionExpression_5E6E3F19_L13C19,
+			[4] class Modules.Stream_Pipeline_Error/FunctionExpression_L9C23/FunctionObject,
+			[5] class Modules.Stream_Pipeline_Error/FunctionExpression_L13C18/FunctionObject,
 			[6] object,
 			[7] object,
-			[8] class Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject_FunctionExpression_06BB7F59_L15C48
+			[8] class Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Pipeline_Error/Scope::.ctor()
@@ -626,13 +626,13 @@
 		IL_0064: ldloc.0
 		IL_0065: stelem.ref
 		IL_0066: stloc.3
-		IL_0067: newobj instance void Modules.Stream_Pipeline_Error/FunctionExpression_L9C23/FunctionObject_FunctionExpression_3399A9B0_L9C24::.ctor()
+		IL_0067: newobj instance void Modules.Stream_Pipeline_Error/FunctionExpression_L9C23/FunctionObject::.ctor()
 		IL_006c: ldc.i4.0
 		IL_006d: conv.r8
 		IL_006e: ldstr ""
 		IL_0073: ldc.i4.0
 		IL_0074: ldc.i4.1
-		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error/FunctionExpression_L9C23/FunctionObject_FunctionExpression_3399A9B0_L9C24>(!!0, float64, string, bool, bool)
+		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error/FunctionExpression_L9C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007a: stloc.s 4
 		IL_007c: ldloc.2
 		IL_007d: ldstr "_transform"
@@ -650,13 +650,13 @@
 		IL_009a: ldloc.0
 		IL_009b: stelem.ref
 		IL_009c: stloc.3
-		IL_009d: newobj instance void Modules.Stream_Pipeline_Error/FunctionExpression_L13C18/FunctionObject_FunctionExpression_5E6E3F19_L13C19::.ctor()
+		IL_009d: newobj instance void Modules.Stream_Pipeline_Error/FunctionExpression_L13C18/FunctionObject::.ctor()
 		IL_00a2: ldc.i4.0
 		IL_00a3: conv.r8
 		IL_00a4: ldstr ""
 		IL_00a9: ldc.i4.0
 		IL_00aa: ldc.i4.1
-		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error/FunctionExpression_L13C18/FunctionObject_FunctionExpression_5E6E3F19_L13C19>(!!0, float64, string, bool, bool)
+		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error/FunctionExpression_L13C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00b0: stloc.s 5
 		IL_00b2: ldloc.2
 		IL_00b3: ldstr "_write"
@@ -684,13 +684,13 @@
 		IL_00e4: ldc.i4.0
 		IL_00e5: ldelem.ref
 		IL_00e6: castclass Modules.Stream_Pipeline_Error/Scope
-		IL_00eb: newobj instance void Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject_FunctionExpression_06BB7F59_L15C48::.ctor(class Modules.Stream_Pipeline_Error/Scope)
+		IL_00eb: newobj instance void Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject::.ctor(class Modules.Stream_Pipeline_Error/Scope)
 		IL_00f0: ldc.i4.1
 		IL_00f1: conv.r8
 		IL_00f2: ldstr ""
 		IL_00f7: ldc.i4.0
 		IL_00f8: ldc.i4.1
-		IL_00f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject_FunctionExpression_06BB7F59_L15C48>(!!0, float64, string, bool, bool)
+		IL_00f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00fe: stloc.s 8
 		IL_0100: ldloc.1
 		IL_0101: ldc.i4.4

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error_PropagatesToPeers.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error_PropagatesToPeers.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E9912D3B_L9C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E9912D3B_L9C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -180,7 +180,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_41CC1C92_L13C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -194,7 +194,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -205,7 +205,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -216,7 +216,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -234,7 +234,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -253,7 +253,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -271,9 +271,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_41CC1C92_L13C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -338,7 +338,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1E2D6AF3_L17C18
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -352,7 +352,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -363,7 +363,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -374,7 +374,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -392,7 +392,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -411,7 +411,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -429,9 +429,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1E2D6AF3_L17C18
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -496,7 +496,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_637A1D91_L21C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -510,7 +510,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -521,7 +521,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -532,7 +532,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -550,7 +550,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -569,7 +569,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -587,9 +587,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_637A1D91_L21C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -654,7 +654,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C8612840_L25C43
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -674,9 +674,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject_FunctionExpression_C8612840_L25C43::_environment0_Stream_Pipeline_Error_PropagatesToPeers
+				IL_0008: stfld class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject::_environment0_Stream_Pipeline_Error_PropagatesToPeers
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -687,7 +687,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -698,7 +698,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -711,14 +711,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject_FunctionExpression_C8612840_L25C43::_environment0_Stream_Pipeline_Error_PropagatesToPeers
+				IL_0001: ldfld class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject::_environment0_Stream_Pipeline_Error_PropagatesToPeers
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42::__js_call__(class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -732,14 +732,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject_FunctionExpression_C8612840_L25C43::_environment0_Stream_Pipeline_Error_PropagatesToPeers
+				IL_0001: ldfld class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject::_environment0_Stream_Pipeline_Error_PropagatesToPeers
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42::__js_call__(class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -757,9 +757,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C8612840_L25C43
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -913,13 +913,13 @@
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 			[2] object,
 			[3] object[],
-			[4] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18/FunctionObject_FunctionExpression_E9912D3B_L9C19,
-			[5] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21/FunctionObject_FunctionExpression_41CC1C92_L13C22,
-			[6] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17/FunctionObject_FunctionExpression_1E2D6AF3_L17C18,
-			[7] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21/FunctionObject_FunctionExpression_637A1D91_L21C22,
+			[4] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18/FunctionObject,
+			[5] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21/FunctionObject,
+			[6] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17/FunctionObject,
+			[7] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21/FunctionObject,
 			[8] object,
 			[9] object,
-			[10] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject_FunctionExpression_C8612840_L25C43
+			[10] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::.ctor()
@@ -969,13 +969,13 @@
 		IL_0064: ldloc.0
 		IL_0065: stelem.ref
 		IL_0066: stloc.3
-		IL_0067: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18/FunctionObject_FunctionExpression_E9912D3B_L9C19::.ctor()
+		IL_0067: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18/FunctionObject::.ctor()
 		IL_006c: ldc.i4.0
 		IL_006d: conv.r8
 		IL_006e: ldstr ""
 		IL_0073: ldc.i4.0
 		IL_0074: ldc.i4.1
-		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18/FunctionObject_FunctionExpression_E9912D3B_L9C19>(!!0, float64, string, bool, bool)
+		IL_0075: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_007a: stloc.s 4
 		IL_007c: ldloc.2
 		IL_007d: ldstr "_write"
@@ -994,13 +994,13 @@
 		IL_009f: ldloc.0
 		IL_00a0: stelem.ref
 		IL_00a1: stloc.3
-		IL_00a2: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21/FunctionObject_FunctionExpression_41CC1C92_L13C22::.ctor()
+		IL_00a2: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21/FunctionObject::.ctor()
 		IL_00a7: ldc.i4.1
 		IL_00a8: conv.r8
 		IL_00a9: ldstr ""
 		IL_00ae: ldc.i4.0
 		IL_00af: ldc.i4.1
-		IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21/FunctionObject_FunctionExpression_41CC1C92_L13C22>(!!0, float64, string, bool, bool)
+		IL_00b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00b5: stloc.s 5
 		IL_00b7: ldloc.2
 		IL_00b8: ldstr "on"
@@ -1019,13 +1019,13 @@
 		IL_00de: ldloc.0
 		IL_00df: stelem.ref
 		IL_00e0: stloc.3
-		IL_00e1: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17/FunctionObject_FunctionExpression_1E2D6AF3_L17C18::.ctor()
+		IL_00e1: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17/FunctionObject::.ctor()
 		IL_00e6: ldc.i4.1
 		IL_00e7: conv.r8
 		IL_00e8: ldstr ""
 		IL_00ed: ldc.i4.0
 		IL_00ee: ldc.i4.1
-		IL_00ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17/FunctionObject_FunctionExpression_1E2D6AF3_L17C18>(!!0, float64, string, bool, bool)
+		IL_00ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00f4: stloc.s 6
 		IL_00f6: ldloc.2
 		IL_00f7: ldstr "on"
@@ -1044,13 +1044,13 @@
 		IL_011d: ldloc.0
 		IL_011e: stelem.ref
 		IL_011f: stloc.3
-		IL_0120: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21/FunctionObject_FunctionExpression_637A1D91_L21C22::.ctor()
+		IL_0120: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21/FunctionObject::.ctor()
 		IL_0125: ldc.i4.1
 		IL_0126: conv.r8
 		IL_0127: ldstr ""
 		IL_012c: ldc.i4.0
 		IL_012d: ldc.i4.1
-		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21/FunctionObject_FunctionExpression_637A1D91_L21C22>(!!0, float64, string, bool, bool)
+		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0133: stloc.s 7
 		IL_0135: ldloc.2
 		IL_0136: ldstr "on"
@@ -1078,13 +1078,13 @@
 		IL_016b: ldc.i4.0
 		IL_016c: ldelem.ref
 		IL_016d: castclass Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope
-		IL_0172: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject_FunctionExpression_C8612840_L25C43::.ctor(class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope)
+		IL_0172: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject::.ctor(class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope)
 		IL_0177: ldc.i4.1
 		IL_0178: conv.r8
 		IL_0179: ldstr ""
 		IL_017e: ldc.i4.0
 		IL_017f: ldc.i4.1
-		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject_FunctionExpression_C8612840_L25C43>(!!0, float64, string, bool, bool)
+		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0185: stloc.s 10
 		IL_0187: ldloc.1
 		IL_0188: ldc.i4.4

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1748DE8B_L8C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -48,7 +48,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -59,7 +59,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -70,7 +70,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -85,7 +85,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -101,7 +101,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -119,9 +119,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_1748DE8B_L8C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -169,7 +169,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F84A6898_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -191,12 +191,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Promises_Finished_Basic/Scope Modules.Stream_Promises_Finished_Basic/main/FunctionObject_FunctionDeclaration_F84A6898_main::_environment0_Stream_Promises_Finished_Basic
+				IL_0008: stfld class Modules.Stream_Promises_Finished_Basic/Scope Modules.Stream_Promises_Finished_Basic/main/FunctionObject::_environment0_Stream_Promises_Finished_Basic
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Stream_Promises_Finished_Basic/main/FunctionObject_FunctionDeclaration_F84A6898_main::_transitionalScopes
+				IL_000f: stfld object[] Modules.Stream_Promises_Finished_Basic/main/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -207,7 +207,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -218,7 +218,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -231,14 +231,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Stream_Promises_Finished_Basic/main/FunctionObject_FunctionDeclaration_F84A6898_main::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Stream_Promises_Finished_Basic/main/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Promises_Finished_Basic/main::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_F84A6898_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -261,7 +261,7 @@
 				[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 				[4] object,
 				[5] object[],
-				[6] class Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20/FunctionObject_FunctionExpression_1748DE8B_L8C21,
+				[6] class Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20/FunctionObject,
 				[7] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule,
 				[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[9] object
@@ -286,7 +286,7 @@
 			IL_0020: ldftn object Modules.Stream_Promises_Finished_Basic/main::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Stream_Promises_Finished_Basic/main/FunctionObject_FunctionDeclaration_F84A6898_main
+			IL_002c: ldtoken Modules.Stream_Promises_Finished_Basic/main/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -338,7 +338,7 @@
 			IL_009b: dup
 			IL_009c: ldc.i4.5
 			IL_009d: ldelem.ref
-			IL_009e: castclass Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20/FunctionObject_FunctionExpression_1748DE8B_L8C21
+			IL_009e: castclass Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20/FunctionObject
 			IL_00a3: stloc.s 6
 			IL_00a5: dup
 			IL_00a6: ldc.i4.6
@@ -382,13 +382,13 @@
 			IL_00fb: ldelem.ref
 			IL_00fc: stelem.ref
 			IL_00fd: stloc.s 5
-			IL_00ff: newobj instance void Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20/FunctionObject_FunctionExpression_1748DE8B_L8C21::.ctor()
+			IL_00ff: newobj instance void Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20/FunctionObject::.ctor()
 			IL_0104: ldc.i4.0
 			IL_0105: conv.r8
 			IL_0106: ldstr ""
 			IL_010b: ldc.i4.0
 			IL_010c: ldc.i4.1
-			IL_010d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20/FunctionObject_FunctionExpression_1748DE8B_L8C21>(!!0, float64, string, bool, bool)
+			IL_010d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0112: stloc.s 6
 			IL_0114: ldloc.1
 			IL_0115: ldstr "_write"
@@ -565,7 +565,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Promises_Finished_Basic/Scope,
-			[1] class Modules.Stream_Promises_Finished_Basic/main/FunctionObject_FunctionDeclaration_F84A6898_main,
+			[1] class Modules.Stream_Promises_Finished_Basic/main/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule
@@ -585,14 +585,14 @@
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Stream_Promises_Finished_Basic/Scope
 		IL_0019: ldloc.2
-		IL_001a: newobj instance void Modules.Stream_Promises_Finished_Basic/main/FunctionObject_FunctionDeclaration_F84A6898_main::.ctor(class Modules.Stream_Promises_Finished_Basic/Scope, object[])
+		IL_001a: newobj instance void Modules.Stream_Promises_Finished_Basic/main/FunctionObject::.ctor(class Modules.Stream_Promises_Finished_Basic/Scope, object[])
 		IL_001f: ldc.i4.0
 		IL_0020: conv.r8
 		IL_0021: ldstr "main"
 		IL_0026: ldc.i4.0
 		IL_0027: ldc.i4.1
-		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Stream_Promises_Finished_Basic/main/FunctionObject_FunctionDeclaration_F84A6898_main>(!!0, float64, string, bool, bool)
-		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Stream_Promises_Finished_Basic/main/FunctionObject_FunctionDeclaration_F84A6898_main>(!!0)
+		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Stream_Promises_Finished_Basic/main/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Stream_Promises_Finished_Basic/main/FunctionObject>(!!0)
 		IL_0032: stloc.1
 		IL_0033: nop
 		IL_0034: ldarg.1

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_AbortSignal.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3167102B_L12C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject_FunctionExpression_3167102B_L12C19::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0008: stfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject::_environment0_Stream_Promises_Pipeline_AbortSignal
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject_FunctionExpression_3167102B_L12C19::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject::_environment0_Stream_Promises_Pipeline_AbortSignal
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject_FunctionExpression_3167102B_L12C19::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject::_environment0_Stream_Promises_Pipeline_AbortSignal
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_3167102B_L12C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -199,7 +199,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FD81F687_L22C9
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -219,9 +219,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject_FunctionExpression_FD81F687_L22C9::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0008: stfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject::_environment0_Stream_Promises_Pipeline_AbortSignal
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -232,7 +232,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -243,7 +243,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -256,11 +256,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject_FunctionExpression_FD81F687_L22C9::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject::_environment0_Stream_Promises_Pipeline_AbortSignal
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -274,11 +274,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject_FunctionExpression_FD81F687_L22C9::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject::_environment0_Stream_Promises_Pipeline_AbortSignal
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -296,9 +296,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_FD81F687_L22C9
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -353,7 +353,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_87CE6C7E_L25C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -373,9 +373,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject_FunctionExpression_87CE6C7E_L25C10::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0008: stfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject::_environment0_Stream_Promises_Pipeline_AbortSignal
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -386,7 +386,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -397,7 +397,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -410,14 +410,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject_FunctionExpression_87CE6C7E_L25C10::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject::_environment0_Stream_Promises_Pipeline_AbortSignal
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -431,14 +431,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject_FunctionExpression_87CE6C7E_L25C10::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject::_environment0_Stream_Promises_Pipeline_AbortSignal
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -456,9 +456,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_87CE6C7E_L25C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -550,7 +550,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_45713D2C_L30C9
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -570,9 +570,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject_FunctionExpression_45713D2C_L30C9::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0008: stfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject::_environment0_Stream_Promises_Pipeline_AbortSignal
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -583,7 +583,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -594,7 +594,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -607,11 +607,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject_FunctionExpression_45713D2C_L30C9::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject::_environment0_Stream_Promises_Pipeline_AbortSignal
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -625,11 +625,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject_FunctionExpression_45713D2C_L30C9::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject::_environment0_Stream_Promises_Pipeline_AbortSignal
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -647,9 +647,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_45713D2C_L30C9
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -816,13 +816,13 @@
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[8] object[],
-			[9] class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject_FunctionExpression_3167102B_L12C19,
+			[9] class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject,
 			[10] object,
 			[11] object,
 			[12] object,
-			[13] class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject_FunctionExpression_FD81F687_L22C9,
-			[14] class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject_FunctionExpression_87CE6C7E_L25C10,
-			[15] class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject_FunctionExpression_45713D2C_L30C9
+			[13] class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject,
+			[14] class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject,
+			[15] class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/Scope::.ctor()
@@ -922,13 +922,13 @@
 		IL_010f: ldc.i4.0
 		IL_0110: ldelem.ref
 		IL_0111: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
-		IL_0116: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject_FunctionExpression_3167102B_L12C19::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
+		IL_0116: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
 		IL_011b: ldc.i4.1
 		IL_011c: conv.r8
 		IL_011d: ldstr ""
 		IL_0122: ldc.i4.0
 		IL_0123: ldc.i4.1
-		IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject_FunctionExpression_3167102B_L12C19>(!!0, float64, string, bool, bool)
+		IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0129: stloc.s 9
 		IL_012b: ldloc.s 5
 		IL_012d: ldstr "_write"
@@ -1009,13 +1009,13 @@
 		IL_01f6: ldc.i4.0
 		IL_01f7: ldelem.ref
 		IL_01f8: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
-		IL_01fd: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject_FunctionExpression_FD81F687_L22C9::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
+		IL_01fd: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
 		IL_0202: ldc.i4.0
 		IL_0203: conv.r8
 		IL_0204: ldstr ""
 		IL_0209: ldc.i4.0
 		IL_020a: ldc.i4.1
-		IL_020b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject_FunctionExpression_FD81F687_L22C9>(!!0, float64, string, bool, bool)
+		IL_020b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0210: stloc.s 13
 		IL_0212: ldloc.s 11
 		IL_0214: ldstr "then"
@@ -1036,13 +1036,13 @@
 		IL_0239: ldc.i4.0
 		IL_023a: ldelem.ref
 		IL_023b: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
-		IL_0240: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject_FunctionExpression_87CE6C7E_L25C10::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
+		IL_0240: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
 		IL_0245: ldc.i4.1
 		IL_0246: conv.r8
 		IL_0247: ldstr ""
 		IL_024c: ldc.i4.0
 		IL_024d: ldc.i4.1
-		IL_024e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject_FunctionExpression_87CE6C7E_L25C10>(!!0, float64, string, bool, bool)
+		IL_024e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0253: stloc.s 14
 		IL_0255: ldloc.s 11
 		IL_0257: ldstr "catch"
@@ -1063,13 +1063,13 @@
 		IL_027c: ldc.i4.0
 		IL_027d: ldelem.ref
 		IL_027e: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
-		IL_0283: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject_FunctionExpression_45713D2C_L30C9::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
+		IL_0283: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
 		IL_0288: ldc.i4.0
 		IL_0289: conv.r8
 		IL_028a: ldstr ""
 		IL_028f: ldc.i4.0
 		IL_0290: ldc.i4.1
-		IL_0291: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject_FunctionExpression_45713D2C_L30C9>(!!0, float64, string, bool, bool)
+		IL_0291: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0296: stloc.s 15
 		IL_0298: ldloc.s 11
 		IL_029a: ldstr "then"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6DDAF3C3_L12C26
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -58,15 +58,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_environment0_Stream_Promises_Pipeline_ObjectMode
+					IL_0008: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject::_environment0_Stream_Promises_Pipeline_ObjectMode
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_environment1_main
+					IL_000f: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject::_environment1_main
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_transitionalScopes
+					IL_0016: stfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -77,7 +77,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -88,7 +88,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -101,14 +101,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -122,14 +122,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -147,9 +147,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_6DDAF3C3_L12C26
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -225,7 +225,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_53DB12A6_L16C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -249,15 +249,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21::_environment0_Stream_Promises_Pipeline_ObjectMode
+					IL_0008: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject::_environment0_Stream_Promises_Pipeline_ObjectMode
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21::_environment1_main
+					IL_000f: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject::_environment1_main
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21::_transitionalScopes
+					IL_0016: stfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -268,7 +268,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -279,7 +279,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -292,14 +292,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -313,14 +313,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -338,9 +338,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_53DB12A6_L16C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -409,7 +409,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8763DEC6_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -431,12 +431,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject_FunctionDeclaration_8763DEC6_main::_environment0_Stream_Promises_Pipeline_ObjectMode
+				IL_0008: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject::_environment0_Stream_Promises_Pipeline_ObjectMode
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject_FunctionDeclaration_8763DEC6_main::_transitionalScopes
+				IL_000f: stfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -447,7 +447,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -458,7 +458,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -471,14 +471,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject_FunctionDeclaration_8763DEC6_main::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Promises_Pipeline_ObjectMode/main::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_8763DEC6_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -505,8 +505,8 @@
 				[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[9] object[],
-				[10] class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26,
-				[11] class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21,
+				[10] class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject,
+				[11] class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject,
 				[12] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule,
 				[13] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[14] object,
@@ -532,7 +532,7 @@
 			IL_0020: ldftn object Modules.Stream_Promises_Pipeline_ObjectMode/main::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject_FunctionDeclaration_8763DEC6_main
+			IL_002c: ldtoken Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -602,12 +602,12 @@
 			IL_00b9: dup
 			IL_00ba: ldc.i4.s 9
 			IL_00bc: ldelem.ref
-			IL_00bd: castclass Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26
+			IL_00bd: castclass Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject
 			IL_00c2: stloc.s 10
 			IL_00c4: dup
 			IL_00c5: ldc.i4.s 10
 			IL_00c7: ldelem.ref
-			IL_00c8: castclass Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21
+			IL_00c8: castclass Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject
 			IL_00cd: stloc.s 11
 			IL_00cf: dup
 			IL_00d0: ldc.i4.s 11
@@ -722,13 +722,13 @@
 			IL_01da: ldelem.ref
 			IL_01db: castclass Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope
 			IL_01e0: ldloc.s 9
-			IL_01e2: newobj instance void Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26::.ctor(class Modules.Stream_Promises_Pipeline_ObjectMode/Scope, class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope, object[])
+			IL_01e2: newobj instance void Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_ObjectMode/Scope, class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope, object[])
 			IL_01e7: ldc.i4.1
 			IL_01e8: conv.r8
 			IL_01e9: ldstr ""
 			IL_01ee: ldc.i4.1
 			IL_01ef: ldc.i4.1
-			IL_01f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26>(!!0, float64, string, bool, bool)
+			IL_01f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_01f5: stloc.s 10
 			IL_01f7: ldloc.2
 			IL_01f8: ldstr "_transform"
@@ -758,13 +758,13 @@
 			IL_0224: ldelem.ref
 			IL_0225: castclass Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope
 			IL_022a: ldloc.s 9
-			IL_022c: newobj instance void Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21::.ctor(class Modules.Stream_Promises_Pipeline_ObjectMode/Scope, class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope, object[])
+			IL_022c: newobj instance void Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_ObjectMode/Scope, class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope, object[])
 			IL_0231: ldc.i4.1
 			IL_0232: conv.r8
 			IL_0233: ldstr ""
 			IL_0238: ldc.i4.0
 			IL_0239: ldc.i4.1
-			IL_023a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21>(!!0, float64, string, bool, bool)
+			IL_023a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_023f: stloc.s 11
 			IL_0241: ldloc.3
 			IL_0242: ldstr "_write"
@@ -1055,7 +1055,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Stream_Promises_Pipeline_ObjectMode/Scope,
-			[1] class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject_FunctionDeclaration_8763DEC6_main,
+			[1] class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule
@@ -1075,14 +1075,14 @@
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Stream_Promises_Pipeline_ObjectMode/Scope
 		IL_0019: ldloc.2
-		IL_001a: newobj instance void Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject_FunctionDeclaration_8763DEC6_main::.ctor(class Modules.Stream_Promises_Pipeline_ObjectMode/Scope, object[])
+		IL_001a: newobj instance void Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject::.ctor(class Modules.Stream_Promises_Pipeline_ObjectMode/Scope, object[])
 		IL_001f: ldc.i4.0
 		IL_0020: conv.r8
 		IL_0021: ldstr "main"
 		IL_0026: ldc.i4.0
 		IL_0027: ldc.i4.1
-		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject_FunctionDeclaration_8763DEC6_main>(!!0, float64, string, bool, bool)
-		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject_FunctionDeclaration_8763DEC6_main>(!!0)
+		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject>(!!0)
 		IL_0032: stloc.1
 		IL_0033: nop
 		IL_0034: ldarg.1

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_39A55734_L13C21
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Readable_Basic/Scope Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject_FunctionExpression_39A55734_L13C21::_environment0_Stream_Readable_Basic
+				IL_0008: stfld class Modules.Stream_Readable_Basic/Scope Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject::_environment0_Stream_Readable_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Readable_Basic/Scope Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject_FunctionExpression_39A55734_L13C21::_environment0_Stream_Readable_Basic
+				IL_0001: ldfld class Modules.Stream_Readable_Basic/Scope Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject::_environment0_Stream_Readable_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Readable_Basic/FunctionExpression_L13C20::__js_call__(class Modules.Stream_Readable_Basic/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Readable_Basic/Scope Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject_FunctionExpression_39A55734_L13C21::_environment0_Stream_Readable_Basic
+				IL_0001: ldfld class Modules.Stream_Readable_Basic/Scope Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject::_environment0_Stream_Readable_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Readable_Basic/FunctionExpression_L13C20::__js_call__(class Modules.Stream_Readable_Basic/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_39A55734_L13C21
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -208,7 +208,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D752F3C8_L18C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -222,7 +222,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -233,7 +233,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -244,7 +244,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -259,7 +259,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Stream_Readable_Basic/FunctionExpression_L18C19::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -275,7 +275,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Stream_Readable_Basic/FunctionExpression_L18C19::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -293,9 +293,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D752F3C8_L18C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -375,8 +375,8 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject_FunctionExpression_39A55734_L13C21,
-			[8] class Modules.Stream_Readable_Basic/FunctionExpression_L18C19/FunctionObject_FunctionExpression_D752F3C8_L18C20
+			[7] class Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject,
+			[8] class Modules.Stream_Readable_Basic/FunctionExpression_L18C19/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Readable_Basic/Scope::.ctor()
@@ -421,13 +421,13 @@
 		IL_006a: ldc.i4.0
 		IL_006b: ldelem.ref
 		IL_006c: castclass Modules.Stream_Readable_Basic/Scope
-		IL_0071: newobj instance void Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject_FunctionExpression_39A55734_L13C21::.ctor(class Modules.Stream_Readable_Basic/Scope)
+		IL_0071: newobj instance void Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject::.ctor(class Modules.Stream_Readable_Basic/Scope)
 		IL_0076: ldc.i4.1
 		IL_0077: conv.r8
 		IL_0078: ldstr ""
 		IL_007d: ldc.i4.0
 		IL_007e: ldc.i4.1
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject_FunctionExpression_39A55734_L13C21>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0084: stloc.s 7
 		IL_0086: ldloc.s 5
 		IL_0088: ldstr "on"
@@ -445,13 +445,13 @@
 		IL_00aa: ldloc.0
 		IL_00ab: stelem.ref
 		IL_00ac: stloc.s 6
-		IL_00ae: newobj instance void Modules.Stream_Readable_Basic/FunctionExpression_L18C19/FunctionObject_FunctionExpression_D752F3C8_L18C20::.ctor()
+		IL_00ae: newobj instance void Modules.Stream_Readable_Basic/FunctionExpression_L18C19/FunctionObject::.ctor()
 		IL_00b3: ldc.i4.0
 		IL_00b4: conv.r8
 		IL_00b5: ldstr ""
 		IL_00ba: ldc.i4.0
 		IL_00bb: ldc.i4.1
-		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Basic/FunctionExpression_L18C19/FunctionObject_FunctionExpression_D752F3C8_L18C20>(!!0, float64, string, bool, bool)
+		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Basic/FunctionExpression_L18C19/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c1: stloc.s 8
 		IL_00c3: ldloc.s 5
 		IL_00c5: ldstr "on"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Pause_Resume.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Pause_Resume.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C97404D1_L8C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject_FunctionExpression_C97404D1_L8C22::_environment0_Stream_Readable_Pause_Resume
+				IL_0008: stfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject::_environment0_Stream_Readable_Pause_Resume
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject_FunctionExpression_C97404D1_L8C22::_environment0_Stream_Readable_Pause_Resume
+				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject::_environment0_Stream_Readable_Pause_Resume
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject_FunctionExpression_C97404D1_L8C22::_environment0_Stream_Readable_Pause_Resume
+				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject::_environment0_Stream_Readable_Pause_Resume
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C97404D1_L8C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -187,7 +187,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D5D9C11F_L12C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -207,9 +207,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject_FunctionExpression_D5D9C11F_L12C23::_environment0_Stream_Readable_Pause_Resume
+				IL_0008: stfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject::_environment0_Stream_Readable_Pause_Resume
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -220,7 +220,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -231,7 +231,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -244,11 +244,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject_FunctionExpression_D5D9C11F_L12C23::_environment0_Stream_Readable_Pause_Resume
+				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject::_environment0_Stream_Readable_Pause_Resume
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -262,11 +262,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject_FunctionExpression_D5D9C11F_L12C23::_environment0_Stream_Readable_Pause_Resume
+				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject::_environment0_Stream_Readable_Pause_Resume
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -284,9 +284,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D5D9C11F_L12C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -344,7 +344,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4492B329_L16C21
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -358,7 +358,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -369,7 +369,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -380,7 +380,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -398,7 +398,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -417,7 +417,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -435,9 +435,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_4492B329_L16C21
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -497,7 +497,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7D772049_L20C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -517,9 +517,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject_FunctionExpression_7D772049_L20C20::_environment0_Stream_Readable_Pause_Resume
+				IL_0008: stfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject::_environment0_Stream_Readable_Pause_Resume
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -530,7 +530,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -541,7 +541,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -554,11 +554,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject_FunctionExpression_7D772049_L20C20::_environment0_Stream_Readable_Pause_Resume
+				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject::_environment0_Stream_Readable_Pause_Resume
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -572,11 +572,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject_FunctionExpression_7D772049_L20C20::_environment0_Stream_Readable_Pause_Resume
+				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject::_environment0_Stream_Readable_Pause_Resume
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -594,9 +594,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7D772049_L20C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -698,10 +698,10 @@
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object[],
-			[6] class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject_FunctionExpression_C97404D1_L8C22,
-			[7] class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject_FunctionExpression_D5D9C11F_L12C23,
-			[8] class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20/FunctionObject_FunctionExpression_4492B329_L16C21,
-			[9] class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject_FunctionExpression_7D772049_L20C20,
+			[6] class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject,
+			[7] class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject,
+			[8] class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20/FunctionObject,
+			[9] class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
 
@@ -739,13 +739,13 @@
 		IL_0047: ldc.i4.0
 		IL_0048: ldelem.ref
 		IL_0049: castclass Modules.Stream_Readable_Pause_Resume/Scope
-		IL_004e: newobj instance void Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject_FunctionExpression_C97404D1_L8C22::.ctor(class Modules.Stream_Readable_Pause_Resume/Scope)
+		IL_004e: newobj instance void Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject::.ctor(class Modules.Stream_Readable_Pause_Resume/Scope)
 		IL_0053: ldc.i4.0
 		IL_0054: conv.r8
 		IL_0055: ldstr ""
 		IL_005a: ldc.i4.0
 		IL_005b: ldc.i4.1
-		IL_005c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject_FunctionExpression_C97404D1_L8C22>(!!0, float64, string, bool, bool)
+		IL_005c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0061: stloc.s 6
 		IL_0063: ldloc.3
 		IL_0064: ldstr "on"
@@ -767,13 +767,13 @@
 		IL_008b: ldc.i4.0
 		IL_008c: ldelem.ref
 		IL_008d: castclass Modules.Stream_Readable_Pause_Resume/Scope
-		IL_0092: newobj instance void Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject_FunctionExpression_D5D9C11F_L12C23::.ctor(class Modules.Stream_Readable_Pause_Resume/Scope)
+		IL_0092: newobj instance void Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject::.ctor(class Modules.Stream_Readable_Pause_Resume/Scope)
 		IL_0097: ldc.i4.0
 		IL_0098: conv.r8
 		IL_0099: ldstr ""
 		IL_009e: ldc.i4.0
 		IL_009f: ldc.i4.1
-		IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject_FunctionExpression_D5D9C11F_L12C23>(!!0, float64, string, bool, bool)
+		IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a5: stloc.s 7
 		IL_00a7: ldloc.3
 		IL_00a8: ldstr "on"
@@ -791,13 +791,13 @@
 		IL_00c9: ldloc.0
 		IL_00ca: stelem.ref
 		IL_00cb: stloc.s 5
-		IL_00cd: newobj instance void Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20/FunctionObject_FunctionExpression_4492B329_L16C21::.ctor()
+		IL_00cd: newobj instance void Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20/FunctionObject::.ctor()
 		IL_00d2: ldc.i4.1
 		IL_00d3: conv.r8
 		IL_00d4: ldstr ""
 		IL_00d9: ldc.i4.0
 		IL_00da: ldc.i4.1
-		IL_00db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20/FunctionObject_FunctionExpression_4492B329_L16C21>(!!0, float64, string, bool, bool)
+		IL_00db: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00e0: stloc.s 8
 		IL_00e2: ldloc.3
 		IL_00e3: ldstr "on"
@@ -819,13 +819,13 @@
 		IL_010a: ldc.i4.0
 		IL_010b: ldelem.ref
 		IL_010c: castclass Modules.Stream_Readable_Pause_Resume/Scope
-		IL_0111: newobj instance void Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject_FunctionExpression_7D772049_L20C20::.ctor(class Modules.Stream_Readable_Pause_Resume/Scope)
+		IL_0111: newobj instance void Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject::.ctor(class Modules.Stream_Readable_Pause_Resume/Scope)
 		IL_0116: ldc.i4.0
 		IL_0117: conv.r8
 		IL_0118: ldstr ""
 		IL_011d: ldc.i4.0
 		IL_011e: ldc.i4.1
-		IL_011f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject_FunctionExpression_7D772049_L20C20>(!!0, float64, string, bool, bool)
+		IL_011f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0124: stloc.s 9
 		IL_0126: ldloc.3
 		IL_0127: ldstr "on"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_SetEncoding_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_SetEncoding_Utf8.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_01F99F03_L15C21
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_01F99F03_L15C21
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -195,7 +195,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8DB2BEB4_L19C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -215,9 +215,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Readable_SetEncoding_Utf8/Scope Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject_FunctionExpression_8DB2BEB4_L19C20::_environment0_Stream_Readable_SetEncoding_Utf8
+				IL_0008: stfld class Modules.Stream_Readable_SetEncoding_Utf8/Scope Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject::_environment0_Stream_Readable_SetEncoding_Utf8
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -228,7 +228,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -239,7 +239,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -252,11 +252,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Readable_SetEncoding_Utf8/Scope Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject_FunctionExpression_8DB2BEB4_L19C20::_environment0_Stream_Readable_SetEncoding_Utf8
+				IL_0001: ldfld class Modules.Stream_Readable_SetEncoding_Utf8/Scope Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject::_environment0_Stream_Readable_SetEncoding_Utf8
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19::__js_call__(class Modules.Stream_Readable_SetEncoding_Utf8/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -270,11 +270,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Readable_SetEncoding_Utf8/Scope Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject_FunctionExpression_8DB2BEB4_L19C20::_environment0_Stream_Readable_SetEncoding_Utf8
+				IL_0001: ldfld class Modules.Stream_Readable_SetEncoding_Utf8/Scope Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject::_environment0_Stream_Readable_SetEncoding_Utf8
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19::__js_call__(class Modules.Stream_Readable_SetEncoding_Utf8/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -292,9 +292,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_8DB2BEB4_L19C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -389,8 +389,8 @@
 			[6] object,
 			[7] string,
 			[8] object[],
-			[9] class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject_FunctionExpression_01F99F03_L15C21,
-			[10] class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject_FunctionExpression_8DB2BEB4_L19C20
+			[9] class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject,
+			[10] class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/Scope::.ctor()
@@ -488,13 +488,13 @@
 		IL_012a: ldloc.0
 		IL_012b: stelem.ref
 		IL_012c: stloc.s 8
-		IL_012e: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject_FunctionExpression_01F99F03_L15C21::.ctor()
+		IL_012e: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject::.ctor()
 		IL_0133: ldc.i4.1
 		IL_0134: conv.r8
 		IL_0135: ldstr ""
 		IL_013a: ldc.i4.0
 		IL_013b: ldc.i4.1
-		IL_013c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject_FunctionExpression_01F99F03_L15C21>(!!0, float64, string, bool, bool)
+		IL_013c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0141: stloc.s 9
 		IL_0143: ldloc.3
 		IL_0144: ldstr "on"
@@ -517,13 +517,13 @@
 		IL_0170: ldc.i4.0
 		IL_0171: ldelem.ref
 		IL_0172: castclass Modules.Stream_Readable_SetEncoding_Utf8/Scope
-		IL_0177: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject_FunctionExpression_8DB2BEB4_L19C20::.ctor(class Modules.Stream_Readable_SetEncoding_Utf8/Scope)
+		IL_0177: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject::.ctor(class Modules.Stream_Readable_SetEncoding_Utf8/Scope)
 		IL_017c: ldc.i4.0
 		IL_017d: conv.r8
 		IL_017e: ldstr ""
 		IL_0183: ldc.i4.0
 		IL_0184: ldc.i4.1
-		IL_0185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject_FunctionExpression_8DB2BEB4_L19C20>(!!0, float64, string, bool, bool)
+		IL_0185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_018a: stloc.s 10
 		IL_018c: ldloc.3
 		IL_018d: ldstr "on"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Transform_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Transform_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6B603F66_L9C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Stream_Transform_Basic/FunctionExpression_L9C23::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Stream_Transform_Basic/FunctionExpression_L9C23::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_6B603F66_L9C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -187,7 +187,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1E7D8B98_L14C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -207,9 +207,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject_FunctionExpression_1E7D8B98_L14C19::_environment0_Stream_Transform_Basic
+				IL_0008: stfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject::_environment0_Stream_Transform_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -220,7 +220,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -231,7 +231,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -244,14 +244,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject_FunctionExpression_1E7D8B98_L14C19::_environment0_Stream_Transform_Basic
+				IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject::_environment0_Stream_Transform_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Transform_Basic/FunctionExpression_L14C18::__js_call__(class Modules.Stream_Transform_Basic/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -265,14 +265,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject_FunctionExpression_1E7D8B98_L14C19::_environment0_Stream_Transform_Basic
+				IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject::_environment0_Stream_Transform_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Transform_Basic/FunctionExpression_L14C18::__js_call__(class Modules.Stream_Transform_Basic/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -290,9 +290,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1E7D8B98_L14C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -351,7 +351,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D96DDE65_L18C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -371,9 +371,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject_FunctionExpression_D96DDE65_L18C23::_environment0_Stream_Transform_Basic
+				IL_0008: stfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject::_environment0_Stream_Transform_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -384,7 +384,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -395,7 +395,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -408,11 +408,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject_FunctionExpression_D96DDE65_L18C23::_environment0_Stream_Transform_Basic
+				IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject::_environment0_Stream_Transform_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Transform_Basic/FunctionExpression_L18C22::__js_call__(class Modules.Stream_Transform_Basic/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -426,11 +426,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject_FunctionExpression_D96DDE65_L18C23::_environment0_Stream_Transform_Basic
+				IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject::_environment0_Stream_Transform_Basic
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Transform_Basic/FunctionExpression_L18C22::__js_call__(class Modules.Stream_Transform_Basic/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -448,9 +448,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D96DDE65_L18C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -553,10 +553,10 @@
 			[4] object,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Stream_Transform_Basic/FunctionExpression_L9C23/FunctionObject_FunctionExpression_6B603F66_L9C24,
+			[7] class Modules.Stream_Transform_Basic/FunctionExpression_L9C23/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[9] class Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject_FunctionExpression_1E7D8B98_L14C19,
-			[10] class Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject_FunctionExpression_D96DDE65_L18C23
+			[9] class Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject,
+			[10] class Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Transform_Basic/Scope::.ctor()
@@ -594,13 +594,13 @@
 		IL_004f: ldloc.0
 		IL_0050: stelem.ref
 		IL_0051: stloc.s 6
-		IL_0053: newobj instance void Modules.Stream_Transform_Basic/FunctionExpression_L9C23/FunctionObject_FunctionExpression_6B603F66_L9C24::.ctor()
+		IL_0053: newobj instance void Modules.Stream_Transform_Basic/FunctionExpression_L9C23/FunctionObject::.ctor()
 		IL_0058: ldc.i4.1
 		IL_0059: conv.r8
 		IL_005a: ldstr ""
 		IL_005f: ldc.i4.1
 		IL_0060: ldc.i4.1
-		IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Transform_Basic/FunctionExpression_L9C23/FunctionObject_FunctionExpression_6B603F66_L9C24>(!!0, float64, string, bool, bool)
+		IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Transform_Basic/FunctionExpression_L9C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0066: stloc.s 7
 		IL_0068: ldloc.3
 		IL_0069: ldstr "_transform"
@@ -625,13 +625,13 @@
 		IL_0095: ldc.i4.0
 		IL_0096: ldelem.ref
 		IL_0097: castclass Modules.Stream_Transform_Basic/Scope
-		IL_009c: newobj instance void Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject_FunctionExpression_1E7D8B98_L14C19::.ctor(class Modules.Stream_Transform_Basic/Scope)
+		IL_009c: newobj instance void Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject::.ctor(class Modules.Stream_Transform_Basic/Scope)
 		IL_00a1: ldc.i4.1
 		IL_00a2: conv.r8
 		IL_00a3: ldstr ""
 		IL_00a8: ldc.i4.0
 		IL_00a9: ldc.i4.1
-		IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject_FunctionExpression_1E7D8B98_L14C19>(!!0, float64, string, bool, bool)
+		IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00af: stloc.s 9
 		IL_00b1: ldloc.s 4
 		IL_00b3: ldstr "_write"
@@ -653,13 +653,13 @@
 		IL_00d8: ldc.i4.0
 		IL_00d9: ldelem.ref
 		IL_00da: castclass Modules.Stream_Transform_Basic/Scope
-		IL_00df: newobj instance void Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject_FunctionExpression_D96DDE65_L18C23::.ctor(class Modules.Stream_Transform_Basic/Scope)
+		IL_00df: newobj instance void Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject::.ctor(class Modules.Stream_Transform_Basic/Scope)
 		IL_00e4: ldc.i4.0
 		IL_00e5: conv.r8
 		IL_00e6: ldstr ""
 		IL_00eb: ldc.i4.0
 		IL_00ec: ldc.i4.1
-		IL_00ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject_FunctionExpression_D96DDE65_L18C23>(!!0, float64, string, bool, bool)
+		IL_00ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00f2: stloc.s 10
 		IL_00f4: ldloc.s 5
 		IL_00f6: ldstr "on"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5E924A40_L12C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Stream_Writable_Basic/FunctionExpression_L12C21::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Stream_Writable_Basic/FunctionExpression_L12C21::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5E924A40_L12C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -171,7 +171,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_57623C26_L17C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -185,7 +185,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -196,7 +196,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -207,7 +207,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -222,7 +222,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Stream_Writable_Basic/FunctionExpression_L17C22::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -238,7 +238,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Stream_Writable_Basic/FunctionExpression_L17C22::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -256,9 +256,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_57623C26_L17C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -330,8 +330,8 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Stream_Writable_Basic/FunctionExpression_L12C21/FunctionObject_FunctionExpression_5E924A40_L12C22,
-			[8] class Modules.Stream_Writable_Basic/FunctionExpression_L17C22/FunctionObject_FunctionExpression_57623C26_L17C23
+			[7] class Modules.Stream_Writable_Basic/FunctionExpression_L12C21/FunctionObject,
+			[8] class Modules.Stream_Writable_Basic/FunctionExpression_L17C22/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Writable_Basic/Scope::.ctor()
@@ -368,13 +368,13 @@
 		IL_0050: ldloc.0
 		IL_0051: stelem.ref
 		IL_0052: stloc.s 6
-		IL_0054: newobj instance void Modules.Stream_Writable_Basic/FunctionExpression_L12C21/FunctionObject_FunctionExpression_5E924A40_L12C22::.ctor()
+		IL_0054: newobj instance void Modules.Stream_Writable_Basic/FunctionExpression_L12C21/FunctionObject::.ctor()
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr ""
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Basic/FunctionExpression_L12C21/FunctionObject_FunctionExpression_5E924A40_L12C22>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Basic/FunctionExpression_L12C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 7
 		IL_0069: ldloc.s 5
 		IL_006b: ldstr "on"
@@ -392,13 +392,13 @@
 		IL_008d: ldloc.0
 		IL_008e: stelem.ref
 		IL_008f: stloc.s 6
-		IL_0091: newobj instance void Modules.Stream_Writable_Basic/FunctionExpression_L17C22/FunctionObject_FunctionExpression_57623C26_L17C23::.ctor()
+		IL_0091: newobj instance void Modules.Stream_Writable_Basic/FunctionExpression_L17C22/FunctionObject::.ctor()
 		IL_0096: ldc.i4.0
 		IL_0097: conv.r8
 		IL_0098: ldstr ""
 		IL_009d: ldc.i4.0
 		IL_009e: ldc.i4.1
-		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Basic/FunctionExpression_L17C22/FunctionObject_FunctionExpression_57623C26_L17C23>(!!0, float64, string, bool, bool)
+		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Basic/FunctionExpression_L17C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a4: stloc.s 8
 		IL_00a6: ldloc.s 5
 		IL_00a8: ldstr "on"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_CustomWrite.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_CustomWrite.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7D100CD1_L11C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Writable_CustomWrite/Scope Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject_FunctionExpression_7D100CD1_L11C19::_environment0_Stream_Writable_CustomWrite
+				IL_0008: stfld class Modules.Stream_Writable_CustomWrite/Scope Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject::_environment0_Stream_Writable_CustomWrite
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_CustomWrite/Scope Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject_FunctionExpression_7D100CD1_L11C19::_environment0_Stream_Writable_CustomWrite
+				IL_0001: ldfld class Modules.Stream_Writable_CustomWrite/Scope Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject::_environment0_Stream_Writable_CustomWrite
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18::__js_call__(class Modules.Stream_Writable_CustomWrite/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_CustomWrite/Scope Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject_FunctionExpression_7D100CD1_L11C19::_environment0_Stream_Writable_CustomWrite
+				IL_0001: ldfld class Modules.Stream_Writable_CustomWrite/Scope Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject::_environment0_Stream_Writable_CustomWrite
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18::__js_call__(class Modules.Stream_Writable_CustomWrite/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7D100CD1_L11C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -268,7 +268,7 @@
 			[4] float64,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[6] object[],
-			[7] class Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject_FunctionExpression_7D100CD1_L11C19,
+			[7] class Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[9] object,
 			[10] float64,
@@ -308,13 +308,13 @@
 		IL_0040: ldc.i4.0
 		IL_0041: ldelem.ref
 		IL_0042: castclass Modules.Stream_Writable_CustomWrite/Scope
-		IL_0047: newobj instance void Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject_FunctionExpression_7D100CD1_L11C19::.ctor(class Modules.Stream_Writable_CustomWrite/Scope)
+		IL_0047: newobj instance void Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject::.ctor(class Modules.Stream_Writable_CustomWrite/Scope)
 		IL_004c: ldc.i4.1
 		IL_004d: conv.r8
 		IL_004e: ldstr ""
 		IL_0053: ldc.i4.0
 		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject_FunctionExpression_7D100CD1_L11C19>(!!0, float64, string, bool, bool)
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005a: stloc.s 7
 		IL_005c: ldloc.3
 		IL_005d: ldstr "_write"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Destroy_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Destroy_Error.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3D3F853C_L8C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_3D3F853C_L8C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -192,7 +192,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_88247D05_L12C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -212,9 +212,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject_FunctionExpression_88247D05_L12C22::_environment0_Stream_Writable_Destroy_Error
+				IL_0008: stfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject::_environment0_Stream_Writable_Destroy_Error
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -225,7 +225,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -236,7 +236,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -249,14 +249,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject_FunctionExpression_88247D05_L12C22::_environment0_Stream_Writable_Destroy_Error
+				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject::_environment0_Stream_Writable_Destroy_Error
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -270,14 +270,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject_FunctionExpression_88247D05_L12C22::_environment0_Stream_Writable_Destroy_Error
+				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject::_environment0_Stream_Writable_Destroy_Error
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -295,9 +295,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_88247D05_L12C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -366,7 +366,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B3B90B0E_L16C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -386,9 +386,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject_FunctionExpression_B3B90B0E_L16C23::_environment0_Stream_Writable_Destroy_Error
+				IL_0008: stfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject::_environment0_Stream_Writable_Destroy_Error
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -399,7 +399,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -410,7 +410,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -423,11 +423,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject_FunctionExpression_B3B90B0E_L16C23::_environment0_Stream_Writable_Destroy_Error
+				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject::_environment0_Stream_Writable_Destroy_Error
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -441,11 +441,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject_FunctionExpression_B3B90B0E_L16C23::_environment0_Stream_Writable_Destroy_Error
+				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject::_environment0_Stream_Writable_Destroy_Error
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -463,9 +463,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_B3B90B0E_L16C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -523,7 +523,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5E2C9FCA_L20C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -543,9 +543,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject_FunctionExpression_5E2C9FCA_L20C22::_environment0_Stream_Writable_Destroy_Error
+				IL_0008: stfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject::_environment0_Stream_Writable_Destroy_Error
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -556,7 +556,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -567,7 +567,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -580,11 +580,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject_FunctionExpression_5E2C9FCA_L20C22::_environment0_Stream_Writable_Destroy_Error
+				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject::_environment0_Stream_Writable_Destroy_Error
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -598,11 +598,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject_FunctionExpression_5E2C9FCA_L20C22::_environment0_Stream_Writable_Destroy_Error
+				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject::_environment0_Stream_Writable_Destroy_Error
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -620,9 +620,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5E2C9FCA_L20C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -741,10 +741,10 @@
 			[2] object,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] object[],
-			[5] class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18/FunctionObject_FunctionExpression_3D3F853C_L8C19,
-			[6] class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject_FunctionExpression_88247D05_L12C22,
-			[7] class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject_FunctionExpression_B3B90B0E_L16C23,
-			[8] class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject_FunctionExpression_5E2C9FCA_L20C22,
+			[5] class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18/FunctionObject,
+			[6] class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject,
+			[7] class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject,
+			[8] class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[10] object
 		)
@@ -782,13 +782,13 @@
 		IL_0046: ldloc.0
 		IL_0047: stelem.ref
 		IL_0048: stloc.s 4
-		IL_004a: newobj instance void Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18/FunctionObject_FunctionExpression_3D3F853C_L8C19::.ctor()
+		IL_004a: newobj instance void Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18/FunctionObject::.ctor()
 		IL_004f: ldc.i4.1
 		IL_0050: conv.r8
 		IL_0051: ldstr ""
 		IL_0056: ldc.i4.0
 		IL_0057: ldc.i4.1
-		IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18/FunctionObject_FunctionExpression_3D3F853C_L8C19>(!!0, float64, string, bool, bool)
+		IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005d: stloc.s 5
 		IL_005f: ldloc.2
 		IL_0060: ldstr "_write"
@@ -811,13 +811,13 @@
 		IL_0088: ldc.i4.0
 		IL_0089: ldelem.ref
 		IL_008a: castclass Modules.Stream_Writable_Destroy_Error/Scope
-		IL_008f: newobj instance void Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject_FunctionExpression_88247D05_L12C22::.ctor(class Modules.Stream_Writable_Destroy_Error/Scope)
+		IL_008f: newobj instance void Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject::.ctor(class Modules.Stream_Writable_Destroy_Error/Scope)
 		IL_0094: ldc.i4.1
 		IL_0095: conv.r8
 		IL_0096: ldstr ""
 		IL_009b: ldc.i4.0
 		IL_009c: ldc.i4.1
-		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject_FunctionExpression_88247D05_L12C22>(!!0, float64, string, bool, bool)
+		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a2: stloc.s 6
 		IL_00a4: ldloc.2
 		IL_00a5: ldstr "on"
@@ -840,13 +840,13 @@
 		IL_00d1: ldc.i4.0
 		IL_00d2: ldelem.ref
 		IL_00d3: castclass Modules.Stream_Writable_Destroy_Error/Scope
-		IL_00d8: newobj instance void Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject_FunctionExpression_B3B90B0E_L16C23::.ctor(class Modules.Stream_Writable_Destroy_Error/Scope)
+		IL_00d8: newobj instance void Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject::.ctor(class Modules.Stream_Writable_Destroy_Error/Scope)
 		IL_00dd: ldc.i4.0
 		IL_00de: conv.r8
 		IL_00df: ldstr ""
 		IL_00e4: ldc.i4.0
 		IL_00e5: ldc.i4.1
-		IL_00e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject_FunctionExpression_B3B90B0E_L16C23>(!!0, float64, string, bool, bool)
+		IL_00e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00eb: stloc.s 7
 		IL_00ed: ldloc.2
 		IL_00ee: ldstr "on"
@@ -869,13 +869,13 @@
 		IL_011a: ldc.i4.0
 		IL_011b: ldelem.ref
 		IL_011c: castclass Modules.Stream_Writable_Destroy_Error/Scope
-		IL_0121: newobj instance void Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject_FunctionExpression_5E2C9FCA_L20C22::.ctor(class Modules.Stream_Writable_Destroy_Error/Scope)
+		IL_0121: newobj instance void Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject::.ctor(class Modules.Stream_Writable_Destroy_Error/Scope)
 		IL_0126: ldc.i4.0
 		IL_0127: conv.r8
 		IL_0128: ldstr ""
 		IL_012d: ldc.i4.0
 		IL_012e: ldc.i4.1
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject_FunctionExpression_5E2C9FCA_L20C22>(!!0, float64, string, bool, bool)
+		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0134: stloc.s 8
 		IL_0136: ldloc.2
 		IL_0137: ldstr "on"

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Drain_Finish_Order.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Drain_Finish_Order.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_01444ED3_L10C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject_FunctionExpression_01444ED3_L10C19::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0008: stfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject::_environment0_Stream_Writable_Drain_Finish_Order
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject_FunctionExpression_01444ED3_L10C19::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject::_environment0_Stream_Writable_Drain_Finish_Order
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject_FunctionExpression_01444ED3_L10C19::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject::_environment0_Stream_Writable_Drain_Finish_Order
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_01444ED3_L10C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -194,7 +194,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EFB8387D_L14C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -214,9 +214,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject_FunctionExpression_EFB8387D_L14C22::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0008: stfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject::_environment0_Stream_Writable_Drain_Finish_Order
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -227,7 +227,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -238,7 +238,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -251,11 +251,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject_FunctionExpression_EFB8387D_L14C22::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject::_environment0_Stream_Writable_Drain_Finish_Order
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -269,11 +269,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject_FunctionExpression_EFB8387D_L14C22::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject::_environment0_Stream_Writable_Drain_Finish_Order
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -291,9 +291,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_EFB8387D_L14C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -351,7 +351,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5C5EA86E_L18C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -371,9 +371,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject_FunctionExpression_5C5EA86E_L18C23::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0008: stfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject::_environment0_Stream_Writable_Drain_Finish_Order
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -384,7 +384,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -395,7 +395,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -408,11 +408,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject_FunctionExpression_5C5EA86E_L18C23::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject::_environment0_Stream_Writable_Drain_Finish_Order
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -426,11 +426,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject_FunctionExpression_5C5EA86E_L18C23::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject::_environment0_Stream_Writable_Drain_Finish_Order
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -448,9 +448,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5C5EA86E_L18C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -576,9 +576,9 @@
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object[],
-			[6] class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject_FunctionExpression_01444ED3_L10C19,
-			[7] class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject_FunctionExpression_EFB8387D_L14C22,
-			[8] class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject_FunctionExpression_5C5EA86E_L18C23,
+			[6] class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject,
+			[7] class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject,
+			[8] class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[10] object
 		)
@@ -626,13 +626,13 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.Stream_Writable_Drain_Finish_Order/Scope
-		IL_006d: newobj instance void Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject_FunctionExpression_01444ED3_L10C19::.ctor(class Modules.Stream_Writable_Drain_Finish_Order/Scope)
+		IL_006d: newobj instance void Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject::.ctor(class Modules.Stream_Writable_Drain_Finish_Order/Scope)
 		IL_0072: ldc.i4.1
 		IL_0073: conv.r8
 		IL_0074: ldstr ""
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject_FunctionExpression_01444ED3_L10C19>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.s 6
 		IL_0082: ldloc.2
 		IL_0083: ldstr "_write"
@@ -654,13 +654,13 @@
 		IL_00a6: ldc.i4.0
 		IL_00a7: ldelem.ref
 		IL_00a8: castclass Modules.Stream_Writable_Drain_Finish_Order/Scope
-		IL_00ad: newobj instance void Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject_FunctionExpression_EFB8387D_L14C22::.ctor(class Modules.Stream_Writable_Drain_Finish_Order/Scope)
+		IL_00ad: newobj instance void Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject::.ctor(class Modules.Stream_Writable_Drain_Finish_Order/Scope)
 		IL_00b2: ldc.i4.0
 		IL_00b3: conv.r8
 		IL_00b4: ldstr ""
 		IL_00b9: ldc.i4.0
 		IL_00ba: ldc.i4.1
-		IL_00bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject_FunctionExpression_EFB8387D_L14C22>(!!0, float64, string, bool, bool)
+		IL_00bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c0: stloc.s 7
 		IL_00c2: ldloc.3
 		IL_00c3: ldstr "on"
@@ -682,13 +682,13 @@
 		IL_00ea: ldc.i4.0
 		IL_00eb: ldelem.ref
 		IL_00ec: castclass Modules.Stream_Writable_Drain_Finish_Order/Scope
-		IL_00f1: newobj instance void Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject_FunctionExpression_5C5EA86E_L18C23::.ctor(class Modules.Stream_Writable_Drain_Finish_Order/Scope)
+		IL_00f1: newobj instance void Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject::.ctor(class Modules.Stream_Writable_Drain_Finish_Order/Scope)
 		IL_00f6: ldc.i4.0
 		IL_00f7: conv.r8
 		IL_00f8: ldstr ""
 		IL_00fd: ldc.i4.0
 		IL_00fe: ldc.i4.1
-		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject_FunctionExpression_5C5EA86E_L18C23>(!!0, float64, string, bool, bool)
+		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0104: stloc.s 8
 		IL_0106: ldloc.3
 		IL_0107: ldstr "on"

--- a/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_MemoryStreamStyle.verified.txt
+++ b/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_MemoryStreamStyle.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -170,7 +170,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3F80BDEB_L9C41
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -190,9 +190,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_StringDecoder_MemoryStreamStyle/Scope Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject_FunctionExpression_3F80BDEB_L9C41::_environment0_Require_StringDecoder_MemoryStreamStyle
+				IL_0008: stfld class Modules.Require_StringDecoder_MemoryStreamStyle/Scope Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject::_environment0_Require_StringDecoder_MemoryStreamStyle
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -203,7 +203,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -214,7 +214,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -227,7 +227,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_StringDecoder_MemoryStreamStyle/Scope Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject_FunctionExpression_3F80BDEB_L9C41::_environment0_Require_StringDecoder_MemoryStreamStyle
+				IL_0001: ldfld class Modules.Require_StringDecoder_MemoryStreamStyle/Scope Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject::_environment0_Require_StringDecoder_MemoryStreamStyle
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -237,7 +237,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40::__js_call__(class Modules.Require_StringDecoder_MemoryStreamStyle/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -251,7 +251,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_StringDecoder_MemoryStreamStyle/Scope Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject_FunctionExpression_3F80BDEB_L9C41::_environment0_Require_StringDecoder_MemoryStreamStyle
+				IL_0001: ldfld class Modules.Require_StringDecoder_MemoryStreamStyle/Scope Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject::_environment0_Require_StringDecoder_MemoryStreamStyle
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -261,7 +261,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40::__js_call__(class Modules.Require_StringDecoder_MemoryStreamStyle/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -279,9 +279,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_3F80BDEB_L9C41
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -430,12 +430,12 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_StringDecoder_MemoryStreamStyle/Scope,
-			[1] class Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream/FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream,
+			[1] class Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStringDecoderModule,
 			[5] object,
-			[6] class Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject_FunctionExpression_3F80BDEB_L9C41,
+			[6] class Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] bool,
 			[9] object,
@@ -451,13 +451,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream/FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::.ctor()
+		IL_0011: newobj instance void Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "MemoryWritableStream"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream/FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: ldarg.1
@@ -498,13 +498,13 @@
 		IL_0082: ldc.i4.0
 		IL_0083: ldelem.ref
 		IL_0084: castclass Modules.Require_StringDecoder_MemoryStreamStyle/Scope
-		IL_0089: newobj instance void Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject_FunctionExpression_3F80BDEB_L9C41::.ctor(class Modules.Require_StringDecoder_MemoryStreamStyle/Scope)
+		IL_0089: newobj instance void Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject::.ctor(class Modules.Require_StringDecoder_MemoryStreamStyle/Scope)
 		IL_008e: ldc.i4.2
 		IL_008f: conv.r8
 		IL_0090: ldstr ""
 		IL_0095: ldc.i4.1
 		IL_0096: ldc.i4.1
-		IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject_FunctionExpression_3F80BDEB_L9C41>(!!0, float64, string, bool, bool)
+		IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_009c: stloc.s 6
 		IL_009e: ldloc.s 5
 		IL_00a0: ldstr "decode"

--- a/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.GlobalTimers_AsValues_WindowLikeAssignment.verified.txt
+++ b/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.GlobalTimers_AsValues_WindowLikeAssignment.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A9D7FBF9_L19C30
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A9D7FBF9_L19C30
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -180,7 +180,7 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] string,
 			[6] object[],
-			[7] class Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id/FunctionObject_FunctionExpression_A9D7FBF9_L19C30
+			[7] class Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.GlobalTimers_AsValues_WindowLikeAssignment/Scope::.ctor()
@@ -283,13 +283,13 @@
 		IL_010d: ldloc.0
 		IL_010e: stelem.ref
 		IL_010f: stloc.s 6
-		IL_0111: newobj instance void Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id/FunctionObject_FunctionExpression_A9D7FBF9_L19C30::.ctor()
+		IL_0111: newobj instance void Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id/FunctionObject::.ctor()
 		IL_0116: ldc.i4.0
 		IL_0117: conv.r8
 		IL_0118: ldstr ""
 		IL_011d: ldc.i4.0
 		IL_011e: ldc.i4.1
-		IL_011f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id/FunctionObject_FunctionExpression_A9D7FBF9_L19C30>(!!0, float64, string, bool, bool)
+		IL_011f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0124: stloc.s 7
 		IL_0126: ldloc.1
 		IL_0127: ldstr "setTimeout"

--- a/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.SetImmediate_WithArgs_PassesCorrectly.verified.txt
+++ b/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.SetImmediate_WithArgs_PassesCorrectly.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E226DE30_logNameAge
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E226DE30_logNameAge
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -214,7 +214,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.SetImmediate_WithArgs_PassesCorrectly/Scope,
-			[1] class Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge/FunctionObject_FunctionDeclaration_E226DE30_logNameAge,
+			[1] class Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
@@ -228,13 +228,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge/FunctionObject_FunctionDeclaration_E226DE30_logNameAge::.ctor()
+		IL_0011: newobj instance void Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "logNameAge"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge/FunctionObject_FunctionDeclaration_E226DE30_logNameAge>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.Timers_Callback_Function_Objects.verified.txt
+++ b/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.Timers_Callback_Function_Objects.verified.txt
@@ -39,7 +39,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -59,9 +59,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate::_transitionalScopes
+				IL_0008: stfld object[] Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -96,15 +96,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Timers_Callback_Function_Objects/generatorImmediate::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -145,7 +145,7 @@
 			IL_001f: ldftn object Modules.Timers_Callback_Function_Objects/generatorImmediate::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate
+			IL_002b: ldtoken Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -260,7 +260,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D3760343_ordinaryImmediate
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -274,7 +274,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D3760343_ordinaryImmediate::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -285,7 +285,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D3760343_ordinaryImmediate::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -296,7 +296,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D3760343_ordinaryImmediate::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -311,7 +311,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Timers_Callback_Function_Objects/ordinaryImmediate::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_D3760343_ordinaryImmediate::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -327,7 +327,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Timers_Callback_Function_Objects/ordinaryImmediate::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D3760343_ordinaryImmediate::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -345,9 +345,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D3760343_ordinaryImmediate::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D3760343_ordinaryImmediate
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -415,7 +415,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F4BCFECB_asyncTimeout
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -435,9 +435,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Timers_Callback_Function_Objects/asyncTimeout/FunctionObject_FunctionExpression_F4BCFECB_asyncTimeout::_transitionalScopes
+				IL_0008: stfld object[] Modules.Timers_Callback_Function_Objects/asyncTimeout/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F4BCFECB_asyncTimeout::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -448,7 +448,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F4BCFECB_asyncTimeout::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -459,7 +459,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F4BCFECB_asyncTimeout::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -472,7 +472,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Timers_Callback_Function_Objects/asyncTimeout/FunctionObject_FunctionExpression_F4BCFECB_asyncTimeout::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Timers_Callback_Function_Objects/asyncTimeout/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -480,9 +480,9 @@
 				IL_0012: call object Modules.Timers_Callback_Function_Objects/asyncTimeout::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionExpression_F4BCFECB_asyncTimeout::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionExpression_F4BCFECB_asyncTimeout
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -607,9 +607,9 @@
 			[3] object,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate,
-			[7] class Modules.Timers_Callback_Function_Objects/ordinaryImmediate/FunctionObject_FunctionExpression_D3760343_ordinaryImmediate,
-			[8] class Modules.Timers_Callback_Function_Objects/asyncTimeout/FunctionObject_FunctionExpression_F4BCFECB_asyncTimeout,
+			[6] class Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject,
+			[7] class Modules.Timers_Callback_Function_Objects/ordinaryImmediate/FunctionObject,
+			[8] class Modules.Timers_Callback_Function_Objects/asyncTimeout/FunctionObject,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[10] object,
 			[11] object
@@ -626,15 +626,15 @@
 		IL_0010: stelem.ref
 		IL_0011: stloc.s 5
 		IL_0013: ldloc.s 5
-		IL_0015: newobj instance void Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate::.ctor(object[])
+		IL_0015: newobj instance void Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject::.ctor(object[])
 		IL_001a: ldc.i4.0
 		IL_001b: conv.r8
 		IL_001c: ldstr "generatorImmediate"
 		IL_0021: ldc.i4.1
 		IL_0022: ldc.i4.1
-		IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate>(!!0, float64, string, bool, bool)
+		IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0028: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_002d: castclass Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject_FunctionExpression_67D3FFC6_generatorImmediate
+		IL_002d: castclass Modules.Timers_Callback_Function_Objects/generatorImmediate/FunctionObject
 		IL_0032: stloc.s 6
 		IL_0034: ldloc.s 6
 		IL_0036: ldc.i4.0
@@ -648,13 +648,13 @@
 		IL_004a: ldloc.0
 		IL_004b: stelem.ref
 		IL_004c: stloc.s 5
-		IL_004e: newobj instance void Modules.Timers_Callback_Function_Objects/ordinaryImmediate/FunctionObject_FunctionExpression_D3760343_ordinaryImmediate::.ctor()
+		IL_004e: newobj instance void Modules.Timers_Callback_Function_Objects/ordinaryImmediate/FunctionObject::.ctor()
 		IL_0053: ldc.i4.0
 		IL_0054: conv.r8
 		IL_0055: ldstr "ordinaryImmediate"
 		IL_005a: ldc.i4.1
 		IL_005b: ldc.i4.1
-		IL_005c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Timers_Callback_Function_Objects/ordinaryImmediate/FunctionObject_FunctionExpression_D3760343_ordinaryImmediate>(!!0, float64, string, bool, bool)
+		IL_005c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Timers_Callback_Function_Objects/ordinaryImmediate/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0061: stloc.s 7
 		IL_0063: ldloc.s 7
 		IL_0065: ldc.i4.0
@@ -669,14 +669,14 @@
 		IL_007a: stelem.ref
 		IL_007b: stloc.s 5
 		IL_007d: ldloc.s 5
-		IL_007f: newobj instance void Modules.Timers_Callback_Function_Objects/asyncTimeout/FunctionObject_FunctionExpression_F4BCFECB_asyncTimeout::.ctor(object[])
+		IL_007f: newobj instance void Modules.Timers_Callback_Function_Objects/asyncTimeout/FunctionObject::.ctor(object[])
 		IL_0084: ldc.i4.1
 		IL_0085: conv.r8
 		IL_0086: ldstr "asyncTimeout"
 		IL_008b: ldc.i4.1
 		IL_008c: ldc.i4.1
-		IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Timers_Callback_Function_Objects/asyncTimeout/FunctionObject_FunctionExpression_F4BCFECB_asyncTimeout>(!!0, float64, string, bool, bool)
-		IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Timers_Callback_Function_Objects/asyncTimeout/FunctionObject_FunctionExpression_F4BCFECB_asyncTimeout>(!!0)
+		IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Timers_Callback_Function_Objects/asyncTimeout/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Timers_Callback_Function_Objects/asyncTimeout/FunctionObject>(!!0)
 		IL_0097: stloc.s 8
 		IL_0099: ldloc.s 8
 		IL_009b: ldc.r8 0.0

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_AbortListener_StableFunctionIdentity.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_AbortListener_StableFunctionIdentity.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_741FC922_L10C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_741FC922_L10C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_741FC922_L10C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_741FC922_L10C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -108,7 +108,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_741FC922_L10C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -130,7 +130,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_741FC922_L10C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -148,9 +148,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_741FC922_L10C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_741FC922_L10C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -295,7 +295,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B00D1901_L18C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -309,7 +309,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_B00D1901_L18C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -320,7 +320,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B00D1901_L18C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -331,7 +331,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B00D1901_L18C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -352,7 +352,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal_L18C25::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_B00D1901_L18C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -374,7 +374,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal_L18C25::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_B00D1901_L18C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -392,9 +392,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B00D1901_L18C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_B00D1901_L18C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -493,7 +493,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5B281FA3_L36C15
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -513,9 +513,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject_FunctionExpression_5B281FA3_L36C15::_environment0_TimersPromises_AbortListener_StableFunctionIdentity
+				IL_0008: stfld class Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject::_environment0_TimersPromises_AbortListener_StableFunctionIdentity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5B281FA3_L36C15::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -526,7 +526,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5B281FA3_L36C15::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -537,7 +537,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5B281FA3_L36C15::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -550,14 +550,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject_FunctionExpression_5B281FA3_L36C15::_environment0_TimersPromises_AbortListener_StableFunctionIdentity
+				IL_0001: ldfld class Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject::_environment0_TimersPromises_AbortListener_StableFunctionIdentity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14::__js_call__(class Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_5B281FA3_L36C15::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -571,14 +571,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject_FunctionExpression_5B281FA3_L36C15::_environment0_TimersPromises_AbortListener_StableFunctionIdentity
+				IL_0001: ldfld class Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject::_environment0_TimersPromises_AbortListener_StableFunctionIdentity
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14::__js_call__(class Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_5B281FA3_L36C15::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -596,9 +596,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5B281FA3_L36C15::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5B281FA3_L36C15
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -705,13 +705,13 @@
 			[2] object,
 			[3] object,
 			[4] object[],
-			[5] class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal/FunctionObject_FunctionExpression_741FC922_L10C23,
-			[6] class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal_L18C25/FunctionObject_FunctionExpression_B00D1901_L18C26,
+			[5] class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal/FunctionObject,
+			[6] class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal_L18C25/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[8] object,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[10] string,
-			[11] class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject_FunctionExpression_5B281FA3_L36C15
+			[11] class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope::.ctor()
@@ -728,13 +728,13 @@
 		IL_001b: ldloc.0
 		IL_001c: stelem.ref
 		IL_001d: stloc.s 4
-		IL_001f: newobj instance void Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal/FunctionObject_FunctionExpression_741FC922_L10C23::.ctor()
+		IL_001f: newobj instance void Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal/FunctionObject::.ctor()
 		IL_0024: ldc.i4.2
 		IL_0025: conv.r8
 		IL_0026: ldstr ""
 		IL_002b: ldc.i4.1
 		IL_002c: ldc.i4.1
-		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal/FunctionObject_FunctionExpression_741FC922_L10C23>(!!0, float64, string, bool, bool)
+		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0032: stloc.s 5
 		IL_0034: ldc.i4.1
 		IL_0035: newarr [System.Runtime]System.Object
@@ -743,13 +743,13 @@
 		IL_003c: ldloc.0
 		IL_003d: stelem.ref
 		IL_003e: stloc.s 4
-		IL_0040: newobj instance void Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal_L18C25/FunctionObject_FunctionExpression_B00D1901_L18C26::.ctor()
+		IL_0040: newobj instance void Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal_L18C25/FunctionObject::.ctor()
 		IL_0045: ldc.i4.2
 		IL_0046: conv.r8
 		IL_0047: ldstr ""
 		IL_004c: ldc.i4.1
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal_L18C25/FunctionObject_FunctionExpression_B00D1901_L18C26>(!!0, float64, string, bool, bool)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_signal_L18C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0053: stloc.s 6
 		IL_0055: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_005a: dup
@@ -850,13 +850,13 @@
 		IL_0178: ldc.i4.0
 		IL_0179: ldelem.ref
 		IL_017a: castclass Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope
-		IL_017f: newobj instance void Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject_FunctionExpression_5B281FA3_L36C15::.ctor(class Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope)
+		IL_017f: newobj instance void Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject::.ctor(class Modules.TimersPromises_AbortListener_StableFunctionIdentity/Scope)
 		IL_0184: ldc.i4.1
 		IL_0185: conv.r8
 		IL_0186: ldstr ""
 		IL_018b: ldc.i4.0
 		IL_018c: ldc.i4.1
-		IL_018d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject_FunctionExpression_5B281FA3_L36C15>(!!0, float64, string, bool, bool)
+		IL_018d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_AbortListener_StableFunctionIdentity/FunctionExpression_L36C14/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0192: stloc.s 11
 		IL_0194: ldloc.s 8
 		IL_0196: ldstr "catch"

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0AB671BF_L7C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_0AB671BF_L7C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -180,7 +180,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E62F123B_L17C9
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -194,7 +194,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -205,7 +205,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -216,7 +216,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -231,7 +231,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -247,7 +247,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -265,9 +265,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E62F123B_L17C9
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -321,7 +321,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D519D947_L20C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -335,7 +335,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -346,7 +346,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -357,7 +357,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -375,7 +375,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -394,7 +394,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -412,9 +412,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D519D947_L20C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -488,7 +488,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7DA2C414_L26C25
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -502,7 +502,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -513,7 +513,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -524,7 +524,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -539,7 +539,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -555,7 +555,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -573,9 +573,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_7DA2C414_L26C25
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -620,7 +620,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_68F621F1_L29C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -634,7 +634,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -645,7 +645,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -656,7 +656,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -671,7 +671,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -687,7 +687,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -705,9 +705,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_68F621F1_L29C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -806,7 +806,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_20FF4171_L24C9
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -826,9 +826,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject_FunctionExpression_20FF4171_L24C9::_environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
+				IL_0008: stfld class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject::_environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -839,7 +839,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -850,7 +850,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -863,11 +863,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject_FunctionExpression_20FF4171_L24C9::_environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
+				IL_0001: ldfld class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject::_environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8::__js_call__(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -881,11 +881,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject_FunctionExpression_20FF4171_L24C9::_environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
+				IL_0001: ldfld class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject::_environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8::__js_call__(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -903,9 +903,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_20FF4171_L24C9
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -931,8 +931,8 @@
 				[4] object,
 				[5] object,
 				[6] object[],
-				[7] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal/FunctionObject_FunctionExpression_7DA2C414_L26C25,
-				[8] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11/FunctionObject_FunctionExpression_68F621F1_L29C12,
+				[7] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal/FunctionObject,
+				[8] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11/FunctionObject,
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[10] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule,
 				[11] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -948,13 +948,13 @@
 			IL_000e: ldarg.0
 			IL_000f: stelem.ref
 			IL_0010: stloc.s 6
-			IL_0012: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal/FunctionObject_FunctionExpression_7DA2C414_L26C25::.ctor()
+			IL_0012: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal/FunctionObject::.ctor()
 			IL_0017: ldc.i4.0
 			IL_0018: conv.r8
 			IL_0019: ldstr ""
 			IL_001e: ldc.i4.0
 			IL_001f: ldc.i4.1
-			IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal/FunctionObject_FunctionExpression_7DA2C414_L26C25>(!!0, float64, string, bool, bool)
+			IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0025: stloc.s 7
 			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_002c: dup
@@ -969,13 +969,13 @@
 			IL_0042: ldarg.0
 			IL_0043: stelem.ref
 			IL_0044: stloc.s 6
-			IL_0046: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11/FunctionObject_FunctionExpression_68F621F1_L29C12::.ctor()
+			IL_0046: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11/FunctionObject::.ctor()
 			IL_004b: ldc.i4.0
 			IL_004c: conv.r8
 			IL_004d: ldstr ""
 			IL_0052: ldc.i4.0
 			IL_0053: ldc.i4.1
-			IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11/FunctionObject_FunctionExpression_68F621F1_L29C12>(!!0, float64, string, bool, bool)
+			IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0059: stloc.s 8
 			IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0060: dup
@@ -1118,14 +1118,14 @@
 			[2] object,
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule,
 			[4] object[],
-			[5] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7/FunctionObject_FunctionExpression_0AB671BF_L7C8,
+			[5] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] object,
 			[9] string,
-			[10] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8/FunctionObject_FunctionExpression_E62F123B_L17C9,
-			[11] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject_FunctionExpression_D519D947_L20C10,
-			[12] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject_FunctionExpression_20FF4171_L24C9
+			[10] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8/FunctionObject,
+			[11] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject,
+			[12] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::.ctor()
@@ -1147,13 +1147,13 @@
 		IL_0028: ldloc.0
 		IL_0029: stelem.ref
 		IL_002a: stloc.s 4
-		IL_002c: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7/FunctionObject_FunctionExpression_0AB671BF_L7C8::.ctor()
+		IL_002c: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7/FunctionObject::.ctor()
 		IL_0031: ldc.i4.0
 		IL_0032: conv.r8
 		IL_0033: ldstr ""
 		IL_0038: ldc.i4.0
 		IL_0039: ldc.i4.1
-		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7/FunctionObject_FunctionExpression_0AB671BF_L7C8>(!!0, float64, string, bool, bool)
+		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_003f: stloc.s 5
 		IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0046: dup
@@ -1199,13 +1199,13 @@
 		IL_00bc: ldloc.0
 		IL_00bd: stelem.ref
 		IL_00be: stloc.s 4
-		IL_00c0: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8/FunctionObject_FunctionExpression_E62F123B_L17C9::.ctor()
+		IL_00c0: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8/FunctionObject::.ctor()
 		IL_00c5: ldc.i4.0
 		IL_00c6: conv.r8
 		IL_00c7: ldstr ""
 		IL_00cc: ldc.i4.0
 		IL_00cd: ldc.i4.1
-		IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8/FunctionObject_FunctionExpression_E62F123B_L17C9>(!!0, float64, string, bool, bool)
+		IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d3: stloc.s 10
 		IL_00d5: ldloc.s 8
 		IL_00d7: ldstr "then"
@@ -1222,13 +1222,13 @@
 		IL_00f6: ldloc.0
 		IL_00f7: stelem.ref
 		IL_00f8: stloc.s 4
-		IL_00fa: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject_FunctionExpression_D519D947_L20C10::.ctor()
+		IL_00fa: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject::.ctor()
 		IL_00ff: ldc.i4.1
 		IL_0100: conv.r8
 		IL_0101: ldstr ""
 		IL_0106: ldc.i4.0
 		IL_0107: ldc.i4.1
-		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject_FunctionExpression_D519D947_L20C10>(!!0, float64, string, bool, bool)
+		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_010d: stloc.s 11
 		IL_010f: ldloc.s 8
 		IL_0111: ldstr "catch"
@@ -1249,13 +1249,13 @@
 		IL_0136: ldc.i4.0
 		IL_0137: ldelem.ref
 		IL_0138: castclass Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope
-		IL_013d: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject_FunctionExpression_20FF4171_L24C9::.ctor(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope)
+		IL_013d: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject::.ctor(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope)
 		IL_0142: ldc.i4.0
 		IL_0143: conv.r8
 		IL_0144: ldstr ""
 		IL_0149: ldc.i4.0
 		IL_014a: ldc.i4.1
-		IL_014b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject_FunctionExpression_20FF4171_L24C9>(!!0, float64, string, bool, bool)
+		IL_014b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0150: stloc.s 12
 		IL_0152: ldloc.s 8
 		IL_0154: ldstr "then"

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
@@ -55,7 +55,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8F2862D0_L8C23
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -69,7 +69,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -80,7 +80,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -91,7 +91,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -112,7 +112,7 @@
 					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0013: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal::__js_call__(object, object, object)
 					IL_0018: ret
-				} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -134,7 +134,7 @@
 					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000f: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal::__js_call__(object, object, object)
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -152,9 +152,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_8F2862D0_L8C23
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -240,7 +240,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C2488DF7_L13C26
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -254,7 +254,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -265,7 +265,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -276,7 +276,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -297,7 +297,7 @@
 					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0013: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25::__js_call__(object, object, object)
 					IL_0018: ret
-				} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -319,7 +319,7 @@
 					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000f: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25::__js_call__(object, object, object)
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -337,9 +337,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_C2488DF7_L13C26
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -462,7 +462,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3A0BD2BC_L22C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -486,15 +486,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+					IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_environment1_createController
+					IL_000f: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject::_environment1_createController
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_transitionalScopes
+					IL_0016: stfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -505,7 +505,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -516,7 +516,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -529,11 +529,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -547,11 +547,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -569,9 +569,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_3A0BD2BC_L22C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -661,7 +661,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_552FE78F_createController
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -681,9 +681,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject_FunctionDeclaration_552FE78F_createController::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -694,7 +694,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -705,7 +705,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -718,11 +718,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject_FunctionDeclaration_552FE78F_createController::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -736,11 +736,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject_FunctionDeclaration_552FE78F_createController::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -758,9 +758,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_552FE78F_createController
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -781,11 +781,11 @@
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope,
 				[1] object[],
-				[2] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal/FunctionObject_FunctionExpression_8F2862D0_L8C23,
-				[3] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25/FunctionObject_FunctionExpression_C2488DF7_L13C26,
+				[2] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal/FunctionObject,
+				[3] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25/FunctionObject,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[5] object,
-				[6] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12
+				[6] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::.ctor()
@@ -797,13 +797,13 @@
 			IL_000e: ldarg.0
 			IL_000f: stelem.ref
 			IL_0010: stloc.1
-			IL_0011: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal/FunctionObject_FunctionExpression_8F2862D0_L8C23::.ctor()
+			IL_0011: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal/FunctionObject::.ctor()
 			IL_0016: ldc.i4.2
 			IL_0017: conv.r8
 			IL_0018: ldstr ""
 			IL_001d: ldc.i4.1
 			IL_001e: ldc.i4.1
-			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal/FunctionObject_FunctionExpression_8F2862D0_L8C23>(!!0, float64, string, bool, bool)
+			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0024: stloc.2
 			IL_0025: ldc.i4.1
 			IL_0026: newarr [System.Runtime]System.Object
@@ -812,13 +812,13 @@
 			IL_002d: ldarg.0
 			IL_002e: stelem.ref
 			IL_002f: stloc.1
-			IL_0030: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25/FunctionObject_FunctionExpression_C2488DF7_L13C26::.ctor()
+			IL_0030: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25/FunctionObject::.ctor()
 			IL_0035: ldc.i4.2
 			IL_0036: conv.r8
 			IL_0037: ldstr ""
 			IL_003c: ldc.i4.1
 			IL_003d: ldc.i4.1
-			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25/FunctionObject_FunctionExpression_C2488DF7_L13C26>(!!0, float64, string, bool, bool)
+			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0043: stloc.3
 			IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0049: dup
@@ -860,13 +860,13 @@
 			IL_0098: ldelem.ref
 			IL_0099: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
 			IL_009e: ldloc.1
-			IL_009f: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope, object[])
+			IL_009f: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope, object[])
 			IL_00a4: ldc.i4.0
 			IL_00a5: conv.r8
 			IL_00a6: ldstr ""
 			IL_00ab: ldc.i4.0
 			IL_00ac: ldc.i4.1
-			IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12>(!!0, float64, string, bool, bool)
+			IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00b2: stloc.s 6
 			IL_00b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_00b9: dup
@@ -907,7 +907,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_44BD824F_logAbort
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -921,7 +921,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -932,7 +932,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -943,7 +943,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -961,7 +961,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -980,7 +980,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -998,9 +998,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_44BD824F_logAbort
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1080,7 +1080,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E4BF264B_L42C9
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1094,7 +1094,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1105,7 +1105,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1116,7 +1116,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1131,7 +1131,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1147,7 +1147,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1165,9 +1165,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E4BF264B_L42C9
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1221,7 +1221,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_86CA2372_L45C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1241,9 +1241,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject_FunctionExpression_86CA2372_L45C10::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1254,7 +1254,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1265,7 +1265,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1278,14 +1278,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject_FunctionExpression_86CA2372_L45C10::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1299,14 +1299,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject_FunctionExpression_86CA2372_L45C10::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1324,9 +1324,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_86CA2372_L45C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1398,7 +1398,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F1462999_L53C13
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -1412,7 +1412,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1423,7 +1423,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1434,7 +1434,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1449,7 +1449,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1465,7 +1465,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1483,9 +1483,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_F1462999_L53C13
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1539,7 +1539,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_00CA7359_L56C14
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1561,12 +1561,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+					IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14::_transitionalScopes
+					IL_000f: stfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1577,7 +1577,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1588,7 +1588,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1601,14 +1601,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14::_transitionalScopes
+					IL_0001: ldfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1622,14 +1622,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14::_transitionalScopes
+					IL_0001: ldfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1647,9 +1647,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_00CA7359_L56C14
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1722,7 +1722,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B08E779D_L48C9
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1742,9 +1742,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject_FunctionExpression_B08E779D_L48C9::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1755,7 +1755,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1766,7 +1766,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1779,11 +1779,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject_FunctionExpression_B08E779D_L48C9::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1797,11 +1797,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject_FunctionExpression_B08E779D_L48C9::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1819,9 +1819,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_B08E779D_L48C9
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1846,8 +1846,8 @@
 				[3] object,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[5] object[],
-				[6] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject_FunctionExpression_F1462999_L53C13,
-				[7] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14
+				[6] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject,
+				[7] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/Scope::.ctor()
@@ -1895,13 +1895,13 @@
 			IL_0070: ldarg.0
 			IL_0071: stelem.ref
 			IL_0072: stloc.s 5
-			IL_0074: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject_FunctionExpression_F1462999_L53C13::.ctor()
+			IL_0074: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject::.ctor()
 			IL_0079: ldc.i4.0
 			IL_007a: conv.r8
 			IL_007b: ldstr ""
 			IL_0080: ldc.i4.0
 			IL_0081: ldc.i4.1
-			IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject_FunctionExpression_F1462999_L53C13>(!!0, float64, string, bool, bool)
+			IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0087: stloc.s 6
 			IL_0089: ldloc.3
 			IL_008a: ldstr "then"
@@ -1927,13 +1927,13 @@
 			IL_00b1: ldelem.ref
 			IL_00b2: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
 			IL_00b7: ldloc.s 5
-			IL_00b9: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object[])
+			IL_00b9: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object[])
 			IL_00be: ldc.i4.1
 			IL_00bf: conv.r8
 			IL_00c0: ldstr ""
 			IL_00c5: ldc.i4.0
 			IL_00c6: ldc.i4.1
-			IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14>(!!0, float64, string, bool, bool)
+			IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00cc: stloc.s 7
 			IL_00ce: ldloc.3
 			IL_00cf: ldstr "catch"
@@ -1998,14 +1998,14 @@
 			[1] object,
 			[2] object,
 			[3] object[],
-			[4] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject_FunctionDeclaration_552FE78F_createController,
-			[5] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort/FunctionObject_FunctionDeclaration_44BD824F_logAbort,
+			[4] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject,
+			[5] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort/FunctionObject,
 			[6] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule,
 			[7] object,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[9] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject_FunctionExpression_E4BF264B_L42C9,
-			[10] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject_FunctionExpression_86CA2372_L45C10,
-			[11] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject_FunctionExpression_B08E779D_L48C9
+			[9] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject,
+			[10] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject,
+			[11] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::.ctor()
@@ -2021,13 +2021,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0019: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject_FunctionDeclaration_552FE78F_createController::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
+		IL_0019: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "createController"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject_FunctionDeclaration_552FE78F_createController>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.s 4
 		IL_002e: ldloc.0
 		IL_002f: ldloc.s 4
@@ -2039,13 +2039,13 @@
 		IL_003e: ldloc.0
 		IL_003f: stelem.ref
 		IL_0040: stloc.3
-		IL_0041: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort/FunctionObject_FunctionDeclaration_44BD824F_logAbort::.ctor()
+		IL_0041: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort/FunctionObject::.ctor()
 		IL_0046: ldc.i4.1
 		IL_0047: conv.r8
 		IL_0048: ldstr "logAbort"
 		IL_004d: ldc.i4.0
 		IL_004e: ldc.i4.1
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort/FunctionObject_FunctionDeclaration_44BD824F_logAbort>(!!0, float64, string, bool, bool)
+		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0054: stloc.s 5
 		IL_0056: ldloc.0
 		IL_0057: ldloc.s 5
@@ -2100,13 +2100,13 @@
 		IL_00ee: ldloc.0
 		IL_00ef: stelem.ref
 		IL_00f0: stloc.3
-		IL_00f1: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject_FunctionExpression_E4BF264B_L42C9::.ctor()
+		IL_00f1: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject::.ctor()
 		IL_00f6: ldc.i4.0
 		IL_00f7: conv.r8
 		IL_00f8: ldstr ""
 		IL_00fd: ldc.i4.0
 		IL_00fe: ldc.i4.1
-		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject_FunctionExpression_E4BF264B_L42C9>(!!0, float64, string, bool, bool)
+		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0104: stloc.s 9
 		IL_0106: ldloc.s 7
 		IL_0108: ldstr "then"
@@ -2127,13 +2127,13 @@
 		IL_012b: ldc.i4.0
 		IL_012c: ldelem.ref
 		IL_012d: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0132: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject_FunctionExpression_86CA2372_L45C10::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
+		IL_0132: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
 		IL_0137: ldc.i4.1
 		IL_0138: conv.r8
 		IL_0139: ldstr ""
 		IL_013e: ldc.i4.0
 		IL_013f: ldc.i4.1
-		IL_0140: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject_FunctionExpression_86CA2372_L45C10>(!!0, float64, string, bool, bool)
+		IL_0140: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0145: stloc.s 10
 		IL_0147: ldloc.s 7
 		IL_0149: ldstr "catch"
@@ -2154,13 +2154,13 @@
 		IL_016c: ldc.i4.0
 		IL_016d: ldelem.ref
 		IL_016e: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0173: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject_FunctionExpression_B08E779D_L48C9::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
+		IL_0173: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
 		IL_0178: ldc.i4.0
 		IL_0179: conv.r8
 		IL_017a: ldstr ""
 		IL_017f: ldc.i4.0
 		IL_0180: ldc.i4.1
-		IL_0181: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject_FunctionExpression_B08E779D_L48C9>(!!0, float64, string, bool, bool)
+		IL_0181: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0186: stloc.s 11
 		IL_0188: ldloc.s 7
 		IL_018a: ldstr "then"

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B088FFC5_L8C18
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject_FunctionExpression_B088FFC5_L8C18::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject_FunctionExpression_B088FFC5_L8C18::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject_FunctionExpression_B088FFC5_L8C18::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_B088FFC5_L8C18
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -187,7 +187,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_62CA5352_L12C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -207,9 +207,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject_FunctionExpression_62CA5352_L12C25::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -220,7 +220,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -231,7 +231,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -244,11 +244,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject_FunctionExpression_62CA5352_L12C25::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -262,11 +262,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject_FunctionExpression_62CA5352_L12C25::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -284,9 +284,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_62CA5352_L12C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -348,7 +348,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_33286A9C_L19C55
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -370,12 +370,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+					IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55::_transitionalScopes
+					IL_000f: stfld object[] Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -386,7 +386,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -397,7 +397,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -410,14 +410,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55::_transitionalScopes
+					IL_0001: ldfld object[] Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -431,14 +431,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55::_transitionalScopes
+					IL_0001: ldfld object[] Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -456,9 +456,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_33286A9C_L19C55
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -565,7 +565,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_85A874E2_L16C47
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -585,9 +585,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject_FunctionExpression_85A874E2_L16C47::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -598,7 +598,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -609,7 +609,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -622,14 +622,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject_FunctionExpression_85A874E2_L16C47::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -643,14 +643,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject_FunctionExpression_85A874E2_L16C47::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -668,9 +668,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_85A874E2_L16C47
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -695,7 +695,7 @@
 				[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule,
 				[3] object,
 				[4] object[],
-				[5] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55
+				[5] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/Scope::.ctor()
@@ -735,13 +735,13 @@
 			IL_0050: ldelem.ref
 			IL_0051: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
 			IL_0056: ldloc.s 4
-			IL_0058: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object[])
+			IL_0058: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object[])
 			IL_005d: ldc.i4.1
 			IL_005e: conv.r8
 			IL_005f: ldstr ""
 			IL_0064: ldc.i4.0
 			IL_0065: ldc.i4.1
-			IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55>(!!0, float64, string, bool, bool)
+			IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_006b: stloc.s 5
 			IL_006d: ldloc.3
 			IL_006e: ldstr "then"
@@ -803,9 +803,9 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object,
 			[4] object[],
-			[5] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject_FunctionExpression_B088FFC5_L8C18,
-			[6] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject_FunctionExpression_62CA5352_L12C25,
-			[7] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject_FunctionExpression_85A874E2_L16C47
+			[5] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject,
+			[6] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject,
+			[7] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::.ctor()
@@ -846,13 +846,13 @@
 		IL_0059: ldc.i4.0
 		IL_005a: ldelem.ref
 		IL_005b: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-		IL_0060: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject_FunctionExpression_B088FFC5_L8C18::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
+		IL_0060: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
 		IL_0065: ldc.i4.0
 		IL_0066: conv.r8
 		IL_0067: ldstr ""
 		IL_006c: ldc.i4.0
 		IL_006d: ldc.i4.1
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject_FunctionExpression_B088FFC5_L8C18>(!!0, float64, string, bool, bool)
+		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0073: stloc.s 5
 		IL_0075: ldloc.3
 		IL_0076: ldstr "nextTick"
@@ -875,13 +875,13 @@
 		IL_00aa: ldc.i4.0
 		IL_00ab: ldelem.ref
 		IL_00ac: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-		IL_00b1: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject_FunctionExpression_62CA5352_L12C25::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
+		IL_00b1: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
 		IL_00b6: ldc.i4.0
 		IL_00b7: conv.r8
 		IL_00b8: ldstr ""
 		IL_00bd: ldc.i4.0
 		IL_00be: ldc.i4.1
-		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject_FunctionExpression_62CA5352_L12C25>(!!0, float64, string, bool, bool)
+		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c4: stloc.s 6
 		IL_00c6: ldloc.3
 		IL_00c7: ldstr "then"
@@ -909,13 +909,13 @@
 		IL_00fc: ldc.i4.0
 		IL_00fd: ldelem.ref
 		IL_00fe: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-		IL_0103: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject_FunctionExpression_85A874E2_L16C47::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
+		IL_0103: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
 		IL_0108: ldc.i4.1
 		IL_0109: conv.r8
 		IL_010a: ldstr ""
 		IL_010f: ldc.i4.0
 		IL_0110: ldc.i4.1
-		IL_0111: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject_FunctionExpression_85A874E2_L16C47>(!!0, float64, string, bool, bool)
+		IL_0111: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0116: stloc.s 7
 		IL_0118: ldloc.3
 		IL_0119: ldstr "then"

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetImmediate_AwaitsValue.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetImmediate_AwaitsValue.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_28C8AC9A_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -57,9 +57,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject_FunctionDeclaration_28C8AC9A_main::_transitionalScopes
+				IL_0008: stfld object[] Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -70,7 +70,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -81,7 +81,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -94,7 +94,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject_FunctionDeclaration_28C8AC9A_main::_transitionalScopes
+				IL_0001: ldfld object[] Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -102,9 +102,9 @@
 				IL_0012: call object Modules.TimersPromises_SetImmediate_AwaitsValue/main::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_28C8AC9A_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -147,7 +147,7 @@
 			IL_0020: ldftn object Modules.TimersPromises_SetImmediate_AwaitsValue/main::__js_call__(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject_FunctionDeclaration_28C8AC9A_main
+			IL_002c: ldtoken Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -305,7 +305,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_SetImmediate_AwaitsValue/Scope,
-			[1] class Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject_FunctionDeclaration_28C8AC9A_main,
+			[1] class Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
 		)
@@ -320,14 +320,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject_FunctionDeclaration_28C8AC9A_main::.ctor(object[])
+		IL_0012: newobj instance void Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "main"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject_FunctionDeclaration_28C8AC9A_main>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject_FunctionDeclaration_28C8AC9A_main>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
@@ -55,7 +55,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DA4E8BE8_L9C23
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -69,7 +69,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -80,7 +80,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -91,7 +91,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -112,7 +112,7 @@
 					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0013: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal::__js_call__(object, object, object)
 					IL_0018: ret
-				} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -134,7 +134,7 @@
 					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000f: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal::__js_call__(object, object, object)
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -152,9 +152,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_DA4E8BE8_L9C23
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -240,7 +240,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CF26639F_L14C26
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -254,7 +254,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -265,7 +265,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -276,7 +276,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -297,7 +297,7 @@
 					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0013: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25::__js_call__(object, object, object)
 					IL_0018: ret
-				} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -319,7 +319,7 @@
 					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000f: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25::__js_call__(object, object, object)
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -337,9 +337,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_CF26639F_L14C26
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -462,7 +462,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C092881A_L23C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -486,15 +486,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+					IL_0008: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12::_environment1_createController
+					IL_000f: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject::_environment1_createController
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12::_transitionalScopes
+					IL_0016: stfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -505,7 +505,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -516,7 +516,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -529,14 +529,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -550,14 +550,14 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
 					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000e: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11::__js_call__(object[], object, object)
 					IL_0013: ret
-				} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -575,9 +575,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_C092881A_L23C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -680,7 +680,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_12B63234_createController
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -700,9 +700,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject_FunctionDeclaration_12B63234_createController::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+				IL_0008: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -713,7 +713,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -724,7 +724,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -737,11 +737,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject_FunctionDeclaration_12B63234_createController::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+				IL_0001: ldfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController::__js_call__(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -755,11 +755,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject_FunctionDeclaration_12B63234_createController::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+				IL_0001: ldfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController::__js_call__(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -777,9 +777,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_12B63234_createController
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -800,11 +800,11 @@
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope,
 				[1] object[],
-				[2] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal/FunctionObject_FunctionExpression_DA4E8BE8_L9C23,
-				[3] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25/FunctionObject_FunctionExpression_CF26639F_L14C26,
+				[2] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal/FunctionObject,
+				[3] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25/FunctionObject,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[5] object,
-				[6] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12
+				[6] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::.ctor()
@@ -816,13 +816,13 @@
 			IL_000e: ldarg.0
 			IL_000f: stelem.ref
 			IL_0010: stloc.1
-			IL_0011: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal/FunctionObject_FunctionExpression_DA4E8BE8_L9C23::.ctor()
+			IL_0011: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal/FunctionObject::.ctor()
 			IL_0016: ldc.i4.2
 			IL_0017: conv.r8
 			IL_0018: ldstr ""
 			IL_001d: ldc.i4.1
 			IL_001e: ldc.i4.1
-			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal/FunctionObject_FunctionExpression_DA4E8BE8_L9C23>(!!0, float64, string, bool, bool)
+			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0024: stloc.2
 			IL_0025: ldc.i4.1
 			IL_0026: newarr [System.Runtime]System.Object
@@ -831,13 +831,13 @@
 			IL_002d: ldarg.0
 			IL_002e: stelem.ref
 			IL_002f: stloc.1
-			IL_0030: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25/FunctionObject_FunctionExpression_CF26639F_L14C26::.ctor()
+			IL_0030: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25/FunctionObject::.ctor()
 			IL_0035: ldc.i4.2
 			IL_0036: conv.r8
 			IL_0037: ldstr ""
 			IL_003c: ldc.i4.1
 			IL_003d: ldc.i4.1
-			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25/FunctionObject_FunctionExpression_CF26639F_L14C26>(!!0, float64, string, bool, bool)
+			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0043: stloc.3
 			IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0049: dup
@@ -884,13 +884,13 @@
 			IL_00a9: ldelem.ref
 			IL_00aa: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
 			IL_00af: ldloc.1
-			IL_00b0: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12::.ctor(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope, object[])
+			IL_00b0: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject::.ctor(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope, object[])
 			IL_00b5: ldc.i4.1
 			IL_00b6: conv.r8
 			IL_00b7: ldstr ""
 			IL_00bc: ldc.i4.0
 			IL_00bd: ldc.i4.1
-			IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12>(!!0, float64, string, bool, bool)
+			IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_00c3: stloc.s 6
 			IL_00c5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_00ca: dup
@@ -935,7 +935,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8CB3E255_L46C11
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -949,7 +949,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -960,7 +960,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -971,7 +971,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -986,7 +986,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1002,7 +1002,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1020,9 +1020,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_8CB3E255_L46C11
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1076,7 +1076,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6820A98B_L49C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -1090,7 +1090,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1101,7 +1101,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1112,7 +1112,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1130,7 +1130,7 @@
 					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000c: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
 					IL_0011: ret
-				} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1149,7 +1149,7 @@
 					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0008: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1167,9 +1167,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_6820A98B_L49C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1283,7 +1283,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AF64659D_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -1305,12 +1305,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject_FunctionDeclaration_AF64659D_main::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+				IL_0008: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject_FunctionDeclaration_AF64659D_main::_transitionalScopes
+				IL_000f: stfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1321,7 +1321,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1332,7 +1332,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -1345,14 +1345,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject_FunctionDeclaration_AF64659D_main::_transitionalScopes
+				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_AF64659D_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1380,8 +1380,8 @@
 				[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[10] class [JavaScriptRuntime]JavaScriptRuntime.Error,
-				[11] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject_FunctionExpression_8CB3E255_L46C11,
-				[12] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject_FunctionExpression_6820A98B_L49C12
+				[11] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject,
+				[12] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject
 			)
 
 			IL_0000: ldarg.0
@@ -1403,7 +1403,7 @@
 			IL_0020: ldftn object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject_FunctionDeclaration_AF64659D_main
+			IL_002c: ldtoken Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -1478,12 +1478,12 @@
 			IL_00c4: dup
 			IL_00c5: ldc.i4.s 10
 			IL_00c7: ldelem.ref
-			IL_00c8: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject_FunctionExpression_8CB3E255_L46C11
+			IL_00c8: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject
 			IL_00cd: stloc.s 11
 			IL_00cf: dup
 			IL_00d0: ldc.i4.s 11
 			IL_00d2: ldelem.ref
-			IL_00d3: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject_FunctionExpression_6820A98B_L49C12
+			IL_00d3: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject
 			IL_00d8: stloc.s 12
 			IL_00da: pop
 
@@ -1733,13 +1733,13 @@
 			IL_02f2: ldelem.ref
 			IL_02f3: stelem.ref
 			IL_02f4: stloc.s 5
-			IL_02f6: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject_FunctionExpression_8CB3E255_L46C11::.ctor()
+			IL_02f6: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject::.ctor()
 			IL_02fb: ldc.i4.0
 			IL_02fc: conv.r8
 			IL_02fd: ldstr ""
 			IL_0302: ldc.i4.0
 			IL_0303: ldc.i4.1
-			IL_0304: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject_FunctionExpression_8CB3E255_L46C11>(!!0, float64, string, bool, bool)
+			IL_0304: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0309: stloc.s 11
 			IL_030b: ldloc.s 7
 			IL_030d: ldstr "then"
@@ -1758,13 +1758,13 @@
 			IL_032e: ldelem.ref
 			IL_032f: stelem.ref
 			IL_0330: stloc.s 5
-			IL_0332: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject_FunctionExpression_6820A98B_L49C12::.ctor()
+			IL_0332: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject::.ctor()
 			IL_0337: ldc.i4.1
 			IL_0338: conv.r8
 			IL_0339: ldstr ""
 			IL_033e: ldc.i4.0
 			IL_033f: ldc.i4.1
-			IL_0340: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject_FunctionExpression_6820A98B_L49C12>(!!0, float64, string, bool, bool)
+			IL_0340: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0345: stloc.s 12
 			IL_0347: ldloc.s 7
 			IL_0349: ldstr "catch"
@@ -1842,9 +1842,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope,
-			[1] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject_FunctionDeclaration_AF64659D_main,
+			[1] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject,
 			[2] object[],
-			[3] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject_FunctionDeclaration_12B63234_createController,
+			[3] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject,
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
 		)
 
@@ -1861,13 +1861,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
-		IL_0019: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject_FunctionDeclaration_12B63234_createController::.ctor(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope)
+		IL_0019: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject::.ctor(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "createController"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject_FunctionDeclaration_12B63234_createController>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.3
 		IL_002d: ldloc.0
 		IL_002e: ldloc.3
@@ -1884,14 +1884,14 @@
 		IL_0041: ldelem.ref
 		IL_0042: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
 		IL_0047: ldloc.2
-		IL_0048: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject_FunctionDeclaration_AF64659D_main::.ctor(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, object[])
+		IL_0048: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject::.ctor(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, object[])
 		IL_004d: ldc.i4.0
 		IL_004e: conv.r8
 		IL_004f: ldstr "main"
 		IL_0054: ldc.i4.0
 		IL_0055: ldc.i4.1
-		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject_FunctionDeclaration_AF64659D_main>(!!0, float64, string, bool, bool)
-		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject_FunctionDeclaration_AF64659D_main>(!!0)
+		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject>(!!0)
 		IL_0060: stloc.1
 		IL_0061: nop
 		IL_0062: ldarg.1

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Backpressure_And_Return.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Backpressure_And_Return.verified.txt
@@ -52,7 +52,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8247CAD9_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -74,12 +74,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject_FunctionDeclaration_8247CAD9_main::_environment0_TimersPromises_SetInterval_Backpressure_And_Return
+				IL_0008: stfld class Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject::_environment0_TimersPromises_SetInterval_Backpressure_And_Return
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject_FunctionDeclaration_8247CAD9_main::_transitionalScopes
+				IL_000f: stfld object[] Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -90,7 +90,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -101,7 +101,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -114,14 +114,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject_FunctionDeclaration_8247CAD9_main::_transitionalScopes
+				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_8247CAD9_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -169,7 +169,7 @@
 			IL_0020: ldftn object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject_FunctionDeclaration_8247CAD9_main
+			IL_002c: ldtoken Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -852,7 +852,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope,
-			[1] class Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject_FunctionDeclaration_8247CAD9_main,
+			[1] class Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
 		)
@@ -871,14 +871,14 @@
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope
 		IL_0019: ldloc.2
-		IL_001a: newobj instance void Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject_FunctionDeclaration_8247CAD9_main::.ctor(class Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope, object[])
+		IL_001a: newobj instance void Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject::.ctor(class Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope, object[])
 		IL_001f: ldc.i4.0
 		IL_0020: conv.r8
 		IL_0021: ldstr "main"
 		IL_0026: ldc.i4.0
 		IL_0027: ldc.i4.1
-		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject_FunctionDeclaration_8247CAD9_main>(!!0, float64, string, bool, bool)
-		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject_FunctionDeclaration_8247CAD9_main>(!!0)
+		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject>(!!0)
 		IL_0032: stloc.1
 		IL_0033: nop
 		IL_0034: ldarg.1

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown.verified.txt
@@ -101,7 +101,7 @@
 
 		} // end of class Scope_ForOf_L8C13
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8194F888_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -123,12 +123,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject_FunctionDeclaration_8194F888_main::_environment0_TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown
+				IL_0008: stfld class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject::_environment0_TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject_FunctionDeclaration_8194F888_main::_transitionalScopes
+				IL_000f: stfld object[] Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_8194F888_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -139,7 +139,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8194F888_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -150,7 +150,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8194F888_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -163,14 +163,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject_FunctionDeclaration_8194F888_main::_transitionalScopes
+				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_8194F888_main::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_8194F888_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -221,7 +221,7 @@
 			IL_0020: ldftn object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject_FunctionDeclaration_8194F888_main
+			IL_002c: ldtoken Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -703,7 +703,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope,
-			[1] class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject_FunctionDeclaration_8194F888_main,
+			[1] class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
 		)
@@ -722,14 +722,14 @@
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope
 		IL_0019: ldloc.2
-		IL_001a: newobj instance void Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject_FunctionDeclaration_8194F888_main::.ctor(class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope, object[])
+		IL_001a: newobj instance void Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject::.ctor(class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope, object[])
 		IL_001f: ldc.i4.0
 		IL_0020: conv.r8
 		IL_0021: ldstr "main"
 		IL_0026: ldc.i4.0
 		IL_0027: ldc.i4.1
-		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject_FunctionDeclaration_8194F888_main>(!!0, float64, string, bool, bool)
-		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject_FunctionDeclaration_8194F888_main>(!!0)
+		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject>(!!0)
 		IL_0032: stloc.1
 		IL_0033: nop
 		IL_0034: ldarg.1

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_InfinityDelay_ClampsToTick.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_InfinityDelay_ClampsToTick.verified.txt
@@ -40,7 +40,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_88CCDF06_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -62,12 +62,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject_FunctionDeclaration_88CCDF06_main::_environment0_TimersPromises_SetInterval_InfinityDelay_ClampsToTick
+				IL_0008: stfld class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject::_environment0_TimersPromises_SetInterval_InfinityDelay_ClampsToTick
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject_FunctionDeclaration_88CCDF06_main::_transitionalScopes
+				IL_000f: stfld object[] Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject::_transitionalScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -78,7 +78,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -89,7 +89,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -102,14 +102,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject_FunctionDeclaration_88CCDF06_main::_transitionalScopes
+				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_88CCDF06_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -154,7 +154,7 @@
 			IL_0020: ldftn object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main::__js_call__(object[], object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject_FunctionDeclaration_88CCDF06_main
+			IL_002c: ldtoken Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.0
 			IL_0037: newarr [System.Runtime]System.Object
@@ -429,7 +429,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope,
-			[1] class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject_FunctionDeclaration_88CCDF06_main,
+			[1] class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
 		)
@@ -448,14 +448,14 @@
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope
 		IL_0019: ldloc.2
-		IL_001a: newobj instance void Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject_FunctionDeclaration_88CCDF06_main::.ctor(class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope, object[])
+		IL_001a: newobj instance void Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject::.ctor(class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope, object[])
 		IL_001f: ldc.i4.0
 		IL_0020: conv.r8
 		IL_0021: ldstr "main"
 		IL_0026: ldc.i4.0
 		IL_0027: ldc.i4.1
-		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject_FunctionDeclaration_88CCDF06_main>(!!0, float64, string, bool, bool)
-		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject_FunctionDeclaration_88CCDF06_main>(!!0)
+		IL_0028: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject>(!!0)
 		IL_0032: stloc.1
 		IL_0033: nop
 		IL_0034: ldarg.1

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetTimeout_AwaitsValue.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetTimeout_AwaitsValue.verified.txt
@@ -37,7 +37,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5AC71590_main
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -57,9 +57,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject_FunctionDeclaration_5AC71590_main::_transitionalScopes
+				IL_0008: stfld object[] Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -70,7 +70,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -81,7 +81,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -94,7 +94,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject_FunctionDeclaration_5AC71590_main::_transitionalScopes
+				IL_0001: ldfld object[] Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -102,9 +102,9 @@
 				IL_0012: call object Modules.TimersPromises_SetTimeout_AwaitsValue/main::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_5AC71590_main
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -147,7 +147,7 @@
 			IL_0020: ldftn object Modules.TimersPromises_SetTimeout_AwaitsValue/main::__js_call__(object[], object, object)
 			IL_0026: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002b: ldarg.0
-			IL_002c: ldtoken Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject_FunctionDeclaration_5AC71590_main
+			IL_002c: ldtoken Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject
 			IL_0031: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0036: ldc.i4.1
 			IL_0037: newarr [System.Runtime]System.Object
@@ -307,7 +307,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TimersPromises_SetTimeout_AwaitsValue/Scope,
-			[1] class Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject_FunctionDeclaration_5AC71590_main,
+			[1] class Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
 		)
@@ -322,14 +322,14 @@
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
 		IL_0011: ldloc.2
-		IL_0012: newobj instance void Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject_FunctionDeclaration_5AC71590_main::.ctor(object[])
+		IL_0012: newobj instance void Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject::.ctor(object[])
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "main"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject_FunctionDeclaration_5AC71590_main>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject_FunctionDeclaration_5AC71590_main>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: nop
 		IL_002c: nop

--- a/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_SearchParams_Mutate.verified.txt
+++ b/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_SearchParams_Mutate.verified.txt
@@ -185,7 +185,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7B874945_L19C29
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -199,7 +199,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -210,7 +210,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -221,7 +221,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -242,7 +242,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -264,7 +264,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -282,9 +282,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7B874945_L19C29
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -569,7 +569,7 @@
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] object[],
 			[9] class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L14C29/FunctionObject,
-			[10] class Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject_FunctionExpression_7B874945_L19C29,
+			[10] class Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject,
 			[11] class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18/FunctionObject
 		)
 
@@ -726,13 +726,13 @@
 		IL_01ec: ldloc.0
 		IL_01ed: stelem.ref
 		IL_01ee: stloc.s 8
-		IL_01f0: newobj instance void Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject_FunctionExpression_7B874945_L19C29::.ctor()
+		IL_01f0: newobj instance void Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject::.ctor()
 		IL_01f5: ldc.i4.2
 		IL_01f6: conv.r8
 		IL_01f7: ldstr ""
 		IL_01fc: ldc.i4.1
 		IL_01fd: ldc.i4.1
-		IL_01fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject_FunctionExpression_7B874945_L19C29>(!!0, float64, string, bool, bool)
+		IL_01fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0203: stloc.s 10
 		IL_0205: ldloc.s 6
 		IL_0207: ldstr "forEach"

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inherits_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inherits_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_01CA746E_Animal
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Require_Util_Inherits_Basic/Animal::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Require_Util_Inherits_Basic/Animal::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_01CA746E_Animal
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -176,7 +176,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9DFEAE32_L10C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -190,7 +190,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -201,7 +201,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -212,7 +212,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -227,7 +227,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -243,7 +243,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -261,9 +261,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_9DFEAE32_L10C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -321,7 +321,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E77D98A8_Dog
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -335,7 +335,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -346,7 +346,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -357,7 +357,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -378,7 +378,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Require_Util_Inherits_Basic/Dog::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -400,7 +400,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Require_Util_Inherits_Basic/Dog::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -418,9 +418,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E77D98A8_Dog
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -502,13 +502,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Inherits_Basic/Scope,
-			[1] class Modules.Require_Util_Inherits_Basic/Animal/FunctionObject_FunctionDeclaration_01CA746E_Animal,
-			[2] class Modules.Require_Util_Inherits_Basic/Dog/FunctionObject_FunctionDeclaration_E77D98A8_Dog,
+			[1] class Modules.Require_Util_Inherits_Basic/Animal/FunctionObject,
+			[2] class Modules.Require_Util_Inherits_Basic/Dog/FunctionObject,
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule,
 			[4] object,
 			[5] object[],
 			[6] object,
-			[7] class Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25/FunctionObject_FunctionExpression_9DFEAE32_L10C26,
+			[7] class Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[9] bool,
 			[10] object
@@ -523,13 +523,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
-		IL_0012: newobj instance void Modules.Require_Util_Inherits_Basic/Animal/FunctionObject_FunctionDeclaration_01CA746E_Animal::.ctor()
+		IL_0012: newobj instance void Modules.Require_Util_Inherits_Basic/Animal/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "Animal"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Inherits_Basic/Animal/FunctionObject_FunctionDeclaration_01CA746E_Animal>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Inherits_Basic/Animal/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -538,13 +538,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 5
-		IL_0032: newobj instance void Modules.Require_Util_Inherits_Basic/Dog/FunctionObject_FunctionDeclaration_E77D98A8_Dog::.ctor()
+		IL_0032: newobj instance void Modules.Require_Util_Inherits_Basic/Dog/FunctionObject::.ctor()
 		IL_0037: ldc.i4.2
 		IL_0038: conv.r8
 		IL_0039: ldstr "Dog"
 		IL_003e: ldc.i4.1
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Inherits_Basic/Dog/FunctionObject_FunctionDeclaration_E77D98A8_Dog>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Inherits_Basic/Dog/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: nop
 		IL_0047: ldarg.1
@@ -563,13 +563,13 @@
 		IL_0069: ldloc.0
 		IL_006a: stelem.ref
 		IL_006b: stloc.s 5
-		IL_006d: newobj instance void Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25/FunctionObject_FunctionExpression_9DFEAE32_L10C26::.ctor()
+		IL_006d: newobj instance void Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25/FunctionObject::.ctor()
 		IL_0072: ldc.i4.0
 		IL_0073: conv.r8
 		IL_0074: ldstr ""
 		IL_0079: ldc.i4.1
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25/FunctionObject_FunctionExpression_9DFEAE32_L10C26>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.s 7
 		IL_0082: ldloc.s 6
 		IL_0084: ldstr "speak"

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inspect_Custom.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inspect_Custom.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5DD29BEB_L9C15
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -90,7 +90,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -115,7 +115,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5DD29BEB_L9C15
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -244,7 +244,7 @@
 			[6] bool,
 			[7] object,
 			[8] object[],
-			[9] class Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14/FunctionObject_FunctionExpression_5DD29BEB_L9C15,
+			[9] class Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14/FunctionObject,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -292,13 +292,13 @@
 		IL_007f: ldloc.0
 		IL_0080: stelem.ref
 		IL_0081: stloc.s 8
-		IL_0083: newobj instance void Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14/FunctionObject_FunctionExpression_5DD29BEB_L9C15::.ctor()
+		IL_0083: newobj instance void Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14/FunctionObject::.ctor()
 		IL_0088: ldc.i4.3
 		IL_0089: conv.r8
 		IL_008a: ldstr ""
 		IL_008f: ldc.i4.1
 		IL_0090: ldc.i4.1
-		IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14/FunctionObject_FunctionExpression_5DD29BEB_L9C15>(!!0, float64, string, bool, bool)
+		IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0096: stloc.s 9
 		IL_0098: ldloc.3
 		IL_0099: ldloc.2

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5D339815_callbackFn
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Require_Util_Promisify_Basic/callbackFn::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Require_Util_Promisify_Basic/callbackFn::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5D339815_callbackFn
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -336,7 +336,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Promisify_Basic/Scope,
-			[1] class Modules.Require_Util_Promisify_Basic/callbackFn/FunctionObject_FunctionDeclaration_5D339815_callbackFn,
+			[1] class Modules.Require_Util_Promisify_Basic/callbackFn/FunctionObject,
 			[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule,
 			[3] object,
 			[4] object[],
@@ -353,13 +353,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void Modules.Require_Util_Promisify_Basic/callbackFn/FunctionObject_FunctionDeclaration_5D339815_callbackFn::.ctor()
+		IL_0012: newobj instance void Modules.Require_Util_Promisify_Basic/callbackFn/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "callbackFn"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_Basic/callbackFn/FunctionObject_FunctionDeclaration_5D339815_callbackFn>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_Basic/callbackFn/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldarg.1

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_ErrorHandling.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_ErrorHandling.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -84,7 +84,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -106,7 +106,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -127,7 +127,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Require_Util_Promisify_ErrorHandling/callbackFn::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -149,7 +149,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Require_Util_Promisify_ErrorHandling/callbackFn::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -167,9 +167,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -755,7 +755,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Promisify_ErrorHandling/Scope,
-			[1] class Modules.Require_Util_Promisify_ErrorHandling/callbackFn/FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn,
+			[1] class Modules.Require_Util_Promisify_ErrorHandling/callbackFn/FunctionObject,
 			[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule,
 			[3] object,
 			[4] object[],
@@ -775,13 +775,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void Modules.Require_Util_Promisify_ErrorHandling/callbackFn/FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::.ctor()
+		IL_0012: newobj instance void Modules.Require_Util_Promisify_ErrorHandling/callbackFn/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "callbackFn"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_ErrorHandling/callbackFn/FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_ErrorHandling/callbackFn/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldarg.1

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_Generated_Functions.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_Generated_Functions.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_928137E0_ordinary
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_928137E0_ordinary::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_928137E0_ordinary::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_928137E0_ordinary::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Require_Util_Types_Generated_Functions/ordinary::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_928137E0_ordinary::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Require_Util_Types_Generated_Functions/ordinary::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_928137E0_ordinary::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_928137E0_ordinary::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_928137E0_ordinary
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -162,7 +162,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3BEDAA02_asyncFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -182,9 +182,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Require_Util_Types_Generated_Functions/asyncFunction/FunctionObject_FunctionDeclaration_3BEDAA02_asyncFunction::_transitionalScopes
+				IL_0008: stfld object[] Modules.Require_Util_Types_Generated_Functions/asyncFunction/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEDAA02_asyncFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -195,7 +195,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEDAA02_asyncFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -206,7 +206,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEDAA02_asyncFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -219,14 +219,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Require_Util_Types_Generated_Functions/asyncFunction/FunctionObject_FunctionDeclaration_3BEDAA02_asyncFunction::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Require_Util_Types_Generated_Functions/asyncFunction/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Require_Util_Types_Generated_Functions/asyncFunction::__js_call__(object[], object)
 				IL_0010: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_0015: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEDAA02_asyncFunction::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionDeclaration_3BEDAA02_asyncFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -273,7 +273,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_98441C17_generatorFunction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -293,9 +293,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject_FunctionDeclaration_98441C17_generatorFunction::_transitionalScopes
+				IL_0008: stfld object[] Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_98441C17_generatorFunction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -306,7 +306,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_98441C17_generatorFunction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -317,7 +317,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_98441C17_generatorFunction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -330,15 +330,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject_FunctionDeclaration_98441C17_generatorFunction::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Require_Util_Types_Generated_Functions/generatorFunction::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_98441C17_generatorFunction::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionDeclaration_98441C17_generatorFunction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -378,7 +378,7 @@
 			IL_001f: ldftn object Modules.Require_Util_Types_Generated_Functions/generatorFunction::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject_FunctionDeclaration_98441C17_generatorFunction
+			IL_002b: ldtoken Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -473,9 +473,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Types_Generated_Functions/Scope,
-			[1] class Modules.Require_Util_Types_Generated_Functions/ordinary/FunctionObject_FunctionDeclaration_928137E0_ordinary,
-			[2] class Modules.Require_Util_Types_Generated_Functions/asyncFunction/FunctionObject_FunctionDeclaration_3BEDAA02_asyncFunction,
-			[3] class Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject_FunctionDeclaration_98441C17_generatorFunction,
+			[1] class Modules.Require_Util_Types_Generated_Functions/ordinary/FunctionObject,
+			[2] class Modules.Require_Util_Types_Generated_Functions/asyncFunction/FunctionObject,
+			[3] class Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject,
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule,
 			[5] object[],
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -492,13 +492,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
-		IL_0012: newobj instance void Modules.Require_Util_Types_Generated_Functions/ordinary/FunctionObject_FunctionDeclaration_928137E0_ordinary::.ctor()
+		IL_0012: newobj instance void Modules.Require_Util_Types_Generated_Functions/ordinary/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "ordinary"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Types_Generated_Functions/ordinary/FunctionObject_FunctionDeclaration_928137E0_ordinary>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Types_Generated_Functions/ordinary/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -508,14 +508,14 @@
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 5
 		IL_0032: ldloc.s 5
-		IL_0034: newobj instance void Modules.Require_Util_Types_Generated_Functions/asyncFunction/FunctionObject_FunctionDeclaration_3BEDAA02_asyncFunction::.ctor(object[])
+		IL_0034: newobj instance void Modules.Require_Util_Types_Generated_Functions/asyncFunction/FunctionObject::.ctor(object[])
 		IL_0039: ldc.i4.0
 		IL_003a: conv.r8
 		IL_003b: ldstr "asyncFunction"
 		IL_0040: ldc.i4.0
 		IL_0041: ldc.i4.1
-		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Require_Util_Types_Generated_Functions/asyncFunction/FunctionObject_FunctionDeclaration_3BEDAA02_asyncFunction>(!!0, float64, string, bool, bool)
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Util_Types_Generated_Functions/asyncFunction/FunctionObject_FunctionDeclaration_3BEDAA02_asyncFunction>(!!0)
+		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Require_Util_Types_Generated_Functions/asyncFunction/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Require_Util_Types_Generated_Functions/asyncFunction/FunctionObject>(!!0)
 		IL_004c: stloc.2
 		IL_004d: ldc.i4.1
 		IL_004e: newarr [System.Runtime]System.Object
@@ -525,15 +525,15 @@
 		IL_0056: stelem.ref
 		IL_0057: stloc.s 5
 		IL_0059: ldloc.s 5
-		IL_005b: newobj instance void Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject_FunctionDeclaration_98441C17_generatorFunction::.ctor(object[])
+		IL_005b: newobj instance void Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject::.ctor(object[])
 		IL_0060: ldc.i4.0
 		IL_0061: conv.r8
 		IL_0062: ldstr "generatorFunction"
 		IL_0067: ldc.i4.1
 		IL_0068: ldc.i4.1
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject_FunctionDeclaration_98441C17_generatorFunction>(!!0, float64, string, bool, bool)
+		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006e: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_0073: castclass Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject_FunctionDeclaration_98441C17_generatorFunction
+		IL_0073: castclass Modules.Require_Util_Types_Generated_Functions/generatorFunction/FunctionObject
 		IL_0078: stloc.3
 		IL_0079: nop
 		IL_007a: ldarg.1

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsFunction.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsFunction.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A71E7C01_regularFn
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Require_Util_Types_IsFunction/regularFn::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Require_Util_Types_IsFunction/regularFn::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A71E7C01_regularFn
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -279,7 +279,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Types_IsFunction/Scope,
-			[1] class Modules.Require_Util_Types_IsFunction/regularFn/FunctionObject_FunctionDeclaration_A71E7C01_regularFn,
+			[1] class Modules.Require_Util_Types_IsFunction/regularFn/FunctionObject,
 			[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule,
 			[3] object,
 			[4] float64,
@@ -300,13 +300,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void Modules.Require_Util_Types_IsFunction/regularFn/FunctionObject_FunctionDeclaration_A71E7C01_regularFn::.ctor()
+		IL_0012: newobj instance void Modules.Require_Util_Types_IsFunction/regularFn/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "regularFn"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Types_IsFunction/regularFn/FunctionObject_FunctionDeclaration_A71E7C01_regularFn>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Types_IsFunction/regularFn/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldarg.1

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E70B6C52_logError
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -84,7 +84,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -106,7 +106,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -128,7 +128,7 @@
 				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0018: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, string, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -151,7 +151,7 @@
 				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0014: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, string, object)
 				IL_0019: ret
-			} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -169,9 +169,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E70B6C52_logError
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1039,7 +1039,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Zlib_ErrorPaths/Scope,
-			[1] class Modules.Require_Zlib_ErrorPaths/logError/FunctionObject_FunctionDeclaration_E70B6C52_logError,
+			[1] class Modules.Require_Zlib_ErrorPaths/logError/FunctionObject,
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
@@ -1074,13 +1074,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void Modules.Require_Zlib_ErrorPaths/logError/FunctionObject_FunctionDeclaration_E70B6C52_logError::.ctor()
+		IL_0012: newobj instance void Modules.Require_Zlib_ErrorPaths/logError/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "logError"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/logError/FunctionObject_FunctionDeclaration_E70B6C52_logError>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/logError/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldarg.1

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_Stream_RoundTrip.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_Stream_RoundTrip.verified.txt
@@ -510,7 +510,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_721B6487_L19C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -530,9 +530,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject_FunctionExpression_721B6487_L19C19::_environment0_Require_Zlib_Stream_RoundTrip
+				IL_0008: stfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject::_environment0_Require_Zlib_Stream_RoundTrip
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -543,7 +543,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -554,7 +554,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -567,14 +567,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject_FunctionExpression_721B6487_L19C19::_environment0_Require_Zlib_Stream_RoundTrip
+				IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject::_environment0_Require_Zlib_Stream_RoundTrip
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18::__js_call__(class Modules.Require_Zlib_Stream_RoundTrip/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -588,14 +588,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject_FunctionExpression_721B6487_L19C19::_environment0_Require_Zlib_Stream_RoundTrip
+				IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject::_environment0_Require_Zlib_Stream_RoundTrip
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18::__js_call__(class Modules.Require_Zlib_Stream_RoundTrip/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -613,9 +613,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_721B6487_L19C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -674,7 +674,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3356B439_L23C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -694,9 +694,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject_FunctionExpression_3356B439_L23C23::_environment0_Require_Zlib_Stream_RoundTrip
+				IL_0008: stfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject::_environment0_Require_Zlib_Stream_RoundTrip
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -707,7 +707,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -718,7 +718,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -731,11 +731,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject_FunctionExpression_3356B439_L23C23::_environment0_Require_Zlib_Stream_RoundTrip
+				IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject::_environment0_Require_Zlib_Stream_RoundTrip
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22::__js_call__(class Modules.Require_Zlib_Stream_RoundTrip/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -749,11 +749,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject_FunctionExpression_3356B439_L23C23::_environment0_Require_Zlib_Stream_RoundTrip
+				IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject::_environment0_Require_Zlib_Stream_RoundTrip
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22::__js_call__(class Modules.Require_Zlib_Stream_RoundTrip/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -771,9 +771,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_3356B439_L23C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -908,8 +908,8 @@
 			[12] class Modules.Require_Zlib_Stream_RoundTrip/ArrowFunction_L15C16/FunctionObject,
 			[13] class Modules.Require_Zlib_Stream_RoundTrip/ArrowFunction_L16C21/FunctionObject,
 			[14] class Modules.Require_Zlib_Stream_RoundTrip/ArrowFunction_L17C18/FunctionObject,
-			[15] class Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject_FunctionExpression_721B6487_L19C19,
-			[16] class Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject_FunctionExpression_3356B439_L23C23,
+			[15] class Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject,
+			[16] class Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject,
 			[17] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
 		)
 
@@ -1091,13 +1091,13 @@
 		IL_01ce: ldc.i4.0
 		IL_01cf: ldelem.ref
 		IL_01d0: castclass Modules.Require_Zlib_Stream_RoundTrip/Scope
-		IL_01d5: newobj instance void Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject_FunctionExpression_721B6487_L19C19::.ctor(class Modules.Require_Zlib_Stream_RoundTrip/Scope)
+		IL_01d5: newobj instance void Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject::.ctor(class Modules.Require_Zlib_Stream_RoundTrip/Scope)
 		IL_01da: ldc.i4.1
 		IL_01db: conv.r8
 		IL_01dc: ldstr ""
 		IL_01e1: ldc.i4.0
 		IL_01e2: ldc.i4.1
-		IL_01e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject_FunctionExpression_721B6487_L19C19>(!!0, float64, string, bool, bool)
+		IL_01e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01e8: stloc.s 15
 		IL_01ea: ldloc.s 6
 		IL_01ec: ldstr "_write"
@@ -1119,13 +1119,13 @@
 		IL_0211: ldc.i4.0
 		IL_0212: ldelem.ref
 		IL_0213: castclass Modules.Require_Zlib_Stream_RoundTrip/Scope
-		IL_0218: newobj instance void Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject_FunctionExpression_3356B439_L23C23::.ctor(class Modules.Require_Zlib_Stream_RoundTrip/Scope)
+		IL_0218: newobj instance void Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject::.ctor(class Modules.Require_Zlib_Stream_RoundTrip/Scope)
 		IL_021d: ldc.i4.0
 		IL_021e: conv.r8
 		IL_021f: ldstr ""
 		IL_0224: ldc.i4.0
 		IL_0225: ldc.i4.1
-		IL_0226: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject_FunctionExpression_3356B439_L23C23>(!!0, float64, string, bool, bool)
+		IL_0226: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_022b: stloc.s 16
 		IL_022d: ldloc.s 7
 		IL_022f: ldstr "on"

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectDefineProperty_Accessor.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectDefineProperty_Accessor.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_477C5B43_L7C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject_FunctionExpression_477C5B43_L7C8::_environment0_ObjectDefineProperty_Accessor
+				IL_0008: stfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject::_environment0_ObjectDefineProperty_Accessor
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject_FunctionExpression_477C5B43_L7C8::_environment0_ObjectDefineProperty_Accessor
+				IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject::_environment0_ObjectDefineProperty_Accessor
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7::__js_call__(class Modules.ObjectDefineProperty_Accessor/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject_FunctionExpression_477C5B43_L7C8::_environment0_ObjectDefineProperty_Accessor
+				IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject::_environment0_ObjectDefineProperty_Accessor
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7::__js_call__(class Modules.ObjectDefineProperty_Accessor/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_477C5B43_L7C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -187,7 +187,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AAFBE7D6_L8C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -207,9 +207,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject_FunctionExpression_AAFBE7D6_L8C8::_environment0_ObjectDefineProperty_Accessor
+				IL_0008: stfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject::_environment0_ObjectDefineProperty_Accessor
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -220,7 +220,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -231,7 +231,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -244,14 +244,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject_FunctionExpression_AAFBE7D6_L8C8::_environment0_ObjectDefineProperty_Accessor
+				IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject::_environment0_ObjectDefineProperty_Accessor
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7::__js_call__(class Modules.ObjectDefineProperty_Accessor/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -265,14 +265,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject_FunctionExpression_AAFBE7D6_L8C8::_environment0_ObjectDefineProperty_Accessor
+				IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject::_environment0_ObjectDefineProperty_Accessor
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7::__js_call__(class Modules.ObjectDefineProperty_Accessor/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -290,9 +290,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_AAFBE7D6_L8C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -379,8 +379,8 @@
 			[0] class Modules.ObjectDefineProperty_Accessor/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[2] object[],
-			[3] class Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject_FunctionExpression_477C5B43_L7C8,
-			[4] class Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject_FunctionExpression_AAFBE7D6_L8C8,
+			[3] class Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject,
+			[4] class Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[7] object
@@ -406,13 +406,13 @@
 		IL_002d: ldc.i4.0
 		IL_002e: ldelem.ref
 		IL_002f: castclass Modules.ObjectDefineProperty_Accessor/Scope
-		IL_0034: newobj instance void Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject_FunctionExpression_477C5B43_L7C8::.ctor(class Modules.ObjectDefineProperty_Accessor/Scope)
+		IL_0034: newobj instance void Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject::.ctor(class Modules.ObjectDefineProperty_Accessor/Scope)
 		IL_0039: ldc.i4.0
 		IL_003a: conv.r8
 		IL_003b: ldstr ""
 		IL_0040: ldc.i4.0
 		IL_0041: ldc.i4.1
-		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject_FunctionExpression_477C5B43_L7C8>(!!0, float64, string, bool, bool)
+		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0047: stloc.3
 		IL_0048: ldc.i4.1
 		IL_0049: newarr [System.Runtime]System.Object
@@ -425,13 +425,13 @@
 		IL_0054: ldc.i4.0
 		IL_0055: ldelem.ref
 		IL_0056: castclass Modules.ObjectDefineProperty_Accessor/Scope
-		IL_005b: newobj instance void Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject_FunctionExpression_AAFBE7D6_L8C8::.ctor(class Modules.ObjectDefineProperty_Accessor/Scope)
+		IL_005b: newobj instance void Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject::.ctor(class Modules.ObjectDefineProperty_Accessor/Scope)
 		IL_0060: ldc.i4.1
 		IL_0061: conv.r8
 		IL_0062: ldstr ""
 		IL_0067: ldc.i4.0
 		IL_0068: ldc.i4.1
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject_FunctionExpression_AAFBE7D6_L8C8>(!!0, float64, string, bool, bool)
+		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006e: stloc.s 4
 		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0075: dup

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_AccessorDefinitions.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_AccessorDefinitions.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_131FC9A5_L5C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,9 +81,9 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_131FC9A5_L5C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -141,7 +141,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A0C76C5C_L8C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -155,7 +155,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -166,7 +166,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -177,7 +177,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -195,9 +195,9 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_A0C76C5C_L8C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -258,7 +258,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_61B490A1_L11C17
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -272,7 +272,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -283,7 +283,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -294,7 +294,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -309,9 +309,9 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_61B490A1_L11C17
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -368,7 +368,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CB10A8EE_L30C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -382,7 +382,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -393,7 +393,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -404,7 +404,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -420,9 +420,9 @@
 				IL_0005: call float64 Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_CB10A8EE_L30C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -467,7 +467,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B2462A16_L38C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -481,7 +481,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -492,7 +492,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -503,7 +503,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -519,9 +519,9 @@
 				IL_0005: call float64 Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_B2462A16_L38C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -584,13 +584,13 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[6] object[],
-			[7] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject_FunctionExpression_131FC9A5_L5C12,
+			[7] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject,
 			[8] object,
-			[9] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17,
+			[9] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[11] string,
-			[12] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8,
-			[13] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8,
+			[12] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject,
+			[13] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -611,14 +611,14 @@
 		IL_002c: ldloc.0
 		IL_002d: stelem.ref
 		IL_002e: stloc.s 6
-		IL_0030: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject_FunctionExpression_131FC9A5_L5C12::.ctor()
+		IL_0030: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject::.ctor()
 		IL_0035: ldc.i4.0
 		IL_0036: conv.r8
 		IL_0037: ldstr ""
 		IL_003c: ldc.i4.1
 		IL_003d: ldc.i4.1
-		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject_FunctionExpression_131FC9A5_L5C12>(!!0, float64, string, bool, bool)
-		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject_FunctionExpression_131FC9A5_L5C12>(!!0)
+		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject>(!!0)
 		IL_0048: stloc.s 7
 		IL_004a: ldloc.s 7
 		IL_004c: ldstr "value"
@@ -641,14 +641,14 @@
 		IL_0079: ldloc.s 5
 		IL_007b: ldstr "value"
 		IL_0080: ldnull
-		IL_0081: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12::.ctor()
+		IL_0081: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject::.ctor()
 		IL_0086: ldc.i4.1
 		IL_0087: conv.r8
 		IL_0088: ldstr ""
 		IL_008d: ldc.i4.1
 		IL_008e: ldc.i4.1
-		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0, float64, string, bool, bool)
-		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0)
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject>(!!0)
 		IL_0099: ldstr "value"
 		IL_009e: ldstr "set"
 		IL_00a3: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
@@ -661,14 +661,14 @@
 		IL_00b6: ldloc.0
 		IL_00b7: stelem.ref
 		IL_00b8: stloc.s 6
-		IL_00ba: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17::.ctor()
+		IL_00ba: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject::.ctor()
 		IL_00bf: ldc.i4.0
 		IL_00c0: conv.r8
 		IL_00c1: ldstr ""
 		IL_00c6: ldc.i4.1
 		IL_00c7: ldc.i4.1
-		IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0, float64, string, bool, bool)
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0)
+		IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject>(!!0)
 		IL_00d2: stloc.s 9
 		IL_00d4: ldloc.s 9
 		IL_00d6: ldstr "double"
@@ -801,14 +801,14 @@
 		IL_025a: ldloc.0
 		IL_025b: stelem.ref
 		IL_025c: stloc.s 6
-		IL_025e: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8::.ctor()
+		IL_025e: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject::.ctor()
 		IL_0263: ldc.i4.0
 		IL_0264: conv.r8
 		IL_0265: ldstr ""
 		IL_026a: ldc.i4.0
 		IL_026b: ldc.i4.1
-		IL_026c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0, float64, string, bool, bool)
-		IL_0271: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0)
+		IL_026c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0271: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject>(!!0)
 		IL_0276: stloc.s 12
 		IL_0278: ldloc.s 12
 		IL_027a: ldstr "x"
@@ -847,14 +847,14 @@
 		IL_02e1: ldloc.0
 		IL_02e2: stelem.ref
 		IL_02e3: stloc.s 6
-		IL_02e5: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8::.ctor()
+		IL_02e5: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject::.ctor()
 		IL_02ea: ldc.i4.0
 		IL_02eb: conv.r8
 		IL_02ec: ldstr ""
 		IL_02f1: ldc.i4.0
 		IL_02f2: ldc.i4.1
-		IL_02f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0, float64, string, bool, bool)
-		IL_02f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0)
+		IL_02f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02f8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject>(!!0)
 		IL_02fd: stloc.s 13
 		IL_02ff: ldloc.s 13
 		IL_0301: ldstr "x"

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ComputedKey_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ComputedKey_EvaluationOrder.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B3D1F03E_f
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject_FunctionDeclaration_B3D1F03E_f::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0008: stfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject_FunctionDeclaration_B3D1F03E_f::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject_FunctionDeclaration_B3D1F03E_f::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B3D1F03E_f
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -191,7 +191,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B4D1F1D1_g
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -211,9 +211,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject_FunctionDeclaration_B4D1F1D1_g::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0008: stfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -224,7 +224,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -235,7 +235,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -248,11 +248,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject_FunctionDeclaration_B4D1F1D1_g::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -266,11 +266,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject_FunctionDeclaration_B4D1F1D1_g::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -288,9 +288,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B4D1F1D1_g
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -353,7 +353,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ADD1E6CC_h
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -373,9 +373,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject_FunctionDeclaration_ADD1E6CC_h::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0008: stfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -386,7 +386,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -397,7 +397,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -410,11 +410,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject_FunctionDeclaration_ADD1E6CC_h::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -428,11 +428,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject_FunctionDeclaration_ADD1E6CC_h::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -450,9 +450,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_ADD1E6CC_h
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -541,9 +541,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope,
-			[1] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject_FunctionDeclaration_B3D1F03E_f,
-			[2] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject_FunctionDeclaration_B4D1F1D1_g,
-			[3] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject_FunctionDeclaration_ADD1E6CC_h,
+			[1] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject,
+			[2] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject,
+			[3] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] object[],
 			[6] object,
@@ -565,13 +565,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
-		IL_001b: newobj instance void Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject_FunctionDeclaration_B3D1F03E_f::.ctor(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope)
+		IL_001b: newobj instance void Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject::.ctor(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "f"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject_FunctionDeclaration_B3D1F03E_f>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: ldc.i4.1
 		IL_0030: newarr [System.Runtime]System.Object
@@ -584,13 +584,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
-		IL_0044: newobj instance void Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject_FunctionDeclaration_B4D1F1D1_g::.ctor(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope)
+		IL_0044: newobj instance void Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject::.ctor(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope)
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr "g"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject_FunctionDeclaration_B4D1F1D1_g>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.2
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object
@@ -603,13 +603,13 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
-		IL_006d: newobj instance void Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject_FunctionDeclaration_ADD1E6CC_h::.ctor(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope)
+		IL_006d: newobj instance void Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject::.ctor(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope)
 		IL_0072: ldc.i4.0
 		IL_0073: conv.r8
 		IL_0074: ldstr "h"
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject_FunctionDeclaration_ADD1E6CC_h>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.3
 		IL_0081: nop
 		IL_0082: ldloc.0

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_EarlyBoundAccess_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_EarlyBoundAccess_Parity.verified.txt
@@ -128,7 +128,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_722B85FE_inspect
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -142,7 +142,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -153,7 +153,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -164,7 +164,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -178,7 +178,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -196,7 +196,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -215,7 +215,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -233,9 +233,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_722B85FE_inspect
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -698,7 +698,7 @@
 		.maxstack 12
 		.locals init (
 			[0] class Modules.ObjectLiteral_EarlyBoundAccess_Parity/Scope,
-			[1] class Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect/FunctionObject_FunctionDeclaration_722B85FE_inspect,
+			[1] class Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect/FunctionObject,
 			[2] class Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible,
 			[3] class Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter,
 			[4] class Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable,
@@ -735,14 +735,14 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 14
-		IL_0012: newobj instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect/FunctionObject_FunctionDeclaration_722B85FE_inspect::.ctor()
+		IL_0012: newobj instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "inspect"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect/FunctionObject_FunctionDeclaration_722B85FE_inspect>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect/FunctionObject_FunctionDeclaration_722B85FE_inspect>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: ldc.i4.1
 		IL_002c: newarr [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_EarlyBoundCapturedVarFunctionCall.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_EarlyBoundCapturedVarFunctionCall.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BE9889E4_L2C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -104,7 +104,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -129,7 +129,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -147,9 +147,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_BE9889E4_L2C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -208,7 +208,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_939DC655_invokeCallable
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -228,9 +228,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable::_environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
+				IL_0008: stfld class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject::_environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -241,7 +241,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -252,7 +252,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -266,7 +266,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -279,11 +279,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable::_environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
+				IL_0001: ldfld class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject::_environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable::__js_call__(class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -297,11 +297,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable::_environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
+				IL_0001: ldfld class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject::_environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable::__js_call__(class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -319,9 +319,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_939DC655_invokeCallable
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -480,9 +480,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope,
-			[1] class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable,
+			[1] class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject,
 			[2] object[],
-			[3] class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable/FunctionObject_FunctionExpression_BE9889E4_L2C8,
+			[3] class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable/FunctionObject,
 			[4] class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/ObjectLiterals/L1C16_callable,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[6] object
@@ -501,14 +501,14 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope
-		IL_0019: newobj instance void Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable::.ctor(class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope)
+		IL_0019: newobj instance void Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject::.ctor(class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "invokeCallable"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.0
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable>(!!0, float64, string, bool, bool)
-		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable>(!!0)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject>(!!0)
 		IL_0031: stloc.1
 		IL_0032: ldc.i4.1
 		IL_0033: newarr [System.Runtime]System.Object
@@ -517,14 +517,14 @@
 		IL_003a: ldloc.0
 		IL_003b: stelem.ref
 		IL_003c: stloc.2
-		IL_003d: newobj instance void Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable/FunctionObject_FunctionExpression_BE9889E4_L2C8::.ctor()
+		IL_003d: newobj instance void Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable/FunctionObject::.ctor()
 		IL_0042: ldc.i4.3
 		IL_0043: conv.r8
 		IL_0044: ldstr ""
 		IL_0049: ldc.i4.0
 		IL_004a: ldc.i4.0
-		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable/FunctionObject_FunctionExpression_BE9889E4_L2C8>(!!0, float64, string, bool, bool)
-		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable/FunctionObject_FunctionExpression_BE9889E4_L2C8>(!!0)
+		IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0050: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable/FunctionObject>(!!0)
 		IL_0055: stloc.3
 		IL_0056: newobj instance void Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/ObjectLiterals/L1C16_callable::.ctor()
 		IL_005b: stloc.s 4

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_GeneratedMethodFunctionObjects.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_GeneratedMethodFunctionObjects.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B788F5CE_L7C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -56,12 +56,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject_FunctionExpression_B788F5CE_L7C12::_environment1_makeObject
+					IL_0008: stfld class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject::_environment1_makeObject
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject_FunctionExpression_B788F5CE_L7C12::_transitionalScopes
+					IL_000f: stfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_B788F5CE_L7C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_B788F5CE_L7C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_B788F5CE_L7C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -96,16 +96,16 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject_FunctionExpression_B788F5CE_L7C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_B788F5CE_L7C12::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_B788F5CE_L7C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -175,7 +175,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_12773EFC_L11C20
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -197,12 +197,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20::_environment1_makeObject
+					IL_0008: stfld class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject::_environment1_makeObject
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20::_transitionalScopes
+					IL_000f: stfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_12773EFC_L11C20::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -213,7 +213,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_12773EFC_L11C20::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -224,7 +224,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_12773EFC_L11C20::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -237,13 +237,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_12773EFC_L11C20::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_12773EFC_L11C20
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -309,7 +309,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_801DB080_L15C20
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -331,12 +331,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20::_environment1_makeObject
+					IL_0008: stfld class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject::_environment1_makeObject
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20::_transitionalScopes
+					IL_000f: stfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_801DB080_L15C20::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -347,7 +347,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_801DB080_L15C20::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -358,7 +358,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_801DB080_L15C20::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -371,16 +371,16 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20::_transitionalScopes
+					IL_0001: ldfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
 					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_0012: call object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19::__js_call__(object[], object, object)
 					IL_0017: ret
-				} // end of method FunctionObject_FunctionExpression_801DB080_L15C20::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_801DB080_L15C20
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -450,7 +450,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F5C752D7_L19C21
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -464,7 +464,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_F5C752D7_L19C21::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -475,7 +475,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F5C752D7_L19C21::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -486,7 +486,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_F5C752D7_L19C21::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -504,9 +504,9 @@
 					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 					IL_000c: call object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20::__js_call__(object, object)
 					IL_0011: ret
-				} // end of method FunctionObject_FunctionExpression_F5C752D7_L19C21::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_F5C752D7_L19C21
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -568,7 +568,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D6C7F660_makeObject
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -588,9 +588,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionObject_FunctionDeclaration_D6C7F660_makeObject::_environment0_ObjectLiteral_GeneratedMethodFunctionObjects
+				IL_0008: stfld class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionObject::_environment0_ObjectLiteral_GeneratedMethodFunctionObjects
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D6C7F660_makeObject::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -601,7 +601,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D6C7F660_makeObject::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -612,7 +612,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D6C7F660_makeObject::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -625,14 +625,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionObject_FunctionDeclaration_D6C7F660_makeObject::_environment0_ObjectLiteral_GeneratedMethodFunctionObjects
+				IL_0001: ldfld class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionObject::_environment0_ObjectLiteral_GeneratedMethodFunctionObjects
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject::__js_call__(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_D6C7F660_makeObject::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -646,14 +646,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionObject_FunctionDeclaration_D6C7F660_makeObject::_environment0_ObjectLiteral_GeneratedMethodFunctionObjects
+				IL_0001: ldfld class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionObject::_environment0_ObjectLiteral_GeneratedMethodFunctionObjects
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject::__js_call__(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_D6C7F660_makeObject::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -671,9 +671,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D6C7F660_makeObject::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D6C7F660_makeObject
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -696,8 +696,8 @@
 				[0] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[2] object[],
-				[3] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject_FunctionExpression_B788F5CE_L7C12,
-				[4] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20,
+				[3] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject,
+				[4] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject,
 				[5] object
 			)
 
@@ -729,14 +729,14 @@
 			IL_0039: ldelem.ref
 			IL_003a: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope
 			IL_003f: ldloc.2
-			IL_0040: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject_FunctionExpression_B788F5CE_L7C12::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope, object[])
+			IL_0040: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope, object[])
 			IL_0045: ldc.i4.1
 			IL_0046: conv.r8
 			IL_0047: ldstr ""
 			IL_004c: ldc.i4.1
 			IL_004d: ldc.i4.1
-			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject_FunctionExpression_B788F5CE_L7C12>(!!0, float64, string, bool, bool)
-			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject_FunctionExpression_B788F5CE_L7C12>(!!0)
+			IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L7C11/FunctionObject>(!!0)
 			IL_0058: stloc.3
 			IL_0059: ldloc.1
 			IL_005a: ldstr "add"
@@ -759,14 +759,14 @@
 			IL_0077: ldelem.ref
 			IL_0078: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope
 			IL_007d: ldloc.2
-			IL_007e: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope, object[])
+			IL_007e: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope, object[])
 			IL_0083: ldc.i4.0
 			IL_0084: conv.r8
 			IL_0085: ldstr ""
 			IL_008a: ldc.i4.1
 			IL_008b: ldc.i4.1
-			IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20>(!!0, float64, string, bool, bool)
-			IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject_FunctionExpression_12773EFC_L11C20>(!!0)
+			IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L11C19/FunctionObject>(!!0)
 			IL_0096: stloc.s 4
 			IL_0098: ldloc.s 4
 			IL_009a: ldstr "current"
@@ -798,14 +798,14 @@
 			IL_00d2: ldelem.ref
 			IL_00d3: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope
 			IL_00d8: ldloc.2
-			IL_00d9: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope, object[])
+			IL_00d9: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/Scope, object[])
 			IL_00de: ldc.i4.1
 			IL_00df: conv.r8
 			IL_00e0: ldstr ""
 			IL_00e5: ldc.i4.1
 			IL_00e6: ldc.i4.1
-			IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0, float64, string, bool, bool)
-			IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject_FunctionExpression_801DB080_L15C20>(!!0)
+			IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L15C19/FunctionObject>(!!0)
 			IL_00f1: ldstr "current"
 			IL_00f6: ldstr "set"
 			IL_00fb: call object [JavaScriptRuntime]JavaScriptRuntime.Function::SetAccessorNameIfAnonymous(object, object, object)
@@ -820,14 +820,14 @@
 			IL_0110: stloc.2
 			IL_0111: ldloc.1
 			IL_0112: ldstr "computed"
-			IL_0117: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21::.ctor()
+			IL_0117: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject::.ctor()
 			IL_011c: ldc.i4.1
 			IL_011d: conv.r8
 			IL_011e: ldstr ""
 			IL_0123: ldc.i4.1
 			IL_0124: ldc.i4.1
-			IL_0125: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21>(!!0, float64, string, bool, bool)
-			IL_012a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject_FunctionExpression_F5C752D7_L19C21>(!!0)
+			IL_0125: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_012a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionExpression_L19C20/FunctionObject>(!!0)
 			IL_012f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, string, object)
 			IL_0134: pop
 			IL_0135: ldloc.1
@@ -859,7 +859,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0A328BE2_L58C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -873,7 +873,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_0A328BE2_L58C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -884,7 +884,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0A328BE2_L58C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -895,7 +895,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0A328BE2_L58C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -910,9 +910,9 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_0A328BE2_L58C10::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_0A328BE2_L58C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -957,7 +957,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_28F083D3_L64C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -979,12 +979,12 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class [System.Runtime]System.Object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10::_homeObject
+				IL_0008: stfld class [System.Runtime]System.Object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject::_homeObject
 				IL_000d: ldarg.0
 				IL_000e: ldarg.2
-				IL_000f: stfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10::_lexicalSuperScopes
+				IL_000f: stfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject::_lexicalSuperScopes
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_28F083D3_L64C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -995,7 +995,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_28F083D3_L64C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1006,7 +1006,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_28F083D3_L64C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object GetLexicalSuperReceiverCore () cil managed 
@@ -1016,9 +1016,9 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class [System.Runtime]System.Object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10::_homeObject
+				IL_0001: ldfld class [System.Runtime]System.Object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject::_homeObject
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_28F083D3_L64C10::GetLexicalSuperReceiverCore
+			} // end of method FunctionObject::GetLexicalSuperReceiverCore
 
 			.method family hidebysig virtual 
 				instance object[] GetLexicalSuperScopesCore () cil managed 
@@ -1028,9 +1028,9 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10::_lexicalSuperScopes
+				IL_0001: ldfld object[] Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject::_lexicalSuperScopes
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_28F083D3_L64C10::GetLexicalSuperScopesCore
+			} // end of method FunctionObject::GetLexicalSuperScopesCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1045,9 +1045,9 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_28F083D3_L64C10::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_28F083D3_L64C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1165,7 +1165,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope,
-			[1] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionObject_FunctionDeclaration_D6C7F660_makeObject,
+			[1] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionObject,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -1192,8 +1192,8 @@
 			[25] object,
 			[26] object,
 			[27] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[28] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject_FunctionExpression_0A328BE2_L58C10,
-			[29] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10
+			[28] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject,
+			[29] class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -1210,13 +1210,13 @@
 		IL_0019: ldc.i4.0
 		IL_001a: ldelem.ref
 		IL_001b: castclass Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope
-		IL_0020: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionObject_FunctionDeclaration_D6C7F660_makeObject::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope)
+		IL_0020: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionObject::.ctor(class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/Scope)
 		IL_0025: ldc.i4.1
 		IL_0026: conv.r8
 		IL_0027: ldstr "makeObject"
 		IL_002c: ldc.i4.0
 		IL_002d: ldc.i4.1
-		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionObject_FunctionDeclaration_D6C7F660_makeObject>(!!0, float64, string, bool, bool)
+		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/makeObject/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0033: stloc.1
 		IL_0034: nop
 		IL_0035: nop
@@ -1594,14 +1594,14 @@
 		IL_048d: ldloc.0
 		IL_048e: stelem.ref
 		IL_048f: stloc.s 15
-		IL_0491: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject_FunctionExpression_0A328BE2_L58C10::.ctor()
+		IL_0491: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject::.ctor()
 		IL_0496: ldc.i4.0
 		IL_0497: conv.r8
 		IL_0498: ldstr ""
 		IL_049d: ldc.i4.0
 		IL_049e: ldc.i4.1
-		IL_049f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject_FunctionExpression_0A328BE2_L58C10>(!!0, float64, string, bool, bool)
-		IL_04a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject_FunctionExpression_0A328BE2_L58C10>(!!0)
+		IL_049f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_base/FunctionObject>(!!0)
 		IL_04a9: stloc.s 28
 		IL_04ab: ldloc.s 19
 		IL_04ad: ldstr "label"
@@ -1625,14 +1625,14 @@
 		IL_04d9: stloc.s 15
 		IL_04db: ldloc.s 19
 		IL_04dd: ldloc.s 15
-		IL_04df: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10::.ctor(class [System.Runtime]System.Object, object[])
+		IL_04df: newobj instance void Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject::.ctor(class [System.Runtime]System.Object, object[])
 		IL_04e4: ldc.i4.0
 		IL_04e5: conv.r8
 		IL_04e6: ldstr ""
 		IL_04eb: ldc.i4.1
 		IL_04ec: ldc.i4.1
-		IL_04ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10>(!!0, float64, string, bool, bool)
-		IL_04f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject_FunctionExpression_28F083D3_L64C10>(!!0)
+		IL_04ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_04f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_GeneratedMethodFunctionObjects/FunctionExpression_derived/FunctionObject>(!!0)
 		IL_04f7: stloc.s 29
 		IL_04f9: ldloc.s 19
 		IL_04fb: ldstr "label"

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Inference_ClosureAndAliasing_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Inference_ClosureAndAliasing_Parity.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_25BCDD16_addFive
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -98,7 +98,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -117,7 +117,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -135,9 +135,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_25BCDD16_addFive
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -201,7 +201,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3385C3D7_bump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -221,9 +221,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -234,7 +234,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -245,7 +245,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -259,7 +259,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -272,11 +272,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -290,11 +290,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -312,9 +312,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3385C3D7_bump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -389,7 +389,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D67744E0_L32C18
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -409,9 +409,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue/FunctionObject_FunctionExpression_D67744E0_L32C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue/FunctionObject::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -422,7 +422,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -433,7 +433,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -447,7 +447,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -460,11 +460,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue/FunctionObject_FunctionExpression_D67744E0_L32C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue/FunctionObject::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -478,11 +478,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue/FunctionObject_FunctionExpression_D67744E0_L32C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue/FunctionObject::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -500,9 +500,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D67744E0_L32C18
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -560,7 +560,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_09405E31_L33C18
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -580,9 +580,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue/FunctionObject_FunctionExpression_09405E31_L33C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue/FunctionObject::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -593,7 +593,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -604,7 +604,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -618,7 +618,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -631,14 +631,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue/FunctionObject_FunctionExpression_09405E31_L33C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue/FunctionObject::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -652,14 +652,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue/FunctionObject_FunctionExpression_09405E31_L33C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue/FunctionObject::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -677,9 +677,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_09405E31_L33C18
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -738,7 +738,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_442D5AC0_flip
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -758,9 +758,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -771,7 +771,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -782,7 +782,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -796,7 +796,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -809,11 +809,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -827,11 +827,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -849,9 +849,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_442D5AC0_flip
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1196,9 +1196,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope,
-			[1] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive/FunctionObject_FunctionDeclaration_25BCDD16_addFive,
-			[2] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump,
-			[3] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip,
+			[1] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive/FunctionObject,
+			[2] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject,
+			[3] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -1227,14 +1227,14 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
-		IL_0012: newobj instance void Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive/FunctionObject_FunctionDeclaration_25BCDD16_addFive::.ctor()
+		IL_0012: newobj instance void Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "addFive"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive/FunctionObject_FunctionDeclaration_25BCDD16_addFive>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive/FunctionObject_FunctionDeclaration_25BCDD16_addFive>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: ldc.i4.1
 		IL_002c: newarr [System.Runtime]System.Object
@@ -1247,14 +1247,14 @@
 		IL_0039: ldc.i4.0
 		IL_003a: ldelem.ref
 		IL_003b: castclass Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope
-		IL_0040: newobj instance void Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump::.ctor(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope)
+		IL_0040: newobj instance void Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject::.ctor(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope)
 		IL_0045: ldc.i4.0
 		IL_0046: conv.r8
 		IL_0047: ldstr "bump"
 		IL_004c: ldc.i4.0
 		IL_004d: ldc.i4.0
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump>(!!0, float64, string, bool, bool)
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump>(!!0)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject>(!!0)
 		IL_0058: stloc.2
 		IL_0059: ldc.i4.1
 		IL_005a: newarr [System.Runtime]System.Object
@@ -1267,14 +1267,14 @@
 		IL_0067: ldc.i4.0
 		IL_0068: ldelem.ref
 		IL_0069: castclass Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope
-		IL_006e: newobj instance void Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip::.ctor(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope)
+		IL_006e: newobj instance void Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject::.ctor(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope)
 		IL_0073: ldc.i4.0
 		IL_0074: conv.r8
 		IL_0075: ldstr "flip"
 		IL_007a: ldc.i4.0
 		IL_007b: ldc.i4.0
-		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip>(!!0, float64, string, bool, bool)
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip>(!!0)
+		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject>(!!0)
 		IL_0086: stloc.3
 		IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_008c: dup

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Inference_EnumerationAndJson_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Inference_EnumerationAndJson_Parity.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F0AB7575_L17C41
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -98,7 +98,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -117,7 +117,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -135,9 +135,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F0AB7575_L17C41
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -203,7 +203,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_094B7E6B_L31C7
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -217,7 +217,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -228,7 +228,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -239,7 +239,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -253,7 +253,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -269,7 +269,7 @@
 				IL_0005: call float64 Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -286,7 +286,7 @@
 				IL_0001: call float64 Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -304,9 +304,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_094B7E6B_L31C7
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -541,9 +541,9 @@
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[14] string,
 			[15] object[],
-			[16] class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject_FunctionExpression_F0AB7575_L17C41,
+			[16] class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject,
 			[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[18] class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject_FunctionExpression_094B7E6B_L31C7,
+			[18] class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject,
 			[19] object,
 			[20] float64,
 			[21] object,
@@ -673,14 +673,14 @@
 		IL_0194: ldloc.0
 		IL_0195: stelem.ref
 		IL_0196: stloc.s 15
-		IL_0198: newobj instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject_FunctionExpression_F0AB7575_L17C41::.ctor()
+		IL_0198: newobj instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject::.ctor()
 		IL_019d: ldc.i4.1
 		IL_019e: conv.r8
 		IL_019f: ldstr ""
 		IL_01a4: ldc.i4.0
 		IL_01a5: ldc.i4.0
-		IL_01a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject_FunctionExpression_F0AB7575_L17C41>(!!0, float64, string, bool, bool)
-		IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject_FunctionExpression_F0AB7575_L17C41>(!!0)
+		IL_01a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject>(!!0)
 		IL_01b0: stloc.s 16
 		IL_01b2: ldloc.s 11
 		IL_01b4: ldstr "map"
@@ -758,14 +758,14 @@
 		IL_02b6: ldloc.0
 		IL_02b7: stelem.ref
 		IL_02b8: stloc.s 15
-		IL_02ba: newobj instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject_FunctionExpression_094B7E6B_L31C7::.ctor()
+		IL_02ba: newobj instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject::.ctor()
 		IL_02bf: ldc.i4.0
 		IL_02c0: conv.r8
 		IL_02c1: ldstr ""
 		IL_02c6: ldc.i4.0
 		IL_02c7: ldc.i4.0
-		IL_02c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject_FunctionExpression_094B7E6B_L31C7>(!!0, float64, string, bool, bool)
-		IL_02cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject_FunctionExpression_094B7E6B_L31C7>(!!0)
+		IL_02c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_02cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject>(!!0)
 		IL_02d2: stloc.s 18
 		IL_02d4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_02d9: dup

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InferredConstruction_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InferredConstruction_Parity.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_076C2543_L6C7
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -95,7 +95,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -111,7 +111,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -129,9 +129,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_076C2543_L6C7
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -176,7 +176,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E0AC30F6_L18C7
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -190,7 +190,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -201,7 +201,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -212,7 +212,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -226,7 +226,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -241,7 +241,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -257,7 +257,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -275,9 +275,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E0AC30F6_L18C7
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -322,7 +322,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3622E258_leak
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -336,7 +336,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -347,7 +347,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -358,7 +358,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -372,7 +372,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -390,7 +390,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ObjectLiteral_InferredConstruction_Parity/leak::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -409,7 +409,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.ObjectLiteral_InferredConstruction_Parity/leak::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -427,9 +427,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3622E258_leak
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -698,13 +698,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_InferredConstruction_Parity/Scope,
-			[1] class Modules.ObjectLiteral_InferredConstruction_Parity/leak/FunctionObject_FunctionDeclaration_3622E258_leak,
+			[1] class Modules.ObjectLiteral_InferredConstruction_Parity/leak/FunctionObject,
 			[2] class Modules.ObjectLiteral_InferredConstruction_Parity/ObjectLiterals/L1C18_eligible,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[6] object[],
-			[7] class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible/FunctionObject_FunctionExpression_076C2543_L6C7,
+			[7] class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[9] string,
 			[10] float64,
@@ -715,7 +715,7 @@
 			[15] object,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject,
 			[17] string,
-			[18] class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a/FunctionObject_FunctionExpression_E0AC30F6_L18C7,
+			[18] class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a/FunctionObject,
 			[19] object,
 			[20] object,
 			[21] object
@@ -730,14 +730,14 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/leak/FunctionObject_FunctionDeclaration_3622E258_leak::.ctor()
+		IL_0012: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/leak/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "leak"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InferredConstruction_Parity/leak/FunctionObject_FunctionDeclaration_3622E258_leak>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InferredConstruction_Parity/leak/FunctionObject_FunctionDeclaration_3622E258_leak>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InferredConstruction_Parity/leak/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InferredConstruction_Parity/leak/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: ldc.i4.1
 		IL_002c: newarr [System.Runtime]System.Object
@@ -746,14 +746,14 @@
 		IL_0033: ldloc.0
 		IL_0034: stelem.ref
 		IL_0035: stloc.s 6
-		IL_0037: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible/FunctionObject_FunctionExpression_076C2543_L6C7::.ctor()
+		IL_0037: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible/FunctionObject::.ctor()
 		IL_003c: ldc.i4.0
 		IL_003d: conv.r8
 		IL_003e: ldstr ""
 		IL_0043: ldc.i4.0
 		IL_0044: ldc.i4.0
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible/FunctionObject_FunctionExpression_076C2543_L6C7>(!!0, float64, string, bool, bool)
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible/FunctionObject_FunctionExpression_076C2543_L6C7>(!!0)
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible/FunctionObject>(!!0)
 		IL_004f: stloc.s 7
 		IL_0051: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/ObjectLiterals/L1C18_eligible::.ctor()
 		IL_0056: stloc.2
@@ -844,14 +844,14 @@
 		IL_0136: ldloc.0
 		IL_0137: stelem.ref
 		IL_0138: stloc.s 6
-		IL_013a: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a/FunctionObject_FunctionExpression_E0AC30F6_L18C7::.ctor()
+		IL_013a: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a/FunctionObject::.ctor()
 		IL_013f: ldc.i4.0
 		IL_0140: conv.r8
 		IL_0141: ldstr ""
 		IL_0146: ldc.i4.0
 		IL_0147: ldc.i4.0
-		IL_0148: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a/FunctionObject_FunctionExpression_E0AC30F6_L18C7>(!!0, float64, string, bool, bool)
-		IL_014d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a/FunctionObject_FunctionExpression_E0AC30F6_L18C7>(!!0)
+		IL_0148: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_014d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a/FunctionObject>(!!0)
 		IL_0152: stloc.s 18
 		IL_0154: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0159: dup

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InlinePropertyInit.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InlinePropertyInit.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6E078FF7_getX
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_InlinePropertyInit/Scope Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject_FunctionDeclaration_6E078FF7_getX::_environment0_ObjectLiteral_InlinePropertyInit
+				IL_0008: stfld class Modules.ObjectLiteral_InlinePropertyInit/Scope Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject::_environment0_ObjectLiteral_InlinePropertyInit
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_InlinePropertyInit/Scope Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject_FunctionDeclaration_6E078FF7_getX::_environment0_ObjectLiteral_InlinePropertyInit
+				IL_0001: ldfld class Modules.ObjectLiteral_InlinePropertyInit/Scope Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject::_environment0_ObjectLiteral_InlinePropertyInit
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.ObjectLiteral_InlinePropertyInit/getX::__js_call__(class Modules.ObjectLiteral_InlinePropertyInit/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_InlinePropertyInit/Scope Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject_FunctionDeclaration_6E078FF7_getX::_environment0_ObjectLiteral_InlinePropertyInit
+				IL_0001: ldfld class Modules.ObjectLiteral_InlinePropertyInit/Scope Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject::_environment0_ObjectLiteral_InlinePropertyInit
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.ObjectLiteral_InlinePropertyInit/getX::__js_call__(class Modules.ObjectLiteral_InlinePropertyInit/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6E078FF7_getX
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -214,7 +214,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_InlinePropertyInit/Scope,
-			[1] class Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject_FunctionDeclaration_6E078FF7_getX,
+			[1] class Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -234,13 +234,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.ObjectLiteral_InlinePropertyInit/Scope
-		IL_0019: newobj instance void Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject_FunctionDeclaration_6E078FF7_getX::.ctor(class Modules.ObjectLiteral_InlinePropertyInit/Scope)
+		IL_0019: newobj instance void Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject::.ctor(class Modules.ObjectLiteral_InlinePropertyInit/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "getX"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject_FunctionDeclaration_6E078FF7_getX>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InterproceduralInference_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InterproceduralInference_Parity.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8C67F5E2_c
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -98,7 +98,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/c::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -117,7 +117,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/c::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -135,9 +135,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8C67F5E2_c
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -197,7 +197,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DDB94903_h6
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -211,7 +211,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -222,7 +222,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -233,7 +233,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -247,7 +247,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -265,7 +265,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h6::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -284,7 +284,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h6::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -302,9 +302,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DDB94903_h6
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -368,7 +368,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DEB94A96_h5
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -388,9 +388,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -401,7 +401,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -412,7 +412,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -426,7 +426,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -439,14 +439,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h5::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -460,14 +460,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h5::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -485,9 +485,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DEB94A96_h5
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -540,7 +540,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DFB94C29_h4
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -560,9 +560,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -573,7 +573,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -584,7 +584,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -598,7 +598,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -611,14 +611,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h4::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -632,14 +632,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h4::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -657,9 +657,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DFB94C29_h4
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -714,7 +714,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E0B94DBC_h3
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -734,9 +734,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -747,7 +747,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -758,7 +758,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -772,7 +772,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -785,14 +785,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h3::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -806,14 +806,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h3::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -831,9 +831,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E0B94DBC_h3
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -888,7 +888,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E1B94F4F_h2
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -908,9 +908,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -921,7 +921,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -932,7 +932,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -946,7 +946,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -959,14 +959,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h2::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -980,14 +980,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h2::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1005,9 +1005,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E1B94F4F_h2
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1062,7 +1062,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E2B950E2_h1
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1082,9 +1082,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1095,7 +1095,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1106,7 +1106,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1120,7 +1120,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1133,14 +1133,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h1::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1154,14 +1154,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject::_environment0_ObjectLiteral_InterproceduralInference_Parity
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h1::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1179,9 +1179,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E2B950E2_h1
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1236,7 +1236,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4A6A76F7_readX
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1250,7 +1250,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1261,7 +1261,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1272,7 +1272,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1286,7 +1286,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1304,7 +1304,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readX::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1323,7 +1323,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readX::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1341,9 +1341,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4A6A76F7_readX
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1407,7 +1407,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_556A8848_readM
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1421,7 +1421,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1432,7 +1432,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1443,7 +1443,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1457,7 +1457,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1475,7 +1475,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readM::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1494,7 +1494,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readM::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1512,9 +1512,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_556A8848_readM
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1574,7 +1574,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AF71EA98_keep
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1588,7 +1588,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1599,7 +1599,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1610,7 +1610,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1624,7 +1624,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1642,7 +1642,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/keep::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1661,7 +1661,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/keep::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1679,9 +1679,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_AF71EA98_keep
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1744,7 +1744,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D398D3EA_readXY
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1758,7 +1758,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1769,7 +1769,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1780,7 +1780,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1794,7 +1794,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1812,7 +1812,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readXY::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1831,7 +1831,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readXY::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1849,9 +1849,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D398D3EA_readXY
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1925,7 +1925,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8838F9A5_bump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1939,7 +1939,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1950,7 +1950,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1961,7 +1961,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1975,7 +1975,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1993,7 +1993,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/bump::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2012,7 +2012,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/bump::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2030,9 +2030,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8838F9A5_bump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2112,7 +2112,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_53EB1517_shift
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2126,7 +2126,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2137,7 +2137,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2148,7 +2148,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -2162,7 +2162,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -2205,7 +2205,7 @@
 
 				IL_002e: ldloc.0
 				IL_002f: ret
-			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2229,7 +2229,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.ObjectLiteral_InterproceduralInference_Parity/shift::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2254,7 +2254,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.ObjectLiteral_InterproceduralInference_Parity/shift::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2272,9 +2272,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_53EB1517_shift
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2791,14 +2791,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope,
-			[1] class Modules.ObjectLiteral_InterproceduralInference_Parity/c/FunctionObject_FunctionDeclaration_8C67F5E2_c,
-			[2] class Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1,
-			[3] class Modules.ObjectLiteral_InterproceduralInference_Parity/readX/FunctionObject_FunctionDeclaration_4A6A76F7_readX,
-			[4] class Modules.ObjectLiteral_InterproceduralInference_Parity/readM/FunctionObject_FunctionDeclaration_556A8848_readM,
-			[5] class Modules.ObjectLiteral_InterproceduralInference_Parity/keep/FunctionObject_FunctionDeclaration_AF71EA98_keep,
-			[6] class Modules.ObjectLiteral_InterproceduralInference_Parity/readXY/FunctionObject_FunctionDeclaration_D398D3EA_readXY,
-			[7] class Modules.ObjectLiteral_InterproceduralInference_Parity/bump/FunctionObject_FunctionDeclaration_8838F9A5_bump,
-			[8] class Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject_FunctionDeclaration_53EB1517_shift,
+			[1] class Modules.ObjectLiteral_InterproceduralInference_Parity/c/FunctionObject,
+			[2] class Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject,
+			[3] class Modules.ObjectLiteral_InterproceduralInference_Parity/readX/FunctionObject,
+			[4] class Modules.ObjectLiteral_InterproceduralInference_Parity/readM/FunctionObject,
+			[5] class Modules.ObjectLiteral_InterproceduralInference_Parity/keep/FunctionObject,
+			[6] class Modules.ObjectLiteral_InterproceduralInference_Parity/readXY/FunctionObject,
+			[7] class Modules.ObjectLiteral_InterproceduralInference_Parity/bump/FunctionObject,
+			[8] class Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject,
 			[9] class Modules.ObjectLiteral_InterproceduralInference_Parity/ObjectLiterals/L2C11_a,
 			[10] class Modules.ObjectLiteral_InterproceduralInference_Parity/ObjectLiterals/L9C11_p,
 			[11] class Modules.ObjectLiteral_InterproceduralInference_Parity/ObjectLiterals/L19C12_s1,
@@ -2812,11 +2812,11 @@
 			[19] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[20] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[21] object[],
-			[22] class Modules.ObjectLiteral_InterproceduralInference_Parity/h6/FunctionObject_FunctionDeclaration_DDB94903_h6,
-			[23] class Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5,
-			[24] class Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4,
-			[25] class Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3,
-			[26] class Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2,
+			[22] class Modules.ObjectLiteral_InterproceduralInference_Parity/h6/FunctionObject,
+			[23] class Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject,
+			[24] class Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject,
+			[25] class Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject,
+			[26] class Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject,
 			[27] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
 
@@ -2829,14 +2829,14 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 21
-		IL_0012: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/c/FunctionObject_FunctionDeclaration_8C67F5E2_c::.ctor()
+		IL_0012: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/c/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "c"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/c/FunctionObject_FunctionDeclaration_8C67F5E2_c>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/c/FunctionObject_FunctionDeclaration_8C67F5E2_c>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/c/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/c/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: ldc.i4.1
 		IL_002c: newarr [System.Runtime]System.Object
@@ -2845,14 +2845,14 @@
 		IL_0033: ldloc.0
 		IL_0034: stelem.ref
 		IL_0035: stloc.s 21
-		IL_0037: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h6/FunctionObject_FunctionDeclaration_DDB94903_h6::.ctor()
+		IL_0037: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h6/FunctionObject::.ctor()
 		IL_003c: ldc.i4.1
 		IL_003d: conv.r8
 		IL_003e: ldstr "h6"
 		IL_0043: ldc.i4.0
 		IL_0044: ldc.i4.0
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h6/FunctionObject_FunctionDeclaration_DDB94903_h6>(!!0, float64, string, bool, bool)
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/h6/FunctionObject_FunctionDeclaration_DDB94903_h6>(!!0)
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h6/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/h6/FunctionObject>(!!0)
 		IL_004f: stloc.s 22
 		IL_0051: ldloc.0
 		IL_0052: ldloc.s 22
@@ -2868,14 +2868,14 @@
 		IL_0067: ldc.i4.0
 		IL_0068: ldelem.ref
 		IL_0069: castclass Modules.ObjectLiteral_InterproceduralInference_Parity/Scope
-		IL_006e: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
+		IL_006e: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
 		IL_0073: ldc.i4.1
 		IL_0074: conv.r8
 		IL_0075: ldstr "h5"
 		IL_007a: ldc.i4.0
 		IL_007b: ldc.i4.0
-		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5>(!!0, float64, string, bool, bool)
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5>(!!0)
+		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject>(!!0)
 		IL_0086: stloc.s 23
 		IL_0088: ldloc.0
 		IL_0089: ldloc.s 23
@@ -2891,14 +2891,14 @@
 		IL_009e: ldc.i4.0
 		IL_009f: ldelem.ref
 		IL_00a0: castclass Modules.ObjectLiteral_InterproceduralInference_Parity/Scope
-		IL_00a5: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
+		IL_00a5: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
 		IL_00aa: ldc.i4.1
 		IL_00ab: conv.r8
 		IL_00ac: ldstr "h4"
 		IL_00b1: ldc.i4.0
 		IL_00b2: ldc.i4.0
-		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4>(!!0, float64, string, bool, bool)
-		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4>(!!0)
+		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject>(!!0)
 		IL_00bd: stloc.s 24
 		IL_00bf: ldloc.0
 		IL_00c0: ldloc.s 24
@@ -2914,14 +2914,14 @@
 		IL_00d5: ldc.i4.0
 		IL_00d6: ldelem.ref
 		IL_00d7: castclass Modules.ObjectLiteral_InterproceduralInference_Parity/Scope
-		IL_00dc: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
+		IL_00dc: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
 		IL_00e1: ldc.i4.1
 		IL_00e2: conv.r8
 		IL_00e3: ldstr "h3"
 		IL_00e8: ldc.i4.0
 		IL_00e9: ldc.i4.0
-		IL_00ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3>(!!0, float64, string, bool, bool)
-		IL_00ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3>(!!0)
+		IL_00ea: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00ef: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject>(!!0)
 		IL_00f4: stloc.s 25
 		IL_00f6: ldloc.0
 		IL_00f7: ldloc.s 25
@@ -2937,14 +2937,14 @@
 		IL_010c: ldc.i4.0
 		IL_010d: ldelem.ref
 		IL_010e: castclass Modules.ObjectLiteral_InterproceduralInference_Parity/Scope
-		IL_0113: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
+		IL_0113: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
 		IL_0118: ldc.i4.1
 		IL_0119: conv.r8
 		IL_011a: ldstr "h2"
 		IL_011f: ldc.i4.0
 		IL_0120: ldc.i4.0
-		IL_0121: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2>(!!0, float64, string, bool, bool)
-		IL_0126: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2>(!!0)
+		IL_0121: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0126: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject>(!!0)
 		IL_012b: stloc.s 26
 		IL_012d: ldloc.0
 		IL_012e: ldloc.s 26
@@ -2960,14 +2960,14 @@
 		IL_0143: ldc.i4.0
 		IL_0144: ldelem.ref
 		IL_0145: castclass Modules.ObjectLiteral_InterproceduralInference_Parity/Scope
-		IL_014a: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
+		IL_014a: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
 		IL_014f: ldc.i4.1
 		IL_0150: conv.r8
 		IL_0151: ldstr "h1"
 		IL_0156: ldc.i4.0
 		IL_0157: ldc.i4.0
-		IL_0158: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1>(!!0, float64, string, bool, bool)
-		IL_015d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1>(!!0)
+		IL_0158: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_015d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject>(!!0)
 		IL_0162: stloc.2
 		IL_0163: ldc.i4.1
 		IL_0164: newarr [System.Runtime]System.Object
@@ -2976,14 +2976,14 @@
 		IL_016b: ldloc.0
 		IL_016c: stelem.ref
 		IL_016d: stloc.s 21
-		IL_016f: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/readX/FunctionObject_FunctionDeclaration_4A6A76F7_readX::.ctor()
+		IL_016f: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/readX/FunctionObject::.ctor()
 		IL_0174: ldc.i4.1
 		IL_0175: conv.r8
 		IL_0176: ldstr "readX"
 		IL_017b: ldc.i4.0
 		IL_017c: ldc.i4.0
-		IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/readX/FunctionObject_FunctionDeclaration_4A6A76F7_readX>(!!0, float64, string, bool, bool)
-		IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/readX/FunctionObject_FunctionDeclaration_4A6A76F7_readX>(!!0)
+		IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/readX/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/readX/FunctionObject>(!!0)
 		IL_0187: stloc.3
 		IL_0188: ldc.i4.1
 		IL_0189: newarr [System.Runtime]System.Object
@@ -2992,14 +2992,14 @@
 		IL_0190: ldloc.0
 		IL_0191: stelem.ref
 		IL_0192: stloc.s 21
-		IL_0194: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/readM/FunctionObject_FunctionDeclaration_556A8848_readM::.ctor()
+		IL_0194: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/readM/FunctionObject::.ctor()
 		IL_0199: ldc.i4.1
 		IL_019a: conv.r8
 		IL_019b: ldstr "readM"
 		IL_01a0: ldc.i4.0
 		IL_01a1: ldc.i4.0
-		IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/readM/FunctionObject_FunctionDeclaration_556A8848_readM>(!!0, float64, string, bool, bool)
-		IL_01a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/readM/FunctionObject_FunctionDeclaration_556A8848_readM>(!!0)
+		IL_01a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/readM/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01a7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/readM/FunctionObject>(!!0)
 		IL_01ac: stloc.s 4
 		IL_01ae: ldc.i4.1
 		IL_01af: newarr [System.Runtime]System.Object
@@ -3008,14 +3008,14 @@
 		IL_01b6: ldloc.0
 		IL_01b7: stelem.ref
 		IL_01b8: stloc.s 21
-		IL_01ba: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/keep/FunctionObject_FunctionDeclaration_AF71EA98_keep::.ctor()
+		IL_01ba: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/keep/FunctionObject::.ctor()
 		IL_01bf: ldc.i4.1
 		IL_01c0: conv.r8
 		IL_01c1: ldstr "keep"
 		IL_01c6: ldc.i4.0
 		IL_01c7: ldc.i4.0
-		IL_01c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/keep/FunctionObject_FunctionDeclaration_AF71EA98_keep>(!!0, float64, string, bool, bool)
-		IL_01cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/keep/FunctionObject_FunctionDeclaration_AF71EA98_keep>(!!0)
+		IL_01c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/keep/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/keep/FunctionObject>(!!0)
 		IL_01d2: stloc.s 5
 		IL_01d4: ldc.i4.1
 		IL_01d5: newarr [System.Runtime]System.Object
@@ -3024,14 +3024,14 @@
 		IL_01dc: ldloc.0
 		IL_01dd: stelem.ref
 		IL_01de: stloc.s 21
-		IL_01e0: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/readXY/FunctionObject_FunctionDeclaration_D398D3EA_readXY::.ctor()
+		IL_01e0: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/readXY/FunctionObject::.ctor()
 		IL_01e5: ldc.i4.1
 		IL_01e6: conv.r8
 		IL_01e7: ldstr "readXY"
 		IL_01ec: ldc.i4.0
 		IL_01ed: ldc.i4.0
-		IL_01ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/readXY/FunctionObject_FunctionDeclaration_D398D3EA_readXY>(!!0, float64, string, bool, bool)
-		IL_01f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/readXY/FunctionObject_FunctionDeclaration_D398D3EA_readXY>(!!0)
+		IL_01ee: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/readXY/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/readXY/FunctionObject>(!!0)
 		IL_01f8: stloc.s 6
 		IL_01fa: ldc.i4.1
 		IL_01fb: newarr [System.Runtime]System.Object
@@ -3040,14 +3040,14 @@
 		IL_0202: ldloc.0
 		IL_0203: stelem.ref
 		IL_0204: stloc.s 21
-		IL_0206: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/bump/FunctionObject_FunctionDeclaration_8838F9A5_bump::.ctor()
+		IL_0206: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/bump/FunctionObject::.ctor()
 		IL_020b: ldc.i4.1
 		IL_020c: conv.r8
 		IL_020d: ldstr "bump"
 		IL_0212: ldc.i4.0
 		IL_0213: ldc.i4.0
-		IL_0214: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/bump/FunctionObject_FunctionDeclaration_8838F9A5_bump>(!!0, float64, string, bool, bool)
-		IL_0219: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/bump/FunctionObject_FunctionDeclaration_8838F9A5_bump>(!!0)
+		IL_0214: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/bump/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0219: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/bump/FunctionObject>(!!0)
 		IL_021e: stloc.s 7
 		IL_0220: ldc.i4.1
 		IL_0221: newarr [System.Runtime]System.Object
@@ -3056,14 +3056,14 @@
 		IL_0228: ldloc.0
 		IL_0229: stelem.ref
 		IL_022a: stloc.s 21
-		IL_022c: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject_FunctionDeclaration_53EB1517_shift::.ctor()
+		IL_022c: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject::.ctor()
 		IL_0231: ldc.i4.3
 		IL_0232: conv.r8
 		IL_0233: ldstr "shift"
 		IL_0238: ldc.i4.0
 		IL_0239: ldc.i4.0
-		IL_023a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject_FunctionDeclaration_53EB1517_shift>(!!0, float64, string, bool, bool)
-		IL_023f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject_FunctionDeclaration_53EB1517_shift>(!!0)
+		IL_023a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_023f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject>(!!0)
 		IL_0244: stloc.s 8
 		IL_0246: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/ObjectLiterals/L2C11_a::.ctor()
 		IL_024b: stloc.s 9
@@ -3213,7 +3213,7 @@
 		IL_0418: ldloc.0
 		IL_0419: stelem.ref
 		IL_041a: ldloc.s 21
-		IL_041c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject_FunctionDeclaration_53EB1517_shift::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
+		IL_041c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject::__js_call_with_arguments__(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, object[], object[])
 		IL_0421: pop
 		IL_0422: ret
 	} // end of method ObjectLiteral_InterproceduralInference_Parity::__js_module_init__

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ShorthandAndMethod.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ShorthandAndMethod.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_95740A33_L8C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,9 +81,9 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_95740A33_L8C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -154,7 +154,7 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] object,
 			[6] object[],
-			[7] class Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o/FunctionObject_FunctionExpression_95740A33_L8C20
+			[7] class Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.ObjectLiteral_ShorthandAndMethod/Scope::.ctor()
@@ -192,14 +192,14 @@
 		IL_0066: ldloc.0
 		IL_0067: stelem.ref
 		IL_0068: stloc.s 6
-		IL_006a: newobj instance void Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o/FunctionObject_FunctionExpression_95740A33_L8C20::.ctor()
+		IL_006a: newobj instance void Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o/FunctionObject::.ctor()
 		IL_006f: ldc.i4.0
 		IL_0070: conv.r8
 		IL_0071: ldstr ""
 		IL_0076: ldc.i4.1
 		IL_0077: ldc.i4.1
-		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o/FunctionObject_FunctionExpression_95740A33_L8C20>(!!0, float64, string, bool, bool)
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o/FunctionObject_FunctionExpression_95740A33_L8C20>(!!0)
+		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o/FunctionObject>(!!0)
 		IL_0082: stloc.s 7
 		IL_0084: ldloc.s 4
 		IL_0086: ldstr "m"

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_AccessorTransitions_And_Invariants.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_AccessorTransitions_And_Invariants.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_652775DD_getter
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -82,7 +82,7 @@
 				IL_0005: call float64 Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -99,7 +99,7 @@
 				IL_0001: call float64 Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -117,9 +117,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_652775DD_getter
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -164,7 +164,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EE8F74E0_setter1
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -184,9 +184,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject_FunctionDeclaration_EE8F74E0_setter1::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+				IL_0008: stfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -197,7 +197,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -208,7 +208,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -221,14 +221,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject_FunctionDeclaration_EE8F74E0_setter1::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+				IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1::__js_call__(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -242,14 +242,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject_FunctionDeclaration_EE8F74E0_setter1::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+				IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1::__js_call__(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -267,9 +267,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_EE8F74E0_setter1
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -335,7 +335,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F18F7999_setter2
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -355,9 +355,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject_FunctionDeclaration_F18F7999_setter2::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+				IL_0008: stfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -368,7 +368,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -379,7 +379,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -392,14 +392,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject_FunctionDeclaration_F18F7999_setter2::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+				IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2::__js_call__(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -413,14 +413,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject_FunctionDeclaration_F18F7999_setter2::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+				IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2::__js_call__(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -438,9 +438,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F18F7999_setter2
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -685,9 +685,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope,
-			[1] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter/FunctionObject_FunctionDeclaration_652775DD_getter,
-			[2] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject_FunctionDeclaration_EE8F74E0_setter1,
-			[3] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject_FunctionDeclaration_F18F7999_setter2,
+			[1] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter/FunctionObject,
+			[2] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject,
+			[3] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] object,
 			[6] class [System.Runtime]System.Exception,
@@ -726,13 +726,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 24
-		IL_0012: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter/FunctionObject_FunctionDeclaration_652775DD_getter::.ctor()
+		IL_0012: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter/FunctionObject::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "getter"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter/FunctionObject_FunctionDeclaration_652775DD_getter>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -745,13 +745,13 @@
 		IL_0034: ldc.i4.0
 		IL_0035: ldelem.ref
 		IL_0036: castclass Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope
-		IL_003b: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject_FunctionDeclaration_EE8F74E0_setter1::.ctor(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope)
+		IL_003b: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject::.ctor(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope)
 		IL_0040: ldc.i4.1
 		IL_0041: conv.r8
 		IL_0042: ldstr "setter1"
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject_FunctionDeclaration_EE8F74E0_setter1>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: ldc.i4.1
 		IL_0050: newarr [System.Runtime]System.Object
@@ -764,13 +764,13 @@
 		IL_005d: ldc.i4.0
 		IL_005e: ldelem.ref
 		IL_005f: castclass Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope
-		IL_0064: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject_FunctionDeclaration_F18F7999_setter2::.ctor(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope)
+		IL_0064: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject::.ctor(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope)
 		IL_0069: ldc.i4.1
 		IL_006a: conv.r8
 		IL_006b: ldstr "setter2"
 		IL_0070: ldc.i4.0
 		IL_0071: ldc.i4.1
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject_FunctionDeclaration_F18F7999_setter2>(!!0, float64, string, bool, bool)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0077: stloc.3
 		IL_0078: nop
 		IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_GroupBy_Basic.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_GroupBy_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7AE9A538_L3C47
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Object_GroupBy_Basic/FunctionExpression_grouped::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Object_GroupBy_Basic/FunctionExpression_grouped::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7AE9A538_L3C47
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -195,7 +195,7 @@
 			[1] object,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object[],
-			[4] class Modules.Object_GroupBy_Basic/FunctionExpression_grouped/FunctionObject_FunctionExpression_7AE9A538_L3C47,
+			[4] class Modules.Object_GroupBy_Basic/FunctionExpression_grouped/FunctionObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[6] object,
 			[7] bool,
@@ -235,13 +235,13 @@
 		IL_0061: ldloc.0
 		IL_0062: stelem.ref
 		IL_0063: stloc.3
-		IL_0064: newobj instance void Modules.Object_GroupBy_Basic/FunctionExpression_grouped/FunctionObject_FunctionExpression_7AE9A538_L3C47::.ctor()
+		IL_0064: newobj instance void Modules.Object_GroupBy_Basic/FunctionExpression_grouped/FunctionObject::.ctor()
 		IL_0069: ldc.i4.1
 		IL_006a: conv.r8
 		IL_006b: ldstr ""
 		IL_0070: ldc.i4.0
 		IL_0071: ldc.i4.1
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_GroupBy_Basic/FunctionExpression_grouped/FunctionObject_FunctionExpression_7AE9A538_L3C47>(!!0, float64, string, bool, bool)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_GroupBy_Basic/FunctionExpression_grouped/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0077: stloc.s 4
 		IL_0079: ldloc.2
 		IL_007a: ldloc.s 4

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Integrity_DefineProperty_And_StrictWrites.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Integrity_DefineProperty_And_StrictWrites.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_268A99E2_L49C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -82,7 +82,7 @@
 				IL_0005: call float64 Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -99,7 +99,7 @@
 				IL_0001: call float64 Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -117,9 +117,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_268A99E2_L49C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -394,7 +394,7 @@
 			[24] object,
 			[25] object,
 			[26] object[],
-			[27] class Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7/FunctionObject_FunctionExpression_268A99E2_L49C8,
+			[27] class Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7/FunctionObject,
 			[28] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -764,13 +764,13 @@
 		IL_0402: ldloc.0
 		IL_0403: stelem.ref
 		IL_0404: stloc.s 26
-		IL_0406: newobj instance void Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7/FunctionObject_FunctionExpression_268A99E2_L49C8::.ctor()
+		IL_0406: newobj instance void Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7/FunctionObject::.ctor()
 		IL_040b: ldc.i4.0
 		IL_040c: conv.r8
 		IL_040d: ldstr ""
 		IL_0412: ldc.i4.0
 		IL_0413: ldc.i4.1
-		IL_0414: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7/FunctionObject_FunctionExpression_268A99E2_L49C8>(!!0, float64, string, bool, bool)
+		IL_0414: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0419: stloc.s 27
 		IL_041b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0420: dup

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Prototype_LegacyAccessors.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Prototype_LegacyAccessors.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_25CE272F_L4C48
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_25CE272F_L4C48
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -170,7 +170,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_33787FB6_L5C48
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -184,7 +184,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -195,7 +195,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -206,7 +206,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -224,7 +224,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -243,7 +243,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -261,9 +261,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_33787FB6_L5C48
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -331,8 +331,8 @@
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[2] object,
 			[3] object[],
-			[4] class Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47/FunctionObject_FunctionExpression_25CE272F_L4C48,
-			[5] class Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47/FunctionObject_FunctionExpression_33787FB6_L5C48,
+			[4] class Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47/FunctionObject,
+			[5] class Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[7] string,
 			[8] bool,
@@ -367,13 +367,13 @@
 		IL_0051: ldloc.0
 		IL_0052: stelem.ref
 		IL_0053: stloc.3
-		IL_0054: newobj instance void Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47/FunctionObject_FunctionExpression_25CE272F_L4C48::.ctor()
+		IL_0054: newobj instance void Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47/FunctionObject::.ctor()
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr ""
 		IL_0060: ldc.i4.1
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47/FunctionObject_FunctionExpression_25CE272F_L4C48>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 4
 		IL_0069: ldloc.2
 		IL_006a: ldstr "call"
@@ -401,13 +401,13 @@
 		IL_00ad: ldloc.0
 		IL_00ae: stelem.ref
 		IL_00af: stloc.3
-		IL_00b0: newobj instance void Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47/FunctionObject_FunctionExpression_33787FB6_L5C48::.ctor()
+		IL_00b0: newobj instance void Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47/FunctionObject::.ctor()
 		IL_00b5: ldc.i4.1
 		IL_00b6: conv.r8
 		IL_00b7: ldstr ""
 		IL_00bc: ldc.i4.1
 		IL_00bd: ldc.i4.1
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47/FunctionObject_FunctionExpression_33787FB6_L5C48>(!!0, float64, string, bool, bool)
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00c3: stloc.s 5
 		IL_00c5: ldloc.2
 		IL_00c6: ldstr "call"

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Callback_Function_Objects.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Callback_Function_Objects.verified.txt
@@ -38,7 +38,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6324E540_ordinaryReaction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -52,7 +52,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_6324E540_ordinaryReaction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6324E540_ordinaryReaction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_6324E540_ordinaryReaction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -92,7 +92,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Promise_Callback_Function_Objects/ordinaryReaction::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_6324E540_ordinaryReaction::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -111,7 +111,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Promise_Callback_Function_Objects/ordinaryReaction::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6324E540_ordinaryReaction::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -129,9 +129,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_6324E540_ordinaryReaction::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_6324E540_ordinaryReaction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -198,7 +198,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4940E47C_asyncReaction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject
 		{
 			// Fields
@@ -218,9 +218,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsAsyncFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject_FunctionExpression_4940E47C_asyncReaction::_transitionalScopes
+				IL_0008: stfld object[] Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_4940E47C_asyncReaction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -231,7 +231,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4940E47C_asyncReaction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -242,7 +242,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4940E47C_asyncReaction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance class [JavaScriptRuntime]JavaScriptRuntime.Promise CallCoreAsync (
@@ -255,7 +255,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject_FunctionExpression_4940E47C_asyncReaction::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -263,9 +263,9 @@
 				IL_0012: call object Modules.Promise_Callback_Function_Objects/asyncReaction::__js_call__(object[], object, object)
 				IL_0017: castclass [JavaScriptRuntime]JavaScriptRuntime.Promise
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionExpression_4940E47C_asyncReaction::CallCoreAsync
+			} // end of method FunctionObject::CallCoreAsync
 
-		} // end of class FunctionObject_FunctionExpression_4940E47C_asyncReaction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -336,7 +336,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_18026FA5_generatorReaction
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -356,9 +356,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject_FunctionExpression_18026FA5_generatorReaction::_transitionalScopes
+				IL_0008: stfld object[] Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_18026FA5_generatorReaction::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -369,7 +369,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_18026FA5_generatorReaction::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -380,7 +380,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_18026FA5_generatorReaction::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -393,7 +393,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject_FunctionExpression_18026FA5_generatorReaction::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -402,9 +402,9 @@
 				IL_0017: ldarg.0
 				IL_0018: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_001d: ret
-			} // end of method FunctionObject_FunctionExpression_18026FA5_generatorReaction::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_18026FA5_generatorReaction
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -447,7 +447,7 @@
 			IL_001f: ldftn object Modules.Promise_Callback_Function_Objects/generatorReaction::__js_call__(object[], object, object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc1::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject_FunctionExpression_18026FA5_generatorReaction
+			IL_002b: ldtoken Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.1
 			IL_0036: newarr [System.Runtime]System.Object
@@ -576,7 +576,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8C999746_consumeGenerator
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -590,7 +590,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_8C999746_consumeGenerator::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -601,7 +601,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8C999746_consumeGenerator::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -612,7 +612,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8C999746_consumeGenerator::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -630,7 +630,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Promise_Callback_Function_Objects/consumeGenerator::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_8C999746_consumeGenerator::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -649,7 +649,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Promise_Callback_Function_Objects/consumeGenerator::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8C999746_consumeGenerator::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -667,9 +667,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8C999746_consumeGenerator::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_8C999746_consumeGenerator
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -772,7 +772,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_507D8164_promiseTryCallback
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -786,7 +786,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_507D8164_promiseTryCallback::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -797,7 +797,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_507D8164_promiseTryCallback::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -808,7 +808,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_507D8164_promiseTryCallback::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -829,7 +829,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Promise_Callback_Function_Objects/promiseTryCallback::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_507D8164_promiseTryCallback::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -851,7 +851,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Promise_Callback_Function_Objects/promiseTryCallback::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_507D8164_promiseTryCallback::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -869,9 +869,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_507D8164_promiseTryCallback::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_507D8164_promiseTryCallback
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -931,7 +931,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1EF3B540_L20C15
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -945,7 +945,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_1EF3B540_L20C15::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -956,7 +956,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1EF3B540_L20C15::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -967,7 +967,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1EF3B540_L20C15::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -985,7 +985,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Promise_Callback_Function_Objects/FunctionExpression_L20C14::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_1EF3B540_L20C15::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1004,7 +1004,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Promise_Callback_Function_Objects/FunctionExpression_L20C14::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1EF3B540_L20C15::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1022,9 +1022,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1EF3B540_L20C15::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1EF3B540_L20C15
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1142,12 +1142,12 @@
 			[4] object,
 			[5] object,
 			[6] object[],
-			[7] class Modules.Promise_Callback_Function_Objects/ordinaryReaction/FunctionObject_FunctionExpression_6324E540_ordinaryReaction,
-			[8] class Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject_FunctionExpression_4940E47C_asyncReaction,
-			[9] class Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject_FunctionExpression_18026FA5_generatorReaction,
-			[10] class Modules.Promise_Callback_Function_Objects/consumeGenerator/FunctionObject_FunctionExpression_8C999746_consumeGenerator,
-			[11] class Modules.Promise_Callback_Function_Objects/promiseTryCallback/FunctionObject_FunctionExpression_507D8164_promiseTryCallback,
-			[12] class Modules.Promise_Callback_Function_Objects/FunctionExpression_L20C14/FunctionObject_FunctionExpression_1EF3B540_L20C15,
+			[7] class Modules.Promise_Callback_Function_Objects/ordinaryReaction/FunctionObject,
+			[8] class Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject,
+			[9] class Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject,
+			[10] class Modules.Promise_Callback_Function_Objects/consumeGenerator/FunctionObject,
+			[11] class Modules.Promise_Callback_Function_Objects/promiseTryCallback/FunctionObject,
+			[12] class Modules.Promise_Callback_Function_Objects/FunctionExpression_L20C14/FunctionObject,
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[14] object
 		)
@@ -1167,13 +1167,13 @@
 		IL_0029: ldloc.0
 		IL_002a: stelem.ref
 		IL_002b: stloc.s 6
-		IL_002d: newobj instance void Modules.Promise_Callback_Function_Objects/ordinaryReaction/FunctionObject_FunctionExpression_6324E540_ordinaryReaction::.ctor()
+		IL_002d: newobj instance void Modules.Promise_Callback_Function_Objects/ordinaryReaction/FunctionObject::.ctor()
 		IL_0032: ldc.i4.1
 		IL_0033: conv.r8
 		IL_0034: ldstr "ordinaryReaction"
 		IL_0039: ldc.i4.1
 		IL_003a: ldc.i4.1
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/ordinaryReaction/FunctionObject_FunctionExpression_6324E540_ordinaryReaction>(!!0, float64, string, bool, bool)
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/ordinaryReaction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0040: stloc.s 7
 		IL_0042: ldloc.s 5
 		IL_0044: ldstr "then"
@@ -1191,14 +1191,14 @@
 		IL_0064: stelem.ref
 		IL_0065: stloc.s 6
 		IL_0067: ldloc.s 6
-		IL_0069: newobj instance void Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject_FunctionExpression_4940E47C_asyncReaction::.ctor(object[])
+		IL_0069: newobj instance void Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject::.ctor(object[])
 		IL_006e: ldc.i4.1
 		IL_006f: conv.r8
 		IL_0070: ldstr "asyncReaction"
 		IL_0075: ldc.i4.1
 		IL_0076: ldc.i4.1
-		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject_FunctionExpression_4940E47C_asyncReaction>(!!0, float64, string, bool, bool)
-		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject_FunctionExpression_4940E47C_asyncReaction>(!!0)
+		IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.AsyncFunction::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Promise_Callback_Function_Objects/asyncReaction/FunctionObject>(!!0)
 		IL_0081: stloc.s 8
 		IL_0083: ldloc.s 5
 		IL_0085: ldstr "then"
@@ -1216,15 +1216,15 @@
 		IL_00a5: stelem.ref
 		IL_00a6: stloc.s 6
 		IL_00a8: ldloc.s 6
-		IL_00aa: newobj instance void Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject_FunctionExpression_18026FA5_generatorReaction::.ctor(object[])
+		IL_00aa: newobj instance void Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject::.ctor(object[])
 		IL_00af: ldc.i4.1
 		IL_00b0: conv.r8
 		IL_00b1: ldstr "generatorReaction"
 		IL_00b6: ldc.i4.1
 		IL_00b7: ldc.i4.1
-		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject_FunctionExpression_18026FA5_generatorReaction>(!!0, float64, string, bool, bool)
+		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00bd: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_00c2: castclass Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject_FunctionExpression_18026FA5_generatorReaction
+		IL_00c2: castclass Modules.Promise_Callback_Function_Objects/generatorReaction/FunctionObject
 		IL_00c7: stloc.s 9
 		IL_00c9: ldloc.s 5
 		IL_00cb: ldstr "then"
@@ -1241,13 +1241,13 @@
 		IL_00ea: ldloc.0
 		IL_00eb: stelem.ref
 		IL_00ec: stloc.s 6
-		IL_00ee: newobj instance void Modules.Promise_Callback_Function_Objects/consumeGenerator/FunctionObject_FunctionExpression_8C999746_consumeGenerator::.ctor()
+		IL_00ee: newobj instance void Modules.Promise_Callback_Function_Objects/consumeGenerator/FunctionObject::.ctor()
 		IL_00f3: ldc.i4.1
 		IL_00f4: conv.r8
 		IL_00f5: ldstr "consumeGenerator"
 		IL_00fa: ldc.i4.1
 		IL_00fb: ldc.i4.1
-		IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/consumeGenerator/FunctionObject_FunctionExpression_8C999746_consumeGenerator>(!!0, float64, string, bool, bool)
+		IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/consumeGenerator/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0101: stloc.s 10
 		IL_0103: ldloc.s 5
 		IL_0105: ldstr "then"
@@ -1265,13 +1265,13 @@
 		IL_012b: ldloc.0
 		IL_012c: stelem.ref
 		IL_012d: stloc.s 6
-		IL_012f: newobj instance void Modules.Promise_Callback_Function_Objects/promiseTryCallback/FunctionObject_FunctionExpression_507D8164_promiseTryCallback::.ctor()
+		IL_012f: newobj instance void Modules.Promise_Callback_Function_Objects/promiseTryCallback/FunctionObject::.ctor()
 		IL_0134: ldc.i4.2
 		IL_0135: conv.r8
 		IL_0136: ldstr "promiseTryCallback"
 		IL_013b: ldc.i4.1
 		IL_013c: ldc.i4.1
-		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/promiseTryCallback/FunctionObject_FunctionExpression_507D8164_promiseTryCallback>(!!0, float64, string, bool, bool)
+		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/promiseTryCallback/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0142: stloc.s 11
 		IL_0144: ldloc.s 5
 		IL_0146: ldstr "try"
@@ -1292,13 +1292,13 @@
 		IL_0181: ldloc.0
 		IL_0182: stelem.ref
 		IL_0183: stloc.s 6
-		IL_0185: newobj instance void Modules.Promise_Callback_Function_Objects/FunctionExpression_L20C14/FunctionObject_FunctionExpression_1EF3B540_L20C15::.ctor()
+		IL_0185: newobj instance void Modules.Promise_Callback_Function_Objects/FunctionExpression_L20C14/FunctionObject::.ctor()
 		IL_018a: ldc.i4.1
 		IL_018b: conv.r8
 		IL_018c: ldstr ""
 		IL_0191: ldc.i4.0
 		IL_0192: ldc.i4.1
-		IL_0193: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/FunctionExpression_L20C14/FunctionObject_FunctionExpression_1EF3B540_L20C15>(!!0, float64, string, bool, bool)
+		IL_0193: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Callback_Function_Objects/FunctionExpression_L20C14/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0198: stloc.s 12
 		IL_019a: ldloc.s 5
 		IL_019c: ldstr "then"

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -439,7 +439,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/Scope,
-			[1] class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl/FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl,
+			[1] class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object,
@@ -456,13 +456,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl/FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::.ctor()
+		IL_0011: newobj instance void Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "thenImpl"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl/FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Rejected.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Rejected.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -439,7 +439,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/Scope,
-			[1] class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl/FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl,
+			[1] class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object,
@@ -456,13 +456,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl/FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::.ctor()
+		IL_0011: newobj instance void Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "thenImpl"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl/FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Nested.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Nested.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_33DE5924_innerThen
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Promise_Thenable_Nested/innerThen::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Promise_Thenable_Nested/innerThen::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_33DE5924_innerThen
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -187,7 +187,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -207,9 +207,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Promise_Thenable_Nested/Scope Modules.Promise_Thenable_Nested/outerThen/FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::_environment0_Promise_Thenable_Nested
+				IL_0008: stfld class Modules.Promise_Thenable_Nested/Scope Modules.Promise_Thenable_Nested/outerThen/FunctionObject::_environment0_Promise_Thenable_Nested
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -220,7 +220,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -231,7 +231,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -244,7 +244,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Promise_Thenable_Nested/Scope Modules.Promise_Thenable_Nested/outerThen/FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::_environment0_Promise_Thenable_Nested
+				IL_0001: ldfld class Modules.Promise_Thenable_Nested/Scope Modules.Promise_Thenable_Nested/outerThen/FunctionObject::_environment0_Promise_Thenable_Nested
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -254,7 +254,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Promise_Thenable_Nested/outerThen::__js_call__(class Modules.Promise_Thenable_Nested/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -268,7 +268,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Promise_Thenable_Nested/Scope Modules.Promise_Thenable_Nested/outerThen/FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::_environment0_Promise_Thenable_Nested
+				IL_0001: ldfld class Modules.Promise_Thenable_Nested/Scope Modules.Promise_Thenable_Nested/outerThen/FunctionObject::_environment0_Promise_Thenable_Nested
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -278,7 +278,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Promise_Thenable_Nested/outerThen::__js_call__(class Modules.Promise_Thenable_Nested/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -296,9 +296,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -511,8 +511,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Nested/Scope,
-			[1] class Modules.Promise_Thenable_Nested/innerThen/FunctionObject_FunctionDeclaration_33DE5924_innerThen,
-			[2] class Modules.Promise_Thenable_Nested/outerThen/FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen,
+			[1] class Modules.Promise_Thenable_Nested/innerThen/FunctionObject,
+			[2] class Modules.Promise_Thenable_Nested/outerThen/FunctionObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object[],
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -529,13 +529,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void Modules.Promise_Thenable_Nested/innerThen/FunctionObject_FunctionDeclaration_33DE5924_innerThen::.ctor()
+		IL_0012: newobj instance void Modules.Promise_Thenable_Nested/innerThen/FunctionObject::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "innerThen"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Nested/innerThen/FunctionObject_FunctionDeclaration_33DE5924_innerThen>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Nested/innerThen/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -548,13 +548,13 @@
 		IL_0034: ldc.i4.0
 		IL_0035: ldelem.ref
 		IL_0036: castclass Modules.Promise_Thenable_Nested/Scope
-		IL_003b: newobj instance void Modules.Promise_Thenable_Nested/outerThen/FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::.ctor(class Modules.Promise_Thenable_Nested/Scope)
+		IL_003b: newobj instance void Modules.Promise_Thenable_Nested/outerThen/FunctionObject::.ctor(class Modules.Promise_Thenable_Nested/Scope)
 		IL_0040: ldc.i4.2
 		IL_0041: conv.r8
 		IL_0042: ldstr "outerThen"
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Nested/outerThen/FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Nested/outerThen/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: nop
 		IL_0050: nop

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Reject.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Reject.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Promise_Thenable_Reject/thenImpl::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Promise_Thenable_Reject/thenImpl::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -324,7 +324,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Reject/Scope,
-			[1] class Modules.Promise_Thenable_Reject/thenImpl/FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl,
+			[1] class Modules.Promise_Thenable_Reject/thenImpl/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
 			[4] object,
@@ -340,13 +340,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Promise_Thenable_Reject/thenImpl/FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::.ctor()
+		IL_0011: newobj instance void Modules.Promise_Thenable_Reject/thenImpl/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "thenImpl"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Reject/thenImpl/FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Reject/thenImpl/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Delayed.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Delayed.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A1F718B1_later
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -56,12 +56,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later::_environment1_thenImpl
+					IL_0008: stfld class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject::_environment1_thenImpl
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later::_transitionalScopes
+					IL_000f: stfld object[] Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -96,11 +96,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -114,11 +114,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -136,9 +136,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_A1F718B1_later
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -220,7 +220,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_86EAAB54_thenImpl
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -240,9 +240,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Promise_Thenable_Resolve_Delayed/Scope Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::_environment0_Promise_Thenable_Resolve_Delayed
+				IL_0008: stfld class Modules.Promise_Thenable_Resolve_Delayed/Scope Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject::_environment0_Promise_Thenable_Resolve_Delayed
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -253,7 +253,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -264,7 +264,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -277,7 +277,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Promise_Thenable_Resolve_Delayed/Scope Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::_environment0_Promise_Thenable_Resolve_Delayed
+				IL_0001: ldfld class Modules.Promise_Thenable_Resolve_Delayed/Scope Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject::_environment0_Promise_Thenable_Resolve_Delayed
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -287,7 +287,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Promise_Thenable_Resolve_Delayed/thenImpl::__js_call__(class Modules.Promise_Thenable_Resolve_Delayed/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -301,7 +301,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Promise_Thenable_Resolve_Delayed/Scope Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::_environment0_Promise_Thenable_Resolve_Delayed
+				IL_0001: ldfld class Modules.Promise_Thenable_Resolve_Delayed/Scope Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject::_environment0_Promise_Thenable_Resolve_Delayed
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -311,7 +311,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Promise_Thenable_Resolve_Delayed/thenImpl::__js_call__(class Modules.Promise_Thenable_Resolve_Delayed/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -329,9 +329,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_86EAAB54_thenImpl
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -353,7 +353,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope,
-				[1] class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later,
+				[1] class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject,
 				[2] object[]
 			)
 
@@ -378,13 +378,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope
 			IL_0024: ldloc.2
-			IL_0025: newobj instance void Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later::.ctor(class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope, object[])
+			IL_0025: newobj instance void Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject::.ctor(class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope, object[])
 			IL_002a: ldc.i4.0
 			IL_002b: conv.r8
 			IL_002c: ldstr "later"
 			IL_0031: ldc.i4.0
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.1
 			IL_0039: nop
 			IL_003a: ldloc.1
@@ -561,7 +561,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Resolve_Delayed/Scope,
-			[1] class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject_FunctionDeclaration_86EAAB54_thenImpl,
+			[1] class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
 			[4] object,
@@ -581,13 +581,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Promise_Thenable_Resolve_Delayed/Scope
-		IL_0019: newobj instance void Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::.ctor(class Modules.Promise_Thenable_Resolve_Delayed/Scope)
+		IL_0019: newobj instance void Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject::.ctor(class Modules.Promise_Thenable_Resolve_Delayed/Scope)
 		IL_001e: ldc.i4.2
 		IL_001f: conv.r8
 		IL_0020: ldstr "thenImpl"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject_FunctionDeclaration_86EAAB54_thenImpl>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Immediate.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Immediate.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_97B71571_thenImpl
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Promise_Thenable_Resolve_Immediate/thenImpl::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Promise_Thenable_Resolve_Immediate/thenImpl::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_97B71571_thenImpl
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -325,7 +325,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Resolve_Immediate/Scope,
-			[1] class Modules.Promise_Thenable_Resolve_Immediate/thenImpl/FunctionObject_FunctionDeclaration_97B71571_thenImpl,
+			[1] class Modules.Promise_Thenable_Resolve_Immediate/thenImpl/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
 			[4] object,
@@ -341,13 +341,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Promise_Thenable_Resolve_Immediate/thenImpl/FunctionObject_FunctionDeclaration_97B71571_thenImpl::.ctor()
+		IL_0011: newobj instance void Modules.Promise_Thenable_Resolve_Immediate/thenImpl/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "thenImpl"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Resolve_Immediate/thenImpl/FunctionObject_FunctionDeclaration_97B71571_thenImpl>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Resolve_Immediate/thenImpl/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Returned_FromHandler.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Returned_FromHandler.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6F5A0281_thenImpl
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Promise_Thenable_Returned_FromHandler/thenImpl::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Promise_Thenable_Returned_FromHandler/thenImpl::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6F5A0281_thenImpl
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -440,7 +440,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Returned_FromHandler/Scope,
-			[1] class Modules.Promise_Thenable_Returned_FromHandler/thenImpl/FunctionObject_FunctionDeclaration_6F5A0281_thenImpl,
+			[1] class Modules.Promise_Thenable_Returned_FromHandler/thenImpl/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object,
@@ -457,13 +457,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Promise_Thenable_Returned_FromHandler/thenImpl/FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::.ctor()
+		IL_0011: newobj instance void Modules.Promise_Thenable_Returned_FromHandler/thenImpl/FunctionObject::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "thenImpl"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Returned_FromHandler/thenImpl/FunctionObject_FunctionDeclaration_6F5A0281_thenImpl>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Returned_FromHandler/thenImpl/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_ApplyAndConstructTraps_WithFallback.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_ApplyAndConstructTraps_WithFallback.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_91358973_add
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_91358973_add::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_91358973_add::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_91358973_add::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_91358973_add::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionDeclaration_91358973_add::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_91358973_add::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_91358973_add
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -183,7 +183,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CCAF019B_L9C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -203,9 +203,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_CCAF019B_L9C10::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
+				IL_0008: stfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -216,7 +216,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -227,7 +227,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -240,7 +240,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_CCAF019B_L9C10::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
+				IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -253,7 +253,7 @@
 				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0020: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
 				IL_0025: ret
-			} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -267,7 +267,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_CCAF019B_L9C10::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
+				IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -280,7 +280,7 @@
 				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001c: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -298,9 +298,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_CCAF019B_L9C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -388,7 +388,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_78A503F9_Box
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -402,7 +402,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -413,7 +413,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -424,7 +424,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -442,7 +442,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -461,7 +461,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -479,9 +479,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_78A503F9_Box
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -534,7 +534,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1C0769A5_L25C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -554,9 +554,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject_FunctionExpression_1C0769A5_L25C14::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
+				IL_0008: stfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -567,7 +567,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -578,7 +578,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -591,7 +591,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject_FunctionExpression_1C0769A5_L25C14::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
+				IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -604,7 +604,7 @@
 				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0020: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
 				IL_0025: ret
-			} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -618,7 +618,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject_FunctionExpression_1C0769A5_L25C14::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
+				IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -631,7 +631,7 @@
 				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001c: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -649,9 +649,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1C0769A5_L25C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -756,8 +756,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope,
-			[1] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'/FunctionObject_FunctionDeclaration_91358973_add,
-			[2] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box/FunctionObject_FunctionDeclaration_78A503F9_Box,
+			[1] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'/FunctionObject,
+			[2] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box/FunctionObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[4] object,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
@@ -765,12 +765,12 @@
 			[7] object,
 			[8] object[],
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[10] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_CCAF019B_L9C10,
+			[10] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[13] object,
 			[14] string,
-			[15] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject_FunctionExpression_1C0769A5_L25C14,
+			[15] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[17] object,
 			[18] bool,
@@ -787,13 +787,13 @@
 		IL_0013: ldloc.0
 		IL_0014: stelem.ref
 		IL_0015: stloc.s 8
-		IL_0017: newobj instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'/FunctionObject_FunctionDeclaration_91358973_add::.ctor()
+		IL_0017: newobj instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'/FunctionObject::.ctor()
 		IL_001c: ldc.i4.2
 		IL_001d: conv.r8
 		IL_001e: ldstr "add"
 		IL_0023: ldc.i4.0
 		IL_0024: ldc.i4.1
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'/FunctionObject_FunctionDeclaration_91358973_add>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002a: stloc.1
 		IL_002b: ldc.i4.1
 		IL_002c: newarr [System.Runtime]System.Object
@@ -802,13 +802,13 @@
 		IL_0033: ldloc.0
 		IL_0034: stelem.ref
 		IL_0035: stloc.s 8
-		IL_0037: newobj instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box/FunctionObject_FunctionDeclaration_78A503F9_Box::.ctor()
+		IL_0037: newobj instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box/FunctionObject::.ctor()
 		IL_003c: ldc.i4.1
 		IL_003d: conv.r8
 		IL_003e: ldstr "Box"
 		IL_0043: ldc.i4.1
 		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box/FunctionObject_FunctionDeclaration_78A503F9_Box>(!!0, float64, string, bool, bool)
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004a: stloc.2
 		IL_004b: nop
 		IL_004c: nop
@@ -829,13 +829,13 @@
 		IL_006b: ldc.i4.0
 		IL_006c: ldelem.ref
 		IL_006d: castclass Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope
-		IL_0072: newobj instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_CCAF019B_L9C10::.ctor(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope)
+		IL_0072: newobj instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject::.ctor(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope)
 		IL_0077: ldc.i4.3
 		IL_0078: conv.r8
 		IL_0079: ldstr ""
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_CCAF019B_L9C10>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 10
 		IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_008c: dup
@@ -894,13 +894,13 @@
 		IL_0124: ldc.i4.0
 		IL_0125: ldelem.ref
 		IL_0126: castclass Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope
-		IL_012b: newobj instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject_FunctionExpression_1C0769A5_L25C14::.ctor(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope)
+		IL_012b: newobj instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject::.ctor(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope)
 		IL_0130: ldc.i4.3
 		IL_0131: conv.r8
 		IL_0132: ldstr ""
 		IL_0137: ldc.i4.0
 		IL_0138: ldc.i4.1
-		IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject_FunctionExpression_1C0769A5_L25C14>(!!0, float64, string, bool, bool)
+		IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_013e: stloc.s 15
 		IL_0140: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0145: dup

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_DeletePropertyTrap_And_Fallback.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_DeletePropertyTrap_And_Fallback.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_66D771F7_L7C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -71,9 +71,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject_FunctionExpression_66D771F7_L7C19::_environment0_Proxy_DeletePropertyTrap_And_Fallback
+				IL_0008: stfld class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject::_environment0_Proxy_DeletePropertyTrap_And_Fallback
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -84,7 +84,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -108,7 +108,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject_FunctionExpression_66D771F7_L7C19::_environment0_Proxy_DeletePropertyTrap_And_Fallback
+				IL_0001: ldfld class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject::_environment0_Proxy_DeletePropertyTrap_And_Fallback
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -118,7 +118,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy::__js_call__(class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -132,7 +132,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject_FunctionExpression_66D771F7_L7C19::_environment0_Proxy_DeletePropertyTrap_And_Fallback
+				IL_0001: ldfld class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject::_environment0_Proxy_DeletePropertyTrap_And_Fallback
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -142,7 +142,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy::__js_call__(class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -160,9 +160,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_66D771F7_L7C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -264,7 +264,7 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[6] object[],
-			[7] class Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject_FunctionExpression_66D771F7_L7C19,
+			[7] class Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[10] bool,
@@ -306,13 +306,13 @@
 		IL_0067: ldc.i4.0
 		IL_0068: ldelem.ref
 		IL_0069: castclass Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope
-		IL_006e: newobj instance void Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject_FunctionExpression_66D771F7_L7C19::.ctor(class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope)
+		IL_006e: newobj instance void Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject::.ctor(class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope)
 		IL_0073: ldc.i4.2
 		IL_0074: conv.r8
 		IL_0075: ldstr ""
 		IL_007a: ldc.i4.0
 		IL_007b: ldc.i4.1
-		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject_FunctionExpression_66D771F7_L7C19>(!!0, float64, string, bool, bool)
+		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0081: stloc.s 7
 		IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0088: dup

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_GetTrap_OverridesProperty.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_GetTrap_OverridesProperty.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_18B12A89_L7C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -90,7 +90,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -115,7 +115,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_18B12A89_L7C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -218,7 +218,7 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[4] object[],
-			[5] class Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler/FunctionObject_FunctionExpression_18B12A89_L7C8,
+			[5] class Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[7] object
 		)
@@ -243,13 +243,13 @@
 		IL_003d: ldloc.0
 		IL_003e: stelem.ref
 		IL_003f: stloc.s 4
-		IL_0041: newobj instance void Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler/FunctionObject_FunctionExpression_18B12A89_L7C8::.ctor()
+		IL_0041: newobj instance void Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler/FunctionObject::.ctor()
 		IL_0046: ldc.i4.3
 		IL_0047: conv.r8
 		IL_0048: ldstr ""
 		IL_004d: ldc.i4.0
 		IL_004e: ldc.i4.1
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler/FunctionObject_FunctionExpression_18B12A89_L7C8>(!!0, float64, string, bool, bool)
+		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0054: stloc.s 5
 		IL_0056: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_005b: dup

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_HasTrap_AffectsInOperator.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_HasTrap_AffectsInOperator.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C3F4D568_L7C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C3F4D568_L7C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -211,7 +211,7 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[4] object[],
-			[5] class Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler/FunctionObject_FunctionExpression_C3F4D568_L7C8,
+			[5] class Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[7] bool,
 			[8] object
@@ -233,13 +233,13 @@
 		IL_0029: ldloc.0
 		IL_002a: stelem.ref
 		IL_002b: stloc.s 4
-		IL_002d: newobj instance void Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler/FunctionObject_FunctionExpression_C3F4D568_L7C8::.ctor()
+		IL_002d: newobj instance void Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler/FunctionObject::.ctor()
 		IL_0032: ldc.i4.2
 		IL_0033: conv.r8
 		IL_0034: ldstr ""
 		IL_0039: ldc.i4.0
 		IL_003a: ldc.i4.1
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler/FunctionObject_FunctionExpression_C3F4D568_L7C8>(!!0, float64, string, bool, bool)
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0040: stloc.s 5
 		IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0047: dup

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_OwnKeys_And_PrototypeTraps_WithFallback.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_OwnKeys_And_PrototypeTraps_WithFallback.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_54FF07F3_L4C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_54FF07F3_L4C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -172,7 +172,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_38BEC47B_L14C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -192,9 +192,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject_FunctionExpression_38BEC47B_L14C19::_environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
+				IL_0008: stfld class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject::_environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -205,7 +205,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -216,7 +216,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -229,11 +229,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject_FunctionExpression_38BEC47B_L14C19::_environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
+				IL_0001: ldfld class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject::_environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy::__js_call__(class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -247,11 +247,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject_FunctionExpression_38BEC47B_L14C19::_environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
+				IL_0001: ldfld class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject::_environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy::__js_call__(class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -269,9 +269,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_38BEC47B_L14C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -320,7 +320,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A30F1C44_L17C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -334,7 +334,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -345,7 +345,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -356,7 +356,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -377,7 +377,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -399,7 +399,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -417,9 +417,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A30F1C44_L17C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -508,12 +508,12 @@
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[8] object[],
-			[9] class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy/FunctionObject_FunctionExpression_54FF07F3_L4C12,
+			[9] class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy/FunctionObject,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[12] object,
-			[13] class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject_FunctionExpression_38BEC47B_L14C19,
-			[14] class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject_FunctionExpression_A30F1C44_L17C19,
+			[13] class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject,
+			[14] class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject,
 			[15] bool,
 			[16] object
 		)
@@ -535,13 +535,13 @@
 		IL_0027: ldloc.0
 		IL_0028: stelem.ref
 		IL_0029: stloc.s 8
-		IL_002b: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy/FunctionObject_FunctionExpression_54FF07F3_L4C12::.ctor()
+		IL_002b: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy/FunctionObject::.ctor()
 		IL_0030: ldc.i4.0
 		IL_0031: conv.r8
 		IL_0032: ldstr ""
 		IL_0037: ldc.i4.0
 		IL_0038: ldc.i4.1
-		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy/FunctionObject_FunctionExpression_54FF07F3_L4C12>(!!0, float64, string, bool, bool)
+		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_003e: stloc.s 9
 		IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0045: dup
@@ -588,13 +588,13 @@
 		IL_00be: ldc.i4.0
 		IL_00bf: ldelem.ref
 		IL_00c0: castclass Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope
-		IL_00c5: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject_FunctionExpression_38BEC47B_L14C19::.ctor(class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope)
+		IL_00c5: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject::.ctor(class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope)
 		IL_00ca: ldc.i4.0
 		IL_00cb: conv.r8
 		IL_00cc: ldstr ""
 		IL_00d1: ldc.i4.0
 		IL_00d2: ldc.i4.1
-		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject_FunctionExpression_38BEC47B_L14C19>(!!0, float64, string, bool, bool)
+		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d8: stloc.s 13
 		IL_00da: ldc.i4.1
 		IL_00db: newarr [System.Runtime]System.Object
@@ -603,13 +603,13 @@
 		IL_00e2: ldloc.0
 		IL_00e3: stelem.ref
 		IL_00e4: stloc.s 8
-		IL_00e6: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject_FunctionExpression_A30F1C44_L17C19::.ctor()
+		IL_00e6: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject::.ctor()
 		IL_00eb: ldc.i4.2
 		IL_00ec: conv.r8
 		IL_00ed: ldstr ""
 		IL_00f2: ldc.i4.0
 		IL_00f3: ldc.i4.1
-		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject_FunctionExpression_A30F1C44_L17C19>(!!0, float64, string, bool, bool)
+		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00f9: stloc.s 14
 		IL_00fb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0100: dup

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5FAC858C_logThrow
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -90,9 +90,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject_FunctionDeclaration_5FAC858C_logThrow::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +103,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,7 +114,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -127,7 +127,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject_FunctionDeclaration_5FAC858C_logThrow::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -138,7 +138,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -152,7 +152,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject_FunctionDeclaration_5FAC858C_logThrow::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -163,7 +163,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -181,9 +181,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5FAC858C_logThrow
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -320,7 +320,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3925BBA6_L14C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -334,7 +334,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -345,7 +345,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -356,7 +356,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -377,7 +377,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -399,7 +399,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -417,9 +417,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_3925BBA6_L14C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -473,7 +473,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F9B416A7_L17C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -487,7 +487,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -498,7 +498,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -509,7 +509,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -533,7 +533,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7::__js_call__(object, object, object, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -558,7 +558,7 @@
 				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0016: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7::__js_call__(object, object, object, object)
 				IL_001b: ret
-			} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -576,9 +576,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F9B416A7_L17C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -633,7 +633,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DCCED563_L28C17
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -653,9 +653,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject_FunctionExpression_DCCED563_L28C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -666,7 +666,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -677,7 +677,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -690,11 +690,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject_FunctionExpression_DCCED563_L28C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -708,11 +708,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject_FunctionExpression_DCCED563_L28C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -730,9 +730,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_DCCED563_L28C17
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -792,7 +792,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_007DCDBA_L29C17
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -812,9 +812,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject_FunctionExpression_007DCDBA_L29C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -825,7 +825,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -836,7 +836,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -849,11 +849,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject_FunctionExpression_007DCDBA_L29C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -867,11 +867,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject_FunctionExpression_007DCDBA_L29C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -889,9 +889,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_007DCDBA_L29C17
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -953,7 +953,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7AF52BFC_L30C17
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -973,9 +973,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject_FunctionExpression_7AF52BFC_L30C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -986,7 +986,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -997,7 +997,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1010,11 +1010,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject_FunctionExpression_7AF52BFC_L30C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1028,11 +1028,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject_FunctionExpression_7AF52BFC_L30C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1050,9 +1050,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7AF52BFC_L30C17
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1114,7 +1114,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3C8D3F03_L31C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1134,9 +1134,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject_FunctionExpression_3C8D3F03_L31C20::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1147,7 +1147,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1158,7 +1158,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1171,11 +1171,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject_FunctionExpression_3C8D3F03_L31C20::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1189,11 +1189,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject_FunctionExpression_3C8D3F03_L31C20::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1211,9 +1211,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_3C8D3F03_L31C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1275,7 +1275,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2D98E99F_L32C18
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1295,9 +1295,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject_FunctionExpression_2D98E99F_L32C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1308,7 +1308,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1319,7 +1319,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1332,11 +1332,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject_FunctionExpression_2D98E99F_L32C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1350,11 +1350,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject_FunctionExpression_2D98E99F_L32C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1372,9 +1372,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_2D98E99F_L32C18
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1439,7 +1439,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1DE7D22D_L33C28
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1459,9 +1459,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject_FunctionExpression_1DE7D22D_L33C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1472,7 +1472,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1483,7 +1483,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1496,11 +1496,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject_FunctionExpression_1DE7D22D_L33C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1514,11 +1514,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject_FunctionExpression_1DE7D22D_L33C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1536,9 +1536,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1DE7D22D_L33C28
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1595,7 +1595,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DB63B8EE_L34C28
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1615,9 +1615,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject_FunctionExpression_DB63B8EE_L34C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1628,7 +1628,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1639,7 +1639,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1652,11 +1652,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject_FunctionExpression_DB63B8EE_L34C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1670,11 +1670,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject_FunctionExpression_DB63B8EE_L34C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1692,9 +1692,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_DB63B8EE_L34C28
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1753,7 +1753,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_81EE28F5_L36C34
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1767,7 +1767,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1778,7 +1778,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1789,7 +1789,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1807,7 +1807,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1826,7 +1826,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1844,9 +1844,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_81EE28F5_L36C34
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1899,7 +1899,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7028F334_L40C18
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1919,9 +1919,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject_FunctionExpression_7028F334_L40C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1932,7 +1932,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1943,7 +1943,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1956,11 +1956,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject_FunctionExpression_7028F334_L40C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1974,11 +1974,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject_FunctionExpression_7028F334_L40C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1996,9 +1996,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7028F334_L40C18
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2063,7 +2063,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4A0EDC35_C
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2077,7 +2077,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2088,7 +2088,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2099,7 +2099,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2117,7 +2117,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/C::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2136,7 +2136,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/C::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2154,9 +2154,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_4A0EDC35_C
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2217,7 +2217,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_35ED904C_L46C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2237,9 +2237,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject_FunctionExpression_35ED904C_L46C23::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2250,7 +2250,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2261,7 +2261,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2274,11 +2274,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject_FunctionExpression_35ED904C_L46C23::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2292,11 +2292,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject_FunctionExpression_35ED904C_L46C23::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject::_environment0_Proxy_Revocable_ThrowsAfterRevoke
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2314,9 +2314,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_35ED904C_L46C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2405,26 +2405,26 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope,
-			[1] class Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject_FunctionDeclaration_5FAC858C_logThrow,
+			[1] class Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
-			[4] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable/FunctionObject_FunctionExpression_3925BBA6_L14C8,
-			[5] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7/FunctionObject_FunctionExpression_F9B416A7_L17C8,
+			[4] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable/FunctionObject,
+			[5] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7/FunctionObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[7] object,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[9] object[],
-			[10] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject_FunctionExpression_DCCED563_L28C17,
-			[11] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject_FunctionExpression_007DCDBA_L29C17,
-			[12] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject_FunctionExpression_7AF52BFC_L30C17,
-			[13] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject_FunctionExpression_3C8D3F03_L31C20,
-			[14] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject_FunctionExpression_2D98E99F_L32C18,
-			[15] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject_FunctionExpression_1DE7D22D_L33C28,
-			[16] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject_FunctionExpression_DB63B8EE_L34C28,
-			[17] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject_FunctionExpression_81EE28F5_L36C34,
-			[18] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject_FunctionExpression_7028F334_L40C18,
-			[19] class Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject_FunctionExpression_4A0EDC35_C,
-			[20] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject_FunctionExpression_35ED904C_L46C23
+			[10] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject,
+			[11] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject,
+			[12] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject,
+			[13] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject,
+			[14] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject,
+			[15] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject,
+			[16] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject,
+			[17] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject,
+			[18] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject,
+			[19] class Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject,
+			[20] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -2441,13 +2441,13 @@
 		IL_0017: ldc.i4.0
 		IL_0018: ldelem.ref
 		IL_0019: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_001e: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject_FunctionDeclaration_5FAC858C_logThrow::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_001e: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_0023: ldc.i4.2
 		IL_0024: conv.r8
 		IL_0025: ldstr "logThrow"
 		IL_002a: ldc.i4.0
 		IL_002b: ldc.i4.1
-		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject_FunctionDeclaration_5FAC858C_logThrow>(!!0, float64, string, bool, bool)
+		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0031: stloc.1
 		IL_0032: nop
 		IL_0033: nop
@@ -2464,13 +2464,13 @@
 		IL_0056: ldloc.0
 		IL_0057: stelem.ref
 		IL_0058: stloc.3
-		IL_0059: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable/FunctionObject_FunctionExpression_3925BBA6_L14C8::.ctor()
+		IL_0059: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable/FunctionObject::.ctor()
 		IL_005e: ldc.i4.2
 		IL_005f: conv.r8
 		IL_0060: ldstr ""
 		IL_0065: ldc.i4.0
 		IL_0066: ldc.i4.1
-		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable/FunctionObject_FunctionExpression_3925BBA6_L14C8>(!!0, float64, string, bool, bool)
+		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_006c: stloc.s 4
 		IL_006e: ldc.i4.1
 		IL_006f: newarr [System.Runtime]System.Object
@@ -2479,13 +2479,13 @@
 		IL_0076: ldloc.0
 		IL_0077: stelem.ref
 		IL_0078: stloc.3
-		IL_0079: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7/FunctionObject_FunctionExpression_F9B416A7_L17C8::.ctor()
+		IL_0079: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7/FunctionObject::.ctor()
 		IL_007e: ldc.i4.3
 		IL_007f: conv.r8
 		IL_0080: ldstr ""
 		IL_0085: ldc.i4.0
 		IL_0086: ldc.i4.1
-		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7/FunctionObject_FunctionExpression_F9B416A7_L17C8>(!!0, float64, string, bool, bool)
+		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_008c: stloc.s 5
 		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0093: dup
@@ -2559,13 +2559,13 @@
 		IL_0163: ldc.i4.0
 		IL_0164: ldelem.ref
 		IL_0165: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_016a: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject_FunctionExpression_DCCED563_L28C17::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_016a: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_016f: ldc.i4.0
 		IL_0170: conv.r8
 		IL_0171: ldstr ""
 		IL_0176: ldc.i4.0
 		IL_0177: ldc.i4.1
-		IL_0178: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject_FunctionExpression_DCCED563_L28C17>(!!0, float64, string, bool, bool)
+		IL_0178: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_017d: stloc.s 10
 		IL_017f: ldloc.1
 		IL_0180: ldloc.3
@@ -2586,13 +2586,13 @@
 		IL_01a2: ldc.i4.0
 		IL_01a3: ldelem.ref
 		IL_01a4: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_01a9: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject_FunctionExpression_007DCDBA_L29C17::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_01a9: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_01ae: ldc.i4.0
 		IL_01af: conv.r8
 		IL_01b0: ldstr ""
 		IL_01b5: ldc.i4.0
 		IL_01b6: ldc.i4.1
-		IL_01b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject_FunctionExpression_007DCDBA_L29C17>(!!0, float64, string, bool, bool)
+		IL_01b7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01bc: stloc.s 11
 		IL_01be: ldloc.1
 		IL_01bf: ldloc.3
@@ -2613,13 +2613,13 @@
 		IL_01e1: ldc.i4.0
 		IL_01e2: ldelem.ref
 		IL_01e3: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_01e8: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject_FunctionExpression_7AF52BFC_L30C17::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_01e8: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_01ed: ldc.i4.0
 		IL_01ee: conv.r8
 		IL_01ef: ldstr ""
 		IL_01f4: ldc.i4.0
 		IL_01f5: ldc.i4.1
-		IL_01f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject_FunctionExpression_7AF52BFC_L30C17>(!!0, float64, string, bool, bool)
+		IL_01f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01fb: stloc.s 12
 		IL_01fd: ldloc.1
 		IL_01fe: ldloc.3
@@ -2640,13 +2640,13 @@
 		IL_0220: ldc.i4.0
 		IL_0221: ldelem.ref
 		IL_0222: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0227: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject_FunctionExpression_3C8D3F03_L31C20::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0227: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_022c: ldc.i4.0
 		IL_022d: conv.r8
 		IL_022e: ldstr ""
 		IL_0233: ldc.i4.0
 		IL_0234: ldc.i4.1
-		IL_0235: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject_FunctionExpression_3C8D3F03_L31C20>(!!0, float64, string, bool, bool)
+		IL_0235: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_023a: stloc.s 13
 		IL_023c: ldloc.1
 		IL_023d: ldloc.3
@@ -2667,13 +2667,13 @@
 		IL_025f: ldc.i4.0
 		IL_0260: ldelem.ref
 		IL_0261: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0266: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject_FunctionExpression_2D98E99F_L32C18::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0266: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_026b: ldc.i4.0
 		IL_026c: conv.r8
 		IL_026d: ldstr ""
 		IL_0272: ldc.i4.0
 		IL_0273: ldc.i4.1
-		IL_0274: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject_FunctionExpression_2D98E99F_L32C18>(!!0, float64, string, bool, bool)
+		IL_0274: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0279: stloc.s 14
 		IL_027b: ldloc.1
 		IL_027c: ldloc.3
@@ -2694,13 +2694,13 @@
 		IL_029e: ldc.i4.0
 		IL_029f: ldelem.ref
 		IL_02a0: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_02a5: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject_FunctionExpression_1DE7D22D_L33C28::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_02a5: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_02aa: ldc.i4.0
 		IL_02ab: conv.r8
 		IL_02ac: ldstr ""
 		IL_02b1: ldc.i4.0
 		IL_02b2: ldc.i4.1
-		IL_02b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject_FunctionExpression_1DE7D22D_L33C28>(!!0, float64, string, bool, bool)
+		IL_02b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02b8: stloc.s 15
 		IL_02ba: ldloc.1
 		IL_02bb: ldloc.3
@@ -2721,13 +2721,13 @@
 		IL_02dd: ldc.i4.0
 		IL_02de: ldelem.ref
 		IL_02df: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_02e4: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject_FunctionExpression_DB63B8EE_L34C28::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_02e4: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_02e9: ldc.i4.0
 		IL_02ea: conv.r8
 		IL_02eb: ldstr ""
 		IL_02f0: ldc.i4.0
 		IL_02f1: ldc.i4.1
-		IL_02f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject_FunctionExpression_DB63B8EE_L34C28>(!!0, float64, string, bool, bool)
+		IL_02f2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02f7: stloc.s 16
 		IL_02f9: ldloc.1
 		IL_02fa: ldloc.3
@@ -2742,13 +2742,13 @@
 		IL_0310: ldloc.0
 		IL_0311: stelem.ref
 		IL_0312: stloc.3
-		IL_0313: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject_FunctionExpression_81EE28F5_L36C34::.ctor()
+		IL_0313: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject::.ctor()
 		IL_0318: ldc.i4.1
 		IL_0319: conv.r8
 		IL_031a: ldstr ""
 		IL_031f: ldc.i4.0
 		IL_0320: ldc.i4.1
-		IL_0321: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject_FunctionExpression_81EE28F5_L36C34>(!!0, float64, string, bool, bool)
+		IL_0321: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0326: stloc.s 17
 		IL_0328: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_032d: stloc.s 6
@@ -2778,13 +2778,13 @@
 		IL_036c: ldc.i4.0
 		IL_036d: ldelem.ref
 		IL_036e: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0373: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject_FunctionExpression_7028F334_L40C18::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0373: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_0378: ldc.i4.0
 		IL_0379: conv.r8
 		IL_037a: ldstr ""
 		IL_037f: ldc.i4.0
 		IL_0380: ldc.i4.1
-		IL_0381: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject_FunctionExpression_7028F334_L40C18>(!!0, float64, string, bool, bool)
+		IL_0381: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0386: stloc.s 18
 		IL_0388: ldloc.1
 		IL_0389: ldloc.3
@@ -2799,13 +2799,13 @@
 		IL_039f: ldloc.0
 		IL_03a0: stelem.ref
 		IL_03a1: stloc.3
-		IL_03a2: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject_FunctionExpression_4A0EDC35_C::.ctor()
+		IL_03a2: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject::.ctor()
 		IL_03a7: ldc.i4.1
 		IL_03a8: conv.r8
 		IL_03a9: ldstr "C"
 		IL_03ae: ldc.i4.1
 		IL_03af: ldc.i4.1
-		IL_03b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject_FunctionExpression_4A0EDC35_C>(!!0, float64, string, bool, bool)
+		IL_03b0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_03b5: stloc.s 19
 		IL_03b7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_03bc: stloc.s 6
@@ -2835,13 +2835,13 @@
 		IL_03fb: ldc.i4.0
 		IL_03fc: ldelem.ref
 		IL_03fd: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0402: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject_FunctionExpression_35ED904C_L46C23::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0402: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_0407: ldc.i4.0
 		IL_0408: conv.r8
 		IL_0409: ldstr ""
 		IL_040e: ldc.i4.0
 		IL_040f: ldc.i4.1
-		IL_0410: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject_FunctionExpression_35ED904C_L46C23>(!!0, float64, string, bool, bool)
+		IL_0410: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0415: stloc.s 20
 		IL_0417: ldloc.1
 		IL_0418: ldloc.3

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_SetTrap_InterceptsWrites.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_SetTrap_InterceptsWrites.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D555D783_L8C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_SetTrap_InterceptsWrites/Scope Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject_FunctionExpression_D555D783_L8C8::_environment0_Proxy_SetTrap_InterceptsWrites
+				IL_0008: stfld class Modules.Proxy_SetTrap_InterceptsWrites/Scope Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject::_environment0_Proxy_SetTrap_InterceptsWrites
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_SetTrap_InterceptsWrites/Scope Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject_FunctionExpression_D555D783_L8C8::_environment0_Proxy_SetTrap_InterceptsWrites
+				IL_0001: ldfld class Modules.Proxy_SetTrap_InterceptsWrites/Scope Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject::_environment0_Proxy_SetTrap_InterceptsWrites
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -103,7 +103,7 @@
 				IL_0022: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0027: call object Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler::__js_call__(class Modules.Proxy_SetTrap_InterceptsWrites/Scope, object, object, object, object, object)
 				IL_002c: ret
-			} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -117,7 +117,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_SetTrap_InterceptsWrites/Scope Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject_FunctionExpression_D555D783_L8C8::_environment0_Proxy_SetTrap_InterceptsWrites
+				IL_0001: ldfld class Modules.Proxy_SetTrap_InterceptsWrites/Scope Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject::_environment0_Proxy_SetTrap_InterceptsWrites
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -133,7 +133,7 @@
 				IL_001e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0023: call object Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler::__js_call__(class Modules.Proxy_SetTrap_InterceptsWrites/Scope, object, object, object, object, object)
 				IL_0028: ret
-			} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -151,9 +151,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_D555D783_L8C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -249,7 +249,7 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object[],
-			[6] class Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject_FunctionExpression_D555D783_L8C8,
+			[6] class Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] object
 		)
@@ -280,13 +280,13 @@
 		IL_003f: ldc.i4.0
 		IL_0040: ldelem.ref
 		IL_0041: castclass Modules.Proxy_SetTrap_InterceptsWrites/Scope
-		IL_0046: newobj instance void Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject_FunctionExpression_D555D783_L8C8::.ctor(class Modules.Proxy_SetTrap_InterceptsWrites/Scope)
+		IL_0046: newobj instance void Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject::.ctor(class Modules.Proxy_SetTrap_InterceptsWrites/Scope)
 		IL_004b: ldc.i4.4
 		IL_004c: conv.r8
 		IL_004d: ldstr ""
 		IL_0052: ldc.i4.0
 		IL_0053: ldc.i4.1
-		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject_FunctionExpression_D555D783_L8C8>(!!0, float64, string, bool, bool)
+		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0059: stloc.s 6
 		IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0060: dup

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_91E97F91_log
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -90,9 +90,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/log/FunctionObject_FunctionDeclaration_91E97F91_log::_environment0_Proxy_Validation_EdgeCases
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/log/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +103,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,7 +114,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -127,7 +127,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/log/FunctionObject_FunctionDeclaration_91E97F91_log::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/log/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -138,7 +138,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -152,7 +152,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/log/FunctionObject_FunctionDeclaration_91E97F91_log::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/log/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -163,7 +163,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -181,9 +181,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_91E97F91_log
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -320,7 +320,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5445B54C_L12C21
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -334,7 +334,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -345,7 +345,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -356,7 +356,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -371,7 +371,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -387,7 +387,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -405,9 +405,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5445B54C_L12C21
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -463,7 +463,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_83DA49A1_L16C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -477,7 +477,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -488,7 +488,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -499,7 +499,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -514,7 +514,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -530,7 +530,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -548,9 +548,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_83DA49A1_L16C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -606,7 +606,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_284DD4EB_L20C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -620,7 +620,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -631,7 +631,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -642,7 +642,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -657,7 +657,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -673,7 +673,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -691,9 +691,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_284DD4EB_L20C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -741,7 +741,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_85F7517A_L24C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -755,7 +755,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -766,7 +766,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -777,7 +777,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -792,7 +792,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -808,7 +808,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -826,9 +826,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_85F7517A_L24C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -876,7 +876,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_35ED5A5E_L29C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -890,7 +890,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -901,7 +901,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -912,7 +912,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -927,7 +927,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -943,7 +943,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -961,9 +961,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_35ED5A5E_L29C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1008,7 +1008,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_72AF61D9_L34C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1028,9 +1028,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject_FunctionExpression_72AF61D9_L34C26::_environment0_Proxy_Validation_EdgeCases
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1041,7 +1041,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1052,7 +1052,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1065,11 +1065,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject_FunctionExpression_72AF61D9_L34C26::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1083,11 +1083,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject_FunctionExpression_72AF61D9_L34C26::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1105,9 +1105,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_72AF61D9_L34C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1169,7 +1169,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_670E5585_L39C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1189,9 +1189,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject_FunctionExpression_670E5585_L39C14::_environment0_Proxy_Validation_EdgeCases
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1202,7 +1202,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1213,7 +1213,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1226,11 +1226,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject_FunctionExpression_670E5585_L39C14::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1244,11 +1244,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject_FunctionExpression_670E5585_L39C14::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1266,9 +1266,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_670E5585_L39C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1320,7 +1320,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1DD156CC_L44C35
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1340,9 +1340,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject_FunctionExpression_1DD156CC_L44C35::_environment0_Proxy_Validation_EdgeCases
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1353,7 +1353,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1364,7 +1364,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1377,11 +1377,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject_FunctionExpression_1DD156CC_L44C35::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1395,11 +1395,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject_FunctionExpression_1DD156CC_L44C35::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1417,9 +1417,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1DD156CC_L44C35
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1486,7 +1486,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_63449D48_Base
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1500,7 +1500,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_63449D48_Base::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1511,7 +1511,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_63449D48_Base::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1522,7 +1522,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_63449D48_Base::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1537,7 +1537,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Proxy_Validation_EdgeCases/Base::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_63449D48_Base::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1553,7 +1553,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Proxy_Validation_EdgeCases/Base::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_63449D48_Base::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1571,9 +1571,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_63449D48_Base::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_63449D48_Base
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1626,7 +1626,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_06B3F2B0_L49C14
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1640,7 +1640,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1651,7 +1651,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1662,7 +1662,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1678,7 +1678,7 @@
 				IL_0005: call float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1695,7 +1695,7 @@
 				IL_0001: call float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1713,9 +1713,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_06B3F2B0_L49C14
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1760,7 +1760,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F9D274F7_L54C35
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1780,9 +1780,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject_FunctionExpression_F9D274F7_L54C35::_environment0_Proxy_Validation_EdgeCases
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1793,7 +1793,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1804,7 +1804,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1817,11 +1817,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject_FunctionExpression_F9D274F7_L54C35::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1835,11 +1835,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject_FunctionExpression_F9D274F7_L54C35::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1857,9 +1857,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_F9D274F7_L54C35
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1919,7 +1919,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C27E696C_L59C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1933,7 +1933,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1944,7 +1944,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1955,7 +1955,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1970,7 +1970,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1986,7 +1986,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2004,9 +2004,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C27E696C_L59C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2052,7 +2052,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9F07F033_L67C19
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2066,7 +2066,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2077,7 +2077,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2088,7 +2088,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2104,7 +2104,7 @@
 				IL_0005: call float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2121,7 +2121,7 @@
 				IL_0001: call float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2139,9 +2139,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_9F07F033_L67C19
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2186,7 +2186,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_11D74249_L72C33
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2206,9 +2206,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject_FunctionExpression_11D74249_L72C33::_environment0_Proxy_Validation_EdgeCases
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2219,7 +2219,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2230,7 +2230,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2243,11 +2243,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject_FunctionExpression_11D74249_L72C33::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2261,11 +2261,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject_FunctionExpression_11D74249_L72C33::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2283,9 +2283,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_11D74249_L72C33
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2341,7 +2341,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E36E315D_L77C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2361,9 +2361,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject_FunctionExpression_E36E315D_L77C12::_environment0_Proxy_Validation_EdgeCases
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2374,7 +2374,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2385,7 +2385,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2398,11 +2398,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject_FunctionExpression_E36E315D_L77C12::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2416,11 +2416,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject_FunctionExpression_E36E315D_L77C12::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2438,9 +2438,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E36E315D_L77C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2500,7 +2500,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_87888FCA_L85C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2520,9 +2520,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject_FunctionExpression_87888FCA_L85C12::_environment0_Proxy_Validation_EdgeCases
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2533,7 +2533,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2544,7 +2544,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2557,11 +2557,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject_FunctionExpression_87888FCA_L85C12::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2575,11 +2575,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject_FunctionExpression_87888FCA_L85C12::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2597,9 +2597,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_87888FCA_L85C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2660,7 +2660,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C0FBDA47_L93C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2674,7 +2674,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2685,7 +2685,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2696,7 +2696,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2711,7 +2711,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2727,7 +2727,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2745,9 +2745,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_C0FBDA47_L93C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2792,7 +2792,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A2005DA7_L98C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2812,9 +2812,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject_FunctionExpression_A2005DA7_L98C26::_environment0_Proxy_Validation_EdgeCases
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2825,7 +2825,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2836,7 +2836,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2849,11 +2849,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject_FunctionExpression_A2005DA7_L98C26::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2867,11 +2867,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject_FunctionExpression_A2005DA7_L98C26::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2889,9 +2889,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_A2005DA7_L98C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2956,7 +2956,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5427424B_L103C12
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2970,7 +2970,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2981,7 +2981,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2992,7 +2992,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3007,7 +3007,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3023,7 +3023,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3041,9 +3041,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5427424B_L103C12
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3092,7 +3092,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0EB74DCF_L108C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -3112,9 +3112,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject_FunctionExpression_0EB74DCF_L108C22::_environment0_Proxy_Validation_EdgeCases
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -3125,7 +3125,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -3136,7 +3136,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -3149,11 +3149,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject_FunctionExpression_0EB74DCF_L108C22::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -3167,11 +3167,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject_FunctionExpression_0EB74DCF_L108C22::_environment0_Proxy_Validation_EdgeCases
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject::_environment0_Proxy_Validation_EdgeCases
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -3189,9 +3189,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_0EB74DCF_L108C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -3295,39 +3295,39 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_Validation_EdgeCases/Scope,
-			[1] class Modules.Proxy_Validation_EdgeCases/log/FunctionObject_FunctionDeclaration_91E97F91_log,
+			[1] class Modules.Proxy_Validation_EdgeCases/log/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[5] object[],
 			[6] object[],
-			[7] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject_FunctionExpression_5445B54C_L12C21,
-			[8] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject_FunctionExpression_83DA49A1_L16C22,
-			[9] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject_FunctionExpression_284DD4EB_L20C25,
-			[10] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject_FunctionExpression_85F7517A_L24C26,
+			[7] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject,
+			[8] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject,
+			[9] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject,
+			[10] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[12] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_35ED5A5E_L29C10,
+			[12] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject,
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
-			[15] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject_FunctionExpression_72AF61D9_L34C26,
-			[16] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject_FunctionExpression_670E5585_L39C14,
-			[17] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject_FunctionExpression_1DD156CC_L44C35,
-			[18] class Modules.Proxy_Validation_EdgeCases/Base/FunctionObject_FunctionExpression_63449D48_Base,
-			[19] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject_FunctionExpression_06B3F2B0_L49C14,
-			[20] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject_FunctionExpression_F9D274F7_L54C35,
-			[21] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject_FunctionExpression_C27E696C_L59C19,
+			[15] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject,
+			[16] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject,
+			[17] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject,
+			[18] class Modules.Proxy_Validation_EdgeCases/Base/FunctionObject,
+			[19] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject,
+			[20] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject,
+			[21] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject,
 			[22] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[23] object,
 			[24] bool,
 			[25] object,
-			[26] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject_FunctionExpression_9F07F033_L67C19,
-			[27] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject_FunctionExpression_11D74249_L72C33,
-			[28] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject_FunctionExpression_E36E315D_L77C12,
-			[29] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject_FunctionExpression_87888FCA_L85C12,
-			[30] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject_FunctionExpression_C0FBDA47_L93C12,
-			[31] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject_FunctionExpression_A2005DA7_L98C26,
-			[32] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject_FunctionExpression_5427424B_L103C12,
-			[33] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject_FunctionExpression_0EB74DCF_L108C22
+			[26] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject,
+			[27] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject,
+			[28] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject,
+			[29] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject,
+			[30] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject,
+			[31] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject,
+			[32] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject,
+			[33] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -3344,13 +3344,13 @@
 		IL_0019: ldc.i4.0
 		IL_001a: ldelem.ref
 		IL_001b: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0020: newobj instance void Modules.Proxy_Validation_EdgeCases/log/FunctionObject_FunctionDeclaration_91E97F91_log::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_0020: newobj instance void Modules.Proxy_Validation_EdgeCases/log/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_0025: ldc.i4.2
 		IL_0026: conv.r8
 		IL_0027: ldstr "log"
 		IL_002c: ldc.i4.0
 		IL_002d: ldc.i4.1
-		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/log/FunctionObject_FunctionDeclaration_91E97F91_log>(!!0, float64, string, bool, bool)
+		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/log/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0033: stloc.1
 		IL_0034: nop
 		IL_0035: nop
@@ -3363,13 +3363,13 @@
 		IL_0045: ldloc.0
 		IL_0046: stelem.ref
 		IL_0047: stloc.s 6
-		IL_0049: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject_FunctionExpression_5445B54C_L12C21::.ctor()
+		IL_0049: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject::.ctor()
 		IL_004e: ldc.i4.0
 		IL_004f: conv.r8
 		IL_0050: ldstr ""
 		IL_0055: ldc.i4.0
 		IL_0056: ldc.i4.1
-		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject_FunctionExpression_5445B54C_L12C21>(!!0, float64, string, bool, bool)
+		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005c: stloc.s 7
 		IL_005e: ldloc.1
 		IL_005f: ldloc.s 5
@@ -3386,13 +3386,13 @@
 		IL_007d: ldloc.0
 		IL_007e: stelem.ref
 		IL_007f: stloc.s 6
-		IL_0081: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject_FunctionExpression_83DA49A1_L16C22::.ctor()
+		IL_0081: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject::.ctor()
 		IL_0086: ldc.i4.0
 		IL_0087: conv.r8
 		IL_0088: ldstr ""
 		IL_008d: ldc.i4.0
 		IL_008e: ldc.i4.1
-		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject_FunctionExpression_83DA49A1_L16C22>(!!0, float64, string, bool, bool)
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0094: stloc.s 8
 		IL_0096: ldloc.1
 		IL_0097: ldloc.s 5
@@ -3409,13 +3409,13 @@
 		IL_00b5: ldloc.0
 		IL_00b6: stelem.ref
 		IL_00b7: stloc.s 6
-		IL_00b9: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject_FunctionExpression_284DD4EB_L20C25::.ctor()
+		IL_00b9: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject::.ctor()
 		IL_00be: ldc.i4.0
 		IL_00bf: conv.r8
 		IL_00c0: ldstr ""
 		IL_00c5: ldc.i4.0
 		IL_00c6: ldc.i4.1
-		IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject_FunctionExpression_284DD4EB_L20C25>(!!0, float64, string, bool, bool)
+		IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00cc: stloc.s 9
 		IL_00ce: ldloc.1
 		IL_00cf: ldloc.s 5
@@ -3432,13 +3432,13 @@
 		IL_00ed: ldloc.0
 		IL_00ee: stelem.ref
 		IL_00ef: stloc.s 6
-		IL_00f1: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject_FunctionExpression_85F7517A_L24C26::.ctor()
+		IL_00f1: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject::.ctor()
 		IL_00f6: ldc.i4.0
 		IL_00f7: conv.r8
 		IL_00f8: ldstr ""
 		IL_00fd: ldc.i4.0
 		IL_00fe: ldc.i4.1
-		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject_FunctionExpression_85F7517A_L24C26>(!!0, float64, string, bool, bool)
+		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0104: stloc.s 10
 		IL_0106: ldloc.1
 		IL_0107: ldloc.s 5
@@ -3455,13 +3455,13 @@
 		IL_0125: ldloc.0
 		IL_0126: stelem.ref
 		IL_0127: stloc.s 5
-		IL_0129: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_35ED5A5E_L29C10::.ctor()
+		IL_0129: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject::.ctor()
 		IL_012e: ldc.i4.0
 		IL_012f: conv.r8
 		IL_0130: ldstr ""
 		IL_0135: ldc.i4.0
 		IL_0136: ldc.i4.1
-		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_35ED5A5E_L29C10>(!!0, float64, string, bool, bool)
+		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_013c: stloc.s 12
 		IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0143: dup
@@ -3489,13 +3489,13 @@
 		IL_017a: ldc.i4.0
 		IL_017b: ldelem.ref
 		IL_017c: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0181: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject_FunctionExpression_72AF61D9_L34C26::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_0181: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_0186: ldc.i4.0
 		IL_0187: conv.r8
 		IL_0188: ldstr ""
 		IL_018d: ldc.i4.0
 		IL_018e: ldc.i4.1
-		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject_FunctionExpression_72AF61D9_L34C26>(!!0, float64, string, bool, bool)
+		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0194: stloc.s 15
 		IL_0196: ldloc.1
 		IL_0197: ldloc.s 5
@@ -3516,13 +3516,13 @@
 		IL_01bb: ldc.i4.0
 		IL_01bc: ldelem.ref
 		IL_01bd: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_01c2: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject_FunctionExpression_670E5585_L39C14::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_01c2: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_01c7: ldc.i4.0
 		IL_01c8: conv.r8
 		IL_01c9: ldstr ""
 		IL_01ce: ldc.i4.0
 		IL_01cf: ldc.i4.1
-		IL_01d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject_FunctionExpression_670E5585_L39C14>(!!0, float64, string, bool, bool)
+		IL_01d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01d5: stloc.s 16
 		IL_01d7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_01dc: dup
@@ -3550,13 +3550,13 @@
 		IL_0213: ldc.i4.0
 		IL_0214: ldelem.ref
 		IL_0215: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_021a: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject_FunctionExpression_1DD156CC_L44C35::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_021a: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_021f: ldc.i4.0
 		IL_0220: conv.r8
 		IL_0221: ldstr ""
 		IL_0226: ldc.i4.0
 		IL_0227: ldc.i4.1
-		IL_0228: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject_FunctionExpression_1DD156CC_L44C35>(!!0, float64, string, bool, bool)
+		IL_0228: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_022d: stloc.s 17
 		IL_022f: ldloc.1
 		IL_0230: ldloc.s 5
@@ -3571,13 +3571,13 @@
 		IL_0247: ldloc.0
 		IL_0248: stelem.ref
 		IL_0249: stloc.s 5
-		IL_024b: newobj instance void Modules.Proxy_Validation_EdgeCases/Base/FunctionObject_FunctionExpression_63449D48_Base::.ctor()
+		IL_024b: newobj instance void Modules.Proxy_Validation_EdgeCases/Base/FunctionObject::.ctor()
 		IL_0250: ldc.i4.0
 		IL_0251: conv.r8
 		IL_0252: ldstr "Base"
 		IL_0257: ldc.i4.1
 		IL_0258: ldc.i4.1
-		IL_0259: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/Base/FunctionObject_FunctionExpression_63449D48_Base>(!!0, float64, string, bool, bool)
+		IL_0259: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/Base/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_025e: stloc.s 18
 		IL_0260: ldc.i4.1
 		IL_0261: newarr [System.Runtime]System.Object
@@ -3586,13 +3586,13 @@
 		IL_0268: ldloc.0
 		IL_0269: stelem.ref
 		IL_026a: stloc.s 5
-		IL_026c: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject_FunctionExpression_06B3F2B0_L49C14::.ctor()
+		IL_026c: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject::.ctor()
 		IL_0271: ldc.i4.0
 		IL_0272: conv.r8
 		IL_0273: ldstr ""
 		IL_0278: ldc.i4.0
 		IL_0279: ldc.i4.1
-		IL_027a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject_FunctionExpression_06B3F2B0_L49C14>(!!0, float64, string, bool, bool)
+		IL_027a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_027f: stloc.s 19
 		IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0286: dup
@@ -3620,13 +3620,13 @@
 		IL_02bd: ldc.i4.0
 		IL_02be: ldelem.ref
 		IL_02bf: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_02c4: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject_FunctionExpression_F9D274F7_L54C35::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_02c4: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_02c9: ldc.i4.0
 		IL_02ca: conv.r8
 		IL_02cb: ldstr ""
 		IL_02d0: ldc.i4.0
 		IL_02d1: ldc.i4.1
-		IL_02d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject_FunctionExpression_F9D274F7_L54C35>(!!0, float64, string, bool, bool)
+		IL_02d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02d7: stloc.s 20
 		IL_02d9: ldloc.1
 		IL_02da: ldloc.s 5
@@ -3643,13 +3643,13 @@
 		IL_02f8: ldloc.0
 		IL_02f9: stelem.ref
 		IL_02fa: stloc.s 5
-		IL_02fc: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject_FunctionExpression_C27E696C_L59C19::.ctor()
+		IL_02fc: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject::.ctor()
 		IL_0301: ldc.i4.0
 		IL_0302: conv.r8
 		IL_0303: ldstr ""
 		IL_0308: ldc.i4.0
 		IL_0309: ldc.i4.1
-		IL_030a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject_FunctionExpression_C27E696C_L59C19>(!!0, float64, string, bool, bool)
+		IL_030a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_030f: stloc.s 21
 		IL_0311: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0316: dup
@@ -3687,13 +3687,13 @@
 		IL_036f: ldloc.0
 		IL_0370: stelem.ref
 		IL_0371: stloc.s 5
-		IL_0373: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject_FunctionExpression_9F07F033_L67C19::.ctor()
+		IL_0373: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject::.ctor()
 		IL_0378: ldc.i4.0
 		IL_0379: conv.r8
 		IL_037a: ldstr ""
 		IL_037f: ldc.i4.0
 		IL_0380: ldc.i4.1
-		IL_0381: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject_FunctionExpression_9F07F033_L67C19>(!!0, float64, string, bool, bool)
+		IL_0381: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0386: stloc.s 26
 		IL_0388: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_038d: dup
@@ -3721,13 +3721,13 @@
 		IL_03c4: ldc.i4.0
 		IL_03c5: ldelem.ref
 		IL_03c6: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_03cb: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject_FunctionExpression_11D74249_L72C33::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_03cb: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_03d0: ldc.i4.0
 		IL_03d1: conv.r8
 		IL_03d2: ldstr ""
 		IL_03d7: ldc.i4.0
 		IL_03d8: ldc.i4.1
-		IL_03d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject_FunctionExpression_11D74249_L72C33>(!!0, float64, string, bool, bool)
+		IL_03d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_03de: stloc.s 27
 		IL_03e0: ldloc.1
 		IL_03e1: ldloc.s 5
@@ -3748,13 +3748,13 @@
 		IL_0405: ldc.i4.0
 		IL_0406: ldelem.ref
 		IL_0407: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_040c: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject_FunctionExpression_E36E315D_L77C12::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_040c: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_0411: ldc.i4.0
 		IL_0412: conv.r8
 		IL_0413: ldstr ""
 		IL_0418: ldc.i4.0
 		IL_0419: ldc.i4.1
-		IL_041a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject_FunctionExpression_E36E315D_L77C12>(!!0, float64, string, bool, bool)
+		IL_041a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_041f: stloc.s 28
 		IL_0421: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0426: dup
@@ -3792,13 +3792,13 @@
 		IL_0481: ldc.i4.0
 		IL_0482: ldelem.ref
 		IL_0483: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0488: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject_FunctionExpression_87888FCA_L85C12::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_0488: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_048d: ldc.i4.0
 		IL_048e: conv.r8
 		IL_048f: ldstr ""
 		IL_0494: ldc.i4.0
 		IL_0495: ldc.i4.1
-		IL_0496: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject_FunctionExpression_87888FCA_L85C12>(!!0, float64, string, bool, bool)
+		IL_0496: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_049b: stloc.s 29
 		IL_049d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_04a2: dup
@@ -3832,13 +3832,13 @@
 		IL_04f9: ldloc.0
 		IL_04fa: stelem.ref
 		IL_04fb: stloc.s 5
-		IL_04fd: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject_FunctionExpression_C0FBDA47_L93C12::.ctor()
+		IL_04fd: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject::.ctor()
 		IL_0502: ldc.i4.0
 		IL_0503: conv.r8
 		IL_0504: ldstr ""
 		IL_0509: ldc.i4.0
 		IL_050a: ldc.i4.1
-		IL_050b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject_FunctionExpression_C0FBDA47_L93C12>(!!0, float64, string, bool, bool)
+		IL_050b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0510: stloc.s 30
 		IL_0512: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0517: dup
@@ -3866,13 +3866,13 @@
 		IL_054e: ldc.i4.0
 		IL_054f: ldelem.ref
 		IL_0550: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0555: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject_FunctionExpression_A2005DA7_L98C26::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_0555: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_055a: ldc.i4.0
 		IL_055b: conv.r8
 		IL_055c: ldstr ""
 		IL_0561: ldc.i4.0
 		IL_0562: ldc.i4.1
-		IL_0563: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject_FunctionExpression_A2005DA7_L98C26>(!!0, float64, string, bool, bool)
+		IL_0563: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0568: stloc.s 31
 		IL_056a: ldloc.1
 		IL_056b: ldloc.s 5
@@ -3889,13 +3889,13 @@
 		IL_0589: ldloc.0
 		IL_058a: stelem.ref
 		IL_058b: stloc.s 5
-		IL_058d: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject_FunctionExpression_5427424B_L103C12::.ctor()
+		IL_058d: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject::.ctor()
 		IL_0592: ldc.i4.0
 		IL_0593: conv.r8
 		IL_0594: ldstr ""
 		IL_0599: ldc.i4.0
 		IL_059a: ldc.i4.1
-		IL_059b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject_FunctionExpression_5427424B_L103C12>(!!0, float64, string, bool, bool)
+		IL_059b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_05a0: stloc.s 32
 		IL_05a2: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_05a7: dup
@@ -3923,13 +3923,13 @@
 		IL_05de: ldc.i4.0
 		IL_05df: ldelem.ref
 		IL_05e0: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_05e5: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject_FunctionExpression_0EB74DCF_L108C22::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_05e5: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_05ea: ldc.i4.0
 		IL_05eb: conv.r8
 		IL_05ec: ldstr ""
 		IL_05f1: ldc.i4.0
 		IL_05f2: ldc.i4.1
-		IL_05f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject_FunctionExpression_0EB74DCF_L108C22>(!!0, float64, string, bool, bool)
+		IL_05f3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_05f8: stloc.s 33
 		IL_05fa: ldloc.1
 		IL_05fb: ldloc.s 5

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Algebra_Methods.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Algebra_Methods.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EA56ECA5_L18C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Set_Algebra_Methods/FunctionExpression_setLike::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Set_Algebra_Methods/FunctionExpression_setLike::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_EA56ECA5_L18C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -196,7 +196,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C83E3C37_L19C11
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -216,9 +216,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld object[] Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject_FunctionExpression_C83E3C37_L19C11::_transitionalScopes
+				IL_0008: stfld object[] Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject::_transitionalScopes
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -229,7 +229,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -240,7 +240,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -253,15 +253,15 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld object[] Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject_FunctionExpression_C83E3C37_L19C11::_transitionalScopes
+				IL_0001: ldfld object[] Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject::_transitionalScopes
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10::__js_call__(object[], object)
 				IL_0010: ldarg.0
 				IL_0011: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeInstanceFromFunction(object, object)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_C83E3C37_L19C11
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -301,7 +301,7 @@
 			IL_001f: ldftn object Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10::__js_call__(object[], object)
 			IL_0025: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunc0::.ctor(object, native int)
 			IL_002a: ldarg.0
-			IL_002b: ldtoken Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject_FunctionExpression_C83E3C37_L19C11
+			IL_002b: ldtoken Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject
 			IL_0030: call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 			IL_0035: ldc.i4.0
 			IL_0036: newarr [System.Runtime]System.Object
@@ -504,8 +504,8 @@
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.Set,
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.Set,
 			[14] object[],
-			[15] class Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject_FunctionExpression_EA56ECA5_L18C10,
-			[16] class Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject_FunctionExpression_C83E3C37_L19C11,
+			[15] class Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject,
+			[16] class Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject,
 			[17] object,
 			[18] bool,
 			[19] object
@@ -727,13 +727,13 @@
 		IL_02b1: ldloc.0
 		IL_02b2: stelem.ref
 		IL_02b3: stloc.s 14
-		IL_02b5: newobj instance void Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject_FunctionExpression_EA56ECA5_L18C10::.ctor()
+		IL_02b5: newobj instance void Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject::.ctor()
 		IL_02ba: ldc.i4.1
 		IL_02bb: conv.r8
 		IL_02bc: ldstr ""
 		IL_02c1: ldc.i4.0
 		IL_02c2: ldc.i4.1
-		IL_02c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject_FunctionExpression_EA56ECA5_L18C10>(!!0, float64, string, bool, bool)
+		IL_02c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02c8: stloc.s 15
 		IL_02ca: ldc.i4.1
 		IL_02cb: newarr [System.Runtime]System.Object
@@ -743,15 +743,15 @@
 		IL_02d3: stelem.ref
 		IL_02d4: stloc.s 14
 		IL_02d6: ldloc.s 14
-		IL_02d8: newobj instance void Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject_FunctionExpression_C83E3C37_L19C11::.ctor(object[])
+		IL_02d8: newobj instance void Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject::.ctor(object[])
 		IL_02dd: ldc.i4.0
 		IL_02de: conv.r8
 		IL_02df: ldstr ""
 		IL_02e4: ldc.i4.1
 		IL_02e5: ldc.i4.1
-		IL_02e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject_FunctionExpression_C83E3C37_L19C11>(!!0, float64, string, bool, bool)
+		IL_02e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.GeneratorObject::InitializeGeneratorFunctionSurface(object)
-		IL_02f0: castclass Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject_FunctionExpression_C83E3C37_L19C11
+		IL_02f0: castclass Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject
 		IL_02f5: stloc.s 16
 		IL_02f7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_02fc: dup

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
@@ -55,7 +55,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3451F94E_L9C17
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -79,15 +79,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17::_environment0_Set_Constructor_Iterable
+					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_environment0_Set_Constructor_Iterable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17::_environment1_FunctionExpression_iterable
+					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_environment1_FunctionExpression_iterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17::_transitionalScopes
+					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -98,7 +98,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -109,7 +109,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -122,13 +122,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_3451F94E_L9C17
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -262,7 +262,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E3E675E5_L4C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -282,9 +282,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22::_environment0_Set_Constructor_Iterable
+				IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject::_environment0_Set_Constructor_Iterable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -295,7 +295,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -306,7 +306,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -319,13 +319,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22::_environment0_Set_Constructor_Iterable
+				IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject::_environment0_Set_Constructor_Iterable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_iterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_E3E675E5_L4C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -348,7 +348,7 @@
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[3] object[],
-				[4] class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17
+				[4] class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope::.ctor()
@@ -397,14 +397,14 @@
 			IL_0083: ldelem.ref
 			IL_0084: castclass Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope
 			IL_0089: ldloc.3
-			IL_008a: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope, object[])
+			IL_008a: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope, object[])
 			IL_008f: ldc.i4.0
 			IL_0090: conv.r8
 			IL_0091: ldstr ""
 			IL_0096: ldc.i4.0
 			IL_0097: ldc.i4.1
-			IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17>(!!0, float64, string, bool, bool)
-			IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17>(!!0)
+			IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject>(!!0)
 			IL_00a2: stloc.s 4
 			IL_00a4: ldloc.2
 			IL_00a5: ldstr "next"
@@ -465,7 +465,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_ECF2574C_L33C17
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -489,15 +489,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17::_environment0_Set_Constructor_Iterable
+					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject::_environment0_Set_Constructor_Iterable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17::_environment1_FunctionExpression_closableIterable
+					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject::_environment1_FunctionExpression_closableIterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17::_transitionalScopes
+					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -508,7 +508,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -519,7 +519,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -532,13 +532,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_ECF2574C_L33C17
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -667,7 +667,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2F5B02BC_L40C19
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -691,15 +691,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19::_environment0_Set_Constructor_Iterable
+					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject::_environment0_Set_Constructor_Iterable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19::_environment1_FunctionExpression_closableIterable
+					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject::_environment1_FunctionExpression_closableIterable
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19::_transitionalScopes
+					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -710,7 +710,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -721,7 +721,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -734,13 +734,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_2F5B02BC_L40C19
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -802,7 +802,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8C0CC403_L28C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -822,9 +822,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22::_environment0_Set_Constructor_Iterable
+				IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject::_environment0_Set_Constructor_Iterable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -835,7 +835,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -846,7 +846,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -859,13 +859,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22::_environment0_Set_Constructor_Iterable
+				IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject::_environment0_Set_Constructor_Iterable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_8C0CC403_L28C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -888,8 +888,8 @@
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[3] object[],
-				[4] class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17,
-				[5] class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19
+				[4] class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject,
+				[5] class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope::.ctor()
@@ -932,14 +932,14 @@
 			IL_0065: ldelem.ref
 			IL_0066: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
 			IL_006b: ldloc.3
-			IL_006c: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope, object[])
+			IL_006c: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope, object[])
 			IL_0071: ldc.i4.0
 			IL_0072: conv.r8
 			IL_0073: ldstr ""
 			IL_0078: ldc.i4.0
 			IL_0079: ldc.i4.1
-			IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17>(!!0, float64, string, bool, bool)
-			IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17>(!!0)
+			IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject>(!!0)
 			IL_0084: stloc.s 4
 			IL_0086: ldloc.2
 			IL_0087: ldstr "next"
@@ -966,14 +966,14 @@
 			IL_00ad: ldelem.ref
 			IL_00ae: castclass Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope
 			IL_00b3: ldloc.3
-			IL_00b4: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope, object[])
+			IL_00b4: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope, object[])
 			IL_00b9: ldc.i4.0
 			IL_00ba: conv.r8
 			IL_00bb: ldstr ""
 			IL_00c0: ldc.i4.0
 			IL_00c1: ldc.i4.1
-			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19>(!!0, float64, string, bool, bool)
-			IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19>(!!0)
+			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject>(!!0)
 			IL_00cc: stloc.s 5
 			IL_00ce: ldloc.2
 			IL_00cf: ldstr "return"
@@ -1009,7 +1009,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C7D81525_L55C8
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1023,7 +1023,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1034,7 +1034,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1045,7 +1045,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1063,9 +1063,9 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_C7D81525_L55C8
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1163,7 +1163,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FCD9C04F_L63C17
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1187,15 +1187,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17::_environment0_Set_Constructor_Iterable
+					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject::_environment0_Set_Constructor_Iterable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17::_environment1_FunctionExpression_unionSetLike_L58C8
+					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject::_environment1_FunctionExpression_unionSetLike_L58C8
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17::_transitionalScopes
+					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1206,7 +1206,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1217,7 +1217,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1230,13 +1230,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_FCD9C04F_L63C17
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1365,7 +1365,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_71DDD6ED_L70C19
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1389,15 +1389,15 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19::_environment0_Set_Constructor_Iterable
+					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject::_environment0_Set_Constructor_Iterable
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19::_environment1_FunctionExpression_unionSetLike_L58C8
+					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject::_environment1_FunctionExpression_unionSetLike_L58C8
 					IL_0014: ldarg.0
 					IL_0015: ldarg.3
-					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19::_transitionalScopes
+					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject::_transitionalScopes
 					IL_001b: ret
-				} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1408,7 +1408,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1419,7 +1419,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1432,13 +1432,13 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::CallCore
+				} // end of method FunctionObject::CallCore
 
-			} // end of class FunctionObject_FunctionExpression_71DDD6ED_L70C19
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1500,7 +1500,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_47D15AD9_L58C9
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1520,9 +1520,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9::_environment0_Set_Constructor_Iterable
+				IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject::_environment0_Set_Constructor_Iterable
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1533,7 +1533,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1544,7 +1544,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1557,13 +1557,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9::_environment0_Set_Constructor_Iterable
+				IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject::_environment0_Set_Constructor_Iterable
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_47D15AD9_L58C9
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1586,8 +1586,8 @@
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[3] object[],
-				[4] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17,
-				[5] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19
+				[4] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject,
+				[5] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope::.ctor()
@@ -1630,14 +1630,14 @@
 			IL_0065: ldelem.ref
 			IL_0066: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope
 			IL_006b: ldloc.3
-			IL_006c: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope, object[])
+			IL_006c: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope, object[])
 			IL_0071: ldc.i4.0
 			IL_0072: conv.r8
 			IL_0073: ldstr ""
 			IL_0078: ldc.i4.0
 			IL_0079: ldc.i4.1
-			IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17>(!!0, float64, string, bool, bool)
-			IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17>(!!0)
+			IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject>(!!0)
 			IL_0084: stloc.s 4
 			IL_0086: ldloc.2
 			IL_0087: ldstr "next"
@@ -1664,14 +1664,14 @@
 			IL_00ad: ldelem.ref
 			IL_00ae: castclass Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope
 			IL_00b3: ldloc.3
-			IL_00b4: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope, object[])
+			IL_00b4: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject::.ctor(class Modules.Set_Constructor_Iterable/Scope, class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope, object[])
 			IL_00b9: ldc.i4.0
 			IL_00ba: conv.r8
 			IL_00bb: ldstr ""
 			IL_00c0: ldc.i4.0
 			IL_00c1: ldc.i4.1
-			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19>(!!0, float64, string, bool, bool)
-			IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19>(!!0)
+			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject>(!!0)
 			IL_00cc: stloc.s 5
 			IL_00ce: ldloc.2
 			IL_00cf: ldstr "return"
@@ -1743,8 +1743,8 @@
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[9] object[],
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console,
-			[11] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8,
-			[12] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9
+			[11] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject,
+			[12] class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Set_Constructor_Iterable/Scope::.ctor()
@@ -1768,14 +1768,14 @@
 		IL_002c: ldc.i4.0
 		IL_002d: ldelem.ref
 		IL_002e: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_0033: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22::.ctor(class Modules.Set_Constructor_Iterable/Scope)
+		IL_0033: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject::.ctor(class Modules.Set_Constructor_Iterable/Scope)
 		IL_0038: ldc.i4.0
 		IL_0039: conv.r8
 		IL_003a: ldstr ""
 		IL_003f: ldc.i4.0
 		IL_0040: ldc.i4.1
-		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22>(!!0, float64, string, bool, bool)
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22>(!!0)
+		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject>(!!0)
 		IL_004b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_0050: pop
 		IL_0051: ldloc.s 8
@@ -1851,14 +1851,14 @@
 		IL_012e: ldc.i4.0
 		IL_012f: ldelem.ref
 		IL_0130: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_0135: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22::.ctor(class Modules.Set_Constructor_Iterable/Scope)
+		IL_0135: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject::.ctor(class Modules.Set_Constructor_Iterable/Scope)
 		IL_013a: ldc.i4.0
 		IL_013b: conv.r8
 		IL_013c: ldstr ""
 		IL_0141: ldc.i4.0
 		IL_0142: ldc.i4.1
-		IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22>(!!0, float64, string, bool, bool)
-		IL_0148: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22>(!!0)
+		IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0148: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject>(!!0)
 		IL_014d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::DefineObjectLiteralDataProperty(object, object, object)
 		IL_0152: pop
 		IL_0153: ldloc.s 8
@@ -1903,14 +1903,14 @@
 		IL_01c7: ldloc.0
 		IL_01c8: stelem.ref
 		IL_01c9: stloc.s 9
-		IL_01cb: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8::.ctor()
+		IL_01cb: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject::.ctor()
 		IL_01d0: ldc.i4.1
 		IL_01d1: conv.r8
 		IL_01d2: ldstr ""
 		IL_01d7: ldc.i4.0
 		IL_01d8: ldc.i4.1
-		IL_01d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8>(!!0, float64, string, bool, bool)
-		IL_01de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_C7D81525_L55C8>(!!0)
+		IL_01d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_01de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike/FunctionObject>(!!0)
 		IL_01e3: stloc.s 11
 		IL_01e5: ldloc.s 8
 		IL_01e7: ldstr "has"
@@ -1928,14 +1928,14 @@
 		IL_0202: ldc.i4.0
 		IL_0203: ldelem.ref
 		IL_0204: castclass Modules.Set_Constructor_Iterable/Scope
-		IL_0209: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9::.ctor(class Modules.Set_Constructor_Iterable/Scope)
+		IL_0209: newobj instance void Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject::.ctor(class Modules.Set_Constructor_Iterable/Scope)
 		IL_020e: ldc.i4.0
 		IL_020f: conv.r8
 		IL_0210: ldstr ""
 		IL_0215: ldc.i4.0
 		IL_0216: ldc.i4.1
-		IL_0217: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9>(!!0, float64, string, bool, bool)
-		IL_021c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9>(!!0)
+		IL_0217: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_021c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject>(!!0)
 		IL_0221: stloc.s 12
 		IL_0223: ldloc.s 8
 		IL_0225: ldstr "keys"

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_ForEach_Basic.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_ForEach_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_67D60462_L7C13
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Set_ForEach_Basic/Scope Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject_FunctionExpression_67D60462_L7C13::_environment0_Set_ForEach_Basic
+				IL_0008: stfld class Modules.Set_ForEach_Basic/Scope Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject::_environment0_Set_ForEach_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Set_ForEach_Basic/Scope Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject_FunctionExpression_67D60462_L7C13::_environment0_Set_ForEach_Basic
+				IL_0001: ldfld class Modules.Set_ForEach_Basic/Scope Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject::_environment0_Set_ForEach_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -100,7 +100,7 @@
 				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0020: call object Modules.Set_ForEach_Basic/FunctionExpression_L7C12::__js_call__(class Modules.Set_ForEach_Basic/Scope, object, object, object, object)
 				IL_0025: ret
-			} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -114,7 +114,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Set_ForEach_Basic/Scope Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject_FunctionExpression_67D60462_L7C13::_environment0_Set_ForEach_Basic
+				IL_0001: ldfld class Modules.Set_ForEach_Basic/Scope Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject::_environment0_Set_ForEach_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -127,7 +127,7 @@
 				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001c: call object Modules.Set_ForEach_Basic/FunctionExpression_L7C12::__js_call__(class Modules.Set_ForEach_Basic/Scope, object, object, object, object)
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -145,9 +145,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_67D60462_L7C13
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -278,7 +278,7 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Set,
 			[4] object,
 			[5] object[],
-			[6] class Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject_FunctionExpression_67D60462_L7C13,
+			[6] class Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[8] object
 		)
@@ -328,13 +328,13 @@
 		IL_0079: ldc.i4.0
 		IL_007a: ldelem.ref
 		IL_007b: castclass Modules.Set_ForEach_Basic/Scope
-		IL_0080: newobj instance void Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject_FunctionExpression_67D60462_L7C13::.ctor(class Modules.Set_ForEach_Basic/Scope)
+		IL_0080: newobj instance void Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject::.ctor(class Modules.Set_ForEach_Basic/Scope)
 		IL_0085: ldc.i4.3
 		IL_0086: conv.r8
 		IL_0087: ldstr ""
 		IL_008c: ldc.i4.1
 		IL_008d: ldc.i4.1
-		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject_FunctionExpression_67D60462_L7C13>(!!0, float64, string, bool, bool)
+		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0093: stloc.s 6
 		IL_0095: ldloc.s 4
 		IL_0097: ldstr "forEach"

--- a/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_MixedNumeric_BoxedArithmetic.verified.txt
+++ b/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_MixedNumeric_BoxedArithmetic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C9451BAE_id
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C9451BAE_id
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -191,7 +191,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/Scope,
-			[1] class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id/FunctionObject_FunctionDeclaration_C9451BAE_id,
+			[1] class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id/FunctionObject,
 			[2] float64,
 			[3] float64,
 			[4] object[],
@@ -210,13 +210,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id/FunctionObject_FunctionDeclaration_C9451BAE_id::.ctor()
+		IL_0012: newobj instance void Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "id"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id/FunctionObject_FunctionDeclaration_C9451BAE_id>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BA59C706_runCommon
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -85,7 +85,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.String_MemberCall_FastPath_CommonMethods/runCommon::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,7 +105,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.String_MemberCall_FastPath_CommonMethods/runCommon::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -123,9 +123,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BA59C706_runCommon
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -386,7 +386,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MemberCall_FastPath_CommonMethods/Scope,
-			[1] class Modules.String_MemberCall_FastPath_CommonMethods/runCommon/FunctionObject_FunctionDeclaration_BA59C706_runCommon,
+			[1] class Modules.String_MemberCall_FastPath_CommonMethods/runCommon/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] string
@@ -401,13 +401,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.String_MemberCall_FastPath_CommonMethods/runCommon/FunctionObject_FunctionDeclaration_BA59C706_runCommon::.ctor()
+		IL_0011: newobj instance void Modules.String_MemberCall_FastPath_CommonMethods/runCommon/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "runCommon"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_MemberCall_FastPath_CommonMethods/runCommon/FunctionObject_FunctionDeclaration_BA59C706_runCommon>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_MemberCall_FastPath_CommonMethods/runCommon/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FB7F8382_L5C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject_FunctionExpression_FB7F8382_L5C24::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject::_environment0_String_RegExp_SymbolDispatch_Custom
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject_FunctionExpression_FB7F8382_L5C24::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject::_environment0_String_RegExp_SymbolDispatch_Custom
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject_FunctionExpression_FB7F8382_L5C24::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject::_environment0_String_RegExp_SymbolDispatch_Custom
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_FB7F8382_L5C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -217,7 +217,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5B4C2DE3_L11C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -237,9 +237,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject_FunctionExpression_5B4C2DE3_L11C26::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject::_environment0_String_RegExp_SymbolDispatch_Custom
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -250,7 +250,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -261,7 +261,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -274,7 +274,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject_FunctionExpression_5B4C2DE3_L11C26::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject::_environment0_String_RegExp_SymbolDispatch_Custom
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -284,7 +284,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -298,7 +298,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject_FunctionExpression_5B4C2DE3_L11C26::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject::_environment0_String_RegExp_SymbolDispatch_Custom
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -308,7 +308,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -326,9 +326,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_5B4C2DE3_L11C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -414,7 +414,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_59AEF9EB_L18C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -434,9 +434,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject_FunctionExpression_59AEF9EB_L18C25::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject::_environment0_String_RegExp_SymbolDispatch_Custom
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -447,7 +447,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -458,7 +458,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -471,14 +471,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject_FunctionExpression_59AEF9EB_L18C25::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject::_environment0_String_RegExp_SymbolDispatch_Custom
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -492,14 +492,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject_FunctionExpression_59AEF9EB_L18C25::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject::_environment0_String_RegExp_SymbolDispatch_Custom
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -517,9 +517,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_59AEF9EB_L18C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -597,7 +597,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_999EB579_L24C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -617,9 +617,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject_FunctionExpression_999EB579_L24C24::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject::_environment0_String_RegExp_SymbolDispatch_Custom
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -630,7 +630,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -641,7 +641,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -654,7 +654,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject_FunctionExpression_999EB579_L24C24::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject::_environment0_String_RegExp_SymbolDispatch_Custom
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -664,7 +664,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -678,7 +678,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject_FunctionExpression_999EB579_L24C24::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject::_environment0_String_RegExp_SymbolDispatch_Custom
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -688,7 +688,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -706,9 +706,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_999EB579_L24C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -869,10 +869,10 @@
 			[11] object,
 			[12] object,
 			[13] object[],
-			[14] class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject_FunctionExpression_FB7F8382_L5C24,
-			[15] class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject_FunctionExpression_5B4C2DE3_L11C26,
-			[16] class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject_FunctionExpression_59AEF9EB_L18C25,
-			[17] class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject_FunctionExpression_999EB579_L24C24,
+			[14] class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject,
+			[15] class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject,
+			[16] class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject,
+			[17] class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject,
 			[18] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[19] string
 		)
@@ -902,13 +902,13 @@
 		IL_0038: ldc.i4.0
 		IL_0039: ldelem.ref
 		IL_003a: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
-		IL_003f: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject_FunctionExpression_FB7F8382_L5C24::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
+		IL_003f: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
 		IL_0044: ldc.i4.1
 		IL_0045: conv.r8
 		IL_0046: ldstr ""
 		IL_004b: ldc.i4.1
 		IL_004c: ldc.i4.1
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject_FunctionExpression_FB7F8382_L5C24>(!!0, float64, string, bool, bool)
+		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0052: stloc.s 14
 		IL_0054: ldloc.s 11
 		IL_0056: ldloc.s 12
@@ -933,13 +933,13 @@
 		IL_0083: ldc.i4.0
 		IL_0084: ldelem.ref
 		IL_0085: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
-		IL_008a: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject_FunctionExpression_5B4C2DE3_L11C26::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
+		IL_008a: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
 		IL_008f: ldc.i4.2
 		IL_0090: conv.r8
 		IL_0091: ldstr ""
 		IL_0096: ldc.i4.1
 		IL_0097: ldc.i4.1
-		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject_FunctionExpression_5B4C2DE3_L11C26>(!!0, float64, string, bool, bool)
+		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_009d: stloc.s 15
 		IL_009f: ldloc.s 12
 		IL_00a1: ldloc.s 11
@@ -964,13 +964,13 @@
 		IL_00ce: ldc.i4.0
 		IL_00cf: ldelem.ref
 		IL_00d0: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
-		IL_00d5: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject_FunctionExpression_59AEF9EB_L18C25::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
+		IL_00d5: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
 		IL_00da: ldc.i4.1
 		IL_00db: conv.r8
 		IL_00dc: ldstr ""
 		IL_00e1: ldc.i4.1
 		IL_00e2: ldc.i4.1
-		IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject_FunctionExpression_59AEF9EB_L18C25>(!!0, float64, string, bool, bool)
+		IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00e8: stloc.s 16
 		IL_00ea: ldloc.s 11
 		IL_00ec: ldloc.s 12
@@ -995,13 +995,13 @@
 		IL_0119: ldc.i4.0
 		IL_011a: ldelem.ref
 		IL_011b: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
-		IL_0120: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject_FunctionExpression_999EB579_L24C24::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
+		IL_0120: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
 		IL_0125: ldc.i4.2
 		IL_0126: conv.r8
 		IL_0127: ldstr ""
 		IL_012c: ldc.i4.1
 		IL_012d: ldc.i4.1
-		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject_FunctionExpression_999EB579_L24C24>(!!0, float64, string, bool, bool)
+		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0133: stloc.s 17
 		IL_0135: ldloc.s 12
 		IL_0137: ldloc.s 11

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpOverride.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpOverride.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_61FDD2C4_L5C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject_FunctionExpression_61FDD2C4_L5C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject_FunctionExpression_61FDD2C4_L5C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject_FunctionExpression_61FDD2C4_L5C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_61FDD2C4_L5C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -223,7 +223,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_74F2042E_L12C22
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -243,9 +243,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject_FunctionExpression_74F2042E_L12C22::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -256,7 +256,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -267,7 +267,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -280,7 +280,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject_FunctionExpression_74F2042E_L12C22::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -290,7 +290,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -304,7 +304,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject_FunctionExpression_74F2042E_L12C22::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -314,7 +314,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -332,9 +332,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_74F2042E_L12C22
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -425,7 +425,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BA49F324_L20C21
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -445,9 +445,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject_FunctionExpression_BA49F324_L20C21::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -458,7 +458,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -469,7 +469,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -482,14 +482,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject_FunctionExpression_BA49F324_L20C21::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -503,14 +503,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject_FunctionExpression_BA49F324_L20C21::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -528,9 +528,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_BA49F324_L20C21
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -615,7 +615,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_88EF580C_L27C20
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -635,9 +635,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject_FunctionExpression_88EF580C_L27C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -648,7 +648,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -659,7 +659,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -672,7 +672,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject_FunctionExpression_88EF580C_L27C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -682,7 +682,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -696,7 +696,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject_FunctionExpression_88EF580C_L27C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -706,7 +706,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -724,9 +724,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_88EF580C_L27C20
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -848,10 +848,10 @@
 			[3] object,
 			[4] object,
 			[5] object[],
-			[6] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject_FunctionExpression_61FDD2C4_L5C20,
-			[7] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject_FunctionExpression_74F2042E_L12C22,
-			[8] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject_FunctionExpression_BA49F324_L20C21,
-			[9] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject_FunctionExpression_88EF580C_L27C20,
+			[6] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject,
+			[7] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject,
+			[8] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject,
+			[9] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
 
@@ -882,13 +882,13 @@
 		IL_003f: ldc.i4.0
 		IL_0040: ldelem.ref
 		IL_0041: castclass Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope
-		IL_0046: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject_FunctionExpression_61FDD2C4_L5C20::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
+		IL_0046: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
 		IL_004b: ldc.i4.1
 		IL_004c: conv.r8
 		IL_004d: ldstr ""
 		IL_0052: ldc.i4.1
 		IL_0053: ldc.i4.1
-		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject_FunctionExpression_61FDD2C4_L5C20>(!!0, float64, string, bool, bool)
+		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0059: stloc.s 6
 		IL_005b: ldloc.3
 		IL_005c: ldloc.s 4
@@ -913,13 +913,13 @@
 		IL_0088: ldc.i4.0
 		IL_0089: ldelem.ref
 		IL_008a: castclass Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope
-		IL_008f: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject_FunctionExpression_74F2042E_L12C22::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
+		IL_008f: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
 		IL_0094: ldc.i4.2
 		IL_0095: conv.r8
 		IL_0096: ldstr ""
 		IL_009b: ldc.i4.1
 		IL_009c: ldc.i4.1
-		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject_FunctionExpression_74F2042E_L12C22>(!!0, float64, string, bool, bool)
+		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a2: stloc.s 7
 		IL_00a4: ldloc.s 4
 		IL_00a6: ldloc.3
@@ -944,13 +944,13 @@
 		IL_00d1: ldc.i4.0
 		IL_00d2: ldelem.ref
 		IL_00d3: castclass Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope
-		IL_00d8: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject_FunctionExpression_BA49F324_L20C21::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
+		IL_00d8: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
 		IL_00dd: ldc.i4.1
 		IL_00de: conv.r8
 		IL_00df: ldstr ""
 		IL_00e4: ldc.i4.1
 		IL_00e5: ldc.i4.1
-		IL_00e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject_FunctionExpression_BA49F324_L20C21>(!!0, float64, string, bool, bool)
+		IL_00e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00eb: stloc.s 8
 		IL_00ed: ldloc.3
 		IL_00ee: ldloc.s 4
@@ -975,13 +975,13 @@
 		IL_011a: ldc.i4.0
 		IL_011b: ldelem.ref
 		IL_011c: castclass Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope
-		IL_0121: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject_FunctionExpression_88EF580C_L27C20::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
+		IL_0121: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
 		IL_0126: ldc.i4.2
 		IL_0127: conv.r8
 		IL_0128: ldstr ""
 		IL_012d: ldc.i4.1
 		IL_012e: ldc.i4.1
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject_FunctionExpression_88EF580C_L27C20>(!!0, float64, string, bool, bool)
+		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0134: stloc.s 9
 		IL_0136: ldloc.s 4
 		IL_0138: ldloc.3

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpPrototypeOverride.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpPrototypeOverride.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4C2EA9D7_L10C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject_FunctionExpression_4C2EA9D7_L10C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,14 +87,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject_FunctionExpression_4C2EA9D7_L10C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -108,14 +108,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject_FunctionExpression_4C2EA9D7_L10C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -133,9 +133,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_4C2EA9D7_L10C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -223,7 +223,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BA77F64A_L17C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -243,9 +243,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject_FunctionExpression_BA77F64A_L17C25::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -256,7 +256,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -267,7 +267,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -280,7 +280,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject_FunctionExpression_BA77F64A_L17C25::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -290,7 +290,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call object Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -304,7 +304,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject_FunctionExpression_BA77F64A_L17C25::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -314,7 +314,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call object Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -332,9 +332,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_BA77F64A_L17C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -425,7 +425,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9B9859A2_L25C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -445,9 +445,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject_FunctionExpression_9B9859A2_L25C24::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -458,7 +458,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -469,7 +469,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -482,14 +482,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject_FunctionExpression_9B9859A2_L25C24::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -503,14 +503,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject_FunctionExpression_9B9859A2_L25C24::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -528,9 +528,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_9B9859A2_L25C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -615,7 +615,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E632B0CF_L32C23
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -635,9 +635,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject_FunctionExpression_E632B0CF_L32C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -648,7 +648,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -659,7 +659,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -672,7 +672,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject_FunctionExpression_E632B0CF_L32C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -682,7 +682,7 @@
 				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object, object)
 				IL_001e: ret
-			} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -696,7 +696,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject_FunctionExpression_E632B0CF_L32C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -706,7 +706,7 @@
 				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object, object)
 				IL_001a: ret
-			} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -724,9 +724,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_E632B0CF_L32C23
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -852,10 +852,10 @@
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[8] object,
 			[9] object[],
-			[10] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject_FunctionExpression_4C2EA9D7_L10C23,
-			[11] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject_FunctionExpression_BA77F64A_L17C25,
-			[12] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject_FunctionExpression_9B9859A2_L25C24,
-			[13] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject_FunctionExpression_E632B0CF_L32C23,
+			[10] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject,
+			[11] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject,
+			[12] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject,
+			[13] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.Console
 		)
 
@@ -918,13 +918,13 @@
 		IL_00a5: ldc.i4.0
 		IL_00a6: ldelem.ref
 		IL_00a7: castclass Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope
-		IL_00ac: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject_FunctionExpression_4C2EA9D7_L10C23::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
+		IL_00ac: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
 		IL_00b1: ldc.i4.1
 		IL_00b2: conv.r8
 		IL_00b3: ldstr ""
 		IL_00b8: ldc.i4.1
 		IL_00b9: ldc.i4.1
-		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject_FunctionExpression_4C2EA9D7_L10C23>(!!0, float64, string, bool, bool)
+		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00bf: stloc.s 10
 		IL_00c1: ldloc.1
 		IL_00c2: ldloc.s 8
@@ -946,13 +946,13 @@
 		IL_00e7: ldc.i4.0
 		IL_00e8: ldelem.ref
 		IL_00e9: castclass Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope
-		IL_00ee: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject_FunctionExpression_BA77F64A_L17C25::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
+		IL_00ee: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
 		IL_00f3: ldc.i4.2
 		IL_00f4: conv.r8
 		IL_00f5: ldstr ""
 		IL_00fa: ldc.i4.1
 		IL_00fb: ldc.i4.1
-		IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject_FunctionExpression_BA77F64A_L17C25>(!!0, float64, string, bool, bool)
+		IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0101: stloc.s 11
 		IL_0103: ldloc.1
 		IL_0104: ldloc.s 8
@@ -974,13 +974,13 @@
 		IL_0129: ldc.i4.0
 		IL_012a: ldelem.ref
 		IL_012b: castclass Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope
-		IL_0130: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject_FunctionExpression_9B9859A2_L25C24::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
+		IL_0130: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
 		IL_0135: ldc.i4.1
 		IL_0136: conv.r8
 		IL_0137: ldstr ""
 		IL_013c: ldc.i4.1
 		IL_013d: ldc.i4.1
-		IL_013e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject_FunctionExpression_9B9859A2_L25C24>(!!0, float64, string, bool, bool)
+		IL_013e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0143: stloc.s 12
 		IL_0145: ldloc.1
 		IL_0146: ldloc.s 8
@@ -1002,13 +1002,13 @@
 		IL_016b: ldc.i4.0
 		IL_016c: ldelem.ref
 		IL_016d: castclass Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope
-		IL_0172: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject_FunctionExpression_E632B0CF_L32C23::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
+		IL_0172: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
 		IL_0177: ldc.i4.2
 		IL_0178: conv.r8
 		IL_0179: ldstr ""
 		IL_017e: ldc.i4.1
 		IL_017f: ldc.i4.1
-		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject_FunctionExpression_E632B0CF_L32C23>(!!0, float64, string, bool, bool)
+		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0185: stloc.s 13
 		IL_0187: ldloc.1
 		IL_0188: ldloc.s 8

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -90,9 +90,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_Repeat_Basic/Scope Modules.String_Repeat_Basic/logRepeat/FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::_environment0_String_Repeat_Basic
+				IL_0008: stfld class Modules.String_Repeat_Basic/Scope Modules.String_Repeat_Basic/logRepeat/FunctionObject::_environment0_String_Repeat_Basic
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -103,7 +103,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -114,7 +114,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -127,7 +127,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_Repeat_Basic/Scope Modules.String_Repeat_Basic/logRepeat/FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::_environment0_String_Repeat_Basic
+				IL_0001: ldfld class Modules.String_Repeat_Basic/Scope Modules.String_Repeat_Basic/logRepeat/FunctionObject::_environment0_String_Repeat_Basic
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -138,7 +138,7 @@
 				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001e: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
 				IL_0023: ret
-			} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -152,7 +152,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_Repeat_Basic/Scope Modules.String_Repeat_Basic/logRepeat/FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::_environment0_String_Repeat_Basic
+				IL_0001: ldfld class Modules.String_Repeat_Basic/Scope Modules.String_Repeat_Basic/logRepeat/FunctionObject::_environment0_String_Repeat_Basic
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -163,7 +163,7 @@
 				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_001a: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
 				IL_001f: ret
-			} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -181,9 +181,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -366,7 +366,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Repeat_Basic/Scope,
-			[1] class Modules.String_Repeat_Basic/logRepeat/FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat,
+			[1] class Modules.String_Repeat_Basic/logRepeat/FunctionObject,
 			[2] object[],
 			[3] float64,
 			[4] object
@@ -385,13 +385,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.String_Repeat_Basic/Scope
-		IL_0019: newobj instance void Modules.String_Repeat_Basic/logRepeat/FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::.ctor(class Modules.String_Repeat_Basic/Scope)
+		IL_0019: newobj instance void Modules.String_Repeat_Basic/logRepeat/FunctionObject::.ctor(class Modules.String_Repeat_Basic/Scope)
 		IL_001e: ldc.i4.2
 		IL_001f: conv.r8
 		IL_0020: ldstr "logRepeat"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_Repeat_Basic/logRepeat/FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_Repeat_Basic/logRepeat/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7C9A65CE_inner
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -56,12 +56,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.String_StartsWith_NestedParam/outer/Scope Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner::_environment1_outer
+					IL_0008: stfld class Modules.String_StartsWith_NestedParam/outer/Scope Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject::_environment1_outer
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner::_transitionalScopes
+					IL_000f: stfld object[] Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -96,7 +96,7 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner::_transitionalScopes
+					IL_0001: ldfld object[] Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: ldarg.2
 					IL_000c: ldc.i4.0
@@ -104,7 +104,7 @@
 					IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 					IL_0017: call object Modules.String_StartsWith_NestedParam/outer/inner::__js_call__(object[], object, string)
 					IL_001c: ret
-				} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -118,7 +118,7 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner::_transitionalScopes
+					IL_0001: ldfld object[] Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: ldarg.2
 					IL_0008: ldc.i4.0
@@ -126,7 +126,7 @@
 					IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 					IL_0013: call object Modules.String_StartsWith_NestedParam/outer/inner::__js_call__(object[], object, string)
 					IL_0018: ret
-				} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -144,9 +144,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_7C9A65CE_inner
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -210,7 +210,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_402202F9_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -230,9 +230,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_StartsWith_NestedParam/Scope Modules.String_StartsWith_NestedParam/outer/FunctionObject_FunctionDeclaration_402202F9_outer::_environment0_String_StartsWith_NestedParam
+				IL_0008: stfld class Modules.String_StartsWith_NestedParam/Scope Modules.String_StartsWith_NestedParam/outer/FunctionObject::_environment0_String_StartsWith_NestedParam
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -243,7 +243,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -254,7 +254,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -267,14 +267,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_StartsWith_NestedParam/Scope Modules.String_StartsWith_NestedParam/outer/FunctionObject_FunctionDeclaration_402202F9_outer::_environment0_String_StartsWith_NestedParam
+				IL_0001: ldfld class Modules.String_StartsWith_NestedParam/Scope Modules.String_StartsWith_NestedParam/outer/FunctionObject::_environment0_String_StartsWith_NestedParam
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.String_StartsWith_NestedParam/outer::__js_call__(class Modules.String_StartsWith_NestedParam/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -288,14 +288,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_StartsWith_NestedParam/Scope Modules.String_StartsWith_NestedParam/outer/FunctionObject_FunctionDeclaration_402202F9_outer::_environment0_String_StartsWith_NestedParam
+				IL_0001: ldfld class Modules.String_StartsWith_NestedParam/Scope Modules.String_StartsWith_NestedParam/outer/FunctionObject::_environment0_String_StartsWith_NestedParam
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.String_StartsWith_NestedParam/outer::__js_call__(class Modules.String_StartsWith_NestedParam/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -313,9 +313,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_402202F9_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -336,7 +336,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.String_StartsWith_NestedParam/outer/Scope,
-				[1] class Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner,
+				[1] class Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject,
 				[2] object[]
 			)
 
@@ -361,13 +361,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.String_StartsWith_NestedParam/outer/Scope
 			IL_0024: ldloc.2
-			IL_0025: newobj instance void Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner::.ctor(class Modules.String_StartsWith_NestedParam/outer/Scope, object[])
+			IL_0025: newobj instance void Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject::.ctor(class Modules.String_StartsWith_NestedParam/outer/Scope, object[])
 			IL_002a: ldc.i4.1
 			IL_002b: conv.r8
 			IL_002c: ldstr "inner"
 			IL_0031: ldc.i4.0
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.1
 			IL_0039: nop
 			IL_003a: ldc.i4.2
@@ -436,7 +436,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_StartsWith_NestedParam/Scope,
-			[1] class Modules.String_StartsWith_NestedParam/outer/FunctionObject_FunctionDeclaration_402202F9_outer,
+			[1] class Modules.String_StartsWith_NestedParam/outer/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -455,13 +455,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.String_StartsWith_NestedParam/Scope
-		IL_0019: newobj instance void Modules.String_StartsWith_NestedParam/outer/FunctionObject_FunctionDeclaration_402202F9_outer::.ctor(class Modules.String_StartsWith_NestedParam/Scope)
+		IL_0019: newobj instance void Modules.String_StartsWith_NestedParam/outer/FunctionObject::.ctor(class Modules.String_StartsWith_NestedParam/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_StartsWith_NestedParam/outer/FunctionObject_FunctionDeclaration_402202F9_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_StartsWith_NestedParam/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_Basic.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_06484AB7_tag
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -103,7 +103,7 @@
 
 				IL_0020: ldloc.0
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -121,7 +121,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.String_TaggedTemplate_Basic/tag::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -140,7 +140,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.String_TaggedTemplate_Basic/tag::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -158,9 +158,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_06484AB7_tag
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -246,7 +246,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_TaggedTemplate_Basic/Scope,
-			[1] class Modules.String_TaggedTemplate_Basic/tag/FunctionObject_FunctionDeclaration_06484AB7_tag,
+			[1] class Modules.String_TaggedTemplate_Basic/tag/FunctionObject,
 			[2] float64,
 			[3] float64,
 			[4] object,
@@ -267,13 +267,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
-		IL_0012: newobj instance void Modules.String_TaggedTemplate_Basic/tag/FunctionObject_FunctionDeclaration_06484AB7_tag::.ctor()
+		IL_0012: newobj instance void Modules.String_TaggedTemplate_Basic/tag/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "tag"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_Basic/tag/FunctionObject_FunctionDeclaration_06484AB7_tag>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_Basic/tag/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_39EEBD13_tag
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -103,7 +103,7 @@
 
 				IL_0020: ldloc.0
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -121,7 +121,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.String_TaggedTemplate_EvaluationOrder/tag::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -140,7 +140,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.String_TaggedTemplate_EvaluationOrder/tag::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -158,9 +158,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_39EEBD13_tag
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -219,7 +219,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BD4F3B6C_getValue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -239,9 +239,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.String_TaggedTemplate_EvaluationOrder/Scope Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::_environment0_String_TaggedTemplate_EvaluationOrder
+				IL_0008: stfld class Modules.String_TaggedTemplate_EvaluationOrder/Scope Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject::_environment0_String_TaggedTemplate_EvaluationOrder
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -252,7 +252,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -263,7 +263,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -276,11 +276,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_TaggedTemplate_EvaluationOrder/Scope Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::_environment0_String_TaggedTemplate_EvaluationOrder
+				IL_0001: ldfld class Modules.String_TaggedTemplate_EvaluationOrder/Scope Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject::_environment0_String_TaggedTemplate_EvaluationOrder
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -294,11 +294,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.String_TaggedTemplate_EvaluationOrder/Scope Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::_environment0_String_TaggedTemplate_EvaluationOrder
+				IL_0001: ldfld class Modules.String_TaggedTemplate_EvaluationOrder/Scope Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject::_environment0_String_TaggedTemplate_EvaluationOrder
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -316,9 +316,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BD4F3B6C_getValue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -424,8 +424,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_TaggedTemplate_EvaluationOrder/Scope,
-			[1] class Modules.String_TaggedTemplate_EvaluationOrder/tag/FunctionObject_FunctionDeclaration_39EEBD13_tag,
-			[2] class Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject_FunctionDeclaration_BD4F3B6C_getValue,
+			[1] class Modules.String_TaggedTemplate_EvaluationOrder/tag/FunctionObject,
+			[2] class Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject,
 			[3] object,
 			[4] object[],
 			[5] object[],
@@ -445,13 +445,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void Modules.String_TaggedTemplate_EvaluationOrder/tag/FunctionObject_FunctionDeclaration_39EEBD13_tag::.ctor()
+		IL_0012: newobj instance void Modules.String_TaggedTemplate_EvaluationOrder/tag/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "tag"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_EvaluationOrder/tag/FunctionObject_FunctionDeclaration_39EEBD13_tag>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_EvaluationOrder/tag/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -464,13 +464,13 @@
 		IL_0034: ldc.i4.0
 		IL_0035: ldelem.ref
 		IL_0036: castclass Modules.String_TaggedTemplate_EvaluationOrder/Scope
-		IL_003b: newobj instance void Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::.ctor(class Modules.String_TaggedTemplate_EvaluationOrder/Scope)
+		IL_003b: newobj instance void Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject::.ctor(class Modules.String_TaggedTemplate_EvaluationOrder/Scope)
 		IL_0040: ldc.i4.0
 		IL_0041: conv.r8
 		IL_0042: ldstr "getValue"
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject_FunctionDeclaration_BD4F3B6C_getValue>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: nop
 		IL_0050: nop

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_NoSubstitutions.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_NoSubstitutions.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BBF496DE_tag
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -84,7 +84,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.String_TaggedTemplate_NoSubstitutions/tag::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -103,7 +103,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.String_TaggedTemplate_NoSubstitutions/tag::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -121,9 +121,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BBF496DE_tag
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -214,7 +214,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_TaggedTemplate_NoSubstitutions/Scope,
-			[1] class Modules.String_TaggedTemplate_NoSubstitutions/tag/FunctionObject_FunctionDeclaration_BBF496DE_tag,
+			[1] class Modules.String_TaggedTemplate_NoSubstitutions/tag/FunctionObject,
 			[2] object,
 			[3] object[],
 			[4] object[],
@@ -231,13 +231,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.String_TaggedTemplate_NoSubstitutions/tag/FunctionObject_FunctionDeclaration_BBF496DE_tag::.ctor()
+		IL_0011: newobj instance void Modules.String_TaggedTemplate_NoSubstitutions/tag/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "tag"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_NoSubstitutions/tag/FunctionObject_FunctionDeclaration_BBF496DE_tag>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_NoSubstitutions/tag/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_RawStrings.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_RawStrings.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A859B7DD_tag
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method assembly hidebysig static 
 				object __js_call_with_arguments__ (
@@ -103,7 +103,7 @@
 
 				IL_0020: ldloc.0
 				IL_0021: ret
-			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::__js_call_with_arguments__
+			} // end of method FunctionObject::__js_call_with_arguments__
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -121,7 +121,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.String_TaggedTemplate_RawStrings/tag::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -140,7 +140,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.String_TaggedTemplate_RawStrings/tag::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -158,9 +158,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A859B7DD_tag
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -285,7 +285,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_TaggedTemplate_RawStrings/Scope,
-			[1] class Modules.String_TaggedTemplate_RawStrings/tag/FunctionObject_FunctionDeclaration_A859B7DD_tag,
+			[1] class Modules.String_TaggedTemplate_RawStrings/tag/FunctionObject,
 			[2] object[],
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array
@@ -300,13 +300,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.String_TaggedTemplate_RawStrings/tag/FunctionObject_FunctionDeclaration_A859B7DD_tag::.ctor()
+		IL_0011: newobj instance void Modules.String_TaggedTemplate_RawStrings/tag/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "tag"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_RawStrings/tag/FunctionObject_FunctionDeclaration_A859B7DD_tag>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_RawStrings/tag/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryFinally_Return.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryFinally_Return.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5219E8A7_f
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -84,7 +84,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -106,7 +106,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -121,7 +121,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.TryFinally_Return/f::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -137,7 +137,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.TryFinally_Return/f::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -155,9 +155,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5219E8A7_f
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -252,7 +252,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryFinally_Return/Scope,
-			[1] class Modules.TryFinally_Return/f/FunctionObject_FunctionDeclaration_5219E8A7_f,
+			[1] class Modules.TryFinally_Return/f/FunctionObject,
 			[2] object[]
 		)
 
@@ -265,13 +265,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.TryFinally_Return/f/FunctionObject_FunctionDeclaration_5219E8A7_f::.ctor()
+		IL_0011: newobj instance void Modules.TryFinally_Return/f/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "f"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TryFinally_Return/f/FunctionObject_FunctionDeclaration_5219E8A7_f>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TryFinally_Return/f/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Callback_Methods.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Callback_Methods.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_802B628E_L5C24
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_802B628E_L5C24
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -183,7 +183,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1281CCCF_L9C27
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -197,7 +197,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -208,7 +208,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -219,7 +219,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -237,7 +237,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -256,7 +256,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -274,9 +274,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1281CCCF_L9C27
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -326,7 +326,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1DD803E1_L13C26
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -340,7 +340,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -351,7 +351,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -362,7 +362,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -380,7 +380,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -399,7 +399,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -417,9 +417,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_1DD803E1_L13C26
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -469,7 +469,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AF6B9F7C_L17C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -483,7 +483,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -494,7 +494,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -505,7 +505,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -523,7 +523,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -542,7 +542,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -560,9 +560,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_AF6B9F7C_L17C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -612,7 +612,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_091FFC5B_L21C25
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -626,7 +626,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -637,7 +637,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -648,7 +648,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -666,7 +666,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -685,7 +685,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -703,9 +703,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_091FFC5B_L21C25
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -755,7 +755,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7EDB3801_L25C30
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -769,7 +769,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -780,7 +780,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -791,7 +791,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -809,7 +809,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -828,7 +828,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -846,9 +846,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_7EDB3801_L25C30
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -898,7 +898,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_83EEFAA3_L30C16
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -918,9 +918,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Float64Array_Callback_Methods/Scope Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject_FunctionExpression_83EEFAA3_L30C16::_environment0_Float64Array_Callback_Methods
+				IL_0008: stfld class Modules.Float64Array_Callback_Methods/Scope Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject::_environment0_Float64Array_Callback_Methods
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -931,7 +931,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -942,7 +942,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -955,14 +955,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Float64Array_Callback_Methods/Scope Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject_FunctionExpression_83EEFAA3_L30C16::_environment0_Float64Array_Callback_Methods
+				IL_0001: ldfld class Modules.Float64Array_Callback_Methods/Scope Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject::_environment0_Float64Array_Callback_Methods
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15::__js_call__(class Modules.Float64Array_Callback_Methods/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -976,14 +976,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Float64Array_Callback_Methods/Scope Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject_FunctionExpression_83EEFAA3_L30C16::_environment0_Float64Array_Callback_Methods
+				IL_0001: ldfld class Modules.Float64Array_Callback_Methods/Scope Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject::_environment0_Float64Array_Callback_Methods
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15::__js_call__(class Modules.Float64Array_Callback_Methods/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1001,9 +1001,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_83EEFAA3_L30C16
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1066,7 +1066,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FC8E004A_L35C27
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1080,7 +1080,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1091,7 +1091,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1102,7 +1102,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1123,7 +1123,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1145,7 +1145,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1163,9 +1163,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_FC8E004A_L35C27
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1242,15 +1242,15 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object[],
-			[5] class Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23/FunctionObject_FunctionExpression_802B628E_L5C24,
+			[5] class Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23/FunctionObject,
 			[6] object,
-			[7] class Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject_FunctionExpression_1281CCCF_L9C27,
-			[8] class Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject_FunctionExpression_1DD803E1_L13C26,
-			[9] class Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject_FunctionExpression_AF6B9F7C_L17C25,
-			[10] class Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject_FunctionExpression_091FFC5B_L21C25,
-			[11] class Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject_FunctionExpression_7EDB3801_L25C30,
-			[12] class Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject_FunctionExpression_83EEFAA3_L30C16,
-			[13] class Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject_FunctionExpression_FC8E004A_L35C27
+			[7] class Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject,
+			[8] class Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject,
+			[9] class Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject,
+			[10] class Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject,
+			[11] class Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject,
+			[12] class Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject,
+			[13] class Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.Float64Array_Callback_Methods/Scope::.ctor()
@@ -1280,13 +1280,13 @@
 		IL_0050: ldloc.0
 		IL_0051: stelem.ref
 		IL_0052: stloc.s 4
-		IL_0054: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23/FunctionObject_FunctionExpression_802B628E_L5C24::.ctor()
+		IL_0054: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23/FunctionObject::.ctor()
 		IL_0059: ldc.i4.2
 		IL_005a: conv.r8
 		IL_005b: ldstr ""
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23/FunctionObject_FunctionExpression_802B628E_L5C24>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 5
 		IL_0069: ldloc.1
 		IL_006a: ldstr "map"
@@ -1312,13 +1312,13 @@
 		IL_00a7: ldloc.0
 		IL_00a8: stelem.ref
 		IL_00a9: stloc.s 4
-		IL_00ab: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject_FunctionExpression_1281CCCF_L9C27::.ctor()
+		IL_00ab: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject::.ctor()
 		IL_00b0: ldc.i4.1
 		IL_00b1: conv.r8
 		IL_00b2: ldstr ""
 		IL_00b7: ldc.i4.0
 		IL_00b8: ldc.i4.1
-		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject_FunctionExpression_1281CCCF_L9C27>(!!0, float64, string, bool, bool)
+		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00be: stloc.s 7
 		IL_00c0: ldloc.1
 		IL_00c1: ldstr "filter"
@@ -1344,13 +1344,13 @@
 		IL_00fe: ldloc.0
 		IL_00ff: stelem.ref
 		IL_0100: stloc.s 4
-		IL_0102: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject_FunctionExpression_1DD803E1_L13C26::.ctor()
+		IL_0102: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject::.ctor()
 		IL_0107: ldc.i4.1
 		IL_0108: conv.r8
 		IL_0109: ldstr ""
 		IL_010e: ldc.i4.0
 		IL_010f: ldc.i4.1
-		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject_FunctionExpression_1DD803E1_L13C26>(!!0, float64, string, bool, bool)
+		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0115: stloc.s 8
 		IL_0117: ldloc.1
 		IL_0118: ldstr "every"
@@ -1370,13 +1370,13 @@
 		IL_013d: ldloc.0
 		IL_013e: stelem.ref
 		IL_013f: stloc.s 4
-		IL_0141: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject_FunctionExpression_AF6B9F7C_L17C25::.ctor()
+		IL_0141: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject::.ctor()
 		IL_0146: ldc.i4.1
 		IL_0147: conv.r8
 		IL_0148: ldstr ""
 		IL_014d: ldc.i4.0
 		IL_014e: ldc.i4.1
-		IL_014f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject_FunctionExpression_AF6B9F7C_L17C25>(!!0, float64, string, bool, bool)
+		IL_014f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0154: stloc.s 9
 		IL_0156: ldloc.1
 		IL_0157: ldstr "some"
@@ -1396,13 +1396,13 @@
 		IL_017c: ldloc.0
 		IL_017d: stelem.ref
 		IL_017e: stloc.s 4
-		IL_0180: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject_FunctionExpression_091FFC5B_L21C25::.ctor()
+		IL_0180: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject::.ctor()
 		IL_0185: ldc.i4.1
 		IL_0186: conv.r8
 		IL_0187: ldstr ""
 		IL_018c: ldc.i4.0
 		IL_018d: ldc.i4.1
-		IL_018e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject_FunctionExpression_091FFC5B_L21C25>(!!0, float64, string, bool, bool)
+		IL_018e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0193: stloc.s 10
 		IL_0195: ldloc.1
 		IL_0196: ldstr "find"
@@ -1422,13 +1422,13 @@
 		IL_01bb: ldloc.0
 		IL_01bc: stelem.ref
 		IL_01bd: stloc.s 4
-		IL_01bf: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject_FunctionExpression_7EDB3801_L25C30::.ctor()
+		IL_01bf: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject::.ctor()
 		IL_01c4: ldc.i4.1
 		IL_01c5: conv.r8
 		IL_01c6: ldstr ""
 		IL_01cb: ldc.i4.0
 		IL_01cc: ldc.i4.1
-		IL_01cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject_FunctionExpression_7EDB3801_L25C30>(!!0, float64, string, bool, bool)
+		IL_01cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01d2: stloc.s 11
 		IL_01d4: ldloc.1
 		IL_01d5: ldstr "findIndex"
@@ -1454,13 +1454,13 @@
 		IL_020e: ldc.i4.0
 		IL_020f: ldelem.ref
 		IL_0210: castclass Modules.Float64Array_Callback_Methods/Scope
-		IL_0215: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject_FunctionExpression_83EEFAA3_L30C16::.ctor(class Modules.Float64Array_Callback_Methods/Scope)
+		IL_0215: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject::.ctor(class Modules.Float64Array_Callback_Methods/Scope)
 		IL_021a: ldc.i4.1
 		IL_021b: conv.r8
 		IL_021c: ldstr ""
 		IL_0221: ldc.i4.0
 		IL_0222: ldc.i4.1
-		IL_0223: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject_FunctionExpression_83EEFAA3_L30C16>(!!0, float64, string, bool, bool)
+		IL_0223: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0228: stloc.s 12
 		IL_022a: ldloc.1
 		IL_022b: ldstr "forEach"
@@ -1485,13 +1485,13 @@
 		IL_025d: ldloc.0
 		IL_025e: stelem.ref
 		IL_025f: stloc.s 4
-		IL_0261: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject_FunctionExpression_FC8E004A_L35C27::.ctor()
+		IL_0261: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject::.ctor()
 		IL_0266: ldc.i4.2
 		IL_0267: conv.r8
 		IL_0268: ldstr ""
 		IL_026d: ldc.i4.0
 		IL_026e: ldc.i4.1
-		IL_026f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject_FunctionExpression_FC8E004A_L35C27>(!!0, float64, string, bool, bool)
+		IL_026f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0274: stloc.s 13
 		IL_0276: ldloc.1
 		IL_0277: ldstr "reduce"

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0242BF45_L17C10
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject_FunctionExpression_0242BF45_L17C10::_environment0_TypedArray_SignedAndClamped_ConversionSemantics
+				IL_0008: stfld class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject::_environment0_TypedArray_SignedAndClamped_ConversionSemantics
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,13 +87,13 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject_FunctionExpression_0242BF45_L17C10::_environment0_TypedArray_SignedAndClamped_ConversionSemantics
+				IL_0001: ldfld class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject::_environment0_TypedArray_SignedAndClamped_ConversionSemantics
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue::__js_call__(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::CallCore
+			} // end of method FunctionObject::CallCore
 
-		} // end of class FunctionObject_FunctionExpression_0242BF45_L17C10
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -232,7 +232,7 @@
 			[13] object,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[15] object[],
-			[16] class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject_FunctionExpression_0242BF45_L17C10
+			[16] class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject
 		)
 
 		IL_0000: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope::.ctor()
@@ -434,14 +434,14 @@
 		IL_0306: ldc.i4.0
 		IL_0307: ldelem.ref
 		IL_0308: castclass Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope
-		IL_030d: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject_FunctionExpression_0242BF45_L17C10::.ctor(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope)
+		IL_030d: newobj instance void Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject::.ctor(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope)
 		IL_0312: ldc.i4.0
 		IL_0313: conv.r8
 		IL_0314: ldstr ""
 		IL_0319: ldc.i4.0
 		IL_031a: ldc.i4.1
-		IL_031b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject_FunctionExpression_0242BF45_L17C10>(!!0, float64, string, bool, bool)
-		IL_0320: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject_FunctionExpression_0242BF45_L17C10>(!!0)
+		IL_031b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0320: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject>(!!0)
 		IL_0325: stloc.s 16
 		IL_0327: ldloc.s 14
 		IL_0329: ldstr "valueOf"

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_Static_From_Of.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_Static_From_Of.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_467B3866_L3C50
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,7 +87,7 @@
 				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0013: call object Modules.TypedArray_Static_From_Of/FunctionExpression_mapped::__js_call__(object, object, object)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -109,7 +109,7 @@
 				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000f: call object Modules.TypedArray_Static_From_Of/FunctionExpression_mapped::__js_call__(object, object, object)
 				IL_0014: ret
-			} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_467B3866_L3C50
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -193,7 +193,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9A551ACB_L14C55
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -207,7 +207,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -218,7 +218,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -229,7 +229,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -247,7 +247,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.TypedArray_Static_From_Of/FunctionExpression_floats::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -266,7 +266,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.TypedArray_Static_From_Of/FunctionExpression_floats::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -284,9 +284,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionExpression_9A551ACB_L14C55
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -354,13 +354,13 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Float64Array,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[6] object[],
-			[7] class Modules.TypedArray_Static_From_Of/FunctionExpression_mapped/FunctionObject_FunctionExpression_467B3866_L3C50,
+			[7] class Modules.TypedArray_Static_From_Of/FunctionExpression_mapped/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[11] object,
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
-			[13] class Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject_FunctionExpression_9A551ACB_L14C55,
+			[13] class Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.Float64Array
 		)
 
@@ -387,13 +387,13 @@
 		IL_0045: ldloc.0
 		IL_0046: stelem.ref
 		IL_0047: stloc.s 6
-		IL_0049: newobj instance void Modules.TypedArray_Static_From_Of/FunctionExpression_mapped/FunctionObject_FunctionExpression_467B3866_L3C50::.ctor()
+		IL_0049: newobj instance void Modules.TypedArray_Static_From_Of/FunctionExpression_mapped/FunctionObject::.ctor()
 		IL_004e: ldc.i4.2
 		IL_004f: conv.r8
 		IL_0050: ldstr ""
 		IL_0055: ldc.i4.1
 		IL_0056: ldc.i4.1
-		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_Static_From_Of/FunctionExpression_mapped/FunctionObject_FunctionExpression_467B3866_L3C50>(!!0, float64, string, bool, bool)
+		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_Static_From_Of/FunctionExpression_mapped/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_005c: stloc.s 7
 		IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0063: dup
@@ -504,13 +504,13 @@
 		IL_01c7: ldloc.0
 		IL_01c8: stelem.ref
 		IL_01c9: stloc.s 6
-		IL_01cb: newobj instance void Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject_FunctionExpression_9A551ACB_L14C55::.ctor()
+		IL_01cb: newobj instance void Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject::.ctor()
 		IL_01d0: ldc.i4.1
 		IL_01d1: conv.r8
 		IL_01d2: ldstr ""
 		IL_01d7: ldc.i4.0
 		IL_01d8: ldc.i4.1
-		IL_01d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject_FunctionExpression_9A551ACB_L14C55>(!!0, float64, string, bool, bool)
+		IL_01d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_01de: stloc.s 13
 		IL_01e0: ldloc.s 12
 		IL_01e2: ldloc.s 13

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4F8A7BA1_logCase
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -94,7 +94,7 @@
 				IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0026: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
 				IL_002b: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -123,7 +123,7 @@
 				IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0022: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
 				IL_0027: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -141,9 +141,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_4F8A7BA1_logCase
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -218,7 +218,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -238,9 +238,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject::_environment0_UnaryOperator_MinusMinusPostfix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -251,7 +251,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -262,7 +262,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -275,11 +275,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject::_environment0_UnaryOperator_MinusMinusPostfix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.UnaryOperator_MinusMinusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -293,11 +293,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject::_environment0_UnaryOperator_MinusMinusPostfix
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.UnaryOperator_MinusMinusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -315,9 +315,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -428,7 +428,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_58646066_argDouble
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -448,9 +448,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject_FunctionDeclaration_58646066_argDouble::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject::_environment0_UnaryOperator_MinusMinusPostfix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -461,7 +461,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -472,7 +472,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -485,7 +485,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject_FunctionDeclaration_58646066_argDouble::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject::_environment0_UnaryOperator_MinusMinusPostfix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -493,7 +493,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call object Modules.UnaryOperator_MinusMinusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -507,7 +507,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject_FunctionDeclaration_58646066_argDouble::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject::_environment0_UnaryOperator_MinusMinusPostfix
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -515,7 +515,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call object Modules.UnaryOperator_MinusMinusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -533,9 +533,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_58646066_argDouble
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -631,7 +631,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8932E6C6_capturedString
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -651,9 +651,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject_FunctionDeclaration_8932E6C6_capturedString::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject::_environment0_UnaryOperator_MinusMinusPostfix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -664,7 +664,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -675,7 +675,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -688,11 +688,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject_FunctionDeclaration_8932E6C6_capturedString::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject::_environment0_UnaryOperator_MinusMinusPostfix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.UnaryOperator_MinusMinusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -706,11 +706,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject_FunctionDeclaration_8932E6C6_capturedString::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject::_environment0_UnaryOperator_MinusMinusPostfix
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.UnaryOperator_MinusMinusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -728,9 +728,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8932E6C6_capturedString
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -832,7 +832,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1EBCC0DE_argString
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -852,9 +852,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject_FunctionDeclaration_1EBCC0DE_argString::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject::_environment0_UnaryOperator_MinusMinusPostfix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -865,7 +865,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -876,7 +876,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -889,14 +889,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject_FunctionDeclaration_1EBCC0DE_argString::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject::_environment0_UnaryOperator_MinusMinusPostfix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.UnaryOperator_MinusMinusPostfix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -910,14 +910,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject_FunctionDeclaration_1EBCC0DE_argString::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject::_environment0_UnaryOperator_MinusMinusPostfix
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.UnaryOperator_MinusMinusPostfix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -935,9 +935,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_1EBCC0DE_argString
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1074,17 +1074,17 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix/Scope,
-			[1] class Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble,
-			[2] class Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject_FunctionDeclaration_58646066_argDouble,
-			[3] class Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject_FunctionDeclaration_8932E6C6_capturedString,
-			[4] class Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject_FunctionDeclaration_1EBCC0DE_argString,
+			[1] class Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject,
+			[2] class Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject,
+			[3] class Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject,
+			[4] class Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject,
 			[5] float64,
 			[6] object,
 			[7] object,
 			[8] object,
 			[9] string,
 			[10] object[],
-			[11] class Modules.UnaryOperator_MinusMinusPostfix/logCase/FunctionObject_FunctionDeclaration_4F8A7BA1_logCase,
+			[11] class Modules.UnaryOperator_MinusMinusPostfix/logCase/FunctionObject,
 			[12] object,
 			[13] object,
 			[14] string,
@@ -1101,13 +1101,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 10
-		IL_0012: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/logCase/FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::.ctor()
+		IL_0012: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/logCase/FunctionObject::.ctor()
 		IL_0017: ldc.i4.4
 		IL_0018: conv.r8
 		IL_0019: ldstr "logCase"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/logCase/FunctionObject_FunctionDeclaration_4F8A7BA1_logCase>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/logCase/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.s 11
 		IL_0027: ldloc.0
 		IL_0028: ldloc.s 11
@@ -1123,13 +1123,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_0044: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
+		IL_0044: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr "capturedDouble"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.1
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object
@@ -1142,13 +1142,13 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_006d: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject_FunctionDeclaration_58646066_argDouble::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
+		IL_006d: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
 		IL_0072: ldc.i4.1
 		IL_0073: conv.r8
 		IL_0074: ldstr "argDouble"
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject_FunctionDeclaration_58646066_argDouble>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.2
 		IL_0081: ldc.i4.1
 		IL_0082: newarr [System.Runtime]System.Object
@@ -1161,13 +1161,13 @@
 		IL_008f: ldc.i4.0
 		IL_0090: ldelem.ref
 		IL_0091: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_0096: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject_FunctionDeclaration_8932E6C6_capturedString::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
+		IL_0096: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
 		IL_009b: ldc.i4.0
 		IL_009c: conv.r8
 		IL_009d: ldstr "capturedString"
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject_FunctionDeclaration_8932E6C6_capturedString>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a9: stloc.3
 		IL_00aa: ldc.i4.1
 		IL_00ab: newarr [System.Runtime]System.Object
@@ -1180,13 +1180,13 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_00bf: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject_FunctionDeclaration_1EBCC0DE_argString::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
+		IL_00bf: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
 		IL_00c4: ldc.i4.1
 		IL_00c5: conv.r8
 		IL_00c6: ldstr "argString"
 		IL_00cb: ldc.i4.0
 		IL_00cc: ldc.i4.1
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject_FunctionDeclaration_1EBCC0DE_argString>(!!0, float64, string, bool, bool)
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d2: stloc.s 4
 		IL_00d4: nop
 		IL_00d5: nop

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BBDAFA63_bump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -106,7 +106,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,7 +126,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -144,9 +144,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BBDAFA63_bump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -315,7 +315,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/Scope,
-			[1] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_BBDAFA63_bump,
+			[1] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump/FunctionObject,
 			[2] object[]
 		)
 
@@ -328,13 +328,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_BBDAFA63_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_BBDAFA63_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BBF9B0A8_bump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -106,7 +106,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,7 +126,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -144,9 +144,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BBF9B0A8_bump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -323,7 +323,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/Scope,
-			[1] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_BBF9B0A8_bump,
+			[1] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject,
 			[2] object[]
 		)
 
@@ -336,13 +336,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_BBF9B0A8_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_BBF9B0A8_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_538EA9FA_logCase
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -94,7 +94,7 @@
 				IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0026: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
 				IL_002b: ret
-			} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -123,7 +123,7 @@
 				IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0022: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
 				IL_0027: ret
-			} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -141,9 +141,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_538EA9FA_logCase
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -218,7 +218,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -238,9 +238,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject::_environment0_UnaryOperator_MinusMinusPrefix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -251,7 +251,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -262,7 +262,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -275,11 +275,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject::_environment0_UnaryOperator_MinusMinusPrefix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.UnaryOperator_MinusMinusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -293,11 +293,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject::_environment0_UnaryOperator_MinusMinusPrefix
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.UnaryOperator_MinusMinusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -315,9 +315,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -421,7 +421,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -441,9 +441,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject::_environment0_UnaryOperator_MinusMinusPrefix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -454,7 +454,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -465,7 +465,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -478,7 +478,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject::_environment0_UnaryOperator_MinusMinusPrefix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -486,7 +486,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call object Modules.UnaryOperator_MinusMinusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -500,7 +500,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject::_environment0_UnaryOperator_MinusMinusPrefix
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -508,7 +508,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call object Modules.UnaryOperator_MinusMinusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -526,9 +526,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -624,7 +624,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3BEB03B7_capturedString
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -644,9 +644,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject::_environment0_UnaryOperator_MinusMinusPrefix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -657,7 +657,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -668,7 +668,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -681,11 +681,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject::_environment0_UnaryOperator_MinusMinusPrefix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.UnaryOperator_MinusMinusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -699,11 +699,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject::_environment0_UnaryOperator_MinusMinusPrefix
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.UnaryOperator_MinusMinusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -721,9 +721,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3BEB03B7_capturedString
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -818,7 +818,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_770CD1D9_argString
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -838,9 +838,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject_FunctionDeclaration_770CD1D9_argString::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject::_environment0_UnaryOperator_MinusMinusPrefix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -851,7 +851,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -862,7 +862,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -875,14 +875,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject_FunctionDeclaration_770CD1D9_argString::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject::_environment0_UnaryOperator_MinusMinusPrefix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.UnaryOperator_MinusMinusPrefix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -896,14 +896,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject_FunctionDeclaration_770CD1D9_argString::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject::_environment0_UnaryOperator_MinusMinusPrefix
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.UnaryOperator_MinusMinusPrefix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -921,9 +921,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_770CD1D9_argString
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1053,17 +1053,17 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix/Scope,
-			[1] class Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble,
-			[2] class Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble,
-			[3] class Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject_FunctionDeclaration_3BEB03B7_capturedString,
-			[4] class Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject_FunctionDeclaration_770CD1D9_argString,
+			[1] class Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject,
+			[2] class Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject,
+			[3] class Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject,
+			[4] class Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject,
 			[5] float64,
 			[6] object,
 			[7] object,
 			[8] object,
 			[9] string,
 			[10] object[],
-			[11] class Modules.UnaryOperator_MinusMinusPrefix/logCase/FunctionObject_FunctionDeclaration_538EA9FA_logCase,
+			[11] class Modules.UnaryOperator_MinusMinusPrefix/logCase/FunctionObject,
 			[12] object,
 			[13] string,
 			[14] float64,
@@ -1079,13 +1079,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 10
-		IL_0012: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/logCase/FunctionObject_FunctionDeclaration_538EA9FA_logCase::.ctor()
+		IL_0012: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/logCase/FunctionObject::.ctor()
 		IL_0017: ldc.i4.4
 		IL_0018: conv.r8
 		IL_0019: ldstr "logCase"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/logCase/FunctionObject_FunctionDeclaration_538EA9FA_logCase>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/logCase/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.s 11
 		IL_0027: ldloc.0
 		IL_0028: ldloc.s 11
@@ -1101,13 +1101,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_0044: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
+		IL_0044: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr "capturedDouble"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.1
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object
@@ -1120,13 +1120,13 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_006d: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
+		IL_006d: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
 		IL_0072: ldc.i4.1
 		IL_0073: conv.r8
 		IL_0074: ldstr "argDouble"
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.2
 		IL_0081: ldc.i4.1
 		IL_0082: newarr [System.Runtime]System.Object
@@ -1139,13 +1139,13 @@
 		IL_008f: ldc.i4.0
 		IL_0090: ldelem.ref
 		IL_0091: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_0096: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
+		IL_0096: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
 		IL_009b: ldc.i4.0
 		IL_009c: conv.r8
 		IL_009d: ldstr "capturedString"
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject_FunctionDeclaration_3BEB03B7_capturedString>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a9: stloc.3
 		IL_00aa: ldc.i4.1
 		IL_00ab: newarr [System.Runtime]System.Object
@@ -1158,13 +1158,13 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_00bf: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject_FunctionDeclaration_770CD1D9_argString::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
+		IL_00bf: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
 		IL_00c4: ldc.i4.1
 		IL_00c5: conv.r8
 		IL_00c6: ldstr "argString"
 		IL_00cb: ldc.i4.0
 		IL_00cc: ldc.i4.1
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject_FunctionDeclaration_770CD1D9_argString>(!!0, float64, string, bool, bool)
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d2: stloc.s 4
 		IL_00d4: nop
 		IL_00d5: nop

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8981CE7C_bump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -106,7 +106,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,7 +126,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -144,9 +144,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8981CE7C_bump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -315,7 +315,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/Scope,
-			[1] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_8981CE7C_bump,
+			[1] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump/FunctionObject,
 			[2] object[]
 		)
 
@@ -328,13 +328,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_8981CE7C_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_8981CE7C_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_429B5AEB_bump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -106,7 +106,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,7 +126,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -144,9 +144,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_429B5AEB_bump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -323,7 +323,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/Scope,
-			[1] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_429B5AEB_bump,
+			[1] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject,
 			[2] object[]
 		)
 
@@ -336,13 +336,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_429B5AEB_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_429B5AEB_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_66FA40A5_inner
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -56,12 +56,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner::_environment1_outer
+					IL_0008: stfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject::_environment1_outer
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner::_transitionalScopes
+					IL_000f: stfld object[] Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -72,7 +72,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -83,7 +83,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -96,11 +96,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner::_transitionalScopes
+					IL_0001: ldfld object[] Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -114,11 +114,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner::_transitionalScopes
+					IL_0001: ldfld object[] Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -136,9 +136,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_66FA40A5_inner
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -304,7 +304,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7FD34D3A_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -324,9 +324,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject_FunctionDeclaration_7FD34D3A_outer::_environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject::_environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -337,7 +337,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -348,7 +348,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -361,11 +361,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject_FunctionDeclaration_7FD34D3A_outer::_environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject::_environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::__js_call__(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -379,11 +379,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject_FunctionDeclaration_7FD34D3A_outer::_environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject::_environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::__js_call__(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -401,9 +401,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7FD34D3A_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -423,7 +423,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope,
-				[1] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner,
+				[1] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject,
 				[2] object[],
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 				[4] object
@@ -447,13 +447,13 @@
 			IL_0017: ldelem.ref
 			IL_0018: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
 			IL_001d: ldloc.2
-			IL_001e: newobj instance void Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner::.ctor(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope, object[])
+			IL_001e: newobj instance void Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject::.ctor(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope, object[])
 			IL_0023: ldc.i4.0
 			IL_0024: conv.r8
 			IL_0025: ldstr "inner"
 			IL_002a: ldc.i4.0
 			IL_002b: ldc.i4.1
-			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner>(!!0, float64, string, bool, bool)
+			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_0031: stloc.1
 			IL_0032: ldloc.0
 			IL_0033: ldc.r8 3
@@ -526,7 +526,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope,
-			[1] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject_FunctionDeclaration_7FD34D3A_outer,
+			[1] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject,
 			[2] object[]
 		)
 
@@ -543,13 +543,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope
-		IL_0019: newobj instance void Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject_FunctionDeclaration_7FD34D3A_outer::.ctor(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope)
+		IL_0019: newobj instance void Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject::.ctor(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject_FunctionDeclaration_7FD34D3A_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E6DD4761_logCase
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -94,7 +94,7 @@
 				IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0026: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
 				IL_002b: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -123,7 +123,7 @@
 				IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0022: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
 				IL_0027: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -141,9 +141,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E6DD4761_logCase
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -218,7 +218,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -238,9 +238,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject::_environment0_UnaryOperator_PlusPlusPostfix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -251,7 +251,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -262,7 +262,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -275,11 +275,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject::_environment0_UnaryOperator_PlusPlusPostfix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.UnaryOperator_PlusPlusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -293,11 +293,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject::_environment0_UnaryOperator_PlusPlusPostfix
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.UnaryOperator_PlusPlusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -315,9 +315,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -428,7 +428,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E6366926_argDouble
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -448,9 +448,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject_FunctionDeclaration_E6366926_argDouble::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject::_environment0_UnaryOperator_PlusPlusPostfix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -461,7 +461,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -472,7 +472,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -485,7 +485,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject_FunctionDeclaration_E6366926_argDouble::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject::_environment0_UnaryOperator_PlusPlusPostfix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -493,7 +493,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call object Modules.UnaryOperator_PlusPlusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -507,7 +507,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject_FunctionDeclaration_E6366926_argDouble::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject::_environment0_UnaryOperator_PlusPlusPostfix
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -515,7 +515,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call object Modules.UnaryOperator_PlusPlusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -533,9 +533,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E6366926_argDouble
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -631,7 +631,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C0242C86_capturedString
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -651,9 +651,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject_FunctionDeclaration_C0242C86_capturedString::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject::_environment0_UnaryOperator_PlusPlusPostfix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -664,7 +664,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -675,7 +675,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -688,11 +688,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject_FunctionDeclaration_C0242C86_capturedString::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject::_environment0_UnaryOperator_PlusPlusPostfix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.UnaryOperator_PlusPlusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -706,11 +706,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject_FunctionDeclaration_C0242C86_capturedString::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject::_environment0_UnaryOperator_PlusPlusPostfix
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.UnaryOperator_PlusPlusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -728,9 +728,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C0242C86_capturedString
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -832,7 +832,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E97FE89E_argString
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -852,9 +852,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject_FunctionDeclaration_E97FE89E_argString::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject::_environment0_UnaryOperator_PlusPlusPostfix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -865,7 +865,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -876,7 +876,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -889,14 +889,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject_FunctionDeclaration_E97FE89E_argString::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject::_environment0_UnaryOperator_PlusPlusPostfix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.UnaryOperator_PlusPlusPostfix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -910,14 +910,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject_FunctionDeclaration_E97FE89E_argString::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject::_environment0_UnaryOperator_PlusPlusPostfix
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.UnaryOperator_PlusPlusPostfix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -935,9 +935,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E97FE89E_argString
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1074,17 +1074,17 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix/Scope,
-			[1] class Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble,
-			[2] class Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject_FunctionDeclaration_E6366926_argDouble,
-			[3] class Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject_FunctionDeclaration_C0242C86_capturedString,
-			[4] class Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject_FunctionDeclaration_E97FE89E_argString,
+			[1] class Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject,
+			[2] class Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject,
+			[3] class Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject,
+			[4] class Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject,
 			[5] float64,
 			[6] object,
 			[7] object,
 			[8] object,
 			[9] string,
 			[10] object[],
-			[11] class Modules.UnaryOperator_PlusPlusPostfix/logCase/FunctionObject_FunctionDeclaration_E6DD4761_logCase,
+			[11] class Modules.UnaryOperator_PlusPlusPostfix/logCase/FunctionObject,
 			[12] object,
 			[13] object,
 			[14] string,
@@ -1101,13 +1101,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 10
-		IL_0012: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/logCase/FunctionObject_FunctionDeclaration_E6DD4761_logCase::.ctor()
+		IL_0012: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/logCase/FunctionObject::.ctor()
 		IL_0017: ldc.i4.4
 		IL_0018: conv.r8
 		IL_0019: ldstr "logCase"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/logCase/FunctionObject_FunctionDeclaration_E6DD4761_logCase>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/logCase/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.s 11
 		IL_0027: ldloc.0
 		IL_0028: ldloc.s 11
@@ -1123,13 +1123,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_0044: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
+		IL_0044: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr "capturedDouble"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.1
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object
@@ -1142,13 +1142,13 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_006d: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject_FunctionDeclaration_E6366926_argDouble::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
+		IL_006d: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
 		IL_0072: ldc.i4.1
 		IL_0073: conv.r8
 		IL_0074: ldstr "argDouble"
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject_FunctionDeclaration_E6366926_argDouble>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.2
 		IL_0081: ldc.i4.1
 		IL_0082: newarr [System.Runtime]System.Object
@@ -1161,13 +1161,13 @@
 		IL_008f: ldc.i4.0
 		IL_0090: ldelem.ref
 		IL_0091: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_0096: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject_FunctionDeclaration_C0242C86_capturedString::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
+		IL_0096: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
 		IL_009b: ldc.i4.0
 		IL_009c: conv.r8
 		IL_009d: ldstr "capturedString"
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject_FunctionDeclaration_C0242C86_capturedString>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a9: stloc.3
 		IL_00aa: ldc.i4.1
 		IL_00ab: newarr [System.Runtime]System.Object
@@ -1180,13 +1180,13 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_00bf: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject_FunctionDeclaration_E97FE89E_argString::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
+		IL_00bf: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
 		IL_00c4: ldc.i4.1
 		IL_00c5: conv.r8
 		IL_00c6: ldstr "argString"
 		IL_00cb: ldc.i4.0
 		IL_00cc: ldc.i4.1
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject_FunctionDeclaration_E97FE89E_argString>(!!0, float64, string, bool, bool)
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d2: stloc.s 4
 		IL_00d4: nop
 		IL_00d5: nop

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_301E9C23_bump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -106,7 +106,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,7 +126,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -144,9 +144,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_301E9C23_bump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -315,7 +315,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/Scope,
-			[1] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_301E9C23_bump,
+			[1] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump/FunctionObject,
 			[2] object[]
 		)
 
@@ -328,13 +328,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_301E9C23_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_301E9C23_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5BEC1868_bump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -106,7 +106,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,7 +126,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -144,9 +144,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_5BEC1868_bump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -323,7 +323,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/Scope,
-			[1] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_5BEC1868_bump,
+			[1] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject,
 			[2] object[]
 		)
 
@@ -336,13 +336,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_5BEC1868_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_5BEC1868_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ADE1F2BA_logCase
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -94,7 +94,7 @@
 				IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0026: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
 				IL_002b: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -123,7 +123,7 @@
 				IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0022: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
 				IL_0027: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -141,9 +141,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_ADE1F2BA_logCase
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -218,7 +218,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -238,9 +238,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject::_environment0_UnaryOperator_PlusPlusPrefix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -251,7 +251,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -262,7 +262,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -275,11 +275,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject::_environment0_UnaryOperator_PlusPlusPrefix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.UnaryOperator_PlusPlusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -293,11 +293,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject::_environment0_UnaryOperator_PlusPlusPrefix
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.UnaryOperator_PlusPlusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -315,9 +315,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -421,7 +421,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3BB8A99D_argDouble
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -441,9 +441,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject::_environment0_UnaryOperator_PlusPlusPrefix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -454,7 +454,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -465,7 +465,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -478,7 +478,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject::_environment0_UnaryOperator_PlusPlusPrefix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -486,7 +486,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call object Modules.UnaryOperator_PlusPlusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -500,7 +500,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject::_environment0_UnaryOperator_PlusPlusPrefix
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -508,7 +508,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call object Modules.UnaryOperator_PlusPlusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -526,9 +526,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3BB8A99D_argDouble
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -624,7 +624,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3D09EA77_capturedString
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -644,9 +644,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject_FunctionDeclaration_3D09EA77_capturedString::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject::_environment0_UnaryOperator_PlusPlusPrefix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -657,7 +657,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -668,7 +668,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -681,11 +681,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject_FunctionDeclaration_3D09EA77_capturedString::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject::_environment0_UnaryOperator_PlusPlusPrefix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.UnaryOperator_PlusPlusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -699,11 +699,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject_FunctionDeclaration_3D09EA77_capturedString::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject::_environment0_UnaryOperator_PlusPlusPrefix
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.UnaryOperator_PlusPlusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -721,9 +721,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3D09EA77_capturedString
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -818,7 +818,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B37D5999_argString
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -838,9 +838,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject_FunctionDeclaration_B37D5999_argString::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject::_environment0_UnaryOperator_PlusPlusPrefix
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -851,7 +851,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -862,7 +862,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -875,14 +875,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject_FunctionDeclaration_B37D5999_argString::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject::_environment0_UnaryOperator_PlusPlusPrefix
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
 				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0012: call object Modules.UnaryOperator_PlusPlusPrefix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
 				IL_0017: ret
-			} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -896,14 +896,14 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject_FunctionDeclaration_B37D5999_argString::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject::_environment0_UnaryOperator_PlusPlusPrefix
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
 				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000e: call object Modules.UnaryOperator_PlusPlusPrefix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
 				IL_0013: ret
-			} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -921,9 +921,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_B37D5999_argString
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1053,17 +1053,17 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix/Scope,
-			[1] class Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble,
-			[2] class Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject_FunctionDeclaration_3BB8A99D_argDouble,
-			[3] class Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject_FunctionDeclaration_3D09EA77_capturedString,
-			[4] class Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject_FunctionDeclaration_B37D5999_argString,
+			[1] class Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject,
+			[2] class Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject,
+			[3] class Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject,
+			[4] class Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject,
 			[5] float64,
 			[6] object,
 			[7] object,
 			[8] object,
 			[9] string,
 			[10] object[],
-			[11] class Modules.UnaryOperator_PlusPlusPrefix/logCase/FunctionObject_FunctionDeclaration_ADE1F2BA_logCase,
+			[11] class Modules.UnaryOperator_PlusPlusPrefix/logCase/FunctionObject,
 			[12] object,
 			[13] string,
 			[14] float64,
@@ -1079,13 +1079,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 10
-		IL_0012: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/logCase/FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::.ctor()
+		IL_0012: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/logCase/FunctionObject::.ctor()
 		IL_0017: ldc.i4.4
 		IL_0018: conv.r8
 		IL_0019: ldstr "logCase"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/logCase/FunctionObject_FunctionDeclaration_ADE1F2BA_logCase>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/logCase/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.s 11
 		IL_0027: ldloc.0
 		IL_0028: ldloc.s 11
@@ -1101,13 +1101,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_0044: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
+		IL_0044: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr "capturedDouble"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.1
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object
@@ -1120,13 +1120,13 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_006d: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
+		IL_006d: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
 		IL_0072: ldc.i4.1
 		IL_0073: conv.r8
 		IL_0074: ldstr "argDouble"
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject_FunctionDeclaration_3BB8A99D_argDouble>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.2
 		IL_0081: ldc.i4.1
 		IL_0082: newarr [System.Runtime]System.Object
@@ -1139,13 +1139,13 @@
 		IL_008f: ldc.i4.0
 		IL_0090: ldelem.ref
 		IL_0091: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_0096: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject_FunctionDeclaration_3D09EA77_capturedString::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
+		IL_0096: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
 		IL_009b: ldc.i4.0
 		IL_009c: conv.r8
 		IL_009d: ldstr "capturedString"
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject_FunctionDeclaration_3D09EA77_capturedString>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00a9: stloc.3
 		IL_00aa: ldc.i4.1
 		IL_00ab: newarr [System.Runtime]System.Object
@@ -1158,13 +1158,13 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_00bf: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject_FunctionDeclaration_B37D5999_argString::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
+		IL_00bf: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
 		IL_00c4: ldc.i4.1
 		IL_00c5: conv.r8
 		IL_00c6: ldstr "argString"
 		IL_00cb: ldc.i4.0
 		IL_00cc: ldc.i4.1
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject_FunctionDeclaration_B37D5999_argString>(!!0, float64, string, bool, bool)
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_00d2: stloc.s 4
 		IL_00d4: nop
 		IL_00d5: nop

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E66FC83C_bump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -106,7 +106,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,7 +126,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -144,9 +144,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_E66FC83C_bump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -315,7 +315,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/Scope,
-			[1] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_E66FC83C_bump,
+			[1] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump/FunctionObject,
 			[2] object[]
 		)
 
@@ -328,13 +328,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_E66FC83C_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_E66FC83C_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -51,7 +51,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A71D4CAB_bump
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -65,7 +65,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -76,7 +76,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -87,7 +87,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -106,7 +106,7 @@
 				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_0011: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -126,7 +126,7 @@
 				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
 				IL_000d: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -144,9 +144,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A71D4CAB_bump
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -323,7 +323,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/Scope,
-			[1] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_A71D4CAB_bump,
+			[1] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject,
 			[2] object[]
 		)
 
@@ -336,13 +336,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_A71D4CAB_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_A71D4CAB_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BA7E0883_run
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_CapturedConst_BoolStringFieldType/Scope Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject_FunctionDeclaration_BA7E0883_run::_environment0_Variable_CapturedConst_BoolStringFieldType
+				IL_0008: stfld class Modules.Variable_CapturedConst_BoolStringFieldType/Scope Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject::_environment0_Variable_CapturedConst_BoolStringFieldType
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_CapturedConst_BoolStringFieldType/Scope Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject_FunctionDeclaration_BA7E0883_run::_environment0_Variable_CapturedConst_BoolStringFieldType
+				IL_0001: ldfld class Modules.Variable_CapturedConst_BoolStringFieldType/Scope Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject::_environment0_Variable_CapturedConst_BoolStringFieldType
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Variable_CapturedConst_BoolStringFieldType/run::__js_call__(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_CapturedConst_BoolStringFieldType/Scope Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject_FunctionDeclaration_BA7E0883_run::_environment0_Variable_CapturedConst_BoolStringFieldType
+				IL_0001: ldfld class Modules.Variable_CapturedConst_BoolStringFieldType/Scope Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject::_environment0_Variable_CapturedConst_BoolStringFieldType
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Variable_CapturedConst_BoolStringFieldType/run::__js_call__(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_BA7E0883_run
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -212,7 +212,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_BoolStringFieldType/Scope,
-			[1] class Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject_FunctionDeclaration_BA7E0883_run,
+			[1] class Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -231,13 +231,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Variable_CapturedConst_BoolStringFieldType/Scope
-		IL_0019: newobj instance void Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject_FunctionDeclaration_BA7E0883_run::.ctor(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope)
+		IL_0019: newobj instance void Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject::.ctor(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "run"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject_FunctionDeclaration_BA7E0883_run>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0E8E929B_run
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_CapturedConst_NumberFieldType/Scope Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject_FunctionDeclaration_0E8E929B_run::_environment0_Variable_CapturedConst_NumberFieldType
+				IL_0008: stfld class Modules.Variable_CapturedConst_NumberFieldType/Scope Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject::_environment0_Variable_CapturedConst_NumberFieldType
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_CapturedConst_NumberFieldType/Scope Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject_FunctionDeclaration_0E8E929B_run::_environment0_Variable_CapturedConst_NumberFieldType
+				IL_0001: ldfld class Modules.Variable_CapturedConst_NumberFieldType/Scope Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject::_environment0_Variable_CapturedConst_NumberFieldType
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Variable_CapturedConst_NumberFieldType/run::__js_call__(class Modules.Variable_CapturedConst_NumberFieldType/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_CapturedConst_NumberFieldType/Scope Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject_FunctionDeclaration_0E8E929B_run::_environment0_Variable_CapturedConst_NumberFieldType
+				IL_0001: ldfld class Modules.Variable_CapturedConst_NumberFieldType/Scope Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject::_environment0_Variable_CapturedConst_NumberFieldType
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Variable_CapturedConst_NumberFieldType/run::__js_call__(class Modules.Variable_CapturedConst_NumberFieldType/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_0E8E929B_run
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -203,7 +203,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_NumberFieldType/Scope,
-			[1] class Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject_FunctionDeclaration_0E8E929B_run,
+			[1] class Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[4] object
@@ -222,13 +222,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Variable_CapturedConst_NumberFieldType/Scope
-		IL_0019: newobj instance void Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject_FunctionDeclaration_0E8E929B_run::.ctor(class Modules.Variable_CapturedConst_NumberFieldType/Scope)
+		IL_0019: newobj instance void Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject::.ctor(class Modules.Variable_CapturedConst_NumberFieldType/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "run"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject_FunctionDeclaration_0E8E929B_run>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_747086A3_readLate
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject_FunctionDeclaration_747086A3_readLate::_environment0_Variable_ConstPrimitivePropagation
+				IL_0008: stfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject::_environment0_Variable_ConstPrimitivePropagation
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject_FunctionDeclaration_747086A3_readLate::_environment0_Variable_ConstPrimitivePropagation
+				IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject::_environment0_Variable_ConstPrimitivePropagation
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Variable_ConstPrimitivePropagation/readLate::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject_FunctionDeclaration_747086A3_readLate::_environment0_Variable_ConstPrimitivePropagation
+				IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject::_environment0_Variable_ConstPrimitivePropagation
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Variable_ConstPrimitivePropagation/readLate::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_747086A3_readLate
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -356,7 +356,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -376,9 +376,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::_environment0_Variable_ConstPrimitivePropagation
+				IL_0008: stfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject::_environment0_Variable_ConstPrimitivePropagation
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -389,7 +389,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -400,7 +400,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -413,11 +413,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::_environment0_Variable_ConstPrimitivePropagation
+				IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject::_environment0_Variable_ConstPrimitivePropagation
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -431,11 +431,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::_environment0_Variable_ConstPrimitivePropagation
+				IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject::_environment0_Variable_ConstPrimitivePropagation
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -453,9 +453,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2172,8 +2172,8 @@
 		.maxstack 12
 		.locals init (
 			[0] class Modules.Variable_ConstPrimitivePropagation/Scope,
-			[1] class Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject_FunctionDeclaration_747086A3_readLate,
-			[2] class Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz,
+			[1] class Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject,
+			[2] class Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject,
 			[3] class Modules.Variable_ConstPrimitivePropagation/Reader,
 			[4] float64,
 			[5] class [System.Runtime]System.Exception,
@@ -2229,13 +2229,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Variable_ConstPrimitivePropagation/Scope
-		IL_001b: newobj instance void Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject_FunctionDeclaration_747086A3_readLate::.ctor(class Modules.Variable_ConstPrimitivePropagation/Scope)
+		IL_001b: newobj instance void Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject::.ctor(class Modules.Variable_ConstPrimitivePropagation/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "readLate"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject_FunctionDeclaration_747086A3_readLate>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: ldc.i4.1
 		IL_0030: newarr [System.Runtime]System.Object
@@ -2248,13 +2248,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.Variable_ConstPrimitivePropagation/Scope
-		IL_0044: newobj instance void Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::.ctor(class Modules.Variable_ConstPrimitivePropagation/Scope)
+		IL_0044: newobj instance void Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject::.ctor(class Modules.Variable_ConstPrimitivePropagation/Scope)
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr "sameCallableTdz"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.2
 		IL_0058: nop
 		IL_0059: nop

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation_With.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation_With.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6DBEEA65_receive
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -80,7 +80,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -98,7 +98,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Variable_ConstPrimitivePropagation_With/receive::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -117,7 +117,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Variable_ConstPrimitivePropagation_With/receive::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -135,9 +135,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_6DBEEA65_receive
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -183,7 +183,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -197,7 +197,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -208,7 +208,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -219,7 +219,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -233,7 +233,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -251,7 +251,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -270,7 +270,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -288,9 +288,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -997,8 +997,8 @@
 		.locals init (
 			[0] class Modules.Variable_ConstPrimitivePropagation_With/Scope,
 			[1] object[],
-			[2] class Modules.Variable_ConstPrimitivePropagation_With/receive/FunctionObject_FunctionDeclaration_6DBEEA65_receive,
-			[3] class Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier/FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier,
+			[2] class Modules.Variable_ConstPrimitivePropagation_With/receive/FunctionObject,
+			[3] class Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier/FunctionObject,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[6] object
@@ -1013,14 +1013,14 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.1
-		IL_0011: newobj instance void Modules.Variable_ConstPrimitivePropagation_With/receive/FunctionObject_FunctionDeclaration_6DBEEA65_receive::.ctor()
+		IL_0011: newobj instance void Modules.Variable_ConstPrimitivePropagation_With/receive/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "receive"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.0
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation_With/receive/FunctionObject_FunctionDeclaration_6DBEEA65_receive>(!!0, float64, string, bool, bool)
-		IL_0024: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_ConstPrimitivePropagation_With/receive/FunctionObject_FunctionDeclaration_6DBEEA65_receive>(!!0)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation_With/receive/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0024: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_ConstPrimitivePropagation_With/receive/FunctionObject>(!!0)
 		IL_0029: stloc.2
 		IL_002a: ldloc.0
 		IL_002b: ldloc.2
@@ -1032,14 +1032,14 @@
 		IL_0039: ldloc.0
 		IL_003a: stelem.ref
 		IL_003b: stloc.1
-		IL_003c: newobj instance void Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier/FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::.ctor()
+		IL_003c: newobj instance void Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier/FunctionObject::.ctor()
 		IL_0041: ldc.i4.1
 		IL_0042: conv.r8
 		IL_0043: ldstr "receiveIdentifier"
 		IL_0048: ldc.i4.0
 		IL_0049: ldc.i4.0
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier/FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier>(!!0, float64, string, bool, bool)
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier/FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier>(!!0)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier/FunctionObject>(!!0)
 		IL_0054: stloc.3
 		IL_0055: ldloc.0
 		IL_0056: ldloc.3

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.verified.txt
@@ -70,7 +70,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_68DA2840_logError
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -84,7 +84,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -95,7 +95,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -106,7 +106,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -124,7 +124,7 @@
 				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_000c: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
 				IL_0011: ret
-			} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -143,7 +143,7 @@
 				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
 				IL_0008: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -161,9 +161,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_68DA2840_logError
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -949,7 +949,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope,
-			[1] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError/FunctionObject_FunctionDeclaration_68DA2840_logError,
+			[1] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError/FunctionObject,
 			[2] object[],
 			[3] object[],
 			[4] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L12C10/FunctionObject,
@@ -967,13 +967,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError/FunctionObject_FunctionDeclaration_68DA2840_logError::.ctor()
+		IL_0011: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError/FunctionObject::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "logError"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError/FunctionObject_FunctionDeclaration_68DA2840_logError>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetFunctionNestedShadowing.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetFunctionNestedShadowing.verified.txt
@@ -34,7 +34,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2693B1C5_inner
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Methods
@@ -48,7 +48,7 @@
 					IL_0000: ldarg.0
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -59,7 +59,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -70,7 +70,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -85,7 +85,7 @@
 					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_0005: call object Modules.Variable_LetFunctionNestedShadowing/outer/inner::__js_call__(object)
 					IL_000a: ret
-				} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -101,7 +101,7 @@
 					IL_0000: ldarg.3
 					IL_0001: call object Modules.Variable_LetFunctionNestedShadowing/outer/inner::__js_call__(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -119,9 +119,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionDeclaration_2693B1C5_inner
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -185,7 +185,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9FF23D5A_outer
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -199,7 +199,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -210,7 +210,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -221,7 +221,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -236,7 +236,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Variable_LetFunctionNestedShadowing/outer::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -252,7 +252,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Variable_LetFunctionNestedShadowing/outer::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -270,9 +270,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9FF23D5A_outer
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -289,7 +289,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Variable_LetFunctionNestedShadowing/outer/Scope,
-				[1] class Modules.Variable_LetFunctionNestedShadowing/outer/inner/FunctionObject_FunctionDeclaration_2693B1C5_inner,
+				[1] class Modules.Variable_LetFunctionNestedShadowing/outer/inner/FunctionObject,
 				[2] float64,
 				[3] object[],
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -300,13 +300,13 @@
 			IL_0005: stloc.0
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.3
-			IL_000c: newobj instance void Modules.Variable_LetFunctionNestedShadowing/outer/inner/FunctionObject_FunctionDeclaration_2693B1C5_inner::.ctor()
+			IL_000c: newobj instance void Modules.Variable_LetFunctionNestedShadowing/outer/inner/FunctionObject::.ctor()
 			IL_0011: ldc.i4.0
 			IL_0012: conv.r8
 			IL_0013: ldstr "inner"
 			IL_0018: ldc.i4.0
 			IL_0019: ldc.i4.1
-			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_LetFunctionNestedShadowing/outer/inner/FunctionObject_FunctionDeclaration_2693B1C5_inner>(!!0, float64, string, bool, bool)
+			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_LetFunctionNestedShadowing/outer/inner/FunctionObject>(!!0, float64, string, bool, bool)
 			IL_001f: stloc.1
 			IL_0020: ldc.r8 1
 			IL_0029: stloc.2
@@ -372,7 +372,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_LetFunctionNestedShadowing/Scope,
-			[1] class Modules.Variable_LetFunctionNestedShadowing/outer/FunctionObject_FunctionDeclaration_9FF23D5A_outer,
+			[1] class Modules.Variable_LetFunctionNestedShadowing/outer/FunctionObject,
 			[2] float64,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -388,13 +388,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Variable_LetFunctionNestedShadowing/outer/FunctionObject_FunctionDeclaration_9FF23D5A_outer::.ctor()
+		IL_0011: newobj instance void Modules.Variable_LetFunctionNestedShadowing/outer/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "outer"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_LetFunctionNestedShadowing/outer/FunctionObject_FunctionDeclaration_9FF23D5A_outer>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_LetFunctionNestedShadowing/outer/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: ldc.r8 0.0

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetShadowing.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetShadowing.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D5D45A6E_f
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -44,7 +44,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -55,7 +55,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -66,7 +66,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -81,7 +81,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Variable_LetShadowing/f::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -97,7 +97,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Variable_LetShadowing/f::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -115,9 +115,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_D5D45A6E_f
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -196,7 +196,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_LetShadowing/Scope,
-			[1] class Modules.Variable_LetShadowing/f/FunctionObject_FunctionDeclaration_D5D45A6E_f,
+			[1] class Modules.Variable_LetShadowing/f/FunctionObject,
 			[2] float64,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -212,13 +212,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void Modules.Variable_LetShadowing/f/FunctionObject_FunctionDeclaration_D5D45A6E_f::.ctor()
+		IL_0011: newobj instance void Modules.Variable_LetShadowing/f/FunctionObject::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "f"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_LetShadowing/f/FunctionObject_FunctionDeclaration_D5D45A6E_f>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_LetShadowing/f/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: ldc.r8 1

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericLetLocalSpecialization.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericLetLocalSpecialization.verified.txt
@@ -110,7 +110,7 @@
 
 		} // end of class Scope_For_L8C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DF2B5EED_calculate
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -130,9 +130,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -143,7 +143,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -154,7 +154,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -168,7 +168,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -181,7 +181,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -189,7 +189,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call object Modules.Variable_NumericLetLocalSpecialization/calculate::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -203,7 +203,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -211,7 +211,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call object Modules.Variable_NumericLetLocalSpecialization/calculate::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -229,9 +229,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_DF2B5EED_calculate
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -441,7 +441,7 @@
 
 		} // end of class Scope_For_L40C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -461,9 +461,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -474,7 +474,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -485,7 +485,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -499,7 +499,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -512,7 +512,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -520,7 +520,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call object Modules.Variable_NumericLetLocalSpecialization/drawLineShape::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -534,7 +534,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -542,7 +542,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call object Modules.Variable_NumericLetLocalSpecialization/drawLineShape::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -560,9 +560,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -753,7 +753,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -767,7 +767,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -778,7 +778,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -789,7 +789,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -803,7 +803,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -818,7 +818,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -834,7 +834,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -852,9 +852,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -996,7 +996,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1010,7 +1010,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1021,7 +1021,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1032,7 +1032,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1046,7 +1046,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1065,7 +1065,7 @@
 				IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_0011: call object Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1085,7 +1085,7 @@
 				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_000d: call object Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1103,9 +1103,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1191,7 +1191,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FCCC06F6_mixedType
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1205,7 +1205,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1216,7 +1216,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1227,7 +1227,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1241,7 +1241,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1260,7 +1260,7 @@
 				IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_0011: call object Modules.Variable_NumericLetLocalSpecialization/mixedType::__js_call__(object, bool)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1280,7 +1280,7 @@
 				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_000d: call object Modules.Variable_NumericLetLocalSpecialization/mixedType::__js_call__(object, bool)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1298,9 +1298,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_FCCC06F6_mixedType
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1370,7 +1370,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C3124A9F_L81C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -1392,12 +1392,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/captured/Scope Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12::_environment1_captured
+					IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/captured/Scope Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject::_environment1_captured
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12::_transitionalScopes
+					IL_000f: stfld object[] Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -1408,7 +1408,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -1419,7 +1419,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -1433,7 +1433,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -1446,11 +1446,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -1464,11 +1464,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -1486,9 +1486,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_C3124A9F_L81C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1559,7 +1559,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_85087881_captured
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1579,9 +1579,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1592,7 +1592,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1603,7 +1603,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1617,7 +1617,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1630,11 +1630,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Variable_NumericLetLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1648,11 +1648,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Variable_NumericLetLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1670,9 +1670,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_85087881_captured
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1693,7 +1693,7 @@
 			.locals init (
 				[0] class Modules.Variable_NumericLetLocalSpecialization/captured/Scope,
 				[1] object[],
-				[2] class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12
+				[2] class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Variable_NumericLetLocalSpecialization/captured/Scope::.ctor()
@@ -1721,14 +1721,14 @@
 			IL_0032: ldelem.ref
 			IL_0033: castclass Modules.Variable_NumericLetLocalSpecialization/captured/Scope
 			IL_0038: ldloc.1
-			IL_0039: newobj instance void Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12::.ctor(class Modules.Variable_NumericLetLocalSpecialization/captured/Scope, object[])
+			IL_0039: newobj instance void Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject::.ctor(class Modules.Variable_NumericLetLocalSpecialization/captured/Scope, object[])
 			IL_003e: ldc.i4.0
 			IL_003f: conv.r8
 			IL_0040: ldstr ""
 			IL_0045: ldc.i4.0
 			IL_0046: ldc.i4.0
-			IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12>(!!0, float64, string, bool, bool)
-			IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12>(!!0)
+			IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject>(!!0)
 			IL_0051: stloc.2
 			IL_0052: ldloc.2
 			IL_0053: ret
@@ -1780,7 +1780,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9A712F73_shadowedSource
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1800,9 +1800,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1813,7 +1813,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1824,7 +1824,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1838,7 +1838,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1851,11 +1851,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Variable_NumericLetLocalSpecialization/shadowedSource::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1869,11 +1869,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Variable_NumericLetLocalSpecialization/shadowedSource::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1891,9 +1891,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9A712F73_shadowedSource
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2005,7 +2005,7 @@
 
 		} // end of class Scope_For_L101C9
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F3E23859_loopCarried
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -2025,9 +2025,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2038,7 +2038,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2049,7 +2049,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -2063,7 +2063,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2076,7 +2076,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: ldarg.2
 				IL_000c: ldc.i4.0
@@ -2084,7 +2084,7 @@
 				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0017: call object Modules.Variable_NumericLetLocalSpecialization/loopCarried::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
 				IL_001c: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2098,7 +2098,7 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject::_environment0_Variable_NumericLetLocalSpecialization
 				IL_0006: ldarg.3
 				IL_0007: ldarg.2
 				IL_0008: ldc.i4.0
@@ -2106,7 +2106,7 @@
 				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0013: call object Modules.Variable_NumericLetLocalSpecialization/loopCarried::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
 				IL_0018: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2124,9 +2124,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_F3E23859_loopCarried
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2272,14 +2272,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_NumericLetLocalSpecialization/Scope,
-			[1] class Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate,
-			[2] class Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape,
-			[3] class Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead/FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead,
-			[4] class Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized,
-			[5] class Modules.Variable_NumericLetLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_FCCC06F6_mixedType,
-			[6] class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured,
-			[7] class Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource,
-			[8] class Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried,
+			[1] class Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject,
+			[2] class Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject,
+			[3] class Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead/FunctionObject,
+			[4] class Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized/FunctionObject,
+			[5] class Modules.Variable_NumericLetLocalSpecialization/mixedType/FunctionObject,
+			[6] class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject,
+			[7] class Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject,
+			[8] class Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject,
 			[9] object,
 			[10] object[],
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -2299,14 +2299,14 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
-		IL_001b: newobj instance void Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
+		IL_001b: newobj instance void Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "calculate"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.0
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate>(!!0, float64, string, bool, bool)
-		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate>(!!0)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject>(!!0)
 		IL_0033: stloc.1
 		IL_0034: ldc.i4.1
 		IL_0035: newarr [System.Runtime]System.Object
@@ -2319,14 +2319,14 @@
 		IL_0042: ldc.i4.0
 		IL_0043: ldelem.ref
 		IL_0044: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
-		IL_0049: newobj instance void Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
+		IL_0049: newobj instance void Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
 		IL_004e: ldc.i4.1
 		IL_004f: conv.r8
 		IL_0050: ldstr "drawLineShape"
 		IL_0055: ldc.i4.0
 		IL_0056: ldc.i4.0
-		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape>(!!0, float64, string, bool, bool)
-		IL_005c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape>(!!0)
+		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_005c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject>(!!0)
 		IL_0061: stloc.2
 		IL_0062: ldc.i4.1
 		IL_0063: newarr [System.Runtime]System.Object
@@ -2335,14 +2335,14 @@
 		IL_006a: ldloc.0
 		IL_006b: stelem.ref
 		IL_006c: stloc.s 10
-		IL_006e: newobj instance void Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead/FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::.ctor()
+		IL_006e: newobj instance void Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead/FunctionObject::.ctor()
 		IL_0073: ldc.i4.0
 		IL_0074: conv.r8
 		IL_0075: ldstr "temporalDeadZoneRead"
 		IL_007a: ldc.i4.0
 		IL_007b: ldc.i4.0
-		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead/FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead>(!!0, float64, string, bool, bool)
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead/FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead>(!!0)
+		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead/FunctionObject>(!!0)
 		IL_0086: stloc.3
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -2351,14 +2351,14 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 10
-		IL_0093: newobj instance void Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::.ctor()
+		IL_0093: newobj instance void Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized/FunctionObject::.ctor()
 		IL_0098: ldc.i4.1
 		IL_0099: conv.r8
 		IL_009a: ldstr "conditionallyInitialized"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.0
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized>(!!0, float64, string, bool, bool)
-		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized>(!!0)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized/FunctionObject>(!!0)
 		IL_00ab: stloc.s 4
 		IL_00ad: ldc.i4.1
 		IL_00ae: newarr [System.Runtime]System.Object
@@ -2367,14 +2367,14 @@
 		IL_00b5: ldloc.0
 		IL_00b6: stelem.ref
 		IL_00b7: stloc.s 10
-		IL_00b9: newobj instance void Modules.Variable_NumericLetLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::.ctor()
+		IL_00b9: newobj instance void Modules.Variable_NumericLetLocalSpecialization/mixedType/FunctionObject::.ctor()
 		IL_00be: ldc.i4.1
 		IL_00bf: conv.r8
 		IL_00c0: ldstr "mixedType"
 		IL_00c5: ldc.i4.0
 		IL_00c6: ldc.i4.0
-		IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_FCCC06F6_mixedType>(!!0, float64, string, bool, bool)
-		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_FCCC06F6_mixedType>(!!0)
+		IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/mixedType/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/mixedType/FunctionObject>(!!0)
 		IL_00d1: stloc.s 5
 		IL_00d3: ldc.i4.1
 		IL_00d4: newarr [System.Runtime]System.Object
@@ -2387,14 +2387,14 @@
 		IL_00e1: ldc.i4.0
 		IL_00e2: ldelem.ref
 		IL_00e3: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
-		IL_00e8: newobj instance void Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
+		IL_00e8: newobj instance void Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
 		IL_00ed: ldc.i4.0
 		IL_00ee: conv.r8
 		IL_00ef: ldstr "captured"
 		IL_00f4: ldc.i4.0
 		IL_00f5: ldc.i4.0
-		IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured>(!!0, float64, string, bool, bool)
-		IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured>(!!0)
+		IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject>(!!0)
 		IL_0100: stloc.s 6
 		IL_0102: ldc.i4.1
 		IL_0103: newarr [System.Runtime]System.Object
@@ -2407,14 +2407,14 @@
 		IL_0110: ldc.i4.0
 		IL_0111: ldelem.ref
 		IL_0112: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
-		IL_0117: newobj instance void Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
+		IL_0117: newobj instance void Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
 		IL_011c: ldc.i4.0
 		IL_011d: conv.r8
 		IL_011e: ldstr "shadowedSource"
 		IL_0123: ldc.i4.0
 		IL_0124: ldc.i4.0
-		IL_0125: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource>(!!0, float64, string, bool, bool)
-		IL_012a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource>(!!0)
+		IL_0125: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_012a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject>(!!0)
 		IL_012f: stloc.s 7
 		IL_0131: ldc.i4.1
 		IL_0132: newarr [System.Runtime]System.Object
@@ -2427,14 +2427,14 @@
 		IL_013f: ldc.i4.0
 		IL_0140: ldelem.ref
 		IL_0141: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
-		IL_0146: newobj instance void Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
+		IL_0146: newobj instance void Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
 		IL_014b: ldc.i4.1
 		IL_014c: conv.r8
 		IL_014d: ldstr "loopCarried"
 		IL_0152: ldc.i4.0
 		IL_0153: ldc.i4.0
-		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried>(!!0, float64, string, bool, bool)
-		IL_0159: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried>(!!0)
+		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0159: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject>(!!0)
 		IL_015e: stloc.s 8
 		IL_0160: nop
 		IL_0161: nop

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericVarLocalSpecialization.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericVarLocalSpecialization.verified.txt
@@ -89,7 +89,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C962BB39_calculate
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -103,7 +103,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -114,7 +114,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -125,7 +125,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -139,7 +139,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -158,7 +158,7 @@
 				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_0011: call object Modules.Variable_NumericVarLocalSpecialization/calculate::__js_call__(object, float64)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -178,7 +178,7 @@
 				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
 				IL_000d: call object Modules.Variable_NumericVarLocalSpecialization/calculate::__js_call__(object, float64)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -196,9 +196,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_C962BB39_calculate
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -300,7 +300,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -314,7 +314,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -325,7 +325,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -336,7 +336,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -350,7 +350,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -366,7 +366,7 @@
 				IL_0005: call float64 Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization::__js_call__(object)
 				IL_000a: box [System.Runtime]System.Double
 				IL_000f: ret
-			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -383,7 +383,7 @@
 				IL_0001: call float64 Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization::__js_call__(object)
 				IL_0006: box [System.Runtime]System.Double
 				IL_000b: ret
-			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -401,9 +401,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -507,7 +507,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -521,7 +521,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -532,7 +532,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -543,7 +543,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -557,7 +557,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -576,7 +576,7 @@
 				IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_0011: call object Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -596,7 +596,7 @@
 				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_000d: call object Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -614,9 +614,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -702,7 +702,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_75C6D3A2_mixedType
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -716,7 +716,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -727,7 +727,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -738,7 +738,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -752,7 +752,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -771,7 +771,7 @@
 				IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_0011: call object Modules.Variable_NumericVarLocalSpecialization/mixedType::__js_call__(object, bool)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -791,7 +791,7 @@
 				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_000d: call object Modules.Variable_NumericVarLocalSpecialization/mixedType::__js_call__(object, bool)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -809,9 +809,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_75C6D3A2_mixedType
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -876,7 +876,7 @@
 
 			} // end of class Scope
 
-			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FEB4A694_L42C12
+			.class nested public auto ansi sealed beforefieldinit FunctionObject
 				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 			{
 				// Fields
@@ -898,12 +898,12 @@
 					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 					IL_0006: ldarg.0
 					IL_0007: ldarg.1
-					IL_0008: stfld class Modules.Variable_NumericVarLocalSpecialization/captured/Scope Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12::_environment1_captured
+					IL_0008: stfld class Modules.Variable_NumericVarLocalSpecialization/captured/Scope Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject::_environment1_captured
 					IL_000d: ldarg.0
 					IL_000e: ldarg.2
-					IL_000f: stfld object[] Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12::_transitionalScopes
+					IL_000f: stfld object[] Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject::_transitionalScopes
 					IL_0014: ret
-				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::.ctor
+				} // end of method FunctionObject::.ctor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_IsConstructor () cil managed 
@@ -914,7 +914,7 @@
 
 					IL_0000: ldc.i4.1
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::get_IsConstructor
+				} // end of method FunctionObject::get_IsConstructor
 
 				.method public hidebysig specialname virtual 
 					instance bool get_RequiresInvocationContext () cil managed 
@@ -925,7 +925,7 @@
 
 					IL_0000: ldc.i4.0
 					IL_0001: ret
-				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::get_RequiresInvocationContext
+				} // end of method FunctionObject::get_RequiresInvocationContext
 
 				.method family hidebysig virtual 
 					instance object ResolveThisArgumentCore (
@@ -939,7 +939,7 @@
 					IL_0000: ldarg.1
 					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 					IL_0006: ret
-				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::ResolveThisArgumentCore
+				} // end of method FunctionObject::ResolveThisArgumentCore
 
 				.method family hidebysig virtual 
 					instance object CallCore (
@@ -952,11 +952,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject::_transitionalScopes
 					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 					IL_000b: call object Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11::__js_call__(object[], object)
 					IL_0010: ret
-				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::CallCore
+				} // end of method FunctionObject::CallCore
 
 				.method family hidebysig virtual 
 					instance object ConstructBodyCore (
@@ -970,11 +970,11 @@
 					.maxstack 8
 
 					IL_0000: ldarg.0
-					IL_0001: ldfld object[] Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12::_transitionalScopes
+					IL_0001: ldfld object[] Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject::_transitionalScopes
 					IL_0006: ldarg.3
 					IL_0007: call object Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11::__js_call__(object[], object)
 					IL_000c: ret
-				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::ConstructBodyCore
+				} // end of method FunctionObject::ConstructBodyCore
 
 				.method family hidebysig virtual 
 					instance object ConstructCore (
@@ -992,9 +992,9 @@
 					IL_0007: ldarg.2
 					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 					IL_000d: ret
-				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::ConstructCore
+				} // end of method FunctionObject::ConstructCore
 
-			} // end of class FunctionObject_FunctionExpression_FEB4A694_L42C12
+			} // end of class FunctionObject
 
 
 			// Methods
@@ -1065,7 +1065,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EAC4700D_captured
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1085,9 +1085,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured::_environment0_Variable_NumericVarLocalSpecialization
+				IL_0008: stfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject::_environment0_Variable_NumericVarLocalSpecialization
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1098,7 +1098,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1109,7 +1109,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1123,7 +1123,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1136,11 +1136,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured::_environment0_Variable_NumericVarLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject::_environment0_Variable_NumericVarLocalSpecialization
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Variable_NumericVarLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1154,11 +1154,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured::_environment0_Variable_NumericVarLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject::_environment0_Variable_NumericVarLocalSpecialization
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Variable_NumericVarLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1176,9 +1176,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_EAC4700D_captured
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1199,7 +1199,7 @@
 			.locals init (
 				[0] class Modules.Variable_NumericVarLocalSpecialization/captured/Scope,
 				[1] object[],
-				[2] class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12
+				[2] class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject
 			)
 
 			IL_0000: newobj instance void Modules.Variable_NumericVarLocalSpecialization/captured/Scope::.ctor()
@@ -1224,14 +1224,14 @@
 			IL_002b: ldelem.ref
 			IL_002c: castclass Modules.Variable_NumericVarLocalSpecialization/captured/Scope
 			IL_0031: ldloc.1
-			IL_0032: newobj instance void Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12::.ctor(class Modules.Variable_NumericVarLocalSpecialization/captured/Scope, object[])
+			IL_0032: newobj instance void Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject::.ctor(class Modules.Variable_NumericVarLocalSpecialization/captured/Scope, object[])
 			IL_0037: ldc.i4.0
 			IL_0038: conv.r8
 			IL_0039: ldstr ""
 			IL_003e: ldc.i4.0
 			IL_003f: ldc.i4.0
-			IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12>(!!0, float64, string, bool, bool)
-			IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12>(!!0)
+			IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject>(!!0, float64, string, bool, bool)
+			IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject>(!!0)
 			IL_004a: stloc.2
 			IL_004b: ldloc.2
 			IL_004c: ret
@@ -1262,7 +1262,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3357054A_hoistedDependency
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1276,7 +1276,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1287,7 +1287,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1298,7 +1298,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1312,7 +1312,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1327,7 +1327,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Variable_NumericVarLocalSpecialization/hoistedDependency::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1343,7 +1343,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Variable_NumericVarLocalSpecialization/hoistedDependency::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1361,9 +1361,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3357054A_hoistedDependency
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1419,7 +1419,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -1439,9 +1439,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::_environment0_Variable_NumericVarLocalSpecialization
+				IL_0008: stfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject::_environment0_Variable_NumericVarLocalSpecialization
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1452,7 +1452,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1463,7 +1463,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1477,7 +1477,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1490,11 +1490,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::_environment0_Variable_NumericVarLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject::_environment0_Variable_NumericVarLocalSpecialization
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1508,11 +1508,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::_environment0_Variable_NumericVarLocalSpecialization
+				IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject::_environment0_Variable_NumericVarLocalSpecialization
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1530,9 +1530,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1651,7 +1651,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1665,7 +1665,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1676,7 +1676,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1687,7 +1687,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1701,7 +1701,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1720,7 +1720,7 @@
 				IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_0011: call object Modules.Variable_NumericVarLocalSpecialization/labeledBreak::__js_call__(object, bool)
 				IL_0016: ret
-			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1740,7 +1740,7 @@
 				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
 				IL_000d: call object Modules.Variable_NumericVarLocalSpecialization/labeledBreak::__js_call__(object, bool)
 				IL_0012: ret
-			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1758,9 +1758,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -1825,7 +1825,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A3543986_optionalWrite
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -1839,7 +1839,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -1850,7 +1850,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -1861,7 +1861,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -1875,7 +1875,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -1890,7 +1890,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Variable_NumericVarLocalSpecialization/optionalWrite::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -1906,7 +1906,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Variable_NumericVarLocalSpecialization/optionalWrite::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -1924,9 +1924,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_A3543986_optionalWrite
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2029,7 +2029,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3B56324F_shadowedSource
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Methods
@@ -2043,7 +2043,7 @@
 				IL_0000: ldarg.0
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -2054,7 +2054,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -2065,7 +2065,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object ResolveThisArgumentCore (
@@ -2079,7 +2079,7 @@
 				IL_0000: ldarg.1
 				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::ResolveThisArgumentCore
+			} // end of method FunctionObject::ResolveThisArgumentCore
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -2094,7 +2094,7 @@
 				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_0005: call object Modules.Variable_NumericVarLocalSpecialization/shadowedSource::__js_call__(object)
 				IL_000a: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -2110,7 +2110,7 @@
 				IL_0000: ldarg.3
 				IL_0001: call object Modules.Variable_NumericVarLocalSpecialization/shadowedSource::__js_call__(object)
 				IL_0006: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -2128,9 +2128,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_3B56324F_shadowedSource
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -2296,16 +2296,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_NumericVarLocalSpecialization/Scope,
-			[1] class Modules.Variable_NumericVarLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_C962BB39_calculate,
-			[2] class Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization/FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization,
-			[3] class Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized,
-			[4] class Modules.Variable_NumericVarLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_75C6D3A2_mixedType,
-			[5] class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured,
-			[6] class Modules.Variable_NumericVarLocalSpecialization/hoistedDependency/FunctionObject_FunctionDeclaration_3357054A_hoistedDependency,
-			[7] class Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite,
-			[8] class Modules.Variable_NumericVarLocalSpecialization/labeledBreak/FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak,
-			[9] class Modules.Variable_NumericVarLocalSpecialization/optionalWrite/FunctionObject_FunctionDeclaration_A3543986_optionalWrite,
-			[10] class Modules.Variable_NumericVarLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_3B56324F_shadowedSource,
+			[1] class Modules.Variable_NumericVarLocalSpecialization/calculate/FunctionObject,
+			[2] class Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization/FunctionObject,
+			[3] class Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized/FunctionObject,
+			[4] class Modules.Variable_NumericVarLocalSpecialization/mixedType/FunctionObject,
+			[5] class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject,
+			[6] class Modules.Variable_NumericVarLocalSpecialization/hoistedDependency/FunctionObject,
+			[7] class Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject,
+			[8] class Modules.Variable_NumericVarLocalSpecialization/labeledBreak/FunctionObject,
+			[9] class Modules.Variable_NumericVarLocalSpecialization/optionalWrite/FunctionObject,
+			[10] class Modules.Variable_NumericVarLocalSpecialization/shadowedSource/FunctionObject,
 			[11] object,
 			[12] object[],
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.Console,
@@ -2323,14 +2323,14 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 12
-		IL_0012: newobj instance void Modules.Variable_NumericVarLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_C962BB39_calculate::.ctor()
+		IL_0012: newobj instance void Modules.Variable_NumericVarLocalSpecialization/calculate/FunctionObject::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "calculate"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_C962BB39_calculate>(!!0, float64, string, bool, bool)
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_C962BB39_calculate>(!!0)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/calculate/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/calculate/FunctionObject>(!!0)
 		IL_002a: stloc.1
 		IL_002b: ldc.i4.1
 		IL_002c: newarr [System.Runtime]System.Object
@@ -2339,14 +2339,14 @@
 		IL_0033: ldloc.0
 		IL_0034: stelem.ref
 		IL_0035: stloc.s 12
-		IL_0037: newobj instance void Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization/FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::.ctor()
+		IL_0037: newobj instance void Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization/FunctionObject::.ctor()
 		IL_003c: ldc.i4.0
 		IL_003d: conv.r8
 		IL_003e: ldstr "readBeforeInitialization"
 		IL_0043: ldc.i4.0
 		IL_0044: ldc.i4.0
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization/FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization>(!!0, float64, string, bool, bool)
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization/FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization>(!!0)
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization/FunctionObject>(!!0)
 		IL_004f: stloc.2
 		IL_0050: ldc.i4.1
 		IL_0051: newarr [System.Runtime]System.Object
@@ -2355,14 +2355,14 @@
 		IL_0058: ldloc.0
 		IL_0059: stelem.ref
 		IL_005a: stloc.s 12
-		IL_005c: newobj instance void Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::.ctor()
+		IL_005c: newobj instance void Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized/FunctionObject::.ctor()
 		IL_0061: ldc.i4.1
 		IL_0062: conv.r8
 		IL_0063: ldstr "conditionallyInitialized"
 		IL_0068: ldc.i4.0
 		IL_0069: ldc.i4.0
-		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized>(!!0, float64, string, bool, bool)
-		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized>(!!0)
+		IL_006a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized/FunctionObject>(!!0)
 		IL_0074: stloc.3
 		IL_0075: ldc.i4.1
 		IL_0076: newarr [System.Runtime]System.Object
@@ -2371,14 +2371,14 @@
 		IL_007d: ldloc.0
 		IL_007e: stelem.ref
 		IL_007f: stloc.s 12
-		IL_0081: newobj instance void Modules.Variable_NumericVarLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::.ctor()
+		IL_0081: newobj instance void Modules.Variable_NumericVarLocalSpecialization/mixedType/FunctionObject::.ctor()
 		IL_0086: ldc.i4.1
 		IL_0087: conv.r8
 		IL_0088: ldstr "mixedType"
 		IL_008d: ldc.i4.0
 		IL_008e: ldc.i4.0
-		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_75C6D3A2_mixedType>(!!0, float64, string, bool, bool)
-		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_75C6D3A2_mixedType>(!!0)
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/mixedType/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/mixedType/FunctionObject>(!!0)
 		IL_0099: stloc.s 4
 		IL_009b: ldc.i4.1
 		IL_009c: newarr [System.Runtime]System.Object
@@ -2391,14 +2391,14 @@
 		IL_00a9: ldc.i4.0
 		IL_00aa: ldelem.ref
 		IL_00ab: castclass Modules.Variable_NumericVarLocalSpecialization/Scope
-		IL_00b0: newobj instance void Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured::.ctor(class Modules.Variable_NumericVarLocalSpecialization/Scope)
+		IL_00b0: newobj instance void Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject::.ctor(class Modules.Variable_NumericVarLocalSpecialization/Scope)
 		IL_00b5: ldc.i4.0
 		IL_00b6: conv.r8
 		IL_00b7: ldstr "captured"
 		IL_00bc: ldc.i4.0
 		IL_00bd: ldc.i4.0
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured>(!!0, float64, string, bool, bool)
-		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured>(!!0)
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject>(!!0)
 		IL_00c8: stloc.s 5
 		IL_00ca: ldc.i4.1
 		IL_00cb: newarr [System.Runtime]System.Object
@@ -2407,14 +2407,14 @@
 		IL_00d2: ldloc.0
 		IL_00d3: stelem.ref
 		IL_00d4: stloc.s 12
-		IL_00d6: newobj instance void Modules.Variable_NumericVarLocalSpecialization/hoistedDependency/FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::.ctor()
+		IL_00d6: newobj instance void Modules.Variable_NumericVarLocalSpecialization/hoistedDependency/FunctionObject::.ctor()
 		IL_00db: ldc.i4.0
 		IL_00dc: conv.r8
 		IL_00dd: ldstr "hoistedDependency"
 		IL_00e2: ldc.i4.0
 		IL_00e3: ldc.i4.0
-		IL_00e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/hoistedDependency/FunctionObject_FunctionDeclaration_3357054A_hoistedDependency>(!!0, float64, string, bool, bool)
-		IL_00e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/hoistedDependency/FunctionObject_FunctionDeclaration_3357054A_hoistedDependency>(!!0)
+		IL_00e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/hoistedDependency/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_00e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/hoistedDependency/FunctionObject>(!!0)
 		IL_00ee: stloc.s 6
 		IL_00f0: ldc.i4.1
 		IL_00f1: newarr [System.Runtime]System.Object
@@ -2427,14 +2427,14 @@
 		IL_00fe: ldc.i4.0
 		IL_00ff: ldelem.ref
 		IL_0100: castclass Modules.Variable_NumericVarLocalSpecialization/Scope
-		IL_0105: newobj instance void Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::.ctor(class Modules.Variable_NumericVarLocalSpecialization/Scope)
+		IL_0105: newobj instance void Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject::.ctor(class Modules.Variable_NumericVarLocalSpecialization/Scope)
 		IL_010a: ldc.i4.0
 		IL_010b: conv.r8
 		IL_010c: ldstr "objectLiteralWrite"
 		IL_0111: ldc.i4.0
 		IL_0112: ldc.i4.0
-		IL_0113: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite>(!!0, float64, string, bool, bool)
-		IL_0118: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite>(!!0)
+		IL_0113: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0118: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject>(!!0)
 		IL_011d: stloc.s 7
 		IL_011f: ldc.i4.1
 		IL_0120: newarr [System.Runtime]System.Object
@@ -2443,14 +2443,14 @@
 		IL_0127: ldloc.0
 		IL_0128: stelem.ref
 		IL_0129: stloc.s 12
-		IL_012b: newobj instance void Modules.Variable_NumericVarLocalSpecialization/labeledBreak/FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::.ctor()
+		IL_012b: newobj instance void Modules.Variable_NumericVarLocalSpecialization/labeledBreak/FunctionObject::.ctor()
 		IL_0130: ldc.i4.1
 		IL_0131: conv.r8
 		IL_0132: ldstr "labeledBreak"
 		IL_0137: ldc.i4.0
 		IL_0138: ldc.i4.0
-		IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/labeledBreak/FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak>(!!0, float64, string, bool, bool)
-		IL_013e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/labeledBreak/FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak>(!!0)
+		IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/labeledBreak/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_013e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/labeledBreak/FunctionObject>(!!0)
 		IL_0143: stloc.s 8
 		IL_0145: ldc.i4.1
 		IL_0146: newarr [System.Runtime]System.Object
@@ -2459,14 +2459,14 @@
 		IL_014d: ldloc.0
 		IL_014e: stelem.ref
 		IL_014f: stloc.s 12
-		IL_0151: newobj instance void Modules.Variable_NumericVarLocalSpecialization/optionalWrite/FunctionObject_FunctionDeclaration_A3543986_optionalWrite::.ctor()
+		IL_0151: newobj instance void Modules.Variable_NumericVarLocalSpecialization/optionalWrite/FunctionObject::.ctor()
 		IL_0156: ldc.i4.0
 		IL_0157: conv.r8
 		IL_0158: ldstr "optionalWrite"
 		IL_015d: ldc.i4.0
 		IL_015e: ldc.i4.0
-		IL_015f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/optionalWrite/FunctionObject_FunctionDeclaration_A3543986_optionalWrite>(!!0, float64, string, bool, bool)
-		IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/optionalWrite/FunctionObject_FunctionDeclaration_A3543986_optionalWrite>(!!0)
+		IL_015f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/optionalWrite/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/optionalWrite/FunctionObject>(!!0)
 		IL_0169: stloc.s 9
 		IL_016b: ldc.i4.1
 		IL_016c: newarr [System.Runtime]System.Object
@@ -2475,14 +2475,14 @@
 		IL_0173: ldloc.0
 		IL_0174: stelem.ref
 		IL_0175: stloc.s 12
-		IL_0177: newobj instance void Modules.Variable_NumericVarLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::.ctor()
+		IL_0177: newobj instance void Modules.Variable_NumericVarLocalSpecialization/shadowedSource/FunctionObject::.ctor()
 		IL_017c: ldc.i4.0
 		IL_017d: conv.r8
 		IL_017e: ldstr "shadowedSource"
 		IL_0183: ldc.i4.0
 		IL_0184: ldc.i4.0
-		IL_0185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_3B56324F_shadowedSource>(!!0, float64, string, bool, bool)
-		IL_018a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_3B56324F_shadowedSource>(!!0)
+		IL_0185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/shadowedSource/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_018a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeLegacyFunctionProperties<class Modules.Variable_NumericVarLocalSpecialization/shadowedSource/FunctionObject>(!!0)
 		IL_018f: stloc.s 10
 		IL_0191: nop
 		IL_0192: nop

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_85C461C3_compute
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_ObjectDestructuring_Captured/Scope Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject_FunctionDeclaration_85C461C3_compute::_environment0_Variable_ObjectDestructuring_Captured
+				IL_0008: stfld class Modules.Variable_ObjectDestructuring_Captured/Scope Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject::_environment0_Variable_ObjectDestructuring_Captured
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_ObjectDestructuring_Captured/Scope Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject_FunctionDeclaration_85C461C3_compute::_environment0_Variable_ObjectDestructuring_Captured
+				IL_0001: ldfld class Modules.Variable_ObjectDestructuring_Captured/Scope Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject::_environment0_Variable_ObjectDestructuring_Captured
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Variable_ObjectDestructuring_Captured/compute::__js_call__(class Modules.Variable_ObjectDestructuring_Captured/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_ObjectDestructuring_Captured/Scope Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject_FunctionDeclaration_85C461C3_compute::_environment0_Variable_ObjectDestructuring_Captured
+				IL_0001: ldfld class Modules.Variable_ObjectDestructuring_Captured/Scope Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject::_environment0_Variable_ObjectDestructuring_Captured
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Variable_ObjectDestructuring_Captured/compute::__js_call__(class Modules.Variable_ObjectDestructuring_Captured/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_85C461C3_compute
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -214,7 +214,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_ObjectDestructuring_Captured/Scope,
-			[1] class Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject_FunctionDeclaration_85C461C3_compute,
+			[1] class Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
 			[4] object,
@@ -234,13 +234,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Variable_ObjectDestructuring_Captured/Scope
-		IL_0019: newobj instance void Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject_FunctionDeclaration_85C461C3_compute::.ctor(class Modules.Variable_ObjectDestructuring_Captured/Scope)
+		IL_0019: newobj instance void Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject::.ctor(class Modules.Variable_ObjectDestructuring_Captured/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "compute"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject_FunctionDeclaration_85C461C3_compute>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_586E5692_readValue
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.Variable_TemporalDeadZoneCapturedRead/Scope Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject_FunctionDeclaration_586E5692_readValue::_environment0_Variable_TemporalDeadZoneCapturedRead
+				IL_0008: stfld class Modules.Variable_TemporalDeadZoneCapturedRead/Scope Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject::_environment0_Variable_TemporalDeadZoneCapturedRead
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_TemporalDeadZoneCapturedRead/Scope Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject_FunctionDeclaration_586E5692_readValue::_environment0_Variable_TemporalDeadZoneCapturedRead
+				IL_0001: ldfld class Modules.Variable_TemporalDeadZoneCapturedRead/Scope Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject::_environment0_Variable_TemporalDeadZoneCapturedRead
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.Variable_TemporalDeadZoneCapturedRead/readValue::__js_call__(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.Variable_TemporalDeadZoneCapturedRead/Scope Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject_FunctionDeclaration_586E5692_readValue::_environment0_Variable_TemporalDeadZoneCapturedRead
+				IL_0001: ldfld class Modules.Variable_TemporalDeadZoneCapturedRead/Scope Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject::_environment0_Variable_TemporalDeadZoneCapturedRead
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.Variable_TemporalDeadZoneCapturedRead/readValue::__js_call__(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_586E5692_readValue
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -256,7 +256,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneCapturedRead/Scope,
-			[1] class Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject_FunctionDeclaration_586E5692_readValue,
+			[1] class Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject,
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
@@ -279,13 +279,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Variable_TemporalDeadZoneCapturedRead/Scope
-		IL_001b: newobj instance void Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject_FunctionDeclaration_586E5692_readValue::.ctor(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope)
+		IL_001b: newobj instance void Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject::.ctor(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "readValue"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject_FunctionDeclaration_586E5692_readValue>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop

--- a/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
+++ b/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
@@ -30,7 +30,7 @@
 
 		} // end of class Scope
 
-		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
 			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
 		{
 			// Fields
@@ -50,9 +50,9 @@
 				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
 				IL_0006: ldarg.0
 				IL_0007: ldarg.1
-				IL_0008: stfld class Modules.WeakRef_Deref_KeptObjects/Scope Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::_environment0_WeakRef_Deref_KeptObjects
+				IL_0008: stfld class Modules.WeakRef_Deref_KeptObjects/Scope Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject::_environment0_WeakRef_Deref_KeptObjects
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::.ctor
+			} // end of method FunctionObject::.ctor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_IsConstructor () cil managed 
@@ -63,7 +63,7 @@
 
 				IL_0000: ldc.i4.1
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::get_IsConstructor
+			} // end of method FunctionObject::get_IsConstructor
 
 			.method public hidebysig specialname virtual 
 				instance bool get_RequiresInvocationContext () cil managed 
@@ -74,7 +74,7 @@
 
 				IL_0000: ldc.i4.0
 				IL_0001: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::get_RequiresInvocationContext
+			} // end of method FunctionObject::get_RequiresInvocationContext
 
 			.method family hidebysig virtual 
 				instance object CallCore (
@@ -87,11 +87,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.WeakRef_Deref_KeptObjects/Scope Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::_environment0_WeakRef_Deref_KeptObjects
+				IL_0001: ldfld class Modules.WeakRef_Deref_KeptObjects/Scope Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject::_environment0_WeakRef_Deref_KeptObjects
 				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
 				IL_000b: call object Modules.WeakRef_Deref_KeptObjects/createWeakRef::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
 				IL_0010: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::CallCore
+			} // end of method FunctionObject::CallCore
 
 			.method family hidebysig virtual 
 				instance object ConstructBodyCore (
@@ -105,11 +105,11 @@
 				.maxstack 8
 
 				IL_0000: ldarg.0
-				IL_0001: ldfld class Modules.WeakRef_Deref_KeptObjects/Scope Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::_environment0_WeakRef_Deref_KeptObjects
+				IL_0001: ldfld class Modules.WeakRef_Deref_KeptObjects/Scope Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject::_environment0_WeakRef_Deref_KeptObjects
 				IL_0006: ldarg.3
 				IL_0007: call object Modules.WeakRef_Deref_KeptObjects/createWeakRef::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
 				IL_000c: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::ConstructBodyCore
+			} // end of method FunctionObject::ConstructBodyCore
 
 			.method family hidebysig virtual 
 				instance object ConstructCore (
@@ -127,9 +127,9 @@
 				IL_0007: ldarg.2
 				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
 				IL_000d: ret
-			} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::ConstructCore
+			} // end of method FunctionObject::ConstructCore
 
-		} // end of class FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef
+		} // end of class FunctionObject
 
 
 		// Methods
@@ -423,7 +423,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakRef_Deref_KeptObjects/Scope,
-			[1] class Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef,
+			[1] class Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject,
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
@@ -448,13 +448,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.WeakRef_Deref_KeptObjects/Scope
-		IL_001b: newobj instance void Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::.ctor(class Modules.WeakRef_Deref_KeptObjects/Scope)
+		IL_001b: newobj instance void Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject::.ctor(class Modules.WeakRef_Deref_KeptObjects/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "createWeakRef"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop


### PR DESCRIPTION
## Summary

Fixes #1797.

- Name generated function declaration and function expression wrappers simply
  `FunctionObject`, matching arrow wrappers.
- Retain unique callable identity through the existing nested owner type
  hierarchy.
- Add planner and emission coverage for declaration/expression wrappers and
  multiple same-scope callables.
- Regenerate the 388 affected generated-IL snapshots.

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore`
  - 2,810 passed, 1 skipped, and 388 expected generator snapshot updates
    before regeneration.
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --filter 'FullyQualifiedName~GeneratedFunctionObject'`
  - 19 passed.

