### PR TITLE
feat(runtime): support JSON RawJSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   injection, with deterministic child-first disposal and disposed-state
   guards. Existing observable runtime state remains in place for the follow-up
   migration stages tracked by #1805.
+
+- runtime/test262: add ES2025 JSON.rawJSON and JSON.isRawJSON support with
+  validated frozen marker objects, raw primitive serialization, root reviver
+  source context, and standard builtin metadata. JSON.stringify now creates
+  its wrapper as an own data property, preserves its key list while getters
+  mutate objects, and applies observable coercion to boxed space values.
+  Activates twenty corresponding pinned test262 fixtures.
+
 - compiler/runtime/test262: complete String well-known-symbol dispatch for
   primitive match/search/replaceAll inputs, invoke observable @@search hooks
   on internally created RegExps, preserve JavaScript number-string precision

--- a/docs/ECMA262/25/Section25_5.json
+++ b/docs/ECMA262/25/Section25_5.json
@@ -74,6 +74,18 @@
       "title": "JSON [ %Symbol.toStringTag% ]",
       "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-json-%symbol.tostringtag%"
+    },
+    {
+      "clause": "25.5.4",
+      "title": "JSON.rawJSON ( text )",
+      "status": "Supported with Limitations",
+      "specUrl": "https://tc39.es/ecma262/#sec-json.rawjson"
+    },
+    {
+      "clause": "25.5.5",
+      "title": "JSON.isRawJSON ( O )",
+      "status": "Supported",
+      "specUrl": "https://tc39.es/ecma262/#sec-json.israwjson"
     }
   ],
   "support": {
@@ -125,11 +137,15 @@
           "test/built-ins/JSON/stringify/replacer-array-proxy-revoked-realm.js",
           "test/built-ins/JSON/stringify/replacer-array-string-object.js",
           "test/built-ins/JSON/stringify/replacer-array-undefined.js",
+          "test/built-ins/JSON/stringify/replacer-function-object-deleted-property.js",
           "test/built-ins/JSON/stringify/replacer-function-result.js",
+          "test/built-ins/JSON/stringify/replacer-function-wrapper.js",
+          "test/built-ins/JSON/stringify/space-number-object.js",
           "test/built-ins/JSON/stringify/space-string.js",
+          "test/built-ins/JSON/stringify/space-string-object.js",
           "test/built-ins/JSON/stringify/value-tojson-result.js"
         ],
-        "notes": "JSON.stringify is implemented for ordinary objects and arrays. Current bounded test262 coverage exercises the builtin function object surface (`JSON.stringify`, `.length`, `.name`, and property descriptor metadata), ordinary property-order serialization, array-replacer ordering/filtering/deduplication, boxed string/number replacer entries, ignored undefined/sparse replacer entries, proxy/revoked-proxy abrupt completion, replacer function return-value serialization, selected toJSON return-value serialization, and string space/gap formatting. Broader cyclic, exotic, BigInt, and cross-realm behavior remains limited."
+        "notes": "JSON.stringify is implemented for ordinary objects and arrays. Current bounded test262 coverage exercises the builtin function object surface (`JSON.stringify`, `.length`, `.name`, and property descriptor metadata), ordinary property-order serialization, stable key-list behavior when getters delete later properties, an own data-property wrapper that bypasses inherited setters, array-replacer ordering/filtering/deduplication, boxed string/number replacer entries, boxed space values with observable ToPrimitive coercion, ignored undefined/sparse replacer entries, proxy/revoked-proxy abrupt completion, replacer function return-value serialization, selected toJSON return-value serialization, and string space/gap formatting. RawJSON marker values serialize as unquoted validated JSON primitives. Broader cyclic, exotic, BigInt, and cross-realm behavior remains limited."
       },
       {
         "clause": "25.5.3",
@@ -143,6 +159,46 @@
           "test/built-ins/JSON/Symbol.toStringTag.js"
         ],
         "notes": "Checked-in coverage now includes JSON @@toStringTag value and descriptor attributes (`value: \"JSON\"`, `writable: false`, `enumerable: false`, `configurable: true`)."
+      },
+      {
+        "clause": "25.5.4",
+        "feature": "JSON.rawJSON",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-json.rawjson",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/JSON/rawJSON/basic.js",
+          "test/built-ins/JSON/rawJSON/bigint-raw-json-can-be-stringified.js",
+          "test/built-ins/JSON/rawJSON/builtin.js",
+          "test/built-ins/JSON/rawJSON/illegal-empty-and-start-end-chars.js",
+          "test/built-ins/JSON/rawJSON/invalid-JSON-text.js",
+          "test/built-ins/JSON/rawJSON/length.js",
+          "test/built-ins/JSON/rawJSON/name.js",
+          "test/built-ins/JSON/rawJSON/not-a-constructor.js",
+          "test/built-ins/JSON/rawJSON/prop-desc.js",
+          "test/built-ins/JSON/rawJSON/returns-expected-object.js"
+        ],
+        "notes": "JSON.rawJSON creates frozen null-prototype marker objects for validated primitive JSON text. JSON.stringify emits those markers without quoting, including replacer-produced values that preserve large integer source text. Current parse source-context support covers the root reviver value; nested source contexts remain limited."
+      },
+      {
+        "clause": "25.5.5",
+        "feature": "JSON.isRawJSON",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-json.israwjson",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/JSON/isRawJSON/basic.js",
+          "test/built-ins/JSON/isRawJSON/builtin.js",
+          "test/built-ins/JSON/isRawJSON/length.js",
+          "test/built-ins/JSON/isRawJSON/name.js",
+          "test/built-ins/JSON/isRawJSON/not-a-constructor.js",
+          "test/built-ins/JSON/isRawJSON/prop-desc.js"
+        ],
+        "notes": "JSON.isRawJSON recognizes only marker objects returned by JSON.rawJSON and exposes the standard non-constructor builtin metadata."
       }
     ]
   }

--- a/docs/ECMA262/25/Section25_5.md
+++ b/docs/ECMA262/25/Section25_5.md
@@ -4,7 +4,7 @@
 
 [Back to Section25](Section25.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-08-14T08:29:24Z
+> Last generated (UTC): 2026-08-14T22:40:15Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -25,6 +25,8 @@
 | 25.5.2.5 | SerializeJSONObject ( state , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-serializejsonobject) |
 | 25.5.2.6 | SerializeJSONArray ( state , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-serializejsonarray) |
 | 25.5.3 | JSON [ %Symbol.toStringTag% ] | Supported | [tc39.es](https://tc39.es/ecma262/#sec-json-%symbol.tostringtag%) |
+| 25.5.4 | JSON.rawJSON ( text ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-json.rawjson) |
+| 25.5.5 | JSON.isRawJSON ( O ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-json.israwjson) |
 
 ## Support
 
@@ -40,11 +42,23 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| JSON.stringify | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/JSON/stringify/ExecutionTests.cs` | `test/built-ins/JSON/stringify/builtin.js`<br>`test/built-ins/JSON/stringify/length.js`<br>`test/built-ins/JSON/stringify/name.js`<br>`test/built-ins/JSON/stringify/property-order.js`<br>`test/built-ins/JSON/stringify/prop-desc.js`<br>`test/built-ins/JSON/stringify/replacer-array-abrupt.js`<br>`test/built-ins/JSON/stringify/replacer-array-duplicates.js`<br>`test/built-ins/JSON/stringify/replacer-array-empty.js`<br>`test/built-ins/JSON/stringify/replacer-array-number.js`<br>`test/built-ins/JSON/stringify/replacer-array-number-object.js`<br>`test/built-ins/JSON/stringify/replacer-array-order.js`<br>`test/built-ins/JSON/stringify/replacer-array-proxy.js`<br>`test/built-ins/JSON/stringify/replacer-array-proxy-revoked.js`<br>`test/built-ins/JSON/stringify/replacer-array-proxy-revoked-realm.js`<br>`test/built-ins/JSON/stringify/replacer-array-string-object.js`<br>`test/built-ins/JSON/stringify/replacer-array-undefined.js`<br>`test/built-ins/JSON/stringify/replacer-function-result.js`<br>`test/built-ins/JSON/stringify/space-string.js`<br>`test/built-ins/JSON/stringify/value-tojson-result.js` | JSON.stringify is implemented for ordinary objects and arrays. Current bounded test262 coverage exercises the builtin function object surface (`JSON.stringify`, `.length`, `.name`, and property descriptor metadata), ordinary property-order serialization, array-replacer ordering/filtering/deduplication, boxed string/number replacer entries, ignored undefined/sparse replacer entries, proxy/revoked-proxy abrupt completion, replacer function return-value serialization, selected toJSON return-value serialization, and string space/gap formatting. Broader cyclic, exotic, BigInt, and cross-realm behavior remains limited. |
+| JSON.stringify | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/JSON/stringify/ExecutionTests.cs` | `test/built-ins/JSON/stringify/builtin.js`<br>`test/built-ins/JSON/stringify/length.js`<br>`test/built-ins/JSON/stringify/name.js`<br>`test/built-ins/JSON/stringify/property-order.js`<br>`test/built-ins/JSON/stringify/prop-desc.js`<br>`test/built-ins/JSON/stringify/replacer-array-abrupt.js`<br>`test/built-ins/JSON/stringify/replacer-array-duplicates.js`<br>`test/built-ins/JSON/stringify/replacer-array-empty.js`<br>`test/built-ins/JSON/stringify/replacer-array-number.js`<br>`test/built-ins/JSON/stringify/replacer-array-number-object.js`<br>`test/built-ins/JSON/stringify/replacer-array-order.js`<br>`test/built-ins/JSON/stringify/replacer-array-proxy.js`<br>`test/built-ins/JSON/stringify/replacer-array-proxy-revoked.js`<br>`test/built-ins/JSON/stringify/replacer-array-proxy-revoked-realm.js`<br>`test/built-ins/JSON/stringify/replacer-array-string-object.js`<br>`test/built-ins/JSON/stringify/replacer-array-undefined.js`<br>`test/built-ins/JSON/stringify/replacer-function-object-deleted-property.js`<br>`test/built-ins/JSON/stringify/replacer-function-result.js`<br>`test/built-ins/JSON/stringify/replacer-function-wrapper.js`<br>`test/built-ins/JSON/stringify/space-number-object.js`<br>`test/built-ins/JSON/stringify/space-string.js`<br>`test/built-ins/JSON/stringify/space-string-object.js`<br>`test/built-ins/JSON/stringify/value-tojson-result.js` | JSON.stringify is implemented for ordinary objects and arrays. Current bounded test262 coverage exercises the builtin function object surface (`JSON.stringify`, `.length`, `.name`, and property descriptor metadata), ordinary property-order serialization, stable key-list behavior when getters delete later properties, an own data-property wrapper that bypasses inherited setters, array-replacer ordering/filtering/deduplication, boxed string/number replacer entries, boxed space values with observable ToPrimitive coercion, ignored undefined/sparse replacer entries, proxy/revoked-proxy abrupt completion, replacer function return-value serialization, selected toJSON return-value serialization, and string space/gap formatting. RawJSON marker values serialize as unquoted validated JSON primitives. Broader cyclic, exotic, BigInt, and cross-realm behavior remains limited. |
 
 ### 25.5.3 ([tc39.es](https://tc39.es/ecma262/#sec-json-%symbol.tostringtag%))
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | JSON[@@toStringTag] descriptor | Supported | `tests/Jroc.Test262.Tests/built-ins/JSON/ExecutionTests.cs` | `test/built-ins/JSON/Symbol.toStringTag.js` | Checked-in coverage now includes JSON @@toStringTag value and descriptor attributes (`value: "JSON"`, `writable: false`, `enumerable: false`, `configurable: true`). |
+
+### 25.5.4 ([tc39.es](https://tc39.es/ecma262/#sec-json.rawjson))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| JSON.rawJSON | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/ExecutionTests.cs` | `test/built-ins/JSON/rawJSON/basic.js`<br>`test/built-ins/JSON/rawJSON/bigint-raw-json-can-be-stringified.js`<br>`test/built-ins/JSON/rawJSON/builtin.js`<br>`test/built-ins/JSON/rawJSON/illegal-empty-and-start-end-chars.js`<br>`test/built-ins/JSON/rawJSON/invalid-JSON-text.js`<br>`test/built-ins/JSON/rawJSON/length.js`<br>`test/built-ins/JSON/rawJSON/name.js`<br>`test/built-ins/JSON/rawJSON/not-a-constructor.js`<br>`test/built-ins/JSON/rawJSON/prop-desc.js`<br>`test/built-ins/JSON/rawJSON/returns-expected-object.js` | JSON.rawJSON creates frozen null-prototype marker objects for validated primitive JSON text. JSON.stringify emits those markers without quoting, including replacer-produced values that preserve large integer source text. Current parse source-context support covers the root reviver value; nested source contexts remain limited. |
+
+### 25.5.5 ([tc39.es](https://tc39.es/ecma262/#sec-json.israwjson))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| JSON.isRawJSON | Supported | `tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/ExecutionTests.cs` | `test/built-ins/JSON/isRawJSON/basic.js`<br>`test/built-ins/JSON/isRawJSON/builtin.js`<br>`test/built-ins/JSON/isRawJSON/length.js`<br>`test/built-ins/JSON/isRawJSON/name.js`<br>`test/built-ins/JSON/isRawJSON/not-a-constructor.js`<br>`test/built-ins/JSON/isRawJSON/prop-desc.js` | JSON.isRawJSON recognizes only marker objects returned by JSON.rawJSON and exposes the standard non-constructor builtin metadata. |
 

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -261,6 +261,10 @@ namespace JavaScriptRuntime
             var reviver = args != null && args.Length > 1 ? args[1] : null;
             return JavaScriptRuntime.JSON.Parse(text, reviver);
         };
+        private static readonly Func<object[], object?[], object?> _jsonRawJsonValue = static (_, args) =>
+            JavaScriptRuntime.JSON.RawJSON(args != null && args.Length > 0 ? args[0] : null);
+        private static readonly Func<object[], object?[], object?> _jsonIsRawJsonValue = static (_, args) =>
+            JavaScriptRuntime.JSON.IsRawJSON(args != null && args.Length > 0 ? args[0] : null);
 
         private static readonly Func<object[], object?[], object?> _errorConstructorValue =
             CreateErrorConstructorValue(static message => new JavaScriptRuntime.Error(message));
@@ -576,6 +580,10 @@ namespace JavaScriptRuntime
                 Value = global::System.Numerics.BigInteger.Zero
             });
             DefineBuiltinFunctionProperty(_jsonValue, "parse", _jsonParseValue, 2d);
+            DefineBuiltinFunctionProperty(_jsonValue, "rawJSON", _jsonRawJsonValue, 1d);
+            DefineBuiltinFunctionProperty(_jsonValue, "isRawJSON", _jsonIsRawJsonValue, 1d);
+            PropertyDescriptorStore.Delete(_jsonRawJsonValue, "prototype");
+            PropertyDescriptorStore.Delete(_jsonIsRawJsonValue, "prototype");
             DefineIntrinsicToStringTagProperty(_atomicsValue, "Atomics");
             DefineBuiltinFunctionProperty(_atomicsValue, "wait", (Func<object?, object?, object?, object?, string>)JavaScriptRuntime.Atomics.wait, 4d);
             ConfigureBuiltinFunctionObject(_jsonStringifyValue);

--- a/src/JavaScriptRuntime/JSON.cs
+++ b/src/JavaScriptRuntime/JSON.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 
@@ -9,6 +10,18 @@ namespace JavaScriptRuntime
     [IntrinsicObject("JSON")]
     public static class JSON
     {
+        private sealed class RawJsonData
+        {
+            public RawJsonData(string text)
+            {
+                Text = text;
+            }
+
+            public string Text { get; }
+        }
+
+        private static readonly ConditionalWeakTable<JsObject, RawJsonData> RawJsonObjects = new();
+
         // JSON.parse(text[, reviver])
         public static object? Parse(object? text)
             => Parse(text, null);
@@ -28,7 +41,7 @@ namespace JavaScriptRuntime
 
                 var root = ObjectRuntime.CreateOrdinaryObject();
                 root.SetBoxedValue(string.Empty, parsed);
-                return InternalizeJsonProperty(root, string.Empty, reviver!);
+                return InternalizeJsonProperty(root, string.Empty, reviver!, doc.RootElement.GetRawText());
             }
             catch (JsonException ex)
             {
@@ -37,7 +50,11 @@ namespace JavaScriptRuntime
             }
         }
 
-        private static object? InternalizeJsonProperty(object holder, string name, object reviver)
+        private static object? InternalizeJsonProperty(
+            object holder,
+            string name,
+            object reviver,
+            string? source = null)
         {
             var value = ObjectRuntime.GetItem(holder, name);
             if (value is Array array)
@@ -80,8 +97,61 @@ namespace JavaScriptRuntime
                 }
             }
 
-            return CallableOperations.Call2(reviver, holder, name, value);
+            if (source is null)
+            {
+                return CallableOperations.Call2(reviver, holder, name, value);
+            }
+
+            var context = ObjectRuntime.CreateOrdinaryObject();
+            context.SetBoxedValue("source", source);
+            return CallableOperations.Call3(reviver, holder, name, value, context);
         }
+
+        public static object RawJSON(object? text)
+        {
+            if (text is Symbol)
+            {
+                throw new TypeError("Cannot convert a Symbol value to a string");
+            }
+
+            var jsonText = DotNet2JSConversions.ToString(text);
+            if (string.IsNullOrEmpty(jsonText)
+                || IsJsonWhitespace(jsonText[0])
+                || IsJsonWhitespace(jsonText[^1]))
+            {
+                throw new SyntaxError("Invalid JSON text");
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(jsonText);
+                if (document.RootElement.ValueKind is JsonValueKind.Array or JsonValueKind.Object)
+                {
+                    throw new SyntaxError("JSON.rawJSON only accepts primitive JSON values");
+                }
+            }
+            catch (JsonException ex)
+            {
+                throw new SyntaxError(ex.Message);
+            }
+
+            var result = new JsObject();
+            PrototypeChain.SetPrototype(result, JsNull.Null);
+            PropertyDescriptorStore.DefineOrUpdate(result, "rawJSON", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = true,
+                Configurable = true,
+                Writable = true,
+                Value = jsonText
+            });
+            ObjectRuntime.freeze(result);
+            RawJsonObjects.Add(result, new RawJsonData(jsonText));
+            return result;
+        }
+
+        public static bool IsRawJSON(object? value)
+            => value is JsObject rawJson && RawJsonObjects.TryGetValue(rawJson, out _);
 
         public static object? Stringify(object? value)
             => Stringify(value, null, null);
@@ -97,7 +167,14 @@ namespace JavaScriptRuntime
                 : null;
             var gap = CreateGap(space);
             var holder = ObjectRuntime.CreateOrdinaryObject();
-            ObjectRuntime.SetItem(holder, string.Empty, value);
+            PropertyDescriptorStore.DefineOrUpdate(holder, string.Empty, new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = true,
+                Configurable = true,
+                Writable = true,
+                Value = value
+            });
             return SerializeProperty(holder, string.Empty, propertyList, replacerFunction, new HashSet<object>(ReferenceEqualityComparer.Instance), gap, string.Empty);
         }
 
@@ -111,7 +188,12 @@ namespace JavaScriptRuntime
             double numericSpace;
             if (Number.TryGetWrappedNumberValue(space, out var wrappedNumber))
             {
-                numericSpace = wrappedNumber;
+                if (!TypeUtilities.TryCoerceObjectToPrimitive(space, "number", out var primitive))
+                {
+                    throw new TypeError("Cannot convert object to primitive value");
+                }
+
+                numericSpace = TypeUtilities.ToNumber(primitive);
             }
             else if (space is double or float or int or long or short or byte or sbyte or uint or ulong or ushort)
             {
@@ -127,7 +209,12 @@ namespace JavaScriptRuntime
                 else if (PropertyDescriptorStore.TryGetOwn(space, String.StringDataPropertyName, out var stringData)
                     && stringData.Kind == JsPropertyDescriptorKind.Data)
                 {
-                    stringSpace = DotNet2JSConversions.ToString(stringData.Value);
+                    if (!TypeUtilities.TryCoerceObjectToPrimitive(space, "string", out var primitive))
+                    {
+                        throw new TypeError("Cannot convert object to primitive value");
+                    }
+
+                    stringSpace = DotNet2JSConversions.ToString(primitive);
                 }
 
                 return stringSpace is null
@@ -296,6 +383,11 @@ namespace JavaScriptRuntime
             string gap,
             string indent)
         {
+            if (value is JsObject rawJson && RawJsonObjects.TryGetValue(rawJson, out var rawJsonData))
+            {
+                return rawJsonData.Text;
+            }
+
             if (CallableOperations.IsCallable(value))
             {
                 return null;
@@ -431,11 +523,6 @@ namespace JavaScriptRuntime
             {
                 foreach (var key in keys)
                 {
-                    if (!ObjectRuntime.hasOwn(value, key))
-                    {
-                        continue;
-                    }
-
                     var serialized = SerializeProperty(value, key, propertyList, replacerFunction, stack, gap, indent);
                     if (serialized is null)
                     {
@@ -487,6 +574,9 @@ namespace JavaScriptRuntime
             builder.Append('"');
             return builder.ToString();
         }
+
+        private static bool IsJsonWhitespace(char value)
+            => value is '\t' or '\n' or '\r' or ' ';
 
         private static object? FromElement(JsonElement el)
         {

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/ExecutionTests.cs
@@ -1,0 +1,26 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.JSON.isRawJSON;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.JSON.isRawJSON") { }
+
+    [Fact(DisplayName = "basic.js")]
+    public Task basic() => ExecutionTestFromFile("basic");
+
+    [Fact(DisplayName = "builtin.js")]
+    public Task builtin() => ExecutionTestFromFile("builtin");
+
+    [Fact(DisplayName = "length.js")]
+    public Task length() => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "not-a-constructor.js")]
+    public Task not_a_constructor() => ExecutionTestFromFile("not-a-constructor");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/JavaScript/basic.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/JavaScript/basic.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-json.israwjson
+description: Basic functionality of JSON.isRawJSON()
+info: |
+  JSON.isRawJSON ( O )
+
+  1. If Type(O) is Object and O has an [[IsRawJSON]] internal slot, return true.
+  2. Return false.
+
+features: [json-parse-with-source]
+---*/
+
+const values = [1, 1.1, null, false, true, '123'];
+for (const value of values) {
+  assert(!JSON.isRawJSON(value));
+  assert(JSON.isRawJSON(JSON.rawJSON(value)));
+}
+assert(!JSON.isRawJSON(undefined));
+assert(!JSON.isRawJSON(Symbol('123')));
+assert(!JSON.isRawJSON([]));
+assert(!JSON.isRawJSON({}));
+assert(!JSON.isRawJSON({ rawJSON: '123' }));

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/JavaScript/builtin.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/JavaScript/builtin.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2024 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-json.israwjson
+description: >
+  JSON.isRawJSON meets the requirements for built-in objects
+info: |
+  JSON.isRawJSON ( O )
+
+  18 ECMAScript Standard Built-in Objects
+  ...
+  Unless specified otherwise, a built-in object that is callable as a function
+  is a built-in function object with the characteristics described in 10.3.
+  Unless specified otherwise, the [[Extensible]] internal slot of a built-in
+  object initially has the value true. Every built-in function object has a
+  [[Realm]] internal slot whose value is the Realm Record of the realm for
+  which the object was initially created.
+  ...
+  Unless otherwise specified every built-in function and every built-in
+  constructor has the Function prototype object, which is the initial value of
+  the expression Function.prototype (20.2.3), as the value of its [[Prototype]]
+  internal slot.
+  ...
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in the
+  description of a particular function.
+
+features: [json-parse-with-source]
+---*/
+
+assert(Object.isExtensible(JSON.isRawJSON), "JSON.isRawJSON is extensible");
+assert.sameValue(
+  typeof JSON.isRawJSON,
+  'function',
+  'The value of `typeof JSON.isRawJSON` is "function"'
+);
+assert.sameValue(
+  Object.getPrototypeOf(JSON.isRawJSON),
+  Function.prototype,
+  'Object.getPrototypeOf(JSON.isRawJSON) must return the value of "Function.prototype"'
+);
+
+assert.sameValue(
+  Object.getOwnPropertyDescriptor(JSON.isRawJSON, "prototype"),
+  undefined,
+  "JSON.isRawJSON has no own prototype property"
+);

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/JavaScript/length.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2024 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-built-in-function-objects
+description: >
+  JSON.isRawJSON.length value and descriptor.
+info: |
+    Every built-in function object, including constructors, has a *"length"*
+    property whose value is a non-negative integral Number. Unless otherwise
+    specified, this value is the number of required parameters shown in the
+    subclause heading for the function description. Optional parameters and rest
+    parameters are not included in the parameter count.
+
+    Unless otherwise specified, the *"length"* property of a built-in function
+    object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*,
+    [[Configurable]]: *true* }.
+includes: [propertyHelper.js]
+features: [json-parse-with-source]
+---*/
+
+verifyProperty(JSON.isRawJSON, 'length', {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/JavaScript/name.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2024 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-built-in-function-objects
+description: >
+  JSON.isRawJSON.name value and descriptor.
+info: |
+    Every built-in function object, including constructors, has a *"name"*
+    property whose value is a String. Unless otherwise specified, this value is
+    the name that is given to the function in this specification. Functions that
+    are identified as anonymous functions use the empty String as the value of
+    the *"name"* property. For functions that are specified as properties of
+    objects, the name value is the property name string used to access the
+    function. Functions that are specified as get or set accessor functions of
+    built-in properties have *"get"* or *"set"* (respectively) passed to the
+    prefix parameter when calling CreateBuiltinFunction.
+
+    The value of the *"name"* property is explicitly specified for each built-in
+    function whose property key is a Symbol value. If such an explicitly
+    specified value starts with the prefix *"get "* or *"set "* and the function
+    for which it is specified is a get or set accessor function of a built-in
+    property, the value without the prefix is passed to the name parameter, and
+    the value *"get"* or *"set"* (respectively) is passed to the prefix
+    parameter when calling CreateBuiltinFunction.
+
+    Unless otherwise specified, the *"name"* property of a built-in function
+    object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*,
+    [[Configurable]]: *true* }.
+
+includes: [propertyHelper.js]
+features: [json-parse-with-source]
+---*/
+
+verifyProperty(JSON.isRawJSON, 'name', {
+  value: "isRawJSON",
+  enumerable: false,
+  writable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/JavaScript/not-a-constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/JavaScript/not-a-constructor.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2024 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  JSON.isRawJSON does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [json-parse-with-source, Reflect.construct]
+---*/
+
+assert.sameValue(isConstructor(JSON.isRawJSON), false, 'isConstructor(JSON.isRawJSON) must return false');
+
+assert.throws(TypeError, () => {
+  new JSON.isRawJSON();
+});

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/isRawJSON/JavaScript/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2024 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-json.israwjson
+description: >
+  Property type and descriptor.
+info: |
+  JSON.isRawJSON ( O )
+
+  18 ECMAScript Standard Built-in Objects
+  ...
+  Every other data property described in clauses 19 through 28 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+
+includes: [propertyHelper.js]
+features: [json-parse-with-source]
+---*/
+
+verifyProperty(JSON, 'isRawJSON', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/ExecutionTests.cs
@@ -1,0 +1,40 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.JSON.rawJSON;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.JSON.rawJSON") { }
+
+    [Fact(DisplayName = "basic.js")]
+    public Task basic() => ExecutionTestFromFile("basic");
+
+    [Fact(DisplayName = "bigint-raw-json-can-be-stringified.js")]
+    public Task bigint_raw_json_can_be_stringified()
+        => ExecutionTestFromFile("bigint-raw-json-can-be-stringified");
+
+    [Fact(DisplayName = "builtin.js")]
+    public Task builtin() => ExecutionTestFromFile("builtin");
+
+    [Fact(DisplayName = "illegal-empty-and-start-end-chars.js")]
+    public Task illegal_empty_and_start_end_chars()
+        => ExecutionTestFromFile("illegal-empty-and-start-end-chars");
+
+    [Fact(DisplayName = "invalid-JSON-text.js")]
+    public Task invalid_JSON_text() => ExecutionTestFromFile("invalid-JSON-text");
+
+    [Fact(DisplayName = "length.js")]
+    public Task length() => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "not-a-constructor.js")]
+    public Task not_a_constructor() => ExecutionTestFromFile("not-a-constructor");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+
+    [Fact(DisplayName = "returns-expected-object.js")]
+    public Task returns_expected_object() => ExecutionTestFromFile("returns-expected-object");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/basic.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/basic.js
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-json.rawjson
+description: Basic functionality of JSON.rawJSON().
+info: |
+  JSON.rawJSON ( text )
+
+  1. Let jsonString be ? ToString(text).
+  ...
+  4. Let internalSlotsList be « [[IsRawJSON]] ».
+  5. Let obj be OrdinaryObjectCreate(null, internalSlotsList).
+  6. Perform ! CreateDataPropertyOrThrow(obj, "rawJSON", jsonString).
+  7. Perform ! SetIntegrityLevel(obj, frozen).
+  8. Return obj.
+
+features: [json-parse-with-source]
+---*/
+
+assert.sameValue(JSON.stringify(JSON.rawJSON(1)), '1');
+assert.sameValue(JSON.stringify(JSON.rawJSON(1.1)), '1.1');
+assert.sameValue(JSON.stringify(JSON.rawJSON(-1)), '-1');
+assert.sameValue(JSON.stringify(JSON.rawJSON(-1.1)), '-1.1');
+assert.sameValue(JSON.stringify(JSON.rawJSON(1.1e1)), '11');
+assert.sameValue(JSON.stringify(JSON.rawJSON(1.1e-1)), '0.11');
+
+assert.sameValue(JSON.stringify(JSON.rawJSON(null)), 'null');
+assert.sameValue(JSON.stringify(JSON.rawJSON(true)), 'true');
+assert.sameValue(JSON.stringify(JSON.rawJSON(false)), 'false');
+assert.sameValue(JSON.stringify(JSON.rawJSON('"foo"')), '"foo"');
+
+assert.sameValue(JSON.stringify({ 42: JSON.rawJSON(37) }), '{"42":37}');
+assert.sameValue(
+  JSON.stringify({ x: JSON.rawJSON(1), y: JSON.rawJSON(2) }),
+  '{"x":1,"y":2}'
+);
+assert.sameValue(
+  JSON.stringify({ x: { x: JSON.rawJSON(1), y: JSON.rawJSON(2) } }),
+  '{"x":{"x":1,"y":2}}'
+);
+
+assert.sameValue(JSON.stringify([JSON.rawJSON(1), JSON.rawJSON(1.1)]), '[1,1.1]');
+assert.sameValue(
+  JSON.stringify([
+    JSON.rawJSON('"1"'),
+    JSON.rawJSON(true),
+    JSON.rawJSON(null),
+    JSON.rawJSON(false),
+  ]),
+  '["1",true,null,false]'
+);
+assert.sameValue(
+  JSON.stringify([{ x: JSON.rawJSON(1), y: JSON.rawJSON(1) }]),
+  '[{"x":1,"y":1}]'
+);

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/bigint-raw-json-can-be-stringified.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/bigint-raw-json-can-be-stringified.js
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-json.rawjson
+description: BigInt rawJSON can be stringified.
+info: |
+  JSON.rawJSON ( text )
+
+  1. Let jsonString be ? ToString(text).
+  ...
+  4. Let internalSlotsList be « [[IsRawJSON]] ».
+  5. Let obj be OrdinaryObjectCreate(null, internalSlotsList).
+  6. Perform ! CreateDataPropertyOrThrow(obj, "rawJSON", jsonString).
+  7. Perform ! SetIntegrityLevel(obj, frozen).
+  8. Return obj.
+
+features: [BigInt, json-parse-with-source]
+---*/
+
+const tooBigForNumber = BigInt(Number.MAX_SAFE_INTEGER) + 2n;
+const intToBigInt = (key, val, { source }) =>
+  typeof val === 'number' && val % 1 === 0 ? BigInt(source) : val;
+const roundTripped = JSON.parse(String(tooBigForNumber), intToBigInt);
+assert.sameValue(roundTripped, tooBigForNumber);
+
+const bigIntToRawJSON = (key, val) =>
+  typeof val === 'bigint' ? JSON.rawJSON(val) : val;
+const embedded = JSON.stringify({ tooBigForNumber }, bigIntToRawJSON);
+assert.sameValue(embedded, '{"tooBigForNumber":9007199254740993}');

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/builtin.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/builtin.js
@@ -1,0 +1,49 @@
+// Copyright (C) 2024 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-json.rawjson
+description: >
+  JSON.rawJSON meets the requirements for built-in objects
+info: |
+  JSON.isRawJSON ( O )
+
+  18 ECMAScript Standard Built-in Objects
+  ...
+  Unless specified otherwise, a built-in object that is callable as a function
+  is a built-in function object with the characteristics described in 10.3.
+  Unless specified otherwise, the [[Extensible]] internal slot of a built-in
+  object initially has the value true. Every built-in function object has a
+  [[Realm]] internal slot whose value is the Realm Record of the realm for
+  which the object was initially created.
+  ...
+  Unless otherwise specified every built-in function and every built-in
+  constructor has the Function prototype object, which is the initial value of
+  the expression Function.prototype (20.2.3), as the value of its [[Prototype]]
+  internal slot.
+  ...
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in the
+  description of a particular function.
+
+features: [json-parse-with-source]
+---*/
+
+assert(Object.isExtensible(JSON.rawJSON), "JSON.rawJSON is extensible");
+assert.sameValue(
+  typeof JSON.rawJSON,
+  'function',
+  'The value of `typeof JSON.rawJSON` is "function"'
+);
+
+assert.sameValue(
+  Object.getPrototypeOf(JSON.rawJSON),
+  Function.prototype,
+  "Prototype of JSON.rawJSON is Function.prototype"
+);
+
+assert.sameValue(
+  Object.getOwnPropertyDescriptor(JSON.rawJSON, "prototype"),
+  undefined,
+  "JSON.rawJSON has no own prototype property"
+);

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/illegal-empty-and-start-end-chars.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/illegal-empty-and-start-end-chars.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-json.rawjson
+description: Throw SyntaxError on empty string, or illegal start/end chars
+info: |
+  JSON.rawJSON ( text )
+
+  1. Let jsonString be ? ToString(text).
+  2. Throw a SyntaxError exception if jsonString is the empty String, or if
+     either the first or last code unit of jsonString is any of 0x0009
+     (CHARACTER TABULATION), 0x000A (LINE FEED), 0x000D (CARRIAGE RETURN), or
+     0x0020 (SPACE).
+
+features: [json-parse-with-source]
+---*/
+
+const ILLEGAL_END_CHARS = ['\n', '\t', '\r', ' '];
+for (const char of ILLEGAL_END_CHARS) {
+  assert.throws(SyntaxError, () => {
+    JSON.rawJSON(`${char}123`);
+  });
+  assert.throws(SyntaxError, () => {
+    JSON.rawJSON(`123${char}`);
+  });
+}
+
+assert.throws(SyntaxError, () => {
+  JSON.rawJSON('');
+});

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/invalid-JSON-text.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/invalid-JSON-text.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-json.rawjson
+description: >
+  Inputs not convertible to string, or convertible to invalid JSON string
+info: |
+  JSON.rawJSON ( text )
+
+  1. Let jsonString be ? ToString(text).
+  ...
+  3. Parse StringToCodePoints(jsonString) as a JSON text as specified in
+     ECMA-404. Throw a SyntaxError exception if it is not a valid JSON text as
+     defined in that specification, or if its outermost value is an object or
+     array as defined in that specification.
+
+features: [json-parse-with-source]
+---*/
+
+assert.throws(TypeError, () => {
+  JSON.rawJSON(Symbol('123'));
+});
+
+assert.throws(SyntaxError, () => {
+  JSON.rawJSON(undefined);
+});
+
+assert.throws(SyntaxError, () => {
+  JSON.rawJSON({});
+});
+
+assert.throws(SyntaxError, () => {
+  JSON.rawJSON([]);
+});

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/length.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2024 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-built-in-function-objects
+description: >
+  JSON.rawJSON.length value and descriptor.
+info: |
+    Every built-in function object, including constructors, has a *"length"*
+    property whose value is a non-negative integral Number. Unless otherwise
+    specified, this value is the number of required parameters shown in the
+    subclause heading for the function description. Optional parameters and rest
+    parameters are not included in the parameter count.
+
+    Unless otherwise specified, the *"length"* property of a built-in function
+    object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*,
+    [[Configurable]]: *true* }.
+
+includes: [propertyHelper.js]
+features: [json-parse-with-source]
+---*/
+
+verifyProperty(JSON.rawJSON, 'length', {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/name.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2024 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-built-in-function-objects
+description: >
+  JSON.rawJSON.name value and descriptor.
+info: |
+    Every built-in function object, including constructors, has a *"name"*
+    property whose value is a String. Unless otherwise specified, this value is
+    the name that is given to the function in this specification. Functions that
+    are identified as anonymous functions use the empty String as the value of
+    the *"name"* property. For functions that are specified as properties of
+    objects, the name value is the property name string used to access the
+    function. Functions that are specified as get or set accessor functions of
+    built-in properties have *"get"* or *"set"* (respectively) passed to the
+    prefix parameter when calling CreateBuiltinFunction.
+
+    The value of the *"name"* property is explicitly specified for each built-in
+    function whose property key is a Symbol value. If such an explicitly
+    specified value starts with the prefix *"get "* or *"set "* and the function
+    for which it is specified is a get or set accessor function of a built-in
+    property, the value without the prefix is passed to the name parameter, and
+    the value *"get"* or *"set"* (respectively) is passed to the prefix
+    parameter when calling CreateBuiltinFunction.
+
+    Unless otherwise specified, the *"name"* property of a built-in function
+    object has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*,
+    [[Configurable]]: *true* }.
+
+includes: [propertyHelper.js]
+features: [json-parse-with-source]
+---*/
+
+verifyProperty(JSON.rawJSON, 'name', {
+  value: "rawJSON",
+  enumerable: false,
+  writable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/not-a-constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/not-a-constructor.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2024 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  JSON.rawJSON does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [json-parse-with-source, Reflect.construct]
+---*/
+
+assert.sameValue(isConstructor(JSON.rawJSON), false, 'isConstructor(JSON.rawJSON) must return false');
+
+assert.throws(TypeError, () => {
+  new JSON.rawJSON();
+});

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2024 Igalia S.L. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-json.rawjson
+description: >
+  Property type and descriptor.
+info: |
+  JSON.rawJSON ( text )
+
+  18 ECMAScript Standard Built-in Objects
+  ...
+  Every other data property described in clauses 19 through 28 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+
+includes: [propertyHelper.js]
+features: [json-parse-with-source]
+---*/
+
+verifyProperty(JSON, 'rawJSON', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/returns-expected-object.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/rawJSON/JavaScript/returns-expected-object.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-json.rawjson
+description: Object returned from JSON.rawJSON() is the expected shape.
+info: |
+  JSON.rawJSON ( text )
+
+  5. Let _obj_ be OrdinaryObjectCreate(*null*, _internalSlotsList_).
+  6. Perform ! CreateDataPropertyOrThrow(_obj_, *"rawJSON"*, _jsonString_).
+  ...
+  8. Return _obj_.
+
+includes: [compareArray.js]
+features: [json-parse-with-source]
+---*/
+
+function assertIsRawJSON(rawJSON, expectedRawJSONValue) {
+  assert.sameValue(Object.getPrototypeOf(rawJSON), null, "RawJSON object should have null prototype");
+  assert(Object.hasOwn(rawJSON, "rawJSON"), "RawJSON object should have rawJSON own property");
+  assert.compareArray(Object.getOwnPropertyNames(rawJSON), ["rawJSON"], "RawJSON object should have only rawJSON own property");
+  assert.compareArray(Object.getOwnPropertySymbols(rawJSON), [], "RawJSON object should have no own property symbols");
+  assert.sameValue(rawJSON.rawJSON, expectedRawJSONValue, "rawJSON value");
+}
+
+assertIsRawJSON(JSON.rawJSON(1), "1");
+assertIsRawJSON(JSON.rawJSON(null), "null");
+assertIsRawJSON(JSON.rawJSON(true), "true");
+assertIsRawJSON(JSON.rawJSON(false), "false");
+assertIsRawJSON(JSON.rawJSON('"foo"'), '"foo"');

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/stringify/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/stringify/ExecutionTests.cs
@@ -156,6 +156,22 @@ public class ExecutionTests : DiskExecutionTestsBase
 
     [Fact(DisplayName = "value-tojson-result")]
     public Task value_tojson_result()
+
         => ExecutionTestFromFile("value-tojson-result");
 
+    [Fact(DisplayName = "replacer-function-object-deleted-property.js")]
+    public Task replacer_function_object_deleted_property()
+        => ExecutionTestFromFile("replacer-function-object-deleted-property");
+
+    [Fact(DisplayName = "replacer-function-wrapper.js")]
+    public Task replacer_function_wrapper()
+        => ExecutionTestFromFile("replacer-function-wrapper");
+
+    [Fact(DisplayName = "space-number-object.js")]
+    public Task space_number_object()
+        => ExecutionTestFromFile("space-number-object");
+
+    [Fact(DisplayName = "space-string-object.js")]
+    public Task space_string_object()
+        => ExecutionTestFromFile("space-string-object");
 }

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/stringify/JavaScript/replacer-function-object-deleted-property.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/stringify/JavaScript/replacer-function-object-deleted-property.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 Alexey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-serializejsonproperty
+description: >
+  Replacer function is called on properties, deleted during stringification.
+info: |
+  SerializeJSONObject ( value )
+
+  [...]
+  5. If PropertyList is not undefined, then
+    [...]
+  6. Else,
+    a. Let K be ? EnumerableOwnPropertyNames(value, key).
+  [...]
+  8. For each element P of K, do
+    a. Let strP be ? SerializeJSONProperty(P, value).
+    [...]
+
+  SerializeJSONProperty ( key, holder )
+
+  1. Let value be ? Get(holder, key).
+  [...]
+  3. If ReplacerFunction is not undefined, then
+    a. Set value to ? Call(ReplacerFunction, holder, « key, value »).
+---*/
+
+var obj = {
+  get a() {
+    delete this.b;
+    return 1;
+  },
+  b: 2,
+};
+
+var replacer = function(key, value) {
+  if (key === 'b') {
+    assert.sameValue(value, undefined);
+    return '<replaced>';
+  }
+
+  return value;
+};
+
+assert.sameValue(
+  JSON.stringify(obj, replacer),
+  '{"a":1,"b":"<replaced>"}'
+);

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/stringify/JavaScript/replacer-function-wrapper.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/stringify/JavaScript/replacer-function-wrapper.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2019 Aleksey Shvayka. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-json.stringify
+description: >
+  Wrapper is plain extensible object with single data property.
+info: |
+  JSON.stringify ( value [ , replacer [ , space ] ] )
+
+  [...]
+  9. Let wrapper be ObjectCreate(%ObjectPrototype%).
+  10. Let status be CreateDataProperty(wrapper, the empty String, value).
+includes: [propertyHelper.js]
+---*/
+
+Object.defineProperty(Object.prototype, '', {
+  set: function() {
+    throw new Test262Error('[[Set]] should not be called.');
+  },
+});
+
+var value = {};
+var wrapper;
+JSON.stringify(value, function() {
+  wrapper = this;
+});
+
+assert.sameValue(typeof wrapper, 'object');
+assert.sameValue(Object.getPrototypeOf(wrapper), Object.prototype);
+assert.sameValue(Object.getOwnPropertyNames(wrapper).length, 1);
+assert(Object.isExtensible(wrapper));
+
+verifyProperty(wrapper, '', {
+  value: value,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/stringify/JavaScript/space-number-object.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/stringify/JavaScript/space-number-object.js
@@ -1,0 +1,47 @@
+// Copyright (C) 2012 Ecma International. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-json.stringify
+description: >
+  Number objects are converted to primitives using ToNumber.
+info: |
+  JSON.stringify ( value [ , replacer [ , space ] ] )
+
+  [...]
+  5. If Type(space) is Object, then
+    a. If space has a [[NumberData]] internal slot, then
+      i. Set space to ? ToNumber(space).
+---*/
+
+var obj = {
+  a1: {
+    b1: [1, 2, 3, 4],
+    b2: {
+      c1: 1,
+      c2: 2,
+    },
+  },
+  a2: 'a2',
+};
+
+assert.sameValue(
+  JSON.stringify(obj, null, new Number(1)),
+  JSON.stringify(obj, null, 1)
+);
+
+var num = new Number(1);
+num.toString = function() { throw new Test262Error('should not be called'); };
+num.valueOf = function() { return 3; };
+
+assert.sameValue(
+  JSON.stringify(obj, null, num),
+  JSON.stringify(obj, null, 3)
+);
+
+var abrupt = new Number(4);
+abrupt.toString = function() { throw new Test262Error(); };
+abrupt.valueOf = function() { throw new Test262Error(); };
+
+assert.throws(Test262Error, function() {
+  JSON.stringify(obj, null, abrupt);
+});

--- a/tests/Jroc.Test262.Tests/built-ins/JSON/stringify/JavaScript/space-string-object.js
+++ b/tests/Jroc.Test262.Tests/built-ins/JSON/stringify/JavaScript/space-string-object.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2012 Ecma International. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-json.stringify
+description: >
+  String exotic objects are converted to primitives using ToString.
+info: |
+  JSON.stringify ( value [ , replacer [ , space ] ] )
+
+  [...]
+  5. If Type(space) is Object, then
+    [...]
+    b. Else if space has a [[StringData]] internal slot, then
+      i. Set space to ? ToString(space).
+---*/
+
+var obj = {
+  a1: {
+    b1: [1, 2, 3, 4],
+    b2: {
+      c1: 1,
+      c2: 2,
+    },
+  },
+  a2: 'a2',
+};
+
+assert.sameValue(
+  JSON.stringify(obj, null, new String('xxx')),
+  JSON.stringify(obj, null, 'xxx')
+);
+
+var str = new String('xxx');
+str.toString = function() { return '---'; };
+str.valueOf = function() { throw new Test262Error('should not be called'); };
+
+assert.sameValue(
+  JSON.stringify(obj, null, str),
+  JSON.stringify(obj, null, '---')
+);
+
+var abrupt = new String('xxx');
+abrupt.toString = function() { throw new Test262Error(); };
+abrupt.valueOf = function() { throw new Test262Error(); };
+
+assert.throws(Test262Error, function() {
+  JSON.stringify(obj, null, abrupt);
+});


### PR DESCRIPTION
## Summary

- add ES2025 `JSON.rawJSON` and `JSON.isRawJSON` runtime support
- correct `JSON.stringify` wrapper, key-list, and boxed-space coercion behavior
- port 20 exact upstream test262 JSON fixtures and update ECMA-262 §25.5 coverage

## Validation

- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --filter 'FullyQualifiedName~built_ins.JSON' --no-restore` (80 passed)
- verified all 20 newly ported fixtures match the pinned upstream test262 cache byte-for-byte
