### PR TITLE
feat(runtime): support AggregateError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime/test262: add the ES2021 AggregateError global, iterable error-list
+  construction, standard constructor/prototype metadata, and message-property
+  behavior. Activates twenty corresponding pinned test262 fixtures.
+
 - runtime: introduce explicit `RuntimeAgentCluster`, `RuntimeAgent`, and
   `RuntimeRealm` lifetime owners. Every runtime service container now belongs
   to exactly one realm and exposes the ownership graph through constructor

--- a/docs/ECMA262/20/Section20_5.json
+++ b/docs/ECMA262/20/Section20_5.json
@@ -198,37 +198,37 @@
     {
       "clause": "20.5.7.2",
       "title": "Properties of the AggregateError Constructor",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-constructors"
     },
     {
       "clause": "20.5.7.2.1",
       "title": "AggregateError.prototype",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error.prototype"
     },
     {
       "clause": "20.5.7.3",
       "title": "Properties of the AggregateError Prototype Object",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-prototype-objects"
     },
     {
       "clause": "20.5.7.3.1",
       "title": "AggregateError.prototype.constructor",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error.prototype.constructor"
     },
     {
       "clause": "20.5.7.3.2",
       "title": "AggregateError.prototype.message",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error.prototype.message"
     },
     {
       "clause": "20.5.7.3.3",
       "title": "AggregateError.prototype.name",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error.prototype.name"
     },
     {
@@ -346,14 +346,59 @@
       },
       {
         "clause": "20.5.7.1.1",
-        "feature": "AggregateError constructors and .errors",
+        "feature": "AggregateError constructor and iterable error list",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-aggregate-error",
         "testScripts": [
-          "tests/Jroc.Tests/TryCatch/JavaScript/TryCatch_NewExpression_BuiltInErrors.js",
-          "tests/Jroc.Tests/Promise/JavaScript/Promise_Any_AllRejected.js"
+          "tests/Jroc.Test262.Tests/built-ins/AggregateError/ExecutionTests.cs"
         ],
-        "notes": "JavaScriptRuntime.AggregateError stores errors in a JavaScriptRuntime.Array. Signature differs from spec in some cases (e.g., the test uses new AggregateError(\"agg\") which maps to a message-only overload). 'options' / 'cause' are not supported."
+        "test262Paths": [
+          "test/built-ins/AggregateError/errors-iterabletolist-failures.js",
+          "test/built-ins/AggregateError/errors-iterabletolist.js",
+          "test/built-ins/AggregateError/message-method-prop-cast.js",
+          "test/built-ins/AggregateError/message-method-prop.js",
+          "test/built-ins/AggregateError/message-tostring-abrupt-symbol.js",
+          "test/built-ins/AggregateError/message-tostring-abrupt.js",
+          "test/built-ins/AggregateError/message-undefined-no-prop.js",
+          "test/built-ins/AggregateError/newtarget-is-undefined.js",
+          "test/built-ins/AggregateError/order-of-args-evaluation.js"
+        ],
+        "notes": "AggregateError accepts iterable error lists, preserves iterable and message coercion order, exposes a writable non-enumerable errors array, and creates an own message property only for defined messages. Error cause options, custom newTarget prototypes, and cross-realm construction remain limited."
+      },
+      {
+        "clause": "20.5.7.2",
+        "feature": "AggregateError constructor function surface",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-constructors",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/AggregateError/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/AggregateError/is-a-constructor.js",
+          "test/built-ins/AggregateError/length.js",
+          "test/built-ins/AggregateError/name.js",
+          "test/built-ins/AggregateError/prop-desc.js",
+          "test/built-ins/AggregateError/proto.js"
+        ],
+        "notes": "The global is a constructible function with the standard global property, name, length, prototype descriptor, and Error constructor prototype."
+      },
+      {
+        "clause": "20.5.7.3",
+        "feature": "AggregateError.prototype surface",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-prototype-objects",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/AggregateError/prototype/constructor.js",
+          "test/built-ins/AggregateError/prototype/errors-absent-on-prototype.js",
+          "test/built-ins/AggregateError/prototype/message.js",
+          "test/built-ins/AggregateError/prototype/name.js",
+          "test/built-ins/AggregateError/prototype/prop-desc.js",
+          "test/built-ins/AggregateError/prototype/proto.js"
+        ],
+        "notes": "AggregateError.prototype inherits Error.prototype and provides the standard constructor, message, and name properties without an own errors property."
       }
     ]
   }

--- a/docs/ECMA262/20/Section20_5.md
+++ b/docs/ECMA262/20/Section20_5.md
@@ -4,7 +4,7 @@
 
 [Back to Section20](Section20.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-07T01:50:59Z
+> Last generated (UTC): 2026-08-14T23:17:53Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -45,72 +45,84 @@
 | 20.5.7 | AggregateError Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error-objects) |
 | 20.5.7.1 | The AggregateError Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error-constructor) |
 | 20.5.7.1.1 | AggregateError ( errors , message [ , options ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error) |
-| 20.5.7.2 | Properties of the AggregateError Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-constructors) |
-| 20.5.7.2.1 | AggregateError.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype) |
-| 20.5.7.3 | Properties of the AggregateError Prototype Object | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-prototype-objects) |
-| 20.5.7.3.1 | AggregateError.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype.constructor) |
-| 20.5.7.3.2 | AggregateError.prototype.message | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype.message) |
-| 20.5.7.3.3 | AggregateError.prototype.name | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype.name) |
+| 20.5.7.2 | Properties of the AggregateError Constructor | Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-constructors) |
+| 20.5.7.2.1 | AggregateError.prototype | Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype) |
+| 20.5.7.3 | Properties of the AggregateError Prototype Object | Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-prototype-objects) |
+| 20.5.7.3.1 | AggregateError.prototype.constructor | Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype.constructor) |
+| 20.5.7.3.2 | AggregateError.prototype.message | Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype.message) |
+| 20.5.7.3.3 | AggregateError.prototype.name | Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype.name) |
 | 20.5.7.4 | Properties of AggregateError Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-aggregate-error-instances) |
 | 20.5.8 | Abstract Operations for Error Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-error-objects) |
 | 20.5.8.1 | InstallErrorCause ( O , options ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-installerrorcause) |
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
 
 ### 20.5.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-error-message))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Error(message) (callable creates instance) | Supported with Limitations | [`IntrinsicCallables_Error_Callable_CreatesInstances.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_Callable_CreatesInstances.js) | Compiler lowers built-in error callables (Error/TypeError/...) to construction of JavaScriptRuntime error types. Currently supports 0 or 1 argument; the optional 'options' parameter is not supported. |
-| new Error(message) and new NativeError(message) | Supported with Limitations | [`TryCatch_NewExpression_BuiltInErrors.js`](../../../tests/Jroc.Tests/TryCatch/JavaScript/TryCatch_NewExpression_BuiltInErrors.js) | Constructs JavaScriptRuntime.Error (and derived types) with message stringification via DotNet2JSConversions.ToString. The runtime does not currently model spec prototype objects; behavior is closer to .NET exceptions with JS-like surface properties. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Error(message) (callable creates instance) | Supported with Limitations | [`IntrinsicCallables_Error_Callable_CreatesInstances.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_Callable_CreatesInstances.js) |  | Compiler lowers built-in error callables (Error/TypeError/...) to construction of JavaScriptRuntime error types. Currently supports 0 or 1 argument; the optional 'options' parameter is not supported. |
+| new Error(message) and new NativeError(message) | Supported with Limitations | [`TryCatch_NewExpression_BuiltInErrors.js`](../../../tests/Jroc.Tests/TryCatch/JavaScript/TryCatch_NewExpression_BuiltInErrors.js) |  | Constructs JavaScriptRuntime.Error (and derived types) with message stringification via DotNet2JSConversions.ToString. The runtime does not currently model spec prototype objects; behavior is closer to .NET exceptions with JS-like surface properties. |
 
 ### 20.5.2.1 ([tc39.es](https://tc39.es/ecma262/#sec-error.iserror))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Error.isError(arg) basic predicate | Supported with Limitations | [`IntrinsicCallables_Error_ConstructorSurface.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_ConstructorSurface.js) | Returns true for JavaScriptRuntime.Error instances (including built-in NativeError subclasses) and false for non-error objects. The full spec [[ErrorData]] internal-slot semantics are not implemented. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Error.isError(arg) basic predicate | Supported with Limitations | [`IntrinsicCallables_Error_ConstructorSurface.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_ConstructorSurface.js) |  | Returns true for JavaScriptRuntime.Error instances (including built-in NativeError subclasses) and false for non-error objects. The full spec [[ErrorData]] internal-slot semantics are not implemented. |
 
 ### 20.5.2.2 ([tc39.es](https://tc39.es/ecma262/#sec-error.prototype))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Error.prototype data property exists (minimal) | Supported with Limitations | [`CommonJS_Global_ErrorPrototype_Read.js`](../../../tests/Jroc.Tests/CommonJS/JavaScript/CommonJS_Global_ErrorPrototype_Read.js)<br>[`CommonJS_Global_ErrorPrototype_Read_Lib.js`](../../../tests/Jroc.Tests/CommonJS/JavaScript/CommonJS_Global_ErrorPrototype_Read_Lib.js) | Exposes the global Error value as a first-class intrinsic and provides a writable Error.prototype object for libraries that read/attach prototype members (e.g., CommonJS polyfills). Constructor/prototype behavior remains partial relative to full spec object-model semantics. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Error.prototype data property exists (minimal) | Supported with Limitations | [`CommonJS_Global_ErrorPrototype_Read.js`](../../../tests/Jroc.Tests/CommonJS/JavaScript/CommonJS_Global_ErrorPrototype_Read.js)<br>[`CommonJS_Global_ErrorPrototype_Read_Lib.js`](../../../tests/Jroc.Tests/CommonJS/JavaScript/CommonJS_Global_ErrorPrototype_Read_Lib.js) |  | Exposes the global Error value as a first-class intrinsic and provides a writable Error.prototype object for libraries that read/attach prototype members (e.g., CommonJS polyfills). Constructor/prototype behavior remains partial relative to full spec object-model semantics. |
 
 ### 20.5.3.1 ([tc39.es](https://tc39.es/ecma262/#sec-error.prototype.constructor))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Error.prototype.constructor | Supported with Limitations | [`IntrinsicCallables_Error_ConstructorSurface.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_ConstructorSurface.js) | Error.prototype.constructor points to the global Error callable value. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Error.prototype.constructor | Supported with Limitations | [`IntrinsicCallables_Error_ConstructorSurface.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_ConstructorSurface.js) |  | Error.prototype.constructor points to the global Error callable value. |
 
 ### 20.5.3.2 ([tc39.es](https://tc39.es/ecma262/#sec-error.prototype.message))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Error.prototype.message default value | Supported with Limitations | [`IntrinsicCallables_Error_ConstructorSurface.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_ConstructorSurface.js) | Provides an empty-string default value on Error.prototype. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Error.prototype.message default value | Supported with Limitations | [`IntrinsicCallables_Error_ConstructorSurface.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_ConstructorSurface.js) |  | Provides an empty-string default value on Error.prototype. |
 
 ### 20.5.3.3 ([tc39.es](https://tc39.es/ecma262/#sec-error.prototype.name))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Error.prototype.name default value | Supported with Limitations | [`IntrinsicCallables_Error_ConstructorSurface.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_ConstructorSurface.js) | Provides the default "Error" value on Error.prototype.name. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Error.prototype.name default value | Supported with Limitations | [`IntrinsicCallables_Error_ConstructorSurface.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_ConstructorSurface.js) |  | Provides the default "Error" value on Error.prototype.name. |
 
 ### 20.5.3.4 ([tc39.es](https://tc39.es/ecma262/#sec-error.prototype.tostring))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Error.prototype.toString() basic formatting | Supported with Limitations | [`IntrinsicCallables_Error_ConstructorSurface.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_ConstructorSurface.js) | Formats values as name/message combinations and supports .call(receiver) usage for object receivers. Throws TypeError for null/undefined receivers. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Error.prototype.toString() basic formatting | Supported with Limitations | [`IntrinsicCallables_Error_ConstructorSurface.js`](../../../tests/Jroc.Tests/IntrinsicCallables/JavaScript/IntrinsicCallables_Error_ConstructorSurface.js) |  | Formats values as name/message combinations and supports .call(receiver) usage for object receivers. Throws TypeError for null/undefined receivers. |
 
 ### 20.5.4 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-error-instances))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| Error instance properties: name, message, stack | Supported with Limitations | [`TryCatch_CallMember_MissingMethod_IsTypeError.js`](../../../tests/Jroc.Tests/TryCatch/JavaScript/TryCatch_CallMember_MissingMethod_IsTypeError.js)<br>[`Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.js) | name/message are exposed as instance properties on JavaScriptRuntime.Error. stack is backed by the .NET stack trace (or a captured construction-time stack if not thrown yet). |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| Error instance properties: name, message, stack | Supported with Limitations | [`TryCatch_CallMember_MissingMethod_IsTypeError.js`](../../../tests/Jroc.Tests/TryCatch/JavaScript/TryCatch_CallMember_MissingMethod_IsTypeError.js)<br>[`Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.js`](../../../tests/Jroc.Tests/Variable/JavaScript/Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.js) |  | name/message are exposed as instance properties on JavaScriptRuntime.Error. stack is backed by the .NET stack trace (or a captured construction-time stack if not thrown yet). |
 
 ### 20.5.7.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-aggregate-error))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| AggregateError constructors and .errors | Supported with Limitations | [`TryCatch_NewExpression_BuiltInErrors.js`](../../../tests/Jroc.Tests/TryCatch/JavaScript/TryCatch_NewExpression_BuiltInErrors.js)<br>[`Promise_Any_AllRejected.js`](../../../tests/Jroc.Tests/Promise/JavaScript/Promise_Any_AllRejected.js) | JavaScriptRuntime.AggregateError stores errors in a JavaScriptRuntime.Array. Signature differs from spec in some cases (e.g., the test uses new AggregateError("agg") which maps to a message-only overload). 'options' / 'cause' are not supported. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| AggregateError constructor and iterable error list | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/AggregateError/ExecutionTests.cs` | `test/built-ins/AggregateError/errors-iterabletolist-failures.js`<br>`test/built-ins/AggregateError/errors-iterabletolist.js`<br>`test/built-ins/AggregateError/message-method-prop-cast.js`<br>`test/built-ins/AggregateError/message-method-prop.js`<br>`test/built-ins/AggregateError/message-tostring-abrupt-symbol.js`<br>`test/built-ins/AggregateError/message-tostring-abrupt.js`<br>`test/built-ins/AggregateError/message-undefined-no-prop.js`<br>`test/built-ins/AggregateError/newtarget-is-undefined.js`<br>`test/built-ins/AggregateError/order-of-args-evaluation.js` | AggregateError accepts iterable error lists, preserves iterable and message coercion order, exposes a writable non-enumerable errors array, and creates an own message property only for defined messages. Error cause options, custom newTarget prototypes, and cross-realm construction remain limited. |
+
+### 20.5.7.2 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-constructors))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| AggregateError constructor function surface | Supported | `tests/Jroc.Test262.Tests/built-ins/AggregateError/ExecutionTests.cs` | `test/built-ins/AggregateError/is-a-constructor.js`<br>`test/built-ins/AggregateError/length.js`<br>`test/built-ins/AggregateError/name.js`<br>`test/built-ins/AggregateError/prop-desc.js`<br>`test/built-ins/AggregateError/proto.js` | The global is a constructible function with the standard global property, name, length, prototype descriptor, and Error constructor prototype. |
+
+### 20.5.7.3 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-aggregate-error-prototype-objects))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| AggregateError.prototype surface | Supported | `tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/ExecutionTests.cs` | `test/built-ins/AggregateError/prototype/constructor.js`<br>`test/built-ins/AggregateError/prototype/errors-absent-on-prototype.js`<br>`test/built-ins/AggregateError/prototype/message.js`<br>`test/built-ins/AggregateError/prototype/name.js`<br>`test/built-ins/AggregateError/prototype/prop-desc.js`<br>`test/built-ins/AggregateError/prototype/proto.js` | AggregateError.prototype inherits Error.prototype and provides the standard constructor, message, and name properties without an own errors property. |
 

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
@@ -295,6 +295,22 @@ public sealed partial class HIRToLIRLowerer
                     {
                         case JavaScriptRuntime.IntrinsicCallKind.BuiltInError:
                             {
+                                if (string.Equals(intrinsicInfo.Name, "AggregateError", StringComparison.Ordinal))
+                                {
+                                    if (!TryEvaluateCallArguments(callExpr.Arguments, callExpr.Arguments.Length, out var aggregateErrorArgs))
+                                    {
+                                        return false;
+                                    }
+
+                                    _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStatic(
+                                        "AggregateError",
+                                        nameof(JavaScriptRuntime.AggregateError.Construct),
+                                        aggregateErrorArgs,
+                                        resultTempVar));
+                                    DefineTempStorage(resultTempVar, GetBuiltInErrorStorage(intrinsicInfo.Name));
+                                    return true;
+                                }
+
                                 if (!TryEvaluateCallArguments(callExpr.Arguments, 1, out var errorArgs))
                                 {
                                     return false;

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionNew.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionNew.cs
@@ -84,6 +84,23 @@ public sealed partial class HIRToLIRLowerer
         // PL3.3a: built-in Error types
         if (BuiltInErrorTypes.IsBuiltInErrorTypeName(ctorName))
         {
+            if (string.Equals(ctorName, "AggregateError", StringComparison.Ordinal))
+            {
+                if (!TryEvaluateCallArguments(newExpr.Arguments, newExpr.Arguments.Count, out var aggregateErrorArgs))
+                {
+                    return false;
+                }
+
+                resultTempVar = CreateTempVariable();
+                _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStatic(
+                    "AggregateError",
+                    nameof(JavaScriptRuntime.AggregateError.Construct),
+                    aggregateErrorArgs,
+                    resultTempVar));
+                DefineTempStorage(resultTempVar, GetBuiltInErrorStorage(ctorName));
+                return true;
+            }
+
             if (newExpr.Arguments.Count > 2)
             {
                 return false;

--- a/src/JavaScriptRuntime/Error.cs
+++ b/src/JavaScriptRuntime/Error.cs
@@ -149,7 +149,6 @@ namespace JavaScriptRuntime
     [IntrinsicObject("AggregateError", IntrinsicCallKind.BuiltInError)]
     public class AggregateError : Error
     {
-        // In JS AggregateError has an iterable of errors. Represent as object[] here.
         public JavaScriptRuntime.Array Errors { get; }
         public JavaScriptRuntime.Array errors => Errors; // JS-style alias
 
@@ -161,12 +160,48 @@ namespace JavaScriptRuntime
         {
             Name = "AggregateError";
             Errors = new Array(errors);
+            InitializeIntrinsicSurface(GlobalThis.AggregateErrorPrototypeValue);
+            InstallErrorsProperty();
         }
 
         public AggregateError(System.Collections.IEnumerable errors, string? message, Exception? inner) : base(message, inner)
         {
             Name = "AggregateError";
             Errors = new Array(errors);
+            InitializeIntrinsicSurface(GlobalThis.AggregateErrorPrototypeValue);
+            InstallErrorsProperty();
+        }
+
+        public static AggregateError Construct(object?[] args)
+        {
+            var hasMessage = args.Length > 1 && args[1] is not null;
+            var message = hasMessage ? CoerceMessage(args[1]) : null;
+            var iterable = args.Length > 0 ? args[0] : null;
+            var iterator = ObjectRuntime.GetIterator(iterable);
+            var values = new List<object?>();
+
+            while (true)
+            {
+                var next = iterator.Next();
+                if (next.done)
+                {
+                    break;
+                }
+
+                values.Add(next.value);
+            }
+
+            var error = new AggregateError(values, message);
+            if (hasMessage)
+            {
+                error.InstallMessageProperty(message!);
+            }
+            else
+            {
+                PropertyDescriptorStore.Delete(error, "message");
+            }
+
+            return error;
         }
 
         public override string ToString()
@@ -174,6 +209,30 @@ namespace JavaScriptRuntime
             var baseStr = base.ToString();
             if (Errors.length == 0) return baseStr;
             return baseStr + $" (errors: {Errors.length})";
+        }
+
+        private void InstallErrorsProperty()
+        {
+            PropertyDescriptorStore.DefineOrUpdate(this, "errors", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = true,
+                Value = Errors
+            });
+        }
+
+        private void InstallMessageProperty(string message)
+        {
+            PropertyDescriptorStore.DefineOrUpdate(this, "message", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = true,
+                Value = message
+            });
         }
     }
 }

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -287,6 +287,9 @@ namespace JavaScriptRuntime
         private static readonly Func<object[], object?[], object?> _uriErrorConstructorValue =
             CreateErrorConstructorValue(static message => new JavaScriptRuntime.URIError(message));
 
+        private static readonly Func<object[], object?[], object?> _aggregateErrorConstructorValue = static (_, args) =>
+            JavaScriptRuntime.AggregateError.Construct(args ?? System.Array.Empty<object?>());
+
         private static readonly Func<object[], object?[], object?> _iteratorConstructorValue = static (_, __) =>
             throw new TypeError("Iterator is not directly constructible in jroc.");
 
@@ -304,6 +307,7 @@ namespace JavaScriptRuntime
         private static readonly object _syntaxErrorPrototypeValue = new JsObject();
         private static readonly object _typeErrorPrototypeValue = new JsObject();
         private static readonly object _uriErrorPrototypeValue = new JsObject();
+        private static readonly object _aggregateErrorPrototypeValue = new JsObject();
 
         // Minimal Object.prototype object used for descriptor/prototype-heavy libraries.
         // NOTE: We intentionally do not enable PrototypeChain here; Object.create/setPrototypeOf
@@ -684,6 +688,7 @@ namespace JavaScriptRuntime
             ConfigureErrorIntrinsicSurface(_syntaxErrorConstructorValue, _syntaxErrorPrototypeValue, "SyntaxError", parentPrototype: _errorPrototypeValue);
             ConfigureErrorIntrinsicSurface(_typeErrorConstructorValue, _typeErrorPrototypeValue, "TypeError", parentPrototype: _errorPrototypeValue);
             ConfigureErrorIntrinsicSurface(_uriErrorConstructorValue, _uriErrorPrototypeValue, "URIError", parentPrototype: _errorPrototypeValue);
+            ConfigureAggregateErrorIntrinsicSurface();
 
             PropertyDescriptorStore.DefineOrUpdate(_booleanPrototypeValue, "constructor", new JsPropertyDescriptor
             {
@@ -1371,6 +1376,9 @@ namespace JavaScriptRuntime
             dict.TryAdd(nameof(GlobalThis.URIError), URIError);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.URIError), dict[nameof(GlobalThis.URIError)]);
 
+            dict.TryAdd(nameof(GlobalThis.AggregateError), AggregateError);
+            DefineNonEnumerableDataProperty(nameof(GlobalThis.AggregateError), dict[nameof(GlobalThis.AggregateError)]);
+
             dict.TryAdd(nameof(GlobalThis.Iterator), Iterator);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.Iterator), dict[nameof(GlobalThis.Iterator)]);
 
@@ -1658,6 +1666,8 @@ namespace JavaScriptRuntime
         public static Func<object[], object?[], object?> TypeError => _typeErrorConstructorValue;
 
         public static Func<object[], object?[], object?> URIError => _uriErrorConstructorValue;
+
+        public static Func<object[], object?[], object?> AggregateError => _aggregateErrorConstructorValue;
 
         public static Func<object[], object?[], object?> Iterator => _iteratorConstructorValue;
 
@@ -2296,6 +2306,7 @@ namespace JavaScriptRuntime
         internal static object SyntaxErrorPrototypeValue => _syntaxErrorPrototypeValue;
         internal static object TypeErrorPrototypeValue => _typeErrorPrototypeValue;
         internal static object URIErrorPrototypeValue => _uriErrorPrototypeValue;
+        internal static object AggregateErrorPrototypeValue => _aggregateErrorPrototypeValue;
         private static Func<object[], object?[], object?> CreateErrorConstructorValue(Func<string?, object> factory)
         {
             return (_, args) =>
@@ -2358,6 +2369,33 @@ namespace JavaScriptRuntime
             });
         }
 
+        private static void ConfigureAggregateErrorIntrinsicSurface()
+        {
+            ConfigureErrorIntrinsicSurface(
+                _aggregateErrorConstructorValue,
+                _aggregateErrorPrototypeValue,
+                "AggregateError",
+                _errorPrototypeValue);
+            PrototypeChain.SetPrototype(_aggregateErrorConstructorValue, _errorConstructorValue);
+
+            PropertyDescriptorStore.DefineOrUpdate(_aggregateErrorConstructorValue, "length", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = false,
+                Value = 2d
+            });
+            PropertyDescriptorStore.DefineOrUpdate(_aggregateErrorConstructorValue, "prototype", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = false,
+                Writable = false,
+                Value = _aggregateErrorPrototypeValue
+            });
+        }
+
         internal static void AssignBuiltInErrorPrototype(JavaScriptRuntime.Error error)
         {
             ArgumentNullException.ThrowIfNull(error);
@@ -2371,6 +2409,7 @@ namespace JavaScriptRuntime
                 JavaScriptRuntime.SyntaxError => _syntaxErrorPrototypeValue,
                 JavaScriptRuntime.TypeError => _typeErrorPrototypeValue,
                 JavaScriptRuntime.URIError => _uriErrorPrototypeValue,
+                JavaScriptRuntime.AggregateError => _aggregateErrorPrototypeValue,
                 _ => _errorPrototypeValue
             };
 

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/ExecutionTests.cs
@@ -1,0 +1,56 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.AggregateError;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.AggregateError") { }
+
+    [Fact(DisplayName = "errors-iterabletolist-failures.js")]
+    public Task errors_iterabletolist_failures()
+        => ExecutionTestFromFile("errors-iterabletolist-failures");
+
+    [Fact(DisplayName = "errors-iterabletolist.js")]
+    public Task errors_iterabletolist()
+        => ExecutionTestFromFile("errors-iterabletolist");
+
+    [Fact(DisplayName = "is-a-constructor.js")]
+    public Task is_a_constructor() => ExecutionTestFromFile("is-a-constructor");
+
+    [Fact(DisplayName = "length.js")]
+    public Task length() => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "message-method-prop-cast.js")]
+    public Task message_method_prop_cast()
+        => ExecutionTestFromFile("message-method-prop-cast");
+
+    [Fact(DisplayName = "message-method-prop.js")]
+    public Task message_method_prop() => ExecutionTestFromFile("message-method-prop");
+
+    [Fact(DisplayName = "message-tostring-abrupt.js")]
+    public Task message_tostring_abrupt() => ExecutionTestFromFile("message-tostring-abrupt");
+
+    [Fact(DisplayName = "message-tostring-abrupt-symbol.js")]
+    public Task message_tostring_abrupt_symbol()
+        => ExecutionTestFromFile("message-tostring-abrupt-symbol");
+
+    [Fact(DisplayName = "message-undefined-no-prop.js")]
+    public Task message_undefined_no_prop()
+        => ExecutionTestFromFile("message-undefined-no-prop");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "newtarget-is-undefined.js")]
+    public Task newtarget_is_undefined() => ExecutionTestFromFile("newtarget-is-undefined");
+
+    [Fact(DisplayName = "order-of-args-evaluation.js")]
+    public Task order_of_args_evaluation()
+        => ExecutionTestFromFile("order-of-args-evaluation");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+
+    [Fact(DisplayName = "proto.js")]
+    public Task proto() => ExecutionTestFromFile("proto");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/errors-iterabletolist-failures.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/errors-iterabletolist-failures.js
@@ -1,0 +1,183 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error
+description: >
+  Return abrupt completion from IterableToList(errors)
+info: |
+  AggregateError ( errors, message )
+
+  ...
+  3. Let errorsList be ? IterableToList(errors).
+  4. Set O.[[AggregateErrors]] to errorsList.
+  ...
+  6. Return O.
+
+  Runtime Semantics: IterableToList ( items [ , method ] )
+
+  1. If method is present, then
+    ...
+  2. Else,
+    b. Let iteratorRecord be ? GetIterator(items, sync).
+  3. Let values be a new empty List.
+  4. Let next be true.
+  5. Repeat, while next is not false
+    a. Set next to ? IteratorStep(iteratorRecord).
+    b. If next is not false, then
+      i. Let nextValue be ? IteratorValue(next).
+      ii. Append nextValue to the end of the List values.
+  6. Return values.
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  6. Let nextMethod be ? GetV(iterator, "next").
+  ...
+  8. Return iteratorRecord.
+features: [AggregateError, Symbol.iterator]
+---*/
+
+var case1 = {
+  get [Symbol.iterator]() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, () => {
+  var obj = new AggregateError(case1);
+}, 'get Symbol.iterator');
+
+var case2 = {
+  get [Symbol.iterator]() {
+    return {};
+  }
+};
+
+assert.throws(TypeError, () => {
+  var obj = new AggregateError(case2);
+}, 'GetMethod(obj, @@iterator) abrupts from non callable');
+
+var case3 = {
+  [Symbol.iterator]() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, () => {
+  var obj = new AggregateError(case3);
+}, 'Abrupt from @@iterator call');
+
+var case4 = {
+  [Symbol.iterator]() {
+    return 'a string';
+  }
+};
+
+assert.throws(TypeError, () => {
+  var obj = new AggregateError(case4);
+}, '@@iterator call returns a string');
+
+var case5 = {
+  [Symbol.iterator]() {
+    return undefined;
+  }
+};
+
+assert.throws(TypeError, () => {
+  var obj = new AggregateError(case5);
+}, '@@iterator call returns undefined');
+
+var case6 = {
+  [Symbol.iterator]() {
+    return {
+      get next() {
+        throw new Test262Error();
+      }
+    }
+  }
+};
+
+assert.throws(Test262Error, () => {
+  var obj = new AggregateError(case6);
+}, 'GetV(iterator, next) returns abrupt');
+
+var case7 = {
+  [Symbol.iterator]() {
+    return {
+      get next() {
+        return {};
+      }
+    }
+  }
+};
+
+assert.throws(TypeError, () => {
+  var obj = new AggregateError(case7);
+}, 'GetV(iterator, next) returns a non callable');
+
+var case8 = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        throw new Test262Error();
+      }
+    }
+  }
+};
+
+assert.throws(Test262Error, () => {
+  var obj = new AggregateError(case8);
+}, 'abrupt from iterator.next()');
+
+var case9 = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return undefined;
+      }
+    }
+  }
+};
+
+assert.throws(TypeError, () => {
+  var obj = new AggregateError(case9);
+}, 'iterator.next() returns undefined');
+
+var case10 = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return 'a string';
+      }
+    }
+  }
+};
+
+assert.throws(TypeError, () => {
+  var obj = new AggregateError(case10);
+}, 'iterator.next() returns a string');
+
+var case11 = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return {
+          get done() {
+            throw new Test262Error();
+          }
+        };
+      }
+    }
+  }
+};
+
+assert.throws(Test262Error, () => {
+  var obj = new AggregateError(case11);
+}, 'IteratorCompete abrupts getting the done property');

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/errors-iterabletolist.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/errors-iterabletolist.js
@@ -1,0 +1,73 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error
+description: >
+  Iteration of errors
+info: |
+  AggregateError ( errors, message )
+
+  ...
+  3. Let errorsList be ? IterableToList(errors).
+  4. Set O.[[AggregateErrors]] to errorsList.
+  ...
+  6. Return O.
+
+  Runtime Semantics: IterableToList ( items [ , method ] )
+
+  1. If method is present, then
+    ...
+  2. Else,
+    b. Let iteratorRecord be ? GetIterator(items, sync).
+  3. Let values be a new empty List.
+  4. Let next be true.
+  5. Repeat, while next is not false
+    a. Set next to ? IteratorStep(iteratorRecord).
+    b. If next is not false, then
+      i. Let nextValue be ? IteratorValue(next).
+      ii. Append nextValue to the end of the List values.
+  6. Return values.
+
+  GetIterator ( obj [ , hint [ , method ] ] )
+
+  ...
+  3. If method is not present, then
+    a. If hint is async, then
+      ...
+    b. Otherwise, set method to ? GetMethod(obj, @@iterator).
+  4. Let iterator be ? Call(method, obj).
+  5. If Type(iterator) is not Object, throw a TypeError exception.
+  6. Let nextMethod be ? GetV(iterator, "next").
+  ...
+  8. Return iteratorRecord.
+features: [AggregateError, Symbol.iterator]
+includes: [compareArray.js]
+---*/
+
+var count = 0;
+var values = [];
+var case1 = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        count += 1;
+        return {
+          done: count === 3,
+          get value() {
+            values.push(count)
+          }
+        };
+      }
+    };
+  }
+};
+
+new AggregateError(case1);
+
+assert.sameValue(count, 3);
+assert.compareArray(values, [1, 2]);
+
+assert.throws(TypeError, () => {
+  new AggregateError();
+}, 'GetMethod(obj, @@iterator) returns undefined');

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/is-a-constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/is-a-constructor.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  The AggregateError constructor implements [[Construct]]
+info: |
+  IsConstructor ( argument )
+
+  The abstract operation IsConstructor takes argument argument (an ECMAScript language value).
+  It determines if argument is a function object with a [[Construct]] internal method.
+  It performs the following steps when called:
+
+  If Type(argument) is not Object, return false.
+  If argument has a [[Construct]] internal method, return true.
+  Return false.
+includes: [isConstructor.js]
+features: [Reflect.construct, AggregateError]
+---*/
+
+assert.sameValue(isConstructor(AggregateError), true, 'isConstructor(AggregateError) must return true');
+new AggregateError([]);
+  

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error
+description: AggregateError.length property descriptor
+info: |
+  AggregateError ( errors, message )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [AggregateError]
+---*/
+
+verifyProperty(AggregateError, 'length', {
+  value: 2,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/message-method-prop-cast.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/message-method-prop-cast.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error
+description: >
+  Cast ToString values of message in the created method property
+info: |
+  AggregateError ( errors, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+
+  CreateMethodProperty ( O, P, V )
+
+  ...
+  3. Let newDesc be the PropertyDescriptor { [[Value]]: V, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.
+  4. Return ? O.[[DefineOwnProperty]](P, newDesc).
+features: [AggregateError]
+includes: [propertyHelper.js]
+---*/
+
+var case1 = new AggregateError([], 42);
+
+verifyProperty(case1, 'message', {
+  value: '42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var case2 = new AggregateError([], false);
+
+verifyProperty(case2, 'message', {
+  value: 'false',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var case3 = new AggregateError([], true);
+
+verifyProperty(case3, 'message', {
+  value: 'true',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var case4 = new AggregateError([], { toString() { return 'string'; }});
+
+verifyProperty(case4, 'message', {
+  value: 'string',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var case5 = new AggregateError([], null);
+
+verifyProperty(case5, 'message', {
+  value: 'null',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/message-method-prop.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/message-method-prop.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error
+description: >
+  Creates a method property for message
+info: |
+  AggregateError ( errors, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+
+  CreateMethodProperty ( O, P, V )
+
+  ...
+  3. Let newDesc be the PropertyDescriptor { [[Value]]: V, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.
+  4. Return ? O.[[DefineOwnProperty]](P, newDesc).
+features: [AggregateError]
+includes: [propertyHelper.js]
+---*/
+
+var obj = new AggregateError([], '42');
+
+verifyProperty(obj, 'message', {
+  value: '42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/message-tostring-abrupt-symbol.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/message-tostring-abrupt-symbol.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error
+description: >
+  Abrupt completions of ToString(Symbol message)
+info: |
+  AggregateError ( errors, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+features: [AggregateError, Symbol, Symbol.toPrimitive]
+---*/
+
+var case1 = Symbol();
+
+assert.throws(TypeError, () => {
+  new AggregateError([], case1);
+}, 'toPrimitive');
+
+var case2 = {
+  [Symbol.toPrimitive]() {
+    return Symbol();
+  },
+  toString() {
+    throw new Test262Error();
+  },
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(TypeError, () => {
+  new AggregateError([], case2);
+}, 'from ToPrimitive');

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/message-tostring-abrupt.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/message-tostring-abrupt.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error
+description: >
+  Abrupt completions of ToString(message)
+info: |
+  AggregateError ( errors, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+features: [AggregateError, Symbol.toPrimitive]
+---*/
+
+var case1 = {
+  [Symbol.toPrimitive]() {
+    throw new Test262Error();
+  },
+  toString() {
+    throw 'toString called';
+  },
+  valueOf() {
+    throw 'valueOf called';
+  }
+};
+
+assert.throws(Test262Error, () => {
+  new AggregateError([], case1);
+}, 'toPrimitive');
+
+var case2 = {
+  [Symbol.toPrimitive]: undefined,
+  toString() {
+    throw new Test262Error();
+  },
+  valueOf() {
+    throw 'valueOf called';
+  }
+};
+
+assert.throws(Test262Error, () => {
+  new AggregateError([], case2);
+}, 'toString');
+
+var case3 = {
+  [Symbol.toPrimitive]: undefined,
+  toString: undefined,
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, () => {
+  new AggregateError([], case3);
+}, 'valueOf');

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/message-undefined-no-prop.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/message-undefined-no-prop.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error
+description: >
+  If message is undefined, no property will be set to the new instance
+info: |
+  AggregateError ( errors, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+features: [AggregateError]
+---*/
+
+var case1 = new AggregateError([], undefined);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(case1, 'message'),
+  false,
+  'explicit'
+);
+
+var case2 = new AggregateError([]);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(case2, 'message'),
+  false,
+  'implicit'
+);

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/name.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error
+description: AggregateError.name property descriptor
+info: |
+  Properties of the AggregateError Constructor
+
+  - has a name property whose value is the String value "AggregateError".
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [AggregateError]
+---*/
+
+verifyProperty(AggregateError, 'name', {
+  value: 'AggregateError',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/newtarget-is-undefined.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/newtarget-is-undefined.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error
+description: >
+  NewTarget is undefined
+info: |
+  AggregateError ( errors, message )
+
+  1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
+
+features: [AggregateError]
+---*/
+
+var obj = AggregateError([], '');
+
+assert.sameValue(Object.getPrototypeOf(obj), AggregateError.prototype);
+assert(obj instanceof AggregateError);

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/order-of-args-evaluation.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/order-of-args-evaluation.js
@@ -1,0 +1,41 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error
+description: >
+  Process arguments in superclass-then-subclass order
+info: |
+  AggregateError ( errors, message )
+
+  TODO: get updated prose
+
+features: [AggregateError, Symbol.iterator]
+includes: [promiseHelper.js]
+---*/
+
+let sequence = [];
+const message = {
+  toString() {
+    sequence.push(1);
+    return '';
+  }
+};
+const errors = {
+  [Symbol.iterator]() {
+    sequence.push(2);
+    return {
+      next() {
+        sequence.push(3);
+        return {
+          done: true
+        };
+      }
+    };
+  }
+};
+
+new AggregateError(errors, message);
+
+assert.sameValue(sequence.length, 3);
+checkSequence(sequence);

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/prop-desc.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error
+description: >
+  Property descriptor of AggregateError
+info: |
+  The AggregateError Object
+
+  ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [AggregateError]
+---*/
+
+assert.sameValue(typeof AggregateError, 'function');
+
+verifyProperty(this, 'AggregateError', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/proto.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/JavaScript/proto.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The prototype of AggregateError constructor is Error
+esid: sec-aggregate-error
+info: |
+  Properties of the AggregateError Constructor
+
+  - has a [[Prototype]] internal slot whose value is the intrinsic object %Error%.
+features: [AggregateError]
+---*/
+
+var proto = Object.getPrototypeOf(AggregateError);
+
+assert.sameValue(proto, Error);

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/ExecutionTests.cs
@@ -1,0 +1,27 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.AggregateError.prototype;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.AggregateError.prototype") { }
+
+    [Fact(DisplayName = "constructor.js")]
+    public Task constructor() => ExecutionTestFromFile("constructor");
+
+    [Fact(DisplayName = "errors-absent-on-prototype.js")]
+    public Task errors_absent_on_prototype()
+        => ExecutionTestFromFile("errors-absent-on-prototype");
+
+    [Fact(DisplayName = "message.js")]
+    public Task message() => ExecutionTestFromFile("message");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+
+    [Fact(DisplayName = "proto.js")]
+    public Task proto() => ExecutionTestFromFile("proto");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/JavaScript/constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/JavaScript/constructor.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error.prototype.constructor
+description: >
+  The `AggregateError.prototype.constructor` property descriptor.
+info: |
+  The initial value of AggregateError.prototype.constructor is the intrinsic
+  object %AggregateError%.
+
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described (...) has the attributes { [[Writable]]: true,
+    [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [AggregateError]
+---*/
+
+verifyProperty(AggregateError.prototype, 'constructor', {
+  value: AggregateError,
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/JavaScript/errors-absent-on-prototype.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/JavaScript/errors-absent-on-prototype.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2020 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-aggregate-error-prototype-objects
+description: >
+  The AggregateError prototype object isn't an AggregateError instance.
+info: |
+  Properties of the AggregateError Prototype Object
+
+  The AggregateError prototype object:
+    ...
+    - is not an Error instance or an AggregateError instance and does not have an
+      [[ErrorData]] internal slot.
+    ...
+features: [AggregateError]
+---*/
+
+assert.sameValue(AggregateError.prototype.hasOwnProperty("errors"), false);

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/JavaScript/message.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/JavaScript/message.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error.prototype.message
+description: >
+  The `AggregateError.prototype.message` property descriptor.
+info: |
+  The initial value of the message property of the prototype for a given AggregateError
+  constructor is the empty String.
+
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described (...) has the attributes { [[Writable]]: true,
+    [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [AggregateError]
+---*/
+
+verifyProperty(AggregateError.prototype, 'message', {
+  value: '',
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/JavaScript/name.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error.prototype.name
+description: >
+  The `AggregateError.prototype.name` property descriptor.
+info: |
+  The initial value of AggregateError.prototype.name is "AggregateError".
+
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described (...) has the attributes { [[Writable]]: true,
+    [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [AggregateError]
+---*/
+
+verifyProperty(AggregateError.prototype, 'name', {
+  value: 'AggregateError',
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/JavaScript/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error.prototype
+description: >
+  Property descriptor of AggregateError.prototype
+info: |
+  AggregateError.prototype
+
+  The initial value of AggregateError.prototype is the intrinsic object %AggregateErrorPrototype%.
+
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+features: [AggregateError]
+---*/
+
+assert.sameValue(typeof AggregateError.prototype, 'object');
+
+verifyProperty(AggregateError, 'prototype', {
+  enumerable: false,
+  writable: false,
+  configurable: false
+});

--- a/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/JavaScript/proto.js
+++ b/tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/JavaScript/proto.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-aggregate-error-prototype-objects
+description: The prototype of AggregateError.prototype constructor is Error.prototype
+info: |
+  Properties of the AggregateError Prototype Object
+
+  - has a [[Prototype]] internal slot whose value is the intrinsic object %Error.prototype%.
+features: [AggregateError]
+---*/
+
+var proto = Object.getPrototypeOf(AggregateError.prototype);
+
+assert.sameValue(proto, Error.prototype);

--- a/tests/Jroc.Tests/TryCatch/Snapshots/ExecutionTests.TryCatch_NewExpression_BuiltInErrors.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/ExecutionTests.TryCatch_NewExpression_BuiltInErrors.verified.txt
@@ -5,4 +5,4 @@ RangeError: range
 ReferenceError: ref
 SyntaxError: syntax
 URIError: uri
-AggregateError: agg
+AggregateError

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NewExpression_BuiltInErrors.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryCatch_NewExpression_BuiltInErrors.verified.txt
@@ -78,7 +78,7 @@
 		) cil managed 
 	{
 		// Header size: 12
-		// Code size: 327 (0x147)
+		// Code size: 336 (0x150)
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryCatch_NewExpression_BuiltInErrors/Scope,
@@ -211,16 +211,21 @@
 		IL_0125: pop
 		IL_0126: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
 		IL_012b: stloc.s 6
-		IL_012d: ldstr "agg"
-		IL_0132: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.AggregateError::.ctor(string)
-		IL_0137: stloc.s 13
-		IL_0139: ldloc.s 6
-		IL_013b: ldloc.s 13
-		IL_013d: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
-		IL_0142: pop
-		IL_0143: ldnull
-		IL_0144: stloc.s 5
-		IL_0146: ret
+		IL_012d: ldc.i4.1
+		IL_012e: newarr [System.Runtime]System.Object
+		IL_0133: dup
+		IL_0134: ldc.i4.0
+		IL_0135: ldstr "agg"
+		IL_013a: stelem.ref
+		IL_013b: call class [JavaScriptRuntime]JavaScriptRuntime.AggregateError [JavaScriptRuntime]JavaScriptRuntime.AggregateError::Construct(object[])
+		IL_0140: stloc.s 13
+		IL_0142: ldloc.s 6
+		IL_0144: ldloc.s 13
+		IL_0146: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_014b: pop
+		IL_014c: ldnull
+		IL_014d: stloc.s 5
+		IL_014f: ret
 	} // end of method TryCatch_NewExpression_BuiltInErrors::__js_module_init__
 
 } // end of class Modules.TryCatch_NewExpression_BuiltInErrors


### PR DESCRIPTION
## Summary

- add the ES2021 `AggregateError` global with constructible function and prototype surfaces
- implement iterable error-list construction and correct message-property semantics
- port 20 exact upstream test262 AggregateError fixtures and update ECMA-262 §20.5

## Validation

- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --filter 'FullyQualifiedName~built_ins.AggregateError' --no-restore` (20 passed)
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --filter 'FullyQualifiedName~built_ins.Error|FullyQualifiedName~built_ins.AggregateError' --no-restore` (27 passed)
- verified all 20 newly ported fixtures match the pinned upstream test262 cache byte-for-byte

The semantic execution snapshot for `TryCatch_NewExpression_BuiltInErrors` is updated. The generator snapshot update is intentionally delegated to the repository workflow.
