### PR TITLE
docs(ecma262): classify Sections 11 through 13

### DIFF
--- a/docs/ECMA262/11/Section11_2.json
+++ b/docs/ECMA262/11/Section11_2.json
@@ -24,13 +24,13 @@
     {
       "clause": "11.2.2.1",
       "title": "Static Semantics: IsStrict ( node )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-isstrict"
     },
     {
       "clause": "11.2.3",
       "title": "Non-ECMAScript Functions",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-non-ecmascript-functions"
     }
   ],

--- a/docs/ECMA262/11/Section11_2.md
+++ b/docs/ECMA262/11/Section11_2.md
@@ -4,7 +4,7 @@
 
 [Back to Section11](Section11.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-06T09:50:24Z
+> Last generated (UTC): 2026-08-14T06:16:15Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -16,8 +16,8 @@
 |---:|---|---|---|
 | 11.2.1 | Directive Prologues and the Use Strict Directive | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-directive-prologues-and-the-use-strict-directive) |
 | 11.2.2 | Strict Mode Code | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-strict-mode-code) |
-| 11.2.2.1 | Static Semantics: IsStrict ( node ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isstrict) |
-| 11.2.3 | Non-ECMAScript Functions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-non-ecmascript-functions) |
+| 11.2.2.1 | Static Semantics: IsStrict ( node ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-isstrict) |
+| 11.2.3 | Non-ECMAScript Functions | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-non-ecmascript-functions) |
 
 ## Support
 

--- a/docs/ECMA262/12/Section12_9.json
+++ b/docs/ECMA262/12/Section12_9.json
@@ -12,13 +12,13 @@
     {
       "clause": "12.9.1",
       "title": "Null Literals",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-null-literals"
     },
     {
       "clause": "12.9.2",
       "title": "Boolean Literals",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-boolean-literals"
     },
     {
@@ -48,61 +48,61 @@
     {
       "clause": "12.9.4",
       "title": "String Literals",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-literals-string-literals"
     },
     {
       "clause": "12.9.4.1",
       "title": "Static Semantics: Early Errors",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-string-literals-early-errors"
     },
     {
       "clause": "12.9.4.2",
       "title": "Static Semantics: SV",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-sv"
     },
     {
       "clause": "12.9.4.3",
       "title": "Static Semantics: MV",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-string-literals-static-semantics-mv"
     },
     {
       "clause": "12.9.5",
       "title": "Regular Expression Literals",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-literals-regular-expression-literals"
     },
     {
       "clause": "12.9.5.1",
       "title": "Static Semantics: BodyText",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-bodytext"
     },
     {
       "clause": "12.9.5.2",
       "title": "Static Semantics: FlagText",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-flagtext"
     },
     {
       "clause": "12.9.6",
       "title": "Template Literal Lexical Components",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-template-literal-lexical-components"
     },
     {
       "clause": "12.9.6.1",
       "title": "Static Semantics: TV",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-tv"
     },
     {
       "clause": "12.9.6.2",
       "title": "Static Semantics: TRV",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-trv"
     }
   ],

--- a/docs/ECMA262/12/Section12_9.md
+++ b/docs/ECMA262/12/Section12_9.md
@@ -4,7 +4,7 @@
 
 [Back to Section12](Section12.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-25T21:53:07Z
+> Last generated (UTC): 2026-08-14T06:17:38Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -14,22 +14,22 @@
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 12.9.1 | Null Literals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-null-literals) |
-| 12.9.2 | Boolean Literals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-boolean-literals) |
+| 12.9.1 | Null Literals | Supported | [tc39.es](https://tc39.es/ecma262/#sec-null-literals) |
+| 12.9.2 | Boolean Literals | Supported | [tc39.es](https://tc39.es/ecma262/#sec-boolean-literals) |
 | 12.9.3 | Numeric Literals | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-literals-numeric-literals) |
 | 12.9.3.1 | Static Semantics: Early Errors | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-numeric-literals-early-errors) |
 | 12.9.3.2 | Static Semantics: MV | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-mv) |
 | 12.9.3.3 | Static Semantics: NumericValue | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-numericvalue) |
-| 12.9.4 | String Literals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-literals-string-literals) |
-| 12.9.4.1 | Static Semantics: Early Errors | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string-literals-early-errors) |
-| 12.9.4.2 | Static Semantics: SV | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-sv) |
-| 12.9.4.3 | Static Semantics: MV | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-string-literals-static-semantics-mv) |
-| 12.9.5 | Regular Expression Literals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-literals-regular-expression-literals) |
-| 12.9.5.1 | Static Semantics: BodyText | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-bodytext) |
-| 12.9.5.2 | Static Semantics: FlagText | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-flagtext) |
-| 12.9.6 | Template Literal Lexical Components | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-template-literal-lexical-components) |
-| 12.9.6.1 | Static Semantics: TV | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-tv) |
-| 12.9.6.2 | Static Semantics: TRV | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-trv) |
+| 12.9.4 | String Literals | Supported | [tc39.es](https://tc39.es/ecma262/#sec-literals-string-literals) |
+| 12.9.4.1 | Static Semantics: Early Errors | Supported | [tc39.es](https://tc39.es/ecma262/#sec-string-literals-early-errors) |
+| 12.9.4.2 | Static Semantics: SV | Supported | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-sv) |
+| 12.9.4.3 | Static Semantics: MV | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-string-literals-static-semantics-mv) |
+| 12.9.5 | Regular Expression Literals | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-literals-regular-expression-literals) |
+| 12.9.5.1 | Static Semantics: BodyText | Supported | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-bodytext) |
+| 12.9.5.2 | Static Semantics: FlagText | Supported | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-flagtext) |
+| 12.9.6 | Template Literal Lexical Components | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-template-literal-lexical-components) |
+| 12.9.6.1 | Static Semantics: TV | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-tv) |
+| 12.9.6.2 | Static Semantics: TRV | Supported | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-trv) |
 
 ## Support
 

--- a/docs/ECMA262/13/Section13_12.json
+++ b/docs/ECMA262/13/Section13_12.json
@@ -12,7 +12,7 @@
     {
       "clause": "13.12.1",
       "title": "Runtime Semantics: Evaluation",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-binary-bitwise-operators-runtime-semantics-evaluation"
     }
   ]

--- a/docs/ECMA262/13/Section13_12.md
+++ b/docs/ECMA262/13/Section13_12.md
@@ -4,7 +4,7 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-08-14T06:16:39Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -14,5 +14,5 @@
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 13.12.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-binary-bitwise-operators-runtime-semantics-evaluation) |
+| 13.12.1 | Runtime Semantics: Evaluation | Supported | [tc39.es](https://tc39.es/ecma262/#sec-binary-bitwise-operators-runtime-semantics-evaluation) |
 

--- a/docs/ECMA262/13/Section13_15.json
+++ b/docs/ECMA262/13/Section13_15.json
@@ -12,25 +12,25 @@
     {
       "clause": "13.15.1",
       "title": "Static Semantics: Early Errors",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors"
     },
     {
       "clause": "13.15.2",
       "title": "Runtime Semantics: Evaluation",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation"
     },
     {
       "clause": "13.15.3",
       "title": "ApplyStringOrNumericBinaryOperator ( lVal , opText , rVal )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-applystringornumericbinaryoperator"
     },
     {
       "clause": "13.15.4",
       "title": "EvaluateStringOrNumericBinaryExpression ( leftOperand , opText , rightOperand )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-evaluatestringornumericbinaryexpression"
     },
     {
@@ -42,7 +42,7 @@
     {
       "clause": "13.15.5.1",
       "title": "Static Semantics: Early Errors",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-destructuring-assignment-static-semantics-early-errors"
     },
     {

--- a/docs/ECMA262/13/Section13_15.md
+++ b/docs/ECMA262/13/Section13_15.md
@@ -4,7 +4,7 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-02T21:37:32Z
+> Last generated (UTC): 2026-08-14T06:16:39Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -14,12 +14,12 @@
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 13.15.1 | Static Semantics: Early Errors | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors) |
-| 13.15.2 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation) |
-| 13.15.3 | ApplyStringOrNumericBinaryOperator ( lVal , opText , rVal ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-applystringornumericbinaryoperator) |
-| 13.15.4 | EvaluateStringOrNumericBinaryExpression ( leftOperand , opText , rightOperand ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-evaluatestringornumericbinaryexpression) |
+| 13.15.1 | Static Semantics: Early Errors | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors) |
+| 13.15.2 | Runtime Semantics: Evaluation | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-assignment-operators-runtime-semantics-evaluation) |
+| 13.15.3 | ApplyStringOrNumericBinaryOperator ( lVal , opText , rVal ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-applystringornumericbinaryoperator) |
+| 13.15.4 | EvaluateStringOrNumericBinaryExpression ( leftOperand , opText , rightOperand ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-evaluatestringornumericbinaryexpression) |
 | 13.15.5 | Destructuring Assignment | Supported | [tc39.es](https://tc39.es/ecma262/#sec-destructuring-assignment) |
-| 13.15.5.1 | Static Semantics: Early Errors | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-destructuring-assignment-static-semantics-early-errors) |
+| 13.15.5.1 | Static Semantics: Early Errors | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-destructuring-assignment-static-semantics-early-errors) |
 | 13.15.5.2 | Runtime Semantics: DestructuringAssignmentEvaluation | Supported | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-destructuringassignmentevaluation) |
 | 13.15.5.3 | Runtime Semantics: PropertyDestructuringAssignmentEvaluation | Supported | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-propertydestructuringassignmentevaluation) |
 | 13.15.5.4 | Runtime Semantics: RestDestructuringAssignmentEvaluation | Supported | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-restdestructuringassignmentevaluation) |

--- a/docs/ECMA262/13/Section13_2.json
+++ b/docs/ECMA262/13/Section13_2.json
@@ -24,37 +24,37 @@
     {
       "clause": "13.2.2",
       "title": "Identifier Reference",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-identifier-reference"
     },
     {
       "clause": "13.2.3",
       "title": "Literals",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-primary-expression-literals"
     },
     {
       "clause": "13.2.3.1",
       "title": "Runtime Semantics: Evaluation",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-literals-runtime-semantics-evaluation"
     },
     {
       "clause": "13.2.4",
       "title": "Array Initializer",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-array-initializer"
     },
     {
       "clause": "13.2.4.1",
       "title": "Runtime Semantics: ArrayAccumulation",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-runtime-semantics-arrayaccumulation"
     },
     {
       "clause": "13.2.4.2",
       "title": "Runtime Semantics: Evaluation",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-array-initializer-runtime-semantics-evaluation"
     },
     {
@@ -66,13 +66,13 @@
     {
       "clause": "13.2.5.1",
       "title": "Static Semantics: Early Errors",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-object-initializer-static-semantics-early-errors"
     },
     {
       "clause": "13.2.5.2",
       "title": "Static Semantics: IsComputedPropertyKey",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-iscomputedpropertykey"
     },
     {
@@ -96,91 +96,91 @@
     {
       "clause": "13.2.6",
       "title": "Function Defining Expressions",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-function-defining-expressions"
     },
     {
       "clause": "13.2.7",
       "title": "Regular Expression Literals",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-primary-expression-regular-expression-literals"
     },
     {
       "clause": "13.2.7.1",
       "title": "Static Semantics: Early Errors",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-primary-expression-regular-expression-literals-static-semantics-early-errors"
     },
     {
       "clause": "13.2.7.2",
       "title": "Static Semantics: IsValidRegularExpressionLiteral ( literal )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-isvalidregularexpressionliteral"
     },
     {
       "clause": "13.2.7.3",
       "title": "Runtime Semantics: Evaluation",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-regular-expression-literals-runtime-semantics-evaluation"
     },
     {
       "clause": "13.2.8",
       "title": "Template Literals",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-template-literals"
     },
     {
       "clause": "13.2.8.1",
       "title": "Static Semantics: Early Errors",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-template-early-errors"
     },
     {
       "clause": "13.2.8.2",
       "title": "Static Semantics: TemplateStrings",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-static-semantics-templatestrings"
     },
     {
       "clause": "13.2.8.3",
       "title": "Static Semantics: TemplateString ( templateToken , raw )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-templatestring"
     },
     {
       "clause": "13.2.8.4",
       "title": "GetTemplateObject ( templateLiteral )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-gettemplateobject"
     },
     {
       "clause": "13.2.8.5",
       "title": "Runtime Semantics: SubstitutionEvaluation",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-runtime-semantics-substitutionevaluation"
     },
     {
       "clause": "13.2.8.6",
       "title": "Runtime Semantics: Evaluation",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-template-literals-runtime-semantics-evaluation"
     },
     {
       "clause": "13.2.9",
       "title": "The Grouping Operator",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-grouping-operator"
     },
     {
       "clause": "13.2.9.1",
       "title": "Static Semantics: Early Errors",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-grouping-operator-static-semantics-early-errors"
     },
     {
       "clause": "13.2.9.2",
       "title": "Runtime Semantics: Evaluation",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-grouping-operator-runtime-semantics-evaluation"
     }
   ],

--- a/docs/ECMA262/13/Section13_2.md
+++ b/docs/ECMA262/13/Section13_2.md
@@ -4,7 +4,7 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-08-07T18:30:40Z
+> Last generated (UTC): 2026-08-14T06:16:39Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -16,33 +16,33 @@
 |---:|---|---|---|
 | 13.2.1 | The this Keyword | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-this-keyword) |
 | 13.2.1.1 | Runtime Semantics: Evaluation | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-this-keyword-runtime-semantics-evaluation) |
-| 13.2.2 | Identifier Reference | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-identifier-reference) |
-| 13.2.3 | Literals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-primary-expression-literals) |
-| 13.2.3.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-literals-runtime-semantics-evaluation) |
-| 13.2.4 | Array Initializer | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-array-initializer) |
-| 13.2.4.1 | Runtime Semantics: ArrayAccumulation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-arrayaccumulation) |
-| 13.2.4.2 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-array-initializer-runtime-semantics-evaluation) |
+| 13.2.2 | Identifier Reference | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-identifier-reference) |
+| 13.2.3 | Literals | Supported | [tc39.es](https://tc39.es/ecma262/#sec-primary-expression-literals) |
+| 13.2.3.1 | Runtime Semantics: Evaluation | Supported | [tc39.es](https://tc39.es/ecma262/#sec-literals-runtime-semantics-evaluation) |
+| 13.2.4 | Array Initializer | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-array-initializer) |
+| 13.2.4.1 | Runtime Semantics: ArrayAccumulation | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-arrayaccumulation) |
+| 13.2.4.2 | Runtime Semantics: Evaluation | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-array-initializer-runtime-semantics-evaluation) |
 | 13.2.5 | Object Initializer | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-object-initializer) |
-| 13.2.5.1 | Static Semantics: Early Errors | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-object-initializer-static-semantics-early-errors) |
-| 13.2.5.2 | Static Semantics: IsComputedPropertyKey | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-iscomputedpropertykey) |
+| 13.2.5.1 | Static Semantics: Early Errors | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-object-initializer-static-semantics-early-errors) |
+| 13.2.5.2 | Static Semantics: IsComputedPropertyKey | Supported | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-iscomputedpropertykey) |
 | 13.2.5.3 | Static Semantics: PropertyNameList | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-propertynamelist) |
 | 13.2.5.4 | Runtime Semantics: Evaluation | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-object-initializer-runtime-semantics-evaluation) |
 | 13.2.5.5 | Runtime Semantics: PropertyDefinitionEvaluation | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-propertydefinitionevaluation) |
-| 13.2.6 | Function Defining Expressions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-function-defining-expressions) |
-| 13.2.7 | Regular Expression Literals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-primary-expression-regular-expression-literals) |
-| 13.2.7.1 | Static Semantics: Early Errors | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-primary-expression-regular-expression-literals-static-semantics-early-errors) |
-| 13.2.7.2 | Static Semantics: IsValidRegularExpressionLiteral ( literal ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isvalidregularexpressionliteral) |
-| 13.2.7.3 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-regular-expression-literals-runtime-semantics-evaluation) |
-| 13.2.8 | Template Literals | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-template-literals) |
-| 13.2.8.1 | Static Semantics: Early Errors | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-template-early-errors) |
-| 13.2.8.2 | Static Semantics: TemplateStrings | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-templatestrings) |
-| 13.2.8.3 | Static Semantics: TemplateString ( templateToken , raw ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-templatestring) |
-| 13.2.8.4 | GetTemplateObject ( templateLiteral ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-gettemplateobject) |
-| 13.2.8.5 | Runtime Semantics: SubstitutionEvaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-substitutionevaluation) |
-| 13.2.8.6 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-template-literals-runtime-semantics-evaluation) |
-| 13.2.9 | The Grouping Operator | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-grouping-operator) |
-| 13.2.9.1 | Static Semantics: Early Errors | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-grouping-operator-static-semantics-early-errors) |
-| 13.2.9.2 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-grouping-operator-runtime-semantics-evaluation) |
+| 13.2.6 | Function Defining Expressions | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-function-defining-expressions) |
+| 13.2.7 | Regular Expression Literals | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-primary-expression-regular-expression-literals) |
+| 13.2.7.1 | Static Semantics: Early Errors | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-primary-expression-regular-expression-literals-static-semantics-early-errors) |
+| 13.2.7.2 | Static Semantics: IsValidRegularExpressionLiteral ( literal ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-isvalidregularexpressionliteral) |
+| 13.2.7.3 | Runtime Semantics: Evaluation | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-regular-expression-literals-runtime-semantics-evaluation) |
+| 13.2.8 | Template Literals | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-template-literals) |
+| 13.2.8.1 | Static Semantics: Early Errors | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-template-early-errors) |
+| 13.2.8.2 | Static Semantics: TemplateStrings | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-static-semantics-templatestrings) |
+| 13.2.8.3 | Static Semantics: TemplateString ( templateToken , raw ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-templatestring) |
+| 13.2.8.4 | GetTemplateObject ( templateLiteral ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-gettemplateobject) |
+| 13.2.8.5 | Runtime Semantics: SubstitutionEvaluation | Supported | [tc39.es](https://tc39.es/ecma262/#sec-runtime-semantics-substitutionevaluation) |
+| 13.2.8.6 | Runtime Semantics: Evaluation | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-template-literals-runtime-semantics-evaluation) |
+| 13.2.9 | The Grouping Operator | Supported | [tc39.es](https://tc39.es/ecma262/#sec-grouping-operator) |
+| 13.2.9.1 | Static Semantics: Early Errors | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-grouping-operator-static-semantics-early-errors) |
+| 13.2.9.2 | Runtime Semantics: Evaluation | Supported | [tc39.es](https://tc39.es/ecma262/#sec-grouping-operator-runtime-semantics-evaluation) |
 
 ## Support
 

--- a/docs/ECMA262/13/Section13_6.json
+++ b/docs/ECMA262/13/Section13_6.json
@@ -12,7 +12,7 @@
     {
       "clause": "13.6.1",
       "title": "Runtime Semantics: Evaluation",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-exp-operator-runtime-semantics-evaluation"
     }
   ]

--- a/docs/ECMA262/13/Section13_6.md
+++ b/docs/ECMA262/13/Section13_6.md
@@ -4,7 +4,7 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-08-14T06:16:39Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -14,5 +14,5 @@
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 13.6.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-exp-operator-runtime-semantics-evaluation) |
+| 13.6.1 | Runtime Semantics: Evaluation | Supported | [tc39.es](https://tc39.es/ecma262/#sec-exp-operator-runtime-semantics-evaluation) |
 

--- a/docs/ECMA262/13/Section13_7.json
+++ b/docs/ECMA262/13/Section13_7.json
@@ -12,7 +12,7 @@
     {
       "clause": "13.7.1",
       "title": "Runtime Semantics: Evaluation",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-multiplicative-operators-runtime-semantics-evaluation"
     }
   ]

--- a/docs/ECMA262/13/Section13_7.md
+++ b/docs/ECMA262/13/Section13_7.md
@@ -4,7 +4,7 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-08-14T06:16:39Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -14,5 +14,5 @@
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 13.7.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-multiplicative-operators-runtime-semantics-evaluation) |
+| 13.7.1 | Runtime Semantics: Evaluation | Supported | [tc39.es](https://tc39.es/ecma262/#sec-multiplicative-operators-runtime-semantics-evaluation) |
 

--- a/docs/ECMA262/13/Section13_8.json
+++ b/docs/ECMA262/13/Section13_8.json
@@ -39,13 +39,13 @@
     {
       "clause": "13.8.2",
       "title": "The Subtraction Operator ( - )",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-subtraction-operator-minus"
     },
     {
       "clause": "13.8.2.1",
       "title": "Runtime Semantics: Evaluation",
-      "status": "Untracked",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-subtraction-operator-minus-runtime-semantics-evaluation"
     }
   ]

--- a/docs/ECMA262/13/Section13_8.md
+++ b/docs/ECMA262/13/Section13_8.md
@@ -4,7 +4,7 @@
 
 [Back to Section13](Section13.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-24T13:09:52Z
+> Last generated (UTC): 2026-08-14T06:16:39Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -16,8 +16,8 @@
 |---:|---|---|---|
 | 13.8.1 | The Addition Operator ( + ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-addition-operator-plus) |
 | 13.8.1.1 | Runtime Semantics: Evaluation | Supported | [tc39.es](https://tc39.es/ecma262/#sec-addition-operator-plus-runtime-semantics-evaluation) |
-| 13.8.2 | The Subtraction Operator ( - ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-subtraction-operator-minus) |
-| 13.8.2.1 | Runtime Semantics: Evaluation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-subtraction-operator-minus-runtime-semantics-evaluation) |
+| 13.8.2 | The Subtraction Operator ( - ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-subtraction-operator-minus) |
+| 13.8.2.1 | Runtime Semantics: Evaluation | Supported | [tc39.es](https://tc39.es/ecma262/#sec-subtraction-operator-minus-runtime-semantics-evaluation) |
 
 ## Support
 


### PR DESCRIPTION
## Summary
- classify all 47 previously untracked clauses in Sections 11, 12, and 13 using implementation and test evidence
- mark implemented semantics as Supported or Supported with Limitations
- classify the non-operative empty String MV heading as N/A (informational)
- regenerate the affected ECMA-262 documentation