### PR TITLE
docs(ecma262): classify Section 5 notation clauses

### DIFF
--- a/docs/ECMA262/5/Section5_1.json
+++ b/docs/ECMA262/5/Section5_1.json
@@ -60,43 +60,43 @@
     {
       "clause": "5.1.5.4",
       "title": "Grammatical Parameters",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-grammatical-parameters"
     },
     {
       "clause": "5.1.5.5",
       "title": "one of",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-one-of"
     },
     {
       "clause": "5.1.5.6",
       "title": "[empty]",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-empty"
     },
     {
       "clause": "5.1.5.7",
       "title": "Lookahead Restrictions",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-lookahead-restrictions"
     },
     {
       "clause": "5.1.5.8",
       "title": "[no LineTerminator here]",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-no-lineterminator-here"
     },
     {
       "clause": "5.1.5.9",
       "title": "but not",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-but-not"
     },
     {
       "clause": "5.1.5.10",
       "title": "Descriptive Phrases",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-descriptive-phrases"
     }
   ]

--- a/docs/ECMA262/5/Section5_1.md
+++ b/docs/ECMA262/5/Section5_1.md
@@ -4,7 +4,7 @@
 
 [Back to Section5](Section5.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-08-14T06:00:09Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -22,11 +22,11 @@
 | 5.1.5.1 | Terminal Symbols | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-terminal-symbols) |
 | 5.1.5.2 | Nonterminal Symbols and Productions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-nonterminal-symbols-and-productions) |
 | 5.1.5.3 | Optional Symbols | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-optional-symbols) |
-| 5.1.5.4 | Grammatical Parameters | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-grammatical-parameters) |
-| 5.1.5.5 | one of | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-one-of) |
-| 5.1.5.6 | [empty] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-empty) |
-| 5.1.5.7 | Lookahead Restrictions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-lookahead-restrictions) |
-| 5.1.5.8 | [no LineTerminator here] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-no-lineterminator-here) |
-| 5.1.5.9 | but not | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-but-not) |
-| 5.1.5.10 | Descriptive Phrases | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-descriptive-phrases) |
+| 5.1.5.4 | Grammatical Parameters | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-grammatical-parameters) |
+| 5.1.5.5 | one of | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-one-of) |
+| 5.1.5.6 | [empty] | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-empty) |
+| 5.1.5.7 | Lookahead Restrictions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-lookahead-restrictions) |
+| 5.1.5.8 | [no LineTerminator here] | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-no-lineterminator-here) |
+| 5.1.5.9 | but not | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-but-not) |
+| 5.1.5.10 | Descriptive Phrases | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-descriptive-phrases) |
 

--- a/docs/ECMA262/5/Section5_2.json
+++ b/docs/ECMA262/5/Section5_2.json
@@ -12,73 +12,73 @@
     {
       "clause": "5.2.1",
       "title": "Evaluation Order",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-evaluation-order"
     },
     {
       "clause": "5.2.2",
       "title": "Abstract Operations",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations"
     },
     {
       "clause": "5.2.3",
       "title": "Syntax-Directed Operations",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations"
     },
     {
       "clause": "5.2.4",
       "title": "Runtime Semantics",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-runtime-semantics"
     },
     {
       "clause": "5.2.4.1",
       "title": "Completion ( completionRecord )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-completion-ao"
     },
     {
       "clause": "5.2.4.2",
       "title": "Throw an Exception",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-throw-an-exception"
     },
     {
       "clause": "5.2.4.3",
       "title": "Shorthands for Unwrapping Completion Records",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-shorthands-for-unwrapping-completion-records"
     },
     {
       "clause": "5.2.4.4",
       "title": "Implicit Normal Completion",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-implicit-normal-completion"
     },
     {
       "clause": "5.2.5",
       "title": "Static Semantics",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-static-semantic-rules"
     },
     {
       "clause": "5.2.6",
       "title": "Mathematical Operations",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-mathematical-operations"
     },
     {
       "clause": "5.2.7",
       "title": "Value Notation",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-value-notation"
     },
     {
       "clause": "5.2.8",
       "title": "Identity",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-identity"
     }
   ]

--- a/docs/ECMA262/5/Section5_2.md
+++ b/docs/ECMA262/5/Section5_2.md
@@ -4,7 +4,7 @@
 
 [Back to Section5](Section5.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-08-14T06:00:09Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -14,16 +14,16 @@
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 5.2.1 | Evaluation Order | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-evaluation-order) |
-| 5.2.2 | Abstract Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations) |
-| 5.2.3 | Syntax-Directed Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations) |
-| 5.2.4 | Runtime Semantics | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics) |
-| 5.2.4.1 | Completion ( completionRecord ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-completion-ao) |
-| 5.2.4.2 | Throw an Exception | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-throw-an-exception) |
-| 5.2.4.3 | Shorthands for Unwrapping Completion Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-shorthands-for-unwrapping-completion-records) |
-| 5.2.4.4 | Implicit Normal Completion | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-implicit-normal-completion) |
-| 5.2.5 | Static Semantics | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantic-rules) |
-| 5.2.6 | Mathematical Operations | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-mathematical-operations) |
-| 5.2.7 | Value Notation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-value-notation) |
-| 5.2.8 | Identity | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-identity) |
+| 5.2.1 | Evaluation Order | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-evaluation-order) |
+| 5.2.2 | Abstract Operations | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-algorithm-conventions-abstract-operations) |
+| 5.2.3 | Syntax-Directed Operations | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations) |
+| 5.2.4 | Runtime Semantics | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics) |
+| 5.2.4.1 | Completion ( completionRecord ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-completion-ao) |
+| 5.2.4.2 | Throw an Exception | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-throw-an-exception) |
+| 5.2.4.3 | Shorthands for Unwrapping Completion Records | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-shorthands-for-unwrapping-completion-records) |
+| 5.2.4.4 | Implicit Normal Completion | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-implicit-normal-completion) |
+| 5.2.5 | Static Semantics | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-static-semantic-rules) |
+| 5.2.6 | Mathematical Operations | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-mathematical-operations) |
+| 5.2.7 | Value Notation | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-value-notation) |
+| 5.2.8 | Identity | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-identity) |
 


### PR DESCRIPTION
## Summary
- classify the 19 previously untracked Section 5 clauses from current implementation and test evidence
- mark editorial and notation-only clauses as N/A (informational)
- document evaluation, completion, exception, and static-semantic concepts as Supported with Limitations
- regenerate Sections 5.1 and 5.2 documentation