### PR TITLE
chore: upgrade Jint from 4.13.0 to 4.16.0

### DIFF
--- a/tests/performance/Benchmarks/Benchmarks.csproj
+++ b/tests/performance/Benchmarks/Benchmarks.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageReference Include="Jint" Version="4.13.0" />
+    <PackageReference Include="Jint" Version="4.16.0" />
     <PackageReference Include="Okojo" Version="0.1.2-preview.1" />
     <PackageReference Include="YantraJS.Core" Version="1.2.418" />
     <PackageReference Include="Microsoft.ClearScript.V8" Version="7.5.1" />

--- a/tests/performance/JintComparison/JintComparison.csproj
+++ b/tests/performance/JintComparison/JintComparison.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jint" Version="4.13.0" />
+    <PackageReference Include="Jint" Version="4.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/performance/mitata/hosts/MitataRuntimeHost.csproj
+++ b/tests/performance/mitata/hosts/MitataRuntimeHost.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Jint" Version="4.13.0" />
+    <PackageReference Include="Jint" Version="4.16.0" />
     <PackageReference Include="Okojo" Version="0.1.2-preview.1" />
     <PackageReference Include="YantraJS.Core" Version="1.2.418" />
     <PackageReference Include="Microsoft.ClearScript.V8" Version="7.5.1" />


### PR DESCRIPTION
Upgrades Jint from `4.13.0` to `4.16.0` across all three references in the performance test projects.

Okojo is already at its latest version (`0.1.2-preview.1`) and requires no change.