### PR TITLE
runtime: introduce explicit realm and agent ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   destructuring bindings. This also builds default-initializer scopes for
   `var` loop heads. Activates 195 corresponding pinned test262 fixtures.
 - compiler/test262: close #1783 by lowering parenthesized function-expression
-  callees in nested   destructuring defaults. This preserves nested iterator
+  callees in nested destructuring defaults. This preserves nested iterator
   acquisition, elision, rest, and abrupt initializer completion in sync,
   async, generator, and async-generator loops. Activates 54 corresponding
   pinned test262 fixtures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime: introduce explicit `RuntimeAgentCluster`, `RuntimeAgent`, and
+  `RuntimeRealm` lifetime owners. Every runtime service container now belongs
+  to exactly one realm and exposes the ownership graph through constructor
+  injection, with deterministic child-first disposal and disposed-state
+  guards. Existing observable runtime state remains in place for the follow-up
+  migration stages tracked by #1805.
 - compiler/runtime/test262: complete String well-known-symbol dispatch for
   primitive match/search/replaceAll inputs, invoke observable @@search hooks
   on internally created RegExps, preserve JavaScript number-string precision
@@ -16,7 +22,7 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   destructuring bindings. This also builds default-initializer scopes for
   `var` loop heads. Activates 195 corresponding pinned test262 fixtures.
 - compiler/test262: close #1783 by lowering parenthesized function-expression
-  callees in nested destructuring defaults. This preserves nested iterator
+  callees in nested   destructuring defaults. This preserves nested iterator
   acquisition, elision, rest, and abrupt initializer completion in sync,
   async, generator, and async-generator loops. Activates 54 corresponding
   pinned test262 fixtures.

--- a/docs/runtime/RuntimeOwnership.md
+++ b/docs/runtime/RuntimeOwnership.md
@@ -1,0 +1,46 @@
+# Runtime ownership
+
+JROC runtime state has three explicit lifetime owners:
+
+```text
+RuntimeAgentCluster
+  -> RuntimeAgent
+      -> RuntimeRealm
+          -> ServiceContainer
+```
+
+- `RuntimeAgentCluster` owns agents and, in later migration stages, only
+  resources intentionally shared across agents.
+- `RuntimeAgent` owns execution and scheduling lifecycle and can own one or
+  more realms.
+- `RuntimeRealm` owns one JavaScript object graph and exactly one runtime
+  `ServiceContainer`.
+
+The child keeps a reference to its parent so services can receive the correct
+owner through constructor injection. Parents keep their children only while
+the children are active. Disposing a child detaches it from its parent.
+Disposing a parent disposes children in reverse creation order, then marks the
+parent disposed. Disposal is idempotent.
+
+Runtime service containers register their realm, agent, and cluster as reserved
+services. Those registrations cannot be replaced or removed. Child DI scopes
+retain the same realm owner. After realm disposal, its service container and
+any child scopes reject further use.
+
+The factory currently creates an isolated cluster, agent, realm, and service
+container for each `RuntimeServices.BuildServiceProvider()` call. Existing
+globals, modules, schedulers, caches, ambient execution state, `Engine`, and
+hosting lifecycle still use their prior implementations; subsequent migration
+issues move that state under these owners.
+
+## Reference rules
+
+- Process-wide code may retain immutable metadata, but not an active realm,
+  agent, or cluster.
+- A cluster may reference its active agents.
+- An agent may reference its cluster and active realms.
+- A realm may reference its agent and service container.
+- Realm services may receive any of the three owners through constructor
+  injection, but must not discover them through a second service locator.
+- Realm-created JavaScript objects must not be stored on an agent or cluster.
+- Cross-agent resources must not retain realm-created wrappers or callbacks.

--- a/src/JavaScriptRuntime/DependencyInjection/ServiceContainer.cs
+++ b/src/JavaScriptRuntime/DependencyInjection/ServiceContainer.cs
@@ -11,6 +11,37 @@ public class ServiceContainer
     private readonly Dictionary<Type, object> _singletons = new();
     private readonly Dictionary<Type, Type> _typeRegistrations = new();
     private readonly object _lock = new();
+    private RuntimeRealm? _owningRealm;
+
+    internal RuntimeRealm? OwningRealm
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _owningRealm;
+            }
+        }
+    }
+
+    internal void AttachOwningRealm(RuntimeRealm realm)
+    {
+        ArgumentNullException.ThrowIfNull(realm);
+
+        lock (_lock)
+        {
+            if (_owningRealm != null && !ReferenceEquals(_owningRealm, realm))
+            {
+                throw new InvalidOperationException(
+                    "A service container cannot be attached to more than one runtime realm.");
+            }
+
+            _owningRealm = realm;
+            _singletons[typeof(RuntimeAgentCluster)] = realm.Agent.Cluster;
+            _singletons[typeof(RuntimeAgent)] = realm.Agent;
+            _singletons[typeof(RuntimeRealm)] = realm;
+        }
+    }
 
     /// <summary>
     /// Registers a singleton instance for a specific type.
@@ -21,9 +52,11 @@ public class ServiceContainer
     public ServiceContainer RegisterInstance<T>(T instance) where T : class
     {
         ArgumentNullException.ThrowIfNull(instance);
-        
+
         lock (_lock)
         {
+            ThrowIfOwningRealmDisposed();
+            ThrowIfReservedOwnershipType(typeof(T));
             _singletons[typeof(T)] = instance;
         }
         return this;
@@ -39,14 +72,16 @@ public class ServiceContainer
     {
         ArgumentNullException.ThrowIfNull(serviceType);
         ArgumentNullException.ThrowIfNull(instance);
-        
+
         if (!serviceType.IsAssignableFrom(instance.GetType()))
         {
             throw new ArgumentException($"Instance of type {instance.GetType().Name} is not assignable to {serviceType.Name}");
         }
-        
+
         lock (_lock)
         {
+            ThrowIfOwningRealmDisposed();
+            ThrowIfReservedOwnershipType(serviceType);
             _singletons[serviceType] = instance;
         }
         return this;
@@ -59,12 +94,14 @@ public class ServiceContainer
     /// <typeparam name="TService">The service type (typically an interface).</typeparam>
     /// <typeparam name="TImplementation">The implementation type.</typeparam>
     /// <returns>The container for fluent configuration.</returns>
-    public ServiceContainer Register<TService, TImplementation>() 
-        where TService : class 
+    public ServiceContainer Register<TService, TImplementation>()
+        where TService : class
         where TImplementation : class, TService
     {
         lock (_lock)
         {
+            ThrowIfOwningRealmDisposed();
+            ThrowIfReservedOwnershipType(typeof(TService));
             _typeRegistrations[typeof(TService)] = typeof(TImplementation);
         }
         return this;
@@ -79,6 +116,8 @@ public class ServiceContainer
     {
         lock (_lock)
         {
+            ThrowIfOwningRealmDisposed();
+            ThrowIfReservedOwnershipType(typeof(T));
             _typeRegistrations[typeof(T)] = typeof(T);
         }
         return this;
@@ -104,9 +143,11 @@ public class ServiceContainer
     public object Resolve(Type serviceType)
     {
         ArgumentNullException.ThrowIfNull(serviceType);
-        
+
         lock (_lock)
         {
+            ThrowIfOwningRealmDisposed();
+
             // Check if we already have an instance
             if (_singletons.TryGetValue(serviceType, out var existing))
             {
@@ -123,10 +164,10 @@ public class ServiceContainer
                 _singletons[serviceType] = existingImplementation;
                 return existingImplementation;
             }
-            
+
             // Create the instance with constructor injection
             var instance = CreateInstance(implementationType);
-            
+
             // Store as singleton (under both service and implementation types) so resolving by
             // interface or concrete type returns the same instance.
             _singletons[serviceType] = instance;
@@ -135,7 +176,7 @@ public class ServiceContainer
             {
                 _singletons[implementationType] = instance;
             }
-            
+
             return instance;
         }
     }
@@ -150,6 +191,8 @@ public class ServiceContainer
     {
         lock (_lock)
         {
+            ThrowIfOwningRealmDisposed();
+
             if (_singletons.TryGetValue(typeof(T), out var obj))
             {
                 instance = (T)obj;
@@ -169,6 +212,7 @@ public class ServiceContainer
     {
         lock (_lock)
         {
+            ThrowIfOwningRealmDisposed();
             return _singletons.ContainsKey(typeof(T)) || _typeRegistrations.ContainsKey(typeof(T));
         }
     }
@@ -183,9 +227,11 @@ public class ServiceContainer
     public ServiceContainer Replace<T>(T instance) where T : class
     {
         ArgumentNullException.ThrowIfNull(instance);
-        
+
         lock (_lock)
         {
+            ThrowIfOwningRealmDisposed();
+            ThrowIfReservedOwnershipType(typeof(T));
             _singletons[typeof(T)] = instance;
         }
         return this;
@@ -200,6 +246,8 @@ public class ServiceContainer
     {
         lock (_lock)
         {
+            ThrowIfOwningRealmDisposed();
+            ThrowIfReservedOwnershipType(typeof(T));
             return _singletons.Remove(typeof(T));
         }
     }
@@ -211,8 +259,10 @@ public class ServiceContainer
     {
         lock (_lock)
         {
+            ThrowIfOwningRealmDisposed();
             _singletons.Clear();
             _typeRegistrations.Clear();
+            RestoreOwnershipRegistrations();
         }
     }
 
@@ -226,6 +276,9 @@ public class ServiceContainer
         var child = new ServiceContainer();
         lock (_lock)
         {
+            ThrowIfOwningRealmDisposed();
+            child._owningRealm = _owningRealm;
+
             foreach (var kvp in _singletons)
             {
                 child._singletons[kvp.Key] = kvp.Value;
@@ -236,6 +289,38 @@ public class ServiceContainer
             }
         }
         return child;
+    }
+
+    private void RestoreOwnershipRegistrations()
+    {
+        if (_owningRealm == null)
+        {
+            return;
+        }
+
+        _singletons[typeof(RuntimeAgentCluster)] = _owningRealm.Agent.Cluster;
+        _singletons[typeof(RuntimeAgent)] = _owningRealm.Agent;
+        _singletons[typeof(RuntimeRealm)] = _owningRealm;
+    }
+
+    private void ThrowIfOwningRealmDisposed()
+    {
+        if (_owningRealm?.IsDisposed == true)
+        {
+            throw new ObjectDisposedException(nameof(RuntimeRealm));
+        }
+    }
+
+    private void ThrowIfReservedOwnershipType(Type serviceType)
+    {
+        if (_owningRealm != null
+            && (serviceType == typeof(RuntimeAgentCluster)
+                || serviceType == typeof(RuntimeAgent)
+                || serviceType == typeof(RuntimeRealm)))
+        {
+            throw new InvalidOperationException(
+                $"Runtime ownership service '{serviceType.Name}' cannot be replaced or removed.");
+        }
     }
 
     private Type ResolveImplementationType(Type serviceType)
@@ -260,7 +345,7 @@ public class ServiceContainer
     {
         // Get the constructor with the most parameters (greedy resolution)
         var constructors = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
-        
+
         if (constructors.Length == 0)
         {
             throw new InvalidOperationException(
@@ -278,7 +363,7 @@ public class ServiceContainer
         for (int i = 0; i < parameters.Length; i++)
         {
             var paramType = parameters[i].ParameterType;
-            
+
             try
             {
                 // Recursively resolve dependencies

--- a/src/JavaScriptRuntime/RuntimeOwnership.cs
+++ b/src/JavaScriptRuntime/RuntimeOwnership.cs
@@ -1,0 +1,252 @@
+using JavaScriptRuntime.DependencyInjection;
+
+namespace JavaScriptRuntime;
+
+internal enum RuntimeOwnershipState
+{
+    Active,
+    Disposing,
+    Disposed
+}
+
+internal sealed class RuntimeAgentCluster : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly List<RuntimeAgent> _agents = [];
+    private RuntimeOwnershipState _state;
+    private long _disposalSequence;
+
+    internal bool IsDisposed
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _state != RuntimeOwnershipState.Active;
+            }
+        }
+    }
+
+    internal int AgentCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _agents.Count;
+            }
+        }
+    }
+
+    internal long DisposalOrder { get; private set; }
+
+    internal RuntimeAgent CreateAgent()
+    {
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+
+            var agent = new RuntimeAgent(this);
+            _agents.Add(agent);
+            return agent;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_state == RuntimeOwnershipState.Disposed)
+            {
+                return;
+            }
+
+            _state = RuntimeOwnershipState.Disposing;
+            var agents = _agents.ToArray();
+            _agents.Clear();
+
+            for (var index = agents.Length - 1; index >= 0; index--)
+            {
+                agents[index].Dispose();
+            }
+
+            DisposalOrder = NextDisposalOrder();
+            _state = RuntimeOwnershipState.Disposed;
+        }
+    }
+
+    internal long NextDisposalOrder()
+        => Interlocked.Increment(ref _disposalSequence);
+
+    internal void Detach(RuntimeAgent agent)
+    {
+        lock (_gate)
+        {
+            _agents.Remove(agent);
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_state != RuntimeOwnershipState.Active)
+        {
+            throw new ObjectDisposedException(nameof(RuntimeAgentCluster));
+        }
+    }
+}
+
+internal sealed class RuntimeAgent : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly List<RuntimeRealm> _realms = [];
+    private RuntimeOwnershipState _state;
+
+    internal RuntimeAgent(RuntimeAgentCluster cluster)
+    {
+        Cluster = cluster;
+    }
+
+    internal RuntimeAgentCluster Cluster { get; }
+
+    internal bool IsDisposed
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _state != RuntimeOwnershipState.Active;
+            }
+        }
+    }
+
+    internal int RealmCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _realms.Count;
+            }
+        }
+    }
+
+    internal long DisposalOrder { get; private set; }
+
+    internal RuntimeRealm CreateRealm()
+    {
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+
+            var realm = new RuntimeRealm(this);
+            _realms.Add(realm);
+            return realm;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_state == RuntimeOwnershipState.Disposed)
+            {
+                return;
+            }
+
+            _state = RuntimeOwnershipState.Disposing;
+            var realms = _realms.ToArray();
+            _realms.Clear();
+
+            for (var index = realms.Length - 1; index >= 0; index--)
+            {
+                realms[index].Dispose();
+            }
+
+            DisposalOrder = Cluster.NextDisposalOrder();
+            _state = RuntimeOwnershipState.Disposed;
+        }
+
+        Cluster.Detach(this);
+    }
+
+    internal void Detach(RuntimeRealm realm)
+    {
+        lock (_gate)
+        {
+            _realms.Remove(realm);
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_state != RuntimeOwnershipState.Active)
+        {
+            throw new ObjectDisposedException(nameof(RuntimeAgent));
+        }
+    }
+}
+
+internal sealed class RuntimeRealm : IDisposable
+{
+    private readonly object _gate = new();
+    private RuntimeOwnershipState _state;
+
+    internal RuntimeRealm(RuntimeAgent agent)
+    {
+        Agent = agent;
+        Services = new ServiceContainer();
+        Services.AttachOwningRealm(this);
+    }
+
+    internal RuntimeAgent Agent { get; }
+
+    internal ServiceContainer Services { get; }
+
+    internal bool IsDisposed
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _state != RuntimeOwnershipState.Active;
+            }
+        }
+    }
+
+    internal long DisposalOrder { get; private set; }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_state == RuntimeOwnershipState.Disposed)
+            {
+                return;
+            }
+
+            _state = RuntimeOwnershipState.Disposing;
+            DisposalOrder = Agent.Cluster.NextDisposalOrder();
+            _state = RuntimeOwnershipState.Disposed;
+        }
+
+        Agent.Detach(this);
+    }
+}
+
+internal static class RuntimeOwnershipFactory
+{
+    internal static RuntimeRealm CreateIsolatedRealm()
+    {
+        var cluster = new RuntimeAgentCluster();
+
+        try
+        {
+            return cluster.CreateAgent().CreateRealm();
+        }
+        catch
+        {
+            cluster.Dispose();
+            throw;
+        }
+    }
+}

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -1722,11 +1722,11 @@ public class RuntimeServices
 
     public static ServiceContainer BuildServiceProvider()
     {
-        var container = new ServiceContainer();
+        var container = RuntimeOwnershipFactory.CreateIsolatedRealm().Services;
         container.RegisterInstance(new GlobalThisOptions());
         container.RegisterInstance(HostRuntimeIntrinsicDescriptors.Empty);
         container.RegisterInstance(new ConsoleOutputSinks());
-        
+
         // Register default engine dependencies
         container.Register<EngineCore.ITickSource, EngineCore.TickSource>();
         container.Register<EngineCore.IWaitHandle, EngineCore.WaitHandle>();
@@ -1745,7 +1745,7 @@ public class RuntimeServices
         container.Register<Node.IChildProcessLauncher, Node.DefaultChildProcessLauncher>();
         container.Register<Node.AsyncContextRuntime>();
         container.Register<Node.DiagnosticsChannelRuntime>();
-        
+
         return container;
     }
 }

--- a/tests/Jroc.Tests/RuntimeOwnershipTests.cs
+++ b/tests/Jroc.Tests/RuntimeOwnershipTests.cs
@@ -1,0 +1,211 @@
+using JavaScriptRuntime;
+using JavaScriptRuntime.DependencyInjection;
+
+namespace Jroc.Tests;
+
+public sealed class RuntimeOwnershipTests
+{
+    [Fact]
+    public void CreateIsolatedRealm_BuildsExplicitOwnershipGraph()
+    {
+        var realm = RuntimeOwnershipFactory.CreateIsolatedRealm();
+        var agent = realm.Agent;
+        var cluster = agent.Cluster;
+
+        Assert.Same(realm, realm.Services.OwningRealm);
+        Assert.Same(realm, realm.Services.Resolve<RuntimeRealm>());
+        Assert.Same(agent, realm.Services.Resolve<RuntimeAgent>());
+        Assert.Same(cluster, realm.Services.Resolve<RuntimeAgentCluster>());
+        Assert.Equal(1, agent.RealmCount);
+        Assert.Equal(1, cluster.AgentCount);
+
+        cluster.Dispose();
+    }
+
+    [Fact]
+    public void RuntimeServices_RegistersOwnersForConstructorInjection()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        var consumer = services.Resolve<OwnerAwareService>();
+
+        Assert.Same(services.OwningRealm, consumer.Realm);
+        Assert.Same(consumer.Realm.Agent, consumer.Agent);
+        Assert.Same(consumer.Agent.Cluster, consumer.Cluster);
+
+        consumer.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void RuntimeServices_CreatesAnIndependentOwnershipGraphPerContainer()
+    {
+        var first = RuntimeServices.BuildServiceProvider();
+        var second = RuntimeServices.BuildServiceProvider();
+
+        Assert.NotSame(first.OwningRealm, second.OwningRealm);
+        Assert.NotSame(
+            first.Resolve<RuntimeAgent>(),
+            second.Resolve<RuntimeAgent>());
+        Assert.NotSame(
+            first.Resolve<RuntimeAgentCluster>(),
+            second.Resolve<RuntimeAgentCluster>());
+
+        first.Resolve<RuntimeAgentCluster>().Dispose();
+        second.Resolve<RuntimeAgentCluster>().Dispose();
+    }
+
+    [Fact]
+    public void Agent_CanOwnMultipleRealms()
+    {
+        var first = RuntimeOwnershipFactory.CreateIsolatedRealm();
+        var agent = first.Agent;
+        var second = agent.CreateRealm();
+
+        Assert.NotSame(first, second);
+        Assert.Same(agent, second.Agent);
+        Assert.Equal(2, agent.RealmCount);
+        Assert.Same(second, second.Services.OwningRealm);
+
+        agent.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void ClusterDisposal_DisposesChildrenInReverseOwnershipOrder()
+    {
+        var cluster = new RuntimeAgentCluster();
+        var firstAgent = cluster.CreateAgent();
+        var firstRealm = firstAgent.CreateRealm();
+        var secondRealm = firstAgent.CreateRealm();
+        var secondAgent = cluster.CreateAgent();
+        var thirdRealm = secondAgent.CreateRealm();
+
+        cluster.Dispose();
+
+        Assert.True(firstRealm.IsDisposed);
+        Assert.True(secondRealm.IsDisposed);
+        Assert.True(thirdRealm.IsDisposed);
+        Assert.True(firstAgent.IsDisposed);
+        Assert.True(secondAgent.IsDisposed);
+        Assert.True(cluster.IsDisposed);
+
+        Assert.True(thirdRealm.DisposalOrder < secondAgent.DisposalOrder);
+        Assert.True(secondAgent.DisposalOrder < secondRealm.DisposalOrder);
+        Assert.True(secondRealm.DisposalOrder < firstRealm.DisposalOrder);
+        Assert.True(firstRealm.DisposalOrder < firstAgent.DisposalOrder);
+        Assert.True(firstAgent.DisposalOrder < cluster.DisposalOrder);
+    }
+
+    [Fact]
+    public void Disposal_IsIdempotentAndDetachesChildren()
+    {
+        var cluster = new RuntimeAgentCluster();
+        var agent = cluster.CreateAgent();
+        var realm = agent.CreateRealm();
+
+        realm.Dispose();
+        realm.Dispose();
+
+        Assert.True(realm.IsDisposed);
+        Assert.Equal(0, agent.RealmCount);
+
+        agent.Dispose();
+        agent.Dispose();
+
+        Assert.True(agent.IsDisposed);
+        Assert.Equal(0, cluster.AgentCount);
+
+        cluster.Dispose();
+        cluster.Dispose();
+
+        Assert.True(cluster.IsDisposed);
+    }
+
+    [Fact]
+    public void DisposedOwnersAndTheirServiceContainersCannotBeReused()
+    {
+        var realm = RuntimeOwnershipFactory.CreateIsolatedRealm();
+        var services = realm.Services;
+        var agent = realm.Agent;
+        var cluster = agent.Cluster;
+
+        realm.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => services.Resolve<RuntimeRealm>());
+
+        agent.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => agent.CreateRealm());
+
+        cluster.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => cluster.CreateAgent());
+    }
+
+    [Fact]
+    public void RealmOwnershipRegistrationsCannotBeReplacedRemovedOrCleared()
+    {
+        var realm = RuntimeOwnershipFactory.CreateIsolatedRealm();
+        var services = realm.Services;
+
+        Assert.Throws<InvalidOperationException>(
+            () => services.Replace(new RuntimeAgentCluster()));
+        Assert.Throws<InvalidOperationException>(
+            () => services.Remove<RuntimeRealm>());
+
+        services.Clear();
+
+        Assert.Same(realm, services.Resolve<RuntimeRealm>());
+        Assert.Same(realm.Agent, services.Resolve<RuntimeAgent>());
+        Assert.Same(realm.Agent.Cluster, services.Resolve<RuntimeAgentCluster>());
+
+        realm.Agent.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void ChildServiceContainerKeepsTheSameRealmOwner()
+    {
+        var realm = RuntimeOwnershipFactory.CreateIsolatedRealm();
+        var child = realm.Services.CreateScope();
+
+        Assert.Same(realm, child.OwningRealm);
+        Assert.Same(realm, child.Resolve<RuntimeRealm>());
+
+        realm.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => child.Resolve<RuntimeRealm>());
+
+        realm.Agent.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void ServiceContainerCannotBeAttachedToASecondRealm()
+    {
+        var first = RuntimeOwnershipFactory.CreateIsolatedRealm();
+        var second = RuntimeOwnershipFactory.CreateIsolatedRealm();
+
+        Assert.Throws<InvalidOperationException>(
+            () => first.Services.AttachOwningRealm(second));
+        Assert.Same(first, first.Services.OwningRealm);
+
+        first.Agent.Cluster.Dispose();
+        second.Agent.Cluster.Dispose();
+    }
+
+    private sealed class OwnerAwareService
+    {
+        public OwnerAwareService(
+            RuntimeAgentCluster cluster,
+            RuntimeAgent agent,
+            RuntimeRealm realm)
+        {
+            Cluster = cluster;
+            Agent = agent;
+            Realm = realm;
+        }
+
+        internal RuntimeAgentCluster Cluster { get; }
+
+        internal RuntimeAgent Agent { get; }
+
+        internal RuntimeRealm Realm { get; }
+    }
+}


### PR DESCRIPTION
## Summary

- add explicit `RuntimeAgentCluster`, `RuntimeAgent`, and `RuntimeRealm`
  ownership nodes plus an isolated ownership factory
- attach every runtime `ServiceContainer` to exactly one realm and reserve the
  owner registrations for constructor injection
- enforce deterministic child-first, idempotent disposal and reject use of
  disposed realm containers
- document ownership/reference rules and add focused lifecycle, isolation, and
  DI coverage

## Scope

This establishes the ownership graph only. It intentionally does not migrate
globals, modules, schedulers, caches, ambient execution state, `Engine`, or
hosting lifecycle; those remain in the follow-up #1805 subissues.

## Validation

- `dotnet build jroc.sln --no-restore`
- 115 focused runtime ownership, DI, globals/prototypes, hosting, and
  collectible in-memory loading tests
- modified C# whitespace formatting verification

Fixes #1821
