### PR TITLE
docs(ecma262): classify Sections 25 and 26

### DIFF
--- a/docs/ECMA262/25/Section25_1.json
+++ b/docs/ECMA262/25/Section25_1.json
@@ -12,7 +12,7 @@
     {
       "clause": "25.1.1",
       "title": "Notation",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-arraybuffer-notation"
     },
     {
@@ -42,19 +42,19 @@
     {
       "clause": "25.1.3.3",
       "title": "ArrayBufferCopyAndDetach ( arrayBuffer , newLength , preserveResizability )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-arraybuffercopyanddetach"
     },
     {
       "clause": "25.1.3.4",
       "title": "IsDetachedBuffer ( arrayBuffer )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-isdetachedbuffer"
     },
     {
       "clause": "25.1.3.5",
       "title": "DetachArrayBuffer ( arrayBuffer [ , key ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-detacharraybuffer"
     },
     {
@@ -66,55 +66,55 @@
     {
       "clause": "25.1.3.7",
       "title": "GetArrayBufferMaxByteLengthOption ( options )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-getarraybuffermaxbytelengthoption"
     },
     {
       "clause": "25.1.3.8",
       "title": "HostResizeArrayBuffer ( buffer , newByteLength )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-hostresizearraybuffer"
     },
     {
       "clause": "25.1.3.9",
       "title": "IsFixedLengthArrayBuffer ( arrayBuffer )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-isfixedlengtharraybuffer"
     },
     {
       "clause": "25.1.3.10",
       "title": "IsUnsignedElementType ( type )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-isunsignedelementtype"
     },
     {
       "clause": "25.1.3.11",
       "title": "IsUnclampedIntegerElementType ( type )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-isunclampedintegerelementtype"
     },
     {
       "clause": "25.1.3.12",
       "title": "IsBigIntElementType ( type )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-isbigintelementtype"
     },
     {
       "clause": "25.1.3.13",
       "title": "IsNoTearConfiguration ( type , order )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-isnotearconfiguration"
     },
     {
       "clause": "25.1.3.14",
       "title": "RawBytesToNumeric ( type , rawBytes , isLittleEndian )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-rawbytestonumeric"
     },
     {
       "clause": "25.1.3.15",
       "title": "GetRawBytesFromSharedBlock ( block , byteIndex , type , isTypedArray , order )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-getrawbytesfromsharedblock"
     },
     {
@@ -138,7 +138,7 @@
     {
       "clause": "25.1.3.19",
       "title": "GetModifySetValueInBuffer ( arrayBuffer , byteIndex , type , value , op )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-getmodifysetvalueinbuffer"
     },
     {
@@ -168,13 +168,13 @@
     {
       "clause": "25.1.5.2",
       "title": "ArrayBuffer.prototype",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-arraybuffer.prototype"
     },
     {
       "clause": "25.1.5.3",
       "title": "get ArrayBuffer [ %Symbol.species% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-get-arraybuffer-%symbol.species%"
     },
     {
@@ -192,31 +192,31 @@
     {
       "clause": "25.1.6.2",
       "title": "ArrayBuffer.prototype.constructor",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-arraybuffer.prototype.constructor"
     },
     {
       "clause": "25.1.6.3",
       "title": "get ArrayBuffer.prototype.detached",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.detached"
     },
     {
       "clause": "25.1.6.4",
       "title": "get ArrayBuffer.prototype.maxByteLength",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.maxbytelength"
     },
     {
       "clause": "25.1.6.5",
       "title": "get ArrayBuffer.prototype.resizable",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.resizable"
     },
     {
       "clause": "25.1.6.6",
       "title": "ArrayBuffer.prototype.resize ( newLength )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-arraybuffer.prototype.resize"
     },
     {
@@ -228,19 +228,19 @@
     {
       "clause": "25.1.6.8",
       "title": "ArrayBuffer.prototype.transfer ( [ newLength ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfer"
     },
     {
       "clause": "25.1.6.9",
       "title": "ArrayBuffer.prototype.transferToFixedLength ( [ newLength ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfertofixedlength"
     },
     {
       "clause": "25.1.6.10",
       "title": "ArrayBuffer.prototype [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-arraybuffer.prototype-%symbol.tostringtag%"
     },
     {
@@ -252,7 +252,7 @@
     {
       "clause": "25.1.8",
       "title": "Resizable ArrayBuffer Guidelines",
-      "status": "Untracked",
+      "status": "N/A (informational)",
       "specUrl": "https://tc39.es/ecma262/#sec-resizable-arraybuffer-guidelines"
     }
   ],

--- a/docs/ECMA262/25/Section25_1.md
+++ b/docs/ECMA262/25/Section25_1.md
@@ -4,7 +4,7 @@
 
 [Back to Section25](Section25.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T06:48:54Z
+> Last generated (UTC): 2026-08-14T08:29:24Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -14,67 +14,67 @@
 
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
-| 25.1.1 | Notation | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer-notation) |
+| 25.1.1 | Notation | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer-notation) |
 | 25.1.2 | Fixed-length and Resizable ArrayBuffer Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-fixed-length-and-resizable-arraybuffer-objects) |
 | 25.1.3 | Abstract Operations For ArrayBuffer Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-arraybuffer-objects) |
 | 25.1.3.1 | AllocateArrayBuffer ( constructor , byteLength [ , maxByteLength ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-allocatearraybuffer) |
 | 25.1.3.2 | ArrayBufferByteLength ( arrayBuffer , order ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-arraybufferbytelength) |
-| 25.1.3.3 | ArrayBufferCopyAndDetach ( arrayBuffer , newLength , preserveResizability ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffercopyanddetach) |
-| 25.1.3.4 | IsDetachedBuffer ( arrayBuffer ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isdetachedbuffer) |
-| 25.1.3.5 | DetachArrayBuffer ( arrayBuffer [ , key ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-detacharraybuffer) |
+| 25.1.3.3 | ArrayBufferCopyAndDetach ( arrayBuffer , newLength , preserveResizability ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffercopyanddetach) |
+| 25.1.3.4 | IsDetachedBuffer ( arrayBuffer ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-isdetachedbuffer) |
+| 25.1.3.5 | DetachArrayBuffer ( arrayBuffer [ , key ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-detacharraybuffer) |
 | 25.1.3.6 | CloneArrayBuffer ( srcBuffer , srcByteOffset , srcLength ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-clonearraybuffer) |
-| 25.1.3.7 | GetArrayBufferMaxByteLengthOption ( options ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getarraybuffermaxbytelengthoption) |
-| 25.1.3.8 | HostResizeArrayBuffer ( buffer , newByteLength ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-hostresizearraybuffer) |
-| 25.1.3.9 | IsFixedLengthArrayBuffer ( arrayBuffer ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isfixedlengtharraybuffer) |
-| 25.1.3.10 | IsUnsignedElementType ( type ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isunsignedelementtype) |
-| 25.1.3.11 | IsUnclampedIntegerElementType ( type ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isunclampedintegerelementtype) |
-| 25.1.3.12 | IsBigIntElementType ( type ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isbigintelementtype) |
-| 25.1.3.13 | IsNoTearConfiguration ( type , order ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isnotearconfiguration) |
-| 25.1.3.14 | RawBytesToNumeric ( type , rawBytes , isLittleEndian ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-rawbytestonumeric) |
-| 25.1.3.15 | GetRawBytesFromSharedBlock ( block , byteIndex , type , isTypedArray , order ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getrawbytesfromsharedblock) |
+| 25.1.3.7 | GetArrayBufferMaxByteLengthOption ( options ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getarraybuffermaxbytelengthoption) |
+| 25.1.3.8 | HostResizeArrayBuffer ( buffer , newByteLength ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-hostresizearraybuffer) |
+| 25.1.3.9 | IsFixedLengthArrayBuffer ( arrayBuffer ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-isfixedlengtharraybuffer) |
+| 25.1.3.10 | IsUnsignedElementType ( type ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-isunsignedelementtype) |
+| 25.1.3.11 | IsUnclampedIntegerElementType ( type ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-isunclampedintegerelementtype) |
+| 25.1.3.12 | IsBigIntElementType ( type ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-isbigintelementtype) |
+| 25.1.3.13 | IsNoTearConfiguration ( type , order ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-isnotearconfiguration) |
+| 25.1.3.14 | RawBytesToNumeric ( type , rawBytes , isLittleEndian ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-rawbytestonumeric) |
+| 25.1.3.15 | GetRawBytesFromSharedBlock ( block , byteIndex , type , isTypedArray , order ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getrawbytesfromsharedblock) |
 | 25.1.3.16 | GetValueFromBuffer ( arrayBuffer , byteIndex , type , isTypedArray , order [ , isLittleEndian ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getvaluefrombuffer) |
 | 25.1.3.17 | NumericToRawBytes ( type , value , isLittleEndian ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-numerictorawbytes) |
 | 25.1.3.18 | SetValueInBuffer ( arrayBuffer , byteIndex , type , value , isTypedArray , order [ , isLittleEndian ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-setvalueinbuffer) |
-| 25.1.3.19 | GetModifySetValueInBuffer ( arrayBuffer , byteIndex , type , value , op ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getmodifysetvalueinbuffer) |
+| 25.1.3.19 | GetModifySetValueInBuffer ( arrayBuffer , byteIndex , type , value , op ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-getmodifysetvalueinbuffer) |
 | 25.1.4 | The ArrayBuffer Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer-constructor) |
 | 25.1.4.1 | ArrayBuffer ( length [ , options ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer-length) |
 | 25.1.5 | Properties of the ArrayBuffer Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-constructor) |
 | 25.1.5.1 | ArrayBuffer.isView ( arg ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.isview) |
-| 25.1.5.2 | ArrayBuffer.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype) |
-| 25.1.5.3 | get ArrayBuffer [ %Symbol.species% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer-%symbol.species%) |
+| 25.1.5.2 | ArrayBuffer.prototype | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype) |
+| 25.1.5.3 | get ArrayBuffer [ %Symbol.species% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer-%symbol.species%) |
 | 25.1.6 | Properties of the ArrayBuffer Prototype Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-prototype-object) |
 | 25.1.6.1 | get ArrayBuffer.prototype.byteLength | Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.bytelength) |
-| 25.1.6.2 | ArrayBuffer.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.constructor) |
-| 25.1.6.3 | get ArrayBuffer.prototype.detached | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.detached) |
-| 25.1.6.4 | get ArrayBuffer.prototype.maxByteLength | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.maxbytelength) |
-| 25.1.6.5 | get ArrayBuffer.prototype.resizable | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.resizable) |
-| 25.1.6.6 | ArrayBuffer.prototype.resize ( newLength ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.resize) |
+| 25.1.6.2 | ArrayBuffer.prototype.constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.constructor) |
+| 25.1.6.3 | get ArrayBuffer.prototype.detached | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.detached) |
+| 25.1.6.4 | get ArrayBuffer.prototype.maxByteLength | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.maxbytelength) |
+| 25.1.6.5 | get ArrayBuffer.prototype.resizable | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-get-arraybuffer.prototype.resizable) |
+| 25.1.6.6 | ArrayBuffer.prototype.resize ( newLength ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.resize) |
 | 25.1.6.7 | ArrayBuffer.prototype.slice ( start , end ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice) |
-| 25.1.6.8 | ArrayBuffer.prototype.transfer ( [ newLength ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfer) |
-| 25.1.6.9 | ArrayBuffer.prototype.transferToFixedLength ( [ newLength ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfertofixedlength) |
-| 25.1.6.10 | ArrayBuffer.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype-%symbol.tostringtag%) |
+| 25.1.6.8 | ArrayBuffer.prototype.transfer ( [ newLength ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfer) |
+| 25.1.6.9 | ArrayBuffer.prototype.transferToFixedLength ( [ newLength ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfertofixedlength) |
+| 25.1.6.10 | ArrayBuffer.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype-%symbol.tostringtag%) |
 | 25.1.7 | Properties of ArrayBuffer Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-instances) |
-| 25.1.8 | Resizable ArrayBuffer Guidelines | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-resizable-arraybuffer-guidelines) |
+| 25.1.8 | Resizable ArrayBuffer Guidelines | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-resizable-arraybuffer-guidelines) |
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
 
 ### 25.1.4.1 ([tc39.es](https://tc39.es/ecma262/#sec-arraybuffer-length))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| ArrayBuffer(length) | Supported with Limitations | [`ArrayBuffer_Construct_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/ArrayBuffer_Construct_ByteLength.js) | Implemented as a fixed-length JavaScriptRuntime.ArrayBuffer backed by byte[]. Length uses ToIndex-like truncation for finite non-negative numbers. Resizable buffers, detached buffers, and transfer APIs are not implemented. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| ArrayBuffer(length) | Supported with Limitations | [`ArrayBuffer_Construct_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/ArrayBuffer_Construct_ByteLength.js) |  | Implemented as a fixed-length JavaScriptRuntime.ArrayBuffer backed by byte[]. Length uses ToIndex-like truncation for finite non-negative numbers. Resizable buffers, detached buffers, and transfer APIs are not implemented. |
 
 ### 25.1.5.1 ([tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.isview))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| ArrayBuffer.isView | Supported with Limitations | [`ArrayBuffer_IsView_DataView.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/ArrayBuffer_IsView_DataView.js) | Recognizes DataView and the current Int32Array typed-array surface as ArrayBuffer views. Broader TypedArray families and shared ArrayBuffer-backed view infrastructure remain follow-up work for issue #774. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| ArrayBuffer.isView | Supported with Limitations | [`ArrayBuffer_IsView_DataView.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/ArrayBuffer_IsView_DataView.js) |  | Recognizes DataView and the current Int32Array typed-array surface as ArrayBuffer views. Broader TypedArray families and shared ArrayBuffer-backed view infrastructure remain follow-up work for issue #774. |
 
 ### 25.1.6 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-prototype-object))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| ArrayBuffer.prototype.byteLength and ArrayBuffer.prototype.slice | Supported with Limitations | [`ArrayBuffer_Construct_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/ArrayBuffer_Construct_ByteLength.js) | byteLength reflects the backing byte[] length, and slice returns a copied fixed-length ArrayBuffer. Species, detach, resize, and transfer semantics are not implemented. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| ArrayBuffer.prototype.byteLength and ArrayBuffer.prototype.slice | Supported with Limitations | [`ArrayBuffer_Construct_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/ArrayBuffer_Construct_ByteLength.js) |  | byteLength reflects the backing byte[] length, and slice returns a copied fixed-length ArrayBuffer. Species, detach, resize, and transfer semantics are not implemented. |
 

--- a/docs/ECMA262/25/Section25_3.json
+++ b/docs/ECMA262/25/Section25_3.json
@@ -18,25 +18,25 @@
     {
       "clause": "25.3.1.1",
       "title": "DataView With Buffer Witness Records",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview-with-buffer-witness-records"
     },
     {
       "clause": "25.3.1.2",
       "title": "MakeDataViewWithBufferWitnessRecord ( obj , order )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-makedataviewwithbufferwitnessrecord"
     },
     {
       "clause": "25.3.1.3",
       "title": "GetViewByteLength ( viewRecord )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-getviewbytelength"
     },
     {
       "clause": "25.3.1.4",
       "title": "IsViewOutOfBounds ( viewRecord )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-isviewoutofbounds"
     },
     {
@@ -66,13 +66,13 @@
     {
       "clause": "25.3.3",
       "title": "Properties of the DataView Constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-dataview-constructor"
     },
     {
       "clause": "25.3.3.1",
       "title": "DataView.prototype",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview.prototype"
     },
     {
@@ -102,25 +102,25 @@
     {
       "clause": "25.3.4.4",
       "title": "DataView.prototype.constructor",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview.prototype.constructor"
     },
     {
       "clause": "25.3.4.5",
       "title": "DataView.prototype.getBigInt64 ( byteOffset [ , littleEndian ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview.prototype.getbigint64"
     },
     {
       "clause": "25.3.4.6",
       "title": "DataView.prototype.getBigUint64 ( byteOffset [ , littleEndian ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview.prototype.getbiguint64"
     },
     {
       "clause": "25.3.4.7",
       "title": "DataView.prototype.getFloat16 ( byteOffset [ , littleEndian ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview.prototype.getfloat16"
     },
     {
@@ -174,19 +174,19 @@
     {
       "clause": "25.3.4.16",
       "title": "DataView.prototype.setBigInt64 ( byteOffset , value [ , littleEndian ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview.prototype.setbigint64"
     },
     {
       "clause": "25.3.4.17",
       "title": "DataView.prototype.setBigUint64 ( byteOffset , value [ , littleEndian ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview.prototype.setbiguint64"
     },
     {
       "clause": "25.3.4.18",
       "title": "DataView.prototype.setFloat16 ( byteOffset , value [ , littleEndian ] )",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview.prototype.setfloat16"
     },
     {
@@ -240,7 +240,7 @@
     {
       "clause": "25.3.4.27",
       "title": "DataView.prototype [ %Symbol.toStringTag% ]",
-      "status": "Untracked",
+      "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview.prototype-%symbol.tostringtag%"
     },
     {

--- a/docs/ECMA262/25/Section25_3.md
+++ b/docs/ECMA262/25/Section25_3.md
@@ -4,7 +4,7 @@
 
 [Back to Section25](Section25.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T09:52:16Z
+> Last generated (UTC): 2026-08-14T08:29:24Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -15,24 +15,24 @@
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
 | 25.3.1 | Abstract Operations For DataView Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-dataview-objects) |
-| 25.3.1.1 | DataView With Buffer Witness Records | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview-with-buffer-witness-records) |
-| 25.3.1.2 | MakeDataViewWithBufferWitnessRecord ( obj , order ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-makedataviewwithbufferwitnessrecord) |
-| 25.3.1.3 | GetViewByteLength ( viewRecord ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-getviewbytelength) |
-| 25.3.1.4 | IsViewOutOfBounds ( viewRecord ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-isviewoutofbounds) |
+| 25.3.1.1 | DataView With Buffer Witness Records | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview-with-buffer-witness-records) |
+| 25.3.1.2 | MakeDataViewWithBufferWitnessRecord ( obj , order ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-makedataviewwithbufferwitnessrecord) |
+| 25.3.1.3 | GetViewByteLength ( viewRecord ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getviewbytelength) |
+| 25.3.1.4 | IsViewOutOfBounds ( viewRecord ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-isviewoutofbounds) |
 | 25.3.1.5 | GetViewValue ( view , requestIndex , isLittleEndian , type ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-getviewvalue) |
 | 25.3.1.6 | SetViewValue ( view , requestIndex , isLittleEndian , type , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-setviewvalue) |
 | 25.3.2 | The DataView Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview-constructor) |
 | 25.3.2.1 | DataView ( buffer [ , byteOffset [ , byteLength ] ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength) |
-| 25.3.3 | Properties of the DataView Constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-dataview-constructor) |
-| 25.3.3.1 | DataView.prototype | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype) |
+| 25.3.3 | Properties of the DataView Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-dataview-constructor) |
+| 25.3.3.1 | DataView.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype) |
 | 25.3.4 | Properties of the DataView Prototype Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-dataview-prototype-object) |
 | 25.3.4.1 | get DataView.prototype.buffer | Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-dataview.prototype.buffer) |
 | 25.3.4.2 | get DataView.prototype.byteLength | Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-dataview.prototype.bytelength) |
 | 25.3.4.3 | get DataView.prototype.byteOffset | Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-dataview.prototype.byteoffset) |
-| 25.3.4.4 | DataView.prototype.constructor | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.constructor) |
-| 25.3.4.5 | DataView.prototype.getBigInt64 ( byteOffset [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getbigint64) |
-| 25.3.4.6 | DataView.prototype.getBigUint64 ( byteOffset [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getbiguint64) |
-| 25.3.4.7 | DataView.prototype.getFloat16 ( byteOffset [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getfloat16) |
+| 25.3.4.4 | DataView.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.constructor) |
+| 25.3.4.5 | DataView.prototype.getBigInt64 ( byteOffset [ , littleEndian ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getbigint64) |
+| 25.3.4.6 | DataView.prototype.getBigUint64 ( byteOffset [ , littleEndian ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getbiguint64) |
+| 25.3.4.7 | DataView.prototype.getFloat16 ( byteOffset [ , littleEndian ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getfloat16) |
 | 25.3.4.8 | DataView.prototype.getFloat32 ( byteOffset [ , littleEndian ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getfloat32) |
 | 25.3.4.9 | DataView.prototype.getFloat64 ( byteOffset [ , littleEndian ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getfloat64) |
 | 25.3.4.10 | DataView.prototype.getInt8 ( byteOffset ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getint8) |
@@ -41,9 +41,9 @@
 | 25.3.4.13 | DataView.prototype.getUint8 ( byteOffset ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getuint8) |
 | 25.3.4.14 | DataView.prototype.getUint16 ( byteOffset [ , littleEndian ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getuint16) |
 | 25.3.4.15 | DataView.prototype.getUint32 ( byteOffset [ , littleEndian ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getuint32) |
-| 25.3.4.16 | DataView.prototype.setBigInt64 ( byteOffset , value [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setbigint64) |
-| 25.3.4.17 | DataView.prototype.setBigUint64 ( byteOffset , value [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setbiguint64) |
-| 25.3.4.18 | DataView.prototype.setFloat16 ( byteOffset , value [ , littleEndian ] ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setfloat16) |
+| 25.3.4.16 | DataView.prototype.setBigInt64 ( byteOffset , value [ , littleEndian ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setbigint64) |
+| 25.3.4.17 | DataView.prototype.setBigUint64 ( byteOffset , value [ , littleEndian ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setbiguint64) |
+| 25.3.4.18 | DataView.prototype.setFloat16 ( byteOffset , value [ , littleEndian ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setfloat16) |
 | 25.3.4.19 | DataView.prototype.setFloat32 ( byteOffset , value [ , littleEndian ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setfloat32) |
 | 25.3.4.20 | DataView.prototype.setFloat64 ( byteOffset , value [ , littleEndian ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setfloat64) |
 | 25.3.4.21 | DataView.prototype.setInt8 ( byteOffset , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setint8) |
@@ -52,23 +52,23 @@
 | 25.3.4.24 | DataView.prototype.setUint8 ( byteOffset , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setuint8) |
 | 25.3.4.25 | DataView.prototype.setUint16 ( byteOffset , value [ , littleEndian ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setuint16) |
 | 25.3.4.26 | DataView.prototype.setUint32 ( byteOffset , value [ , littleEndian ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setuint32) |
-| 25.3.4.27 | DataView.prototype [ %Symbol.toStringTag% ] | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype-%symbol.tostringtag%) |
+| 25.3.4.27 | DataView.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype-%symbol.tostringtag%) |
 | 25.3.5 | Properties of DataView Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-dataview-instances) |
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
 
 ### 25.3.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| DataView(buffer, byteOffset, byteLength) | Supported with Limitations | [`DataView_ByteOffset_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_ByteOffset_ByteLength.js)<br>[`DataView_BoundsChecks_RangeError.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_BoundsChecks_RangeError.js)<br>[`DataView_InvalidByteOffset_ByteLength_Messages.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_InvalidByteOffset_ByteLength_Messages.js) | Supports fixed-length ArrayBuffer-backed views with byteOffset/byteLength validation, distinct RangeError diagnostics for invalid byteOffset versus byteLength, and bounds checks. SharedArrayBuffer, resizable buffers, and detached buffer semantics are not implemented. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| DataView(buffer, byteOffset, byteLength) | Supported with Limitations | [`DataView_ByteOffset_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_ByteOffset_ByteLength.js)<br>[`DataView_BoundsChecks_RangeError.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_BoundsChecks_RangeError.js)<br>[`DataView_InvalidByteOffset_ByteLength_Messages.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_InvalidByteOffset_ByteLength_Messages.js) |  | Supports fixed-length ArrayBuffer-backed views with byteOffset/byteLength validation, distinct RangeError diagnostics for invalid byteOffset versus byteLength, and bounds checks. SharedArrayBuffer, resizable buffers, and detached buffer semantics are not implemented. |
 
 ### 25.3.4 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-dataview-prototype-object))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| DataView integer and floating-point getters/setters | Supported with Limitations | [`DataView_SetGet_UintAndEndian.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_SetGet_UintAndEndian.js)<br>[`DataView_Float32_Float64_RoundTrip.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_Float32_Float64_RoundTrip.js) | Implements get/set for Int8, Uint8, Int16, Uint16, Int32, Uint32, Float32, and Float64 with optional littleEndian support (default big-endian). BigInt64, BigUint64, and Float16 remain unimplemented. |
-| DataView prototype accessors | Supported | [`DataView_ByteOffset_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_ByteOffset_ByteLength.js) | buffer, byteOffset, and byteLength are exposed as runtime properties on JavaScriptRuntime.DataView. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| DataView integer and floating-point getters/setters | Supported with Limitations | [`DataView_SetGet_UintAndEndian.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_SetGet_UintAndEndian.js)<br>[`DataView_Float32_Float64_RoundTrip.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_Float32_Float64_RoundTrip.js) |  | Implements get/set for Int8, Uint8, Int16, Uint16, Int32, Uint32, Float32, and Float64 with optional littleEndian support (default big-endian). BigInt64, BigUint64, and Float16 remain unimplemented. |
+| DataView prototype accessors | Supported | [`DataView_ByteOffset_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_ByteOffset_ByteLength.js) |  | buffer, byteOffset, and byteLength are exposed as runtime properties on JavaScriptRuntime.DataView. |
 

--- a/docs/ECMA262/25/Section25_5.json
+++ b/docs/ECMA262/25/Section25_5.json
@@ -18,13 +18,13 @@
     {
       "clause": "25.5.1.1",
       "title": "ParseJSON ( text )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-ParseJSON"
     },
     {
       "clause": "25.5.1.2",
       "title": "InternalizeJSONProperty ( holder , name , reviver )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-internalizejsonproperty"
     },
     {
@@ -36,37 +36,37 @@
     {
       "clause": "25.5.2.1",
       "title": "JSON Serialization Record",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-json-serialization-record"
     },
     {
       "clause": "25.5.2.2",
       "title": "SerializeJSONProperty ( state , key , holder )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-serializejsonproperty"
     },
     {
       "clause": "25.5.2.3",
       "title": "QuoteJSONString ( value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-quotejsonstring"
     },
     {
       "clause": "25.5.2.4",
       "title": "UnicodeEscape ( C )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-unicodeescape"
     },
     {
       "clause": "25.5.2.5",
       "title": "SerializeJSONObject ( state , value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-serializejsonobject"
     },
     {
       "clause": "25.5.2.6",
       "title": "SerializeJSONArray ( state , value )",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-serializejsonarray"
     },
     {

--- a/docs/ECMA262/25/Section25_5.md
+++ b/docs/ECMA262/25/Section25_5.md
@@ -4,7 +4,7 @@
 
 [Back to Section25](Section25.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-12T04:40:20Z
+> Last generated (UTC): 2026-08-14T08:29:24Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -15,15 +15,15 @@
 | Clause | Title | Status | Spec |
 |---:|---|---|---|
 | 25.5.1 | JSON.parse ( text [ , reviver ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-json.parse) |
-| 25.5.1.1 | ParseJSON ( text ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-ParseJSON) |
-| 25.5.1.2 | InternalizeJSONProperty ( holder , name , reviver ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-internalizejsonproperty) |
+| 25.5.1.1 | ParseJSON ( text ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ParseJSON) |
+| 25.5.1.2 | InternalizeJSONProperty ( holder , name , reviver ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-internalizejsonproperty) |
 | 25.5.2 | JSON.stringify ( value [ , replacer [ , space ] ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-json.stringify) |
-| 25.5.2.1 | JSON Serialization Record | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-json-serialization-record) |
-| 25.5.2.2 | SerializeJSONProperty ( state , key , holder ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-serializejsonproperty) |
-| 25.5.2.3 | QuoteJSONString ( value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-quotejsonstring) |
-| 25.5.2.4 | UnicodeEscape ( C ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-unicodeescape) |
-| 25.5.2.5 | SerializeJSONObject ( state , value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-serializejsonobject) |
-| 25.5.2.6 | SerializeJSONArray ( state , value ) | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-serializejsonarray) |
+| 25.5.2.1 | JSON Serialization Record | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-json-serialization-record) |
+| 25.5.2.2 | SerializeJSONProperty ( state , key , holder ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-serializejsonproperty) |
+| 25.5.2.3 | QuoteJSONString ( value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-quotejsonstring) |
+| 25.5.2.4 | UnicodeEscape ( C ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-unicodeescape) |
+| 25.5.2.5 | SerializeJSONObject ( state , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-serializejsonobject) |
+| 25.5.2.6 | SerializeJSONArray ( state , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-serializejsonarray) |
 | 25.5.3 | JSON [ %Symbol.toStringTag% ] | Supported | [tc39.es](https://tc39.es/ecma262/#sec-json-%symbol.tostringtag%) |
 
 ## Support

--- a/docs/ECMA262/26/Section26_2.json
+++ b/docs/ECMA262/26/Section26_2.json
@@ -66,7 +66,7 @@
     {
       "clause": "26.2.4",
       "title": "Properties of FinalizationRegistry Instances",
-      "status": "Untracked",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-finalization-registry-instances"
     }
   ],

--- a/docs/ECMA262/26/Section26_2.md
+++ b/docs/ECMA262/26/Section26_2.md
@@ -4,7 +4,7 @@
 
 [Back to Section26](Section26.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-10T00:19:15Z
+> Last generated (UTC): 2026-08-14T08:27:55Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -23,15 +23,15 @@
 | 26.2.3.2 | FinalizationRegistry.prototype.register ( target , heldValue [ , unregisterToken ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype.register) |
 | 26.2.3.3 | FinalizationRegistry.prototype.unregister ( unregisterToken ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister) |
 | 26.2.3.4 | FinalizationRegistry.prototype [ %Symbol.toStringTag% ] | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype-%symbol.tostringtag%) |
-| 26.2.4 | Properties of FinalizationRegistry Instances | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-finalization-registry-instances) |
+| 26.2.4 | Properties of FinalizationRegistry Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-finalization-registry-instances) |
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
 
 ### 26.2 ([tc39.es](https://tc39.es/ecma262/#sec-finalization-registry-objects))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| FinalizationRegistry constructor, register/unregister, and cleanup callback baseline | Supported with Limitations | [`FinalizationRegistry_Cleanup_Order.js`](../../../tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Cleanup_Order.js)<br>[`FinalizationRegistry_Unregister_Basic.js`](../../../tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Unregister_Basic.js) | Supports `new FinalizationRegistry(cleanupCallback)` in construct positions plus `register(target, heldValue, [unregisterToken])`, `unregister(token)`, and `%Symbol.toStringTag%`. Cleanup callbacks are queued through a host-managed finalization queue and become deterministic in tests when a host-opt-in non-standard global `gc()` helper forces collection. jroc does not yet expose a full first-class `FinalizationRegistry` constructor/prototype object on `globalThis`, and cleanup timing otherwise depends on .NET GC plus event-loop checkpoints. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| FinalizationRegistry constructor, register/unregister, and cleanup callback baseline | Supported with Limitations | [`FinalizationRegistry_Cleanup_Order.js`](../../../tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Cleanup_Order.js)<br>[`FinalizationRegistry_Unregister_Basic.js`](../../../tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Unregister_Basic.js) |  | Supports `new FinalizationRegistry(cleanupCallback)` in construct positions plus `register(target, heldValue, [unregisterToken])`, `unregister(token)`, and `%Symbol.toStringTag%`. Cleanup callbacks are queued through a host-managed finalization queue and become deterministic in tests when a host-opt-in non-standard global `gc()` helper forces collection. jroc does not yet expose a full first-class `FinalizationRegistry` constructor/prototype object on `globalThis`, and cleanup timing otherwise depends on .NET GC plus event-loop checkpoints. |
 


### PR DESCRIPTION
## Summary
- classify all 48 previously untracked Structured Data and Managing Memory clauses using current implementation and test evidence
- identify unsupported ArrayBuffer detachment/transfer, BigInt/Float16 DataView APIs, and incomplete constructor surfaces
- document implemented ArrayBuffer, DataView, JSON, and FinalizationRegistry behavior with appropriate limitations
- regenerate all affected ECMA-262 documentation