### PR TITLE
docs(ecma262): classify Section 4 glossary clauses

### DIFF
--- a/docs/ECMA262/4/Section4_3.json
+++ b/docs/ECMA262/4/Section4_3.json
@@ -12,13 +12,13 @@
     {
       "clause": "4.3.1",
       "title": "Objects",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-objects"
     },
     {
       "clause": "4.3.2",
       "title": "The Strict Variant of ECMAScript",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-strict-variant-of-ecmascript"
     }
   ]

--- a/docs/ECMA262/4/Section4_3.md
+++ b/docs/ECMA262/4/Section4_3.md
@@ -4,7 +4,7 @@
 
 [Back to Section4](Section4.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-08-14T05:48:56Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -14,6 +14,6 @@
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 4.3.1 | Objects | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-objects) |
-| 4.3.2 | The Strict Variant of ECMAScript | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-strict-variant-of-ecmascript) |
+| 4.3.1 | Objects | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-objects) |
+| 4.3.2 | The Strict Variant of ECMAScript | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-strict-variant-of-ecmascript) |
 

--- a/docs/ECMA262/4/Section4_4.json
+++ b/docs/ECMA262/4/Section4_4.json
@@ -12,253 +12,253 @@
     {
       "clause": "4.4.1",
       "title": "implementation-approximated",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-implementation-approximated"
     },
     {
       "clause": "4.4.2",
       "title": "implementation-defined",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-implementation-defined"
     },
     {
       "clause": "4.4.3",
       "title": "host-defined",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-host-defined"
     },
     {
       "clause": "4.4.4",
       "title": "type",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-type"
     },
     {
       "clause": "4.4.5",
       "title": "primitive value",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-primitive-value"
     },
     {
       "clause": "4.4.6",
       "title": "object",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-object"
     },
     {
       "clause": "4.4.7",
       "title": "constructor",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-constructor"
     },
     {
       "clause": "4.4.8",
       "title": "prototype",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-prototype"
     },
     {
       "clause": "4.4.9",
       "title": "ordinary object",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-ordinary-object"
     },
     {
       "clause": "4.4.10",
       "title": "exotic object",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-exotic-object"
     },
     {
       "clause": "4.4.11",
       "title": "standard object",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-standard-object"
     },
     {
       "clause": "4.4.12",
       "title": "built-in object",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-built-in-object"
     },
     {
       "clause": "4.4.13",
       "title": "undefined value",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-undefined-value"
     },
     {
       "clause": "4.4.14",
       "title": "Undefined type",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-undefined-type"
     },
     {
       "clause": "4.4.15",
       "title": "null value",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-null-value"
     },
     {
       "clause": "4.4.16",
       "title": "Null type",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-null-type"
     },
     {
       "clause": "4.4.17",
       "title": "Boolean value",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-boolean-value"
     },
     {
       "clause": "4.4.18",
       "title": "Boolean type",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-boolean-type"
     },
     {
       "clause": "4.4.19",
       "title": "Boolean object",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-boolean-object"
     },
     {
       "clause": "4.4.20",
       "title": "String value",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-string-value"
     },
     {
       "clause": "4.4.21",
       "title": "String type",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-string-type"
     },
     {
       "clause": "4.4.22",
       "title": "String object",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-string-object"
     },
     {
       "clause": "4.4.23",
       "title": "Number value",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-number-value"
     },
     {
       "clause": "4.4.24",
       "title": "Number type",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-number-type"
     },
     {
       "clause": "4.4.25",
       "title": "Number object",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-number-object"
     },
     {
       "clause": "4.4.26",
       "title": "Infinity",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-infinity"
     },
     {
       "clause": "4.4.27",
       "title": "NaN",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-nan"
     },
     {
       "clause": "4.4.28",
       "title": "BigInt value",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-bigint-value"
     },
     {
       "clause": "4.4.29",
       "title": "BigInt type",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-bigint-type"
     },
     {
       "clause": "4.4.30",
       "title": "BigInt object",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-bigint-object"
     },
     {
       "clause": "4.4.31",
       "title": "Symbol value",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-symbol-value"
     },
     {
       "clause": "4.4.32",
       "title": "Symbol type",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-symbol-type"
     },
     {
       "clause": "4.4.33",
       "title": "Symbol object",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-symbol-object"
     },
     {
       "clause": "4.4.34",
       "title": "function",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-terms-and-definitions-function"
     },
     {
       "clause": "4.4.35",
       "title": "built-in function",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-built-in-function"
     },
     {
       "clause": "4.4.36",
       "title": "built-in constructor",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-built-in-constructor"
     },
     {
       "clause": "4.4.37",
       "title": "property",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-property"
     },
     {
       "clause": "4.4.38",
       "title": "method",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-method"
     },
     {
       "clause": "4.4.39",
       "title": "built-in method",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-built-in-method"
     },
     {
       "clause": "4.4.40",
       "title": "attribute",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-attribute"
     },
     {
       "clause": "4.4.41",
       "title": "own property",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-own-property"
     },
     {
       "clause": "4.4.42",
       "title": "inherited property",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-inherited-property"
     }
   ]

--- a/docs/ECMA262/4/Section4_4.md
+++ b/docs/ECMA262/4/Section4_4.md
@@ -4,7 +4,7 @@
 
 [Back to Section4](Section4.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-08-14T05:48:56Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -14,46 +14,46 @@
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 4.4.1 | implementation-approximated | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-implementation-approximated) |
-| 4.4.2 | implementation-defined | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-implementation-defined) |
-| 4.4.3 | host-defined | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-host-defined) |
-| 4.4.4 | type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-type) |
-| 4.4.5 | primitive value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-primitive-value) |
-| 4.4.6 | object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-object) |
-| 4.4.7 | constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-constructor) |
-| 4.4.8 | prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-prototype) |
-| 4.4.9 | ordinary object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object) |
-| 4.4.10 | exotic object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-exotic-object) |
-| 4.4.11 | standard object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-standard-object) |
-| 4.4.12 | built-in object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-object) |
-| 4.4.13 | undefined value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-undefined-value) |
-| 4.4.14 | Undefined type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-undefined-type) |
-| 4.4.15 | null value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-null-value) |
-| 4.4.16 | Null type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-null-type) |
-| 4.4.17 | Boolean value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-boolean-value) |
-| 4.4.18 | Boolean type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-boolean-type) |
-| 4.4.19 | Boolean object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-boolean-object) |
-| 4.4.20 | String value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-string-value) |
-| 4.4.21 | String type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-string-type) |
-| 4.4.22 | String object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string-object) |
-| 4.4.23 | Number value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-number-value) |
-| 4.4.24 | Number type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-number-type) |
-| 4.4.25 | Number object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-number-object) |
-| 4.4.26 | Infinity | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-infinity) |
-| 4.4.27 | NaN | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-nan) |
-| 4.4.28 | BigInt value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-bigint-value) |
-| 4.4.29 | BigInt type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-bigint-type) |
-| 4.4.30 | BigInt object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-bigint-object) |
-| 4.4.31 | Symbol value | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-symbol-value) |
-| 4.4.32 | Symbol type | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-symbol-type) |
-| 4.4.33 | Symbol object | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-symbol-object) |
-| 4.4.34 | function | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-function) |
-| 4.4.35 | built-in function | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function) |
-| 4.4.36 | built-in constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-constructor) |
-| 4.4.37 | property | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-property) |
-| 4.4.38 | method | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-method) |
-| 4.4.39 | built-in method | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-built-in-method) |
-| 4.4.40 | attribute | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-attribute) |
-| 4.4.41 | own property | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-own-property) |
-| 4.4.42 | inherited property | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-inherited-property) |
+| 4.4.1 | implementation-approximated | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-implementation-approximated) |
+| 4.4.2 | implementation-defined | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-implementation-defined) |
+| 4.4.3 | host-defined | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-host-defined) |
+| 4.4.4 | type | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-type) |
+| 4.4.5 | primitive value | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-primitive-value) |
+| 4.4.6 | object | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-object) |
+| 4.4.7 | constructor | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-constructor) |
+| 4.4.8 | prototype | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-prototype) |
+| 4.4.9 | ordinary object | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-object) |
+| 4.4.10 | exotic object | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-exotic-object) |
+| 4.4.11 | standard object | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-standard-object) |
+| 4.4.12 | built-in object | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-built-in-object) |
+| 4.4.13 | undefined value | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-undefined-value) |
+| 4.4.14 | Undefined type | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-undefined-type) |
+| 4.4.15 | null value | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-null-value) |
+| 4.4.16 | Null type | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-null-type) |
+| 4.4.17 | Boolean value | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-boolean-value) |
+| 4.4.18 | Boolean type | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-boolean-type) |
+| 4.4.19 | Boolean object | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-boolean-object) |
+| 4.4.20 | String value | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-string-value) |
+| 4.4.21 | String type | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-string-type) |
+| 4.4.22 | String object | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-string-object) |
+| 4.4.23 | Number value | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-number-value) |
+| 4.4.24 | Number type | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-number-type) |
+| 4.4.25 | Number object | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-number-object) |
+| 4.4.26 | Infinity | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-infinity) |
+| 4.4.27 | NaN | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-nan) |
+| 4.4.28 | BigInt value | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-bigint-value) |
+| 4.4.29 | BigInt type | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-bigint-type) |
+| 4.4.30 | BigInt object | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-bigint-object) |
+| 4.4.31 | Symbol value | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-symbol-value) |
+| 4.4.32 | Symbol type | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-symbol-type) |
+| 4.4.33 | Symbol object | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-symbol-object) |
+| 4.4.34 | function | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terms-and-definitions-function) |
+| 4.4.35 | built-in function | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-built-in-function) |
+| 4.4.36 | built-in constructor | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-built-in-constructor) |
+| 4.4.37 | property | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-property) |
+| 4.4.38 | method | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-method) |
+| 4.4.39 | built-in method | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-built-in-method) |
+| 4.4.40 | attribute | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-attribute) |
+| 4.4.41 | own property | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-own-property) |
+| 4.4.42 | inherited property | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-inherited-property) |
 


### PR DESCRIPTION
## Summary
- classify all 44 previously untracked Section 4 overview and glossary subclauses as N/A (informational)
- regenerate the Section 4.3 and 4.4 documentation

Section 4 is descriptive terminology; support for the referenced runtime behavior remains tracked in its normative clauses.