### PR TITLE
fix: use npm.cmd on Windows in CheerioGeneratorTests

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -87,7 +87,7 @@ jobs:
               }
 
               const latestCompleted = matchingRuns[0];
-              core.info(`No successful ${workflowId} run yet for ${targetTag}. Latest completed run ${latestCompleted.id} concluded ${latestCompleted.conclusion ?? 'n/a'}. Retrying...`);
+              core.info(`No successful ${workflowId} run yet for ${targetTag}. Latest completed run ${latestCompleted.id} concluded ${latestCompleted.conclusion ?? 'n/a'}. Retrying in ${pollMs / 1000}s... (Tip: manually re-trigger ${workflowId} for ${targetTag} to unblock retries of this job)`);
               await new Promise(resolve => setTimeout(resolve, pollMs));
             }
 

--- a/tests/Jroc.Tests/Integration/CheerioGeneratorTests.cs
+++ b/tests/Jroc.Tests/Integration/CheerioGeneratorTests.cs
@@ -72,9 +72,10 @@ public class CheerioGeneratorTests
 
     private static void InstallFixture(string root)
     {
+        var npmFileName = OperatingSystem.IsWindows() ? "npm.cmd" : "npm";
         var startInfo = new ProcessStartInfo
         {
-            FileName = "npm",
+            FileName = npmFileName,
             Arguments = "ci --ignore-scripts --no-audit --no-fund",
             WorkingDirectory = root,
             RedirectStandardOutput = true,


### PR DESCRIPTION
## Root Cause

publish-tool.yml failed (run #31690153244) because CheerioGeneratorTests tried to start 
pm with UseShellExecute = false on Windows. On Windows, npm is a .cmd batch file (
pm.cmd), not a standalone executable. With UseShellExecute = false, the OS cannot locate it, causing a Win32Exception.

## Changes

- **CheerioGeneratorTests.cs**: Use 
pm.cmd on Windows, 
pm elsewhere (OperatingSystem.IsWindows())
- **linux-smoke.yml**: Improve the polling message to hint that manually re-triggering publish-tool.yml is needed to unblock a smoke test retry

## Why retries of the smoke test fail

The linux-smoke.yml "Wait for published Jroc packages" step polls for a *successful* publish-tool.yml run. When the smoke test is retried, the publish-tool.yml run for 0.12.5 has already concluded with ailure. Since retrying the smoke job does not re-trigger publish-tool.yml, the smoke test will always time out (20 min) on every retry.

**To retry the smoke test for v0.12.5 successfully**, after merging this fix:
1. Manually dispatch publish-tool.yml with ref 0.12.5 (or update the tag to point to the fixed commit)
2. Once that run succeeds, re-run the failed smoke job
