### PR TITLE
runtime: add scoped execution frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   construction, standard constructor/prototype metadata, and message-property
   behavior. Activates twenty corresponding pinned test262 fixtures.
 
+- runtime: replace thread-local runtime discovery with balanced,
+  async-flow-safe execution frames. Engine and hosted entry points now enter
+  explicit realm/agent scopes; service-provider, descriptor-store, module-path,
+  global-object, and bootstrap-override lookup follow the active frame. Root
+  entry suppresses inherited JavaScript invocation state for worker-safe
+  bootstrap.
+
 - runtime: introduce explicit `RuntimeAgentCluster`, `RuntimeAgent`, and
   `RuntimeRealm` lifetime owners. Every runtime service container now belongs
   to exactly one realm and exposes the ownership graph through constructor

--- a/docs/runtime/RuntimeExecutionFrames.md
+++ b/docs/runtime/RuntimeExecutionFrames.md
@@ -1,0 +1,33 @@
+# Runtime execution frames
+
+`RuntimeExecutionContext` is the single ambient pointer for active JROC
+execution. It flows through asynchronous continuations with `AsyncLocal` and
+identifies:
+
+- the current `RuntimeRealm` and owning `RuntimeAgent`;
+- the realm's `ServiceContainer`;
+- hosted/standalone bootstrap metadata;
+- current module filename and directory;
+- the realm-specific global object and property descriptor store.
+
+Use `Enter()` for balanced nested realm entry. Use `EnterAsRoot()` for a new
+engine, hosted runtime, or worker bootstrap. Root entry suppresses inherited
+runtime overrides and JavaScript invocation state (`this`, arguments,
+`new.target`, callee, lexical-super state, and direct constructor/call stacks)
+until the scope exits.
+
+Scopes must be disposed in reverse entry order. Disposal restores the complete
+previous ambient state and throws for out-of-order exit. Entering a disposed
+realm is rejected.
+
+`GlobalThis.ServiceProvider`, module path lookup, runtime property descriptors,
+and the engine's test/bootstrap service override all resolve through this
+frame. Thread identity is not a runtime identity boundary.
+
+The existing invocation-state fields remain separate for now. The
+continuation-scoped values preserve per-continuation snapshots without
+allocating a new execution frame on hot JavaScript call paths. Root frame
+entry explicitly captures, clears, and restores those values and the
+thread-affine direct-call stacks so a new agent cannot inherit its creator's
+call state. Root engine and hosted entry scopes remain synchronous and
+thread-affine while those stacks use thread-static storage.

--- a/docs/runtime/RuntimeOwnership.md
+++ b/docs/runtime/RuntimeOwnership.md
@@ -7,6 +7,7 @@ RuntimeAgentCluster
   -> RuntimeAgent
       -> RuntimeRealm
           -> ServiceContainer
+          -> RuntimeExecutionContext (while entered)
 ```
 
 - `RuntimeAgentCluster` owns agents and, in later migration stages, only
@@ -40,6 +41,8 @@ issues move that state under these owners.
 - A cluster may reference its active agents.
 - An agent may reference its cluster and active realms.
 - A realm may reference its agent and service container.
+- An entered execution context is the only ambient pointer to a realm and
+  agent; thread identity is not an ownership boundary.
 - Realm services may receive any of the three owners through constructor
   injection, but must not discover them through a second service locator.
 - Realm-created JavaScript objects must not be stored on an agent or cluster.

--- a/src/JavaScriptRuntime/Engine/Engine.cs
+++ b/src/JavaScriptRuntime/Engine/Engine.cs
@@ -13,68 +13,64 @@ namespace JavaScriptRuntime;
 /// </summary>
 public class Engine
 {
-    /// <summary>
-    /// Per-thread override for the runtime service provider (primarily used by tests).
-    /// If set, <see cref="ConfigureServiceProviderForCurrentThread"/> will use it instead of building a new container.
-    /// </summary>
-    internal readonly static ThreadLocal<ServiceContainer?> _serviceProviderOverride = new(() => null);
+    internal static readonly RuntimeServiceProviderOverride _serviceProviderOverride = new();
 
     public void Execute([NotNull] ModuleMainDelegate scriptEntryPoint)
     {
+        ArgumentNullException.ThrowIfNull(scriptEntryPoint);
+
         try
         {
-            // Validate caller provided a valid entry point delegate.
-            // Note: the delegate's Method/Module/Assembly is used to discover the compiled module assembly.
-            ArgumentNullException.ThrowIfNull(scriptEntryPoint);
-            RuntimeServices.SetCurrentThis(null);
-
-            // Configure per-thread services and install the Node-like synchronization context.
-            // This enables timers/microtasks and other async behavior to run deterministically on this thread.
-            var serviceProvider = ConfigureServiceProviderForCurrentThread(
+            var serviceProvider = ConfigureRuntime(
                 modulesAssembly: scriptEntryPoint.Method.Module.Assembly,
                 isHostedExecution: false);
+            var runtimeContext = serviceProvider.Resolve<RuntimeExecutionContext>();
 
-            // Register fork IPC before module setup resolves the global process object.
-            ConfigureChildProcessIpc(serviceProvider);
-            var moduleExecutor = new ModuleExecutor(serviceProvider);
-
-            var forkEntryModule = System.Environment.GetEnvironmentVariable(ChildProcessRuntimeOptions.ForkEntryModuleEnvVar);
-            if (!string.IsNullOrWhiteSpace(forkEntryModule))
+            using (runtimeContext.EnterAsRoot())
             {
-                moduleExecutor.Execute(scriptEntryPoint, forkEntryModule);
-            }
-            else
-            {
-                // Execute the script using the CommonJS module system.
-                // Future: Add ESM support with a different executor.
-                moduleExecutor.Execute(scriptEntryPoint);
-            }
+                try
+                {
+                    RuntimeServices.SetCurrentThis(null);
+                    ConfigureChildProcessIpc(serviceProvider);
+                    var moduleExecutor = new ModuleExecutor(serviceProvider);
 
-            // Drain microtasks and timers until no more work remains.
-            RunEventLoopUntilIdle(serviceProvider.Resolve<NodeEventLoopPump>(), waitForTimers: true);
+                    var forkEntryModule = System.Environment.GetEnvironmentVariable(
+                        ChildProcessRuntimeOptions.ForkEntryModuleEnvVar);
+                    if (!string.IsNullOrWhiteSpace(forkEntryModule))
+                    {
+                        moduleExecutor.Execute(scriptEntryPoint, forkEntryModule);
+                    }
+                    else
+                    {
+                        moduleExecutor.Execute(scriptEntryPoint);
+                    }
+
+                    RunEventLoopUntilIdle(
+                        serviceProvider.Resolve<NodeEventLoopPump>(),
+                        waitForTimers: true);
+                }
+                finally
+                {
+                    RuntimeServices.UnregisterModuleRequires(
+                        runtimeContext.RegisteredModuleRequires);
+                    if (serviceProvider.TryResolve<AsyncContextRuntime>(
+                            out var asyncContext)
+                        && asyncContext != null)
+                    {
+                        asyncContext.Reset();
+                    }
+
+                    RuntimeServices.SetCurrentThis(null);
+                }
+            }
         }
         finally
         {
-            if (GlobalThis.ServiceProvider?.TryResolve<RuntimeExecutionContext>(out var runtimeContext) == true
-                && runtimeContext != null)
-            {
-                RuntimeServices.UnregisterModuleRequires(runtimeContext.RegisteredModuleRequires);
-            }
-            if (GlobalThis.ServiceProvider?.TryResolve<AsyncContextRuntime>(out var asyncContext) == true
-                && asyncContext != null)
-            {
-                asyncContext.Reset();
-            }
-
-            // Cleanup global/thread-local state so repeated Engine.Execute calls (and tests) do not leak state.
-            // TODO: change globalthis to be a instance
-            GlobalThis.ServiceProvider = null;
             _serviceProviderOverride.Value = null;
-            RuntimeServices.SetCurrentThis(null);
         }
     }
 
-    internal static ServiceContainer ConfigureServiceProviderForCurrentThread(
+    internal static ServiceContainer ConfigureRuntime(
         Assembly modulesAssembly,
         bool isHostedExecution = false,
         string? compiledAssemblyPath = null)
@@ -83,35 +79,42 @@ public class Engine
 
         // Prevent accidentally hosting multiple runtimes on the same thread.
         // This catches common integration bugs where a host thread is reused and global state leaks.
-        if (GlobalThis.ServiceProvider != null)
+        if (RuntimeExecutionContext.Current != null)
         {
             throw new InvalidOperationException(
-                "A JROC runtime is already configured for the current thread. " +
-                "Create a dedicated thread per loaded module/runtime, or ensure the previous engine cleaned up correctly.");
+                "A JROC runtime execution frame is already active. " +
+                "Exit the current frame before starting another engine.");
         }
 
         // Use the test override if present; otherwise construct the default runtime container.
         var serviceProvider = _serviceProviderOverride.Value ?? RuntimeServices.BuildServiceProvider();
 
-        serviceProvider.RegisterInstance(new RuntimeExecutionContext(
+        _ = RuntimeExecutionContext.GetOrCreate(
+            serviceProvider,
             isHostedExecution,
             CompiledAssemblyPathResolver.Resolve(
                 modulesAssembly,
                 compiledAssemblyPath,
-                allowAssemblyLocationFallback: !isHostedExecution)));
+                allowAssemblyLocationFallback: !isHostedExecution));
 
         // Resolve scheduler/event-loop singletons via DI so other services can depend on them.
         // Note: ServiceContainer manages singleton instances per-container.
         _ = serviceProvider.Resolve<NodeSchedulerState>();
         _ = serviceProvider.Resolve<NodeEventLoopPump>();
 
-        // Expose the service provider via GlobalThis (current design uses global state).
-        GlobalThis.ServiceProvider = serviceProvider;
-
         // Provide the compiled modules assembly for runtime dependency/module resolution.
         serviceProvider.Resolve<LocalModulesAssembly>().ModulesAssembly = modulesAssembly;
 
         return serviceProvider;
+    }
+
+    internal sealed class RuntimeServiceProviderOverride
+    {
+        internal ServiceContainer? Value
+        {
+            get => RuntimeExecutionContext.ServiceProviderOverride;
+            set => RuntimeExecutionContext.ServiceProviderOverride = value;
+        }
     }
 
     internal static void RunEventLoopUntilIdle(NodeEventLoopPump ctx, bool waitForTimers)

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -14,10 +14,7 @@ namespace JavaScriptRuntime
     [IntrinsicObject("GlobalThis")]
     public class GlobalThis : JsObject, IDictionary<string, object?>
     {
-        private static readonly ThreadLocal<ServiceContainer?> _serviceProvider = new(() => null);
-
-        // Per-"realm" (thread) global object. This backs the ECMAScript globalThis value.
-        private static readonly ThreadLocal<GlobalThis?> _globalObject = new(() => null);
+        private static readonly ThreadLocal<GlobalThis?> _fallbackGlobalObject = new(() => null);
         private static readonly ConcurrentDictionary<string, BuiltinDelegateFunctionAdapter>
             _globalFunctionValues = new(StringComparer.Ordinal);
 
@@ -1084,23 +1081,11 @@ namespace JavaScriptRuntime
 
         internal static ServiceContainer? ServiceProvider
         {
-            get => _serviceProvider.Value;
+            get => RuntimeExecutionContext.Current?.Services;
             set
             {
-                _serviceProvider.Value = value;
-                if (value?.TryResolve<IPropertyDescriptorStore>(out var propertyDescriptorStore) == true
-                    && propertyDescriptorStore != null)
-                {
-                    PropertyDescriptorStore.SetCurrentRuntimeStore(propertyDescriptorStore);
-                }
-                else
-                {
-                    PropertyDescriptorStore.SetCurrentRuntimeStore(null);
-                }
-
-                // Each configured runtime corresponds to a new execution context/realm.
-                // Ensure we don't leak a prior global object across Engine.Execute calls on the same thread.
-                _globalObject.Value = null;
+                RuntimeExecutionContext.SetLegacyServiceProvider(value);
+                _fallbackGlobalObject.Value = null;
             }
         }
 
@@ -1124,11 +1109,16 @@ namespace JavaScriptRuntime
 
         private static GlobalThis GetOrCreateGlobalObject()
         {
-            var obj = _globalObject.Value;
+            if (RuntimeExecutionContext.Current is { } executionContext)
+            {
+                return executionContext.GetOrCreateGlobalObject();
+            }
+
+            var obj = _fallbackGlobalObject.Value;
             if (obj == null)
             {
                 obj = new GlobalThis();
-                _globalObject.Value = obj;
+                _fallbackGlobalObject.Value = obj;
             }
             return obj;
         }
@@ -1537,7 +1527,7 @@ namespace JavaScriptRuntime
         {
             get
             {
-                var serviceProvider = _serviceProvider.Value;
+                var serviceProvider = ServiceProvider;
                 return serviceProvider != null
                     ? serviceProvider.Resolve<JavaScriptRuntime.Node.Process>()
                     : _defaultProcess;
@@ -1552,7 +1542,7 @@ namespace JavaScriptRuntime
         {
             get
             {
-                var serviceProvider = _serviceProvider.Value;
+                var serviceProvider = ServiceProvider;
                 return serviceProvider != null
                     ? serviceProvider.Resolve<JavaScriptRuntime.Console>()
                     : _defaultConsole;
@@ -1739,7 +1729,7 @@ namespace JavaScriptRuntime
         /// </summary>
         public static object? gc()
         {
-            var serviceProvider = _serviceProvider.Value;
+            var serviceProvider = ServiceProvider;
             if (serviceProvider == null
                 || !serviceProvider.IsRegistered<JavaScriptRuntime.EngineCore.IFinalizationRegistryHost>())
             {
@@ -2108,7 +2098,7 @@ namespace JavaScriptRuntime
 
         private static Timers GetTimers()
         {
-            return _serviceProvider.Value!.Resolve<Timers>();
+            return ServiceProvider!.Resolve<Timers>();
         }
 
         /// <summary>

--- a/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
+++ b/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
@@ -427,6 +427,7 @@ internal sealed class JsRuntimeInstance : IDisposable
 
     private void ThreadMain(Assembly compiledAssembly, string moduleSpecifier)
     {
+        IDisposable? executionScope = null;
         try
         {
             // Extremely defensive: under normal usage, Dispose cannot be called until after the ctor returns
@@ -439,11 +440,14 @@ internal sealed class JsRuntimeInstance : IDisposable
             }
 
             // Configure engine services *for this thread*; the sync context/event loop are thread-affine.
-            var serviceProvider = Engine.ConfigureServiceProviderForCurrentThread(
+            var serviceProvider = Engine.ConfigureRuntime(
                 compiledAssembly,
                 isHostedExecution: true,
                 compiledAssemblyPath: _options?.CompiledAssemblyPath);
             _serviceProvider = serviceProvider;
+            executionScope = serviceProvider
+                .Resolve<RuntimeExecutionContext>()
+                .EnterAsRoot();
 
             if (_options?.HostRuntimeIntrinsics != null)
             {
@@ -512,8 +516,7 @@ internal sealed class JsRuntimeInstance : IDisposable
                 RuntimeServices.UnregisterModuleRequires(runtimeContext.RegisteredModuleRequires);
             }
 
-            // Clear ambient global provider to avoid leaking thread-local state after thread exits.
-            GlobalThis.ServiceProvider = null;
+            executionScope?.Dispose();
             _exports = null;
             _eventLoop = null;
             _serviceProvider = null;

--- a/src/JavaScriptRuntime/Modules/CommonJS/ModuleContext.cs
+++ b/src/JavaScriptRuntime/Modules/CommonJS/ModuleContext.cs
@@ -3,14 +3,12 @@ using System.Reflection;
 using JavaScriptRuntime.DependencyInjection;
 
 namespace JavaScriptRuntime.Modules.CommonJS;
+
 public class ModuleContext
 {
-    /// <summary>
-    /// temporary statics
-    /// </summary>
-
-    private readonly static ThreadLocal<string> dirname = new ThreadLocal<string>();
-    private readonly static ThreadLocal<string> filename = new ThreadLocal<string>();
+    private static readonly string DefaultFilename = GetDefaultFilename();
+    private static readonly string DefaultDirectory =
+        Path.GetDirectoryName(DefaultFilename) ?? string.Empty;
 
     private static RequireDelegate CreateRequireDelegate(Require requireService)
     {
@@ -25,55 +23,57 @@ public class ModuleContext
         };
     }
 
-    static ModuleContext()
-    {
-            // Provide sensible defaults when running out-of-proc: resolve to the entry assembly path.
-            try
-            {
-                var entry = Assembly.GetEntryAssembly();
-                var file = entry?.Location;
-                if (!string.IsNullOrEmpty(file))
-                {
-                    filename.Value = file!;
-                    dirname.Value = System.IO.Path.GetDirectoryName(file!) ?? string.Empty;
-                    // argv is resolved on-demand by Process.argv from the environment provider.
-                }
-            }
-            catch
-            {
-                // Best-effort; leave defaults if anything goes wrong.
-            }    
-    }
-
     public static void SetModuleContext(string dir, string file)
     {
-        dirname.Value = dir;
-        filename.Value = file;
+        var context = RuntimeExecutionContext.CurrentOrOverride
+            ?? throw new InvalidOperationException(
+                "A runtime execution context is required to set module location.");
+        context.SetModuleLocation(dir, file);
     }
 
     public static void ClearModuleContext()
     {
-        dirname.Value = string.Empty;
-        filename.Value = string.Empty;
+        RuntimeExecutionContext.CurrentOrOverride?.SetModuleLocation(
+            string.Empty,
+            string.Empty);
     }
 
     public static ModuleContext CreateModuleContext([NotNull] ServiceContainer serviceProvider)
     {
         ArgumentNullException.ThrowIfNull(serviceProvider);
         var requireService = serviceProvider.Resolve<Require>();
+        var executionContext = RuntimeExecutionContext.GetOrCreate(serviceProvider);
+        var (directory, filename) = executionContext.GetModuleLocation();
         var context = new ModuleContext
         {
             require = CreateRequireDelegate(requireService),
-            __dirname = dirname.Value!,
-            __filename = filename.Value!
+            __dirname = string.IsNullOrEmpty(directory)
+                ? DefaultDirectory
+                : directory,
+            __filename = string.IsNullOrEmpty(filename)
+                ? DefaultFilename
+                : filename
         };
         return context;
     }
 
     public static ModuleContext CreateModuleContext()
     {
-        // Fallback for legacy call sites (e.g. Node.Process.argv). Prefer passing a container.
-        return CreateModuleContext(JavaScriptRuntime.RuntimeServices.BuildServiceProvider());
+        var services = RuntimeExecutionContext.CurrentOrOverride?.Services
+            ?? JavaScriptRuntime.RuntimeServices.BuildServiceProvider();
+        return CreateModuleContext(services);
+    }
+
+    private static string GetDefaultFilename()
+    {
+        try
+        {
+            return Assembly.GetEntryAssembly()?.Location ?? string.Empty;
+        }
+        catch
+        {
+            return string.Empty;
+        }
     }
 
     public object? Exports { get; set; }

--- a/src/JavaScriptRuntime/Node/ChildProcess.cs
+++ b/src/JavaScriptRuntime/Node/ChildProcess.cs
@@ -1755,6 +1755,10 @@ namespace JavaScriptRuntime.Node
                 {
                     return;
                 }
+                catch (InvalidOperationException) when (_disposed || _connected.Task.IsCompleted)
+                {
+                    return;
+                }
                 catch (Exception ex)
                 {
                     if (!_disposed)

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -260,7 +260,6 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
     }
 
     private static readonly IntrinsicPropertyDescriptorStore _intrinsicStore = new();
-    private static readonly ThreadLocal<IPropertyDescriptorStore?> _currentRuntimeStore = new(() => null);
     private static readonly ThreadLocal<PropertyDescriptorStore?> _defaultRuntimeStore = new(() => null);
     private static readonly ThreadLocal<int> _intrinsicInitializationDepth = new(() => 0);
 
@@ -296,11 +295,10 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
     {
     }
 
-    internal static void SetCurrentRuntimeStore(IPropertyDescriptorStore? store)
+    internal static void OnExecutionContextChanged(
+        IPropertyDescriptorStore? previous,
+        IPropertyDescriptorStore? current)
     {
-        var previous = _currentRuntimeStore.Value ?? _defaultRuntimeStore.Value;
-        _currentRuntimeStore.Value = store;
-        var current = store ?? _defaultRuntimeStore.Value;
         if (HasCanonicalIndexOverrides(previous) || HasCanonicalIndexOverrides(current))
         {
             Array.NotifyPrototypeMutation();
@@ -575,7 +573,7 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
             return true;
         }
 
-        if (_currentRuntimeStore.Value is PropertyDescriptorStore runtimeStore
+        if (CurrentRuntimeStore is PropertyDescriptorStore runtimeStore
             && runtimeStore._overrideSlots.TryGetValue(target, out _))
         {
             return true;
@@ -842,16 +840,19 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
     private static IPropertyDescriptorStore CurrentStore
         => _intrinsicInitializationDepth.Value > 0
             ? _intrinsicStore
-            : _currentRuntimeStore.Value ?? _intrinsicStore;
+            : CurrentRuntimeStore ?? _intrinsicStore;
 
     private static PropertyDescriptorStore SharedIntrinsicRuntimeStore
-        => _currentRuntimeStore.Value as PropertyDescriptorStore
+        => CurrentRuntimeStore as PropertyDescriptorStore
             ?? (_defaultRuntimeStore.Value ??= new PropertyDescriptorStore());
+
+    private static IPropertyDescriptorStore? CurrentRuntimeStore
+        => RuntimeExecutionContext.Current?.DescriptorStore;
 
     private static IPropertyDescriptorStore GetLookupStore(object target)
         => !IsIntrinsicInitialization
             && target is JsObject { HasSharedIntrinsicBaseline: true }
-                ? (IPropertyDescriptorStore?)_currentRuntimeStore.Value
+                ? CurrentRuntimeStore
                     ?? (IPropertyDescriptorStore?)_defaultRuntimeStore.Value
                     ?? _intrinsicStore
                 : CurrentStore;

--- a/src/JavaScriptRuntime/RuntimeExecutionContext.cs
+++ b/src/JavaScriptRuntime/RuntimeExecutionContext.cs
@@ -1,25 +1,264 @@
 namespace JavaScriptRuntime;
 
+using JavaScriptRuntime.DependencyInjection;
 using JavaScriptRuntime.Modules.CommonJS;
 
 internal sealed class RuntimeExecutionContext
 {
-    private readonly List<KeyValuePair<string, RequireDelegate>> _registeredModuleRequires = new();
+    private static readonly AsyncLocal<AmbientState?> Ambient = new();
 
-    internal RuntimeExecutionContext(bool isHosted, string? compiledAssemblyPath = null)
+    private readonly object _stateGate = new();
+    private readonly List<KeyValuePair<string, RequireDelegate>> _registeredModuleRequires = [];
+    private GlobalThis? _globalObject;
+
+    private RuntimeExecutionContext(
+        RuntimeRealm realm,
+        bool isHosted,
+        string? compiledAssemblyPath)
     {
+        Realm = realm;
         IsHosted = isHosted;
         CompiledAssemblyPath = compiledAssemblyPath;
+        DescriptorStore = realm.Services.Resolve<IPropertyDescriptorStore>();
     }
 
-    internal bool IsHosted { get; }
+    internal static RuntimeExecutionContext? Current
+        => Ambient.Value?.Frame?.Context;
 
-    internal string? CompiledAssemblyPath { get; }
+    internal static ServiceContainer? ServiceProviderOverride
+    {
+        get => Ambient.Value?.ServiceProviderOverride;
+        set
+        {
+            var current = Ambient.Value;
+            Ambient.Value = new AmbientState(
+                current?.Frame,
+                value);
+        }
+    }
 
-    internal IReadOnlyList<KeyValuePair<string, RequireDelegate>> RegisteredModuleRequires => _registeredModuleRequires;
+    internal RuntimeRealm Realm { get; }
+
+    internal RuntimeAgent Agent => Realm.Agent;
+
+    internal ServiceContainer Services => Realm.Services;
+
+    internal IPropertyDescriptorStore DescriptorStore { get; }
+
+    internal bool IsHosted { get; private set; }
+
+    internal string? CompiledAssemblyPath { get; private set; }
+
+    internal string ModuleDirectory { get; private set; } = string.Empty;
+
+    internal string ModuleFilename { get; private set; } = string.Empty;
+
+    internal IReadOnlyList<KeyValuePair<string, RequireDelegate>> RegisteredModuleRequires
+        => _registeredModuleRequires;
+
+    internal static RuntimeExecutionContext GetOrCreate(
+        ServiceContainer services,
+        bool? isHosted = null,
+        string? compiledAssemblyPath = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        if (services.TryResolve<RuntimeExecutionContext>(out var existing)
+            && existing != null)
+        {
+            if (isHosted.HasValue)
+            {
+                existing.Configure(isHosted.Value, compiledAssemblyPath);
+            }
+
+            return existing;
+        }
+
+        var realm = services.OwningRealm
+            ?? throw new InvalidOperationException(
+                "Runtime service containers must have an owning realm.");
+        var context = new RuntimeExecutionContext(
+            realm,
+            isHosted ?? false,
+            compiledAssemblyPath);
+        services.RegisterInstance(context);
+        return context;
+    }
+
+    internal static RuntimeExecutionContext? CurrentOrOverride
+    {
+        get
+        {
+            if (Current is { } current)
+            {
+                return current;
+            }
+
+            var services = ServiceProviderOverride;
+            return services == null
+                ? null
+                : GetOrCreate(services);
+        }
+    }
+
+    internal IDisposable Enter()
+        => EnterCore(asRoot: false);
+
+    internal IDisposable EnterAsRoot()
+        => EnterCore(asRoot: true);
+
+    internal static void SetLegacyServiceProvider(ServiceContainer? services)
+    {
+        var current = Ambient.Value;
+        if (current?.Frame is { IsLegacy: false })
+        {
+            throw new InvalidOperationException(
+                "The active runtime execution frame must be exited through its scope.");
+        }
+
+        var frame = services == null
+            ? null
+            : new ExecutionFrame(
+                GetOrCreate(services),
+                IsLegacy: true);
+        SetAmbient(new AmbientState(
+            frame,
+            current?.ServiceProviderOverride));
+    }
+
+    internal void SetModuleLocation(string directory, string filename)
+    {
+        ArgumentNullException.ThrowIfNull(directory);
+        ArgumentNullException.ThrowIfNull(filename);
+
+        lock (_stateGate)
+        {
+            ModuleDirectory = directory;
+            ModuleFilename = filename;
+        }
+    }
+
+    internal (string Directory, string Filename) GetModuleLocation()
+    {
+        lock (_stateGate)
+        {
+            return (ModuleDirectory, ModuleFilename);
+        }
+    }
+
+    internal GlobalThis GetOrCreateGlobalObject()
+    {
+        lock (_stateGate)
+        {
+            return _globalObject ??= new GlobalThis();
+        }
+    }
 
     internal void TrackModuleRequire(string moduleId, RequireDelegate require)
     {
-        _registeredModuleRequires.Add(new KeyValuePair<string, RequireDelegate>(moduleId, require));
+        _registeredModuleRequires.Add(
+            new KeyValuePair<string, RequireDelegate>(moduleId, require));
+    }
+
+    private IDisposable EnterCore(bool asRoot)
+    {
+        if (Realm.IsDisposed)
+        {
+            throw new ObjectDisposedException(nameof(RuntimeRealm));
+        }
+
+        var previous = Ambient.Value;
+        object? invocationState = null;
+        if (asRoot)
+        {
+            invocationState = RuntimeServices.CaptureAndClearAmbientInvocationState();
+        }
+
+        var frame = new ExecutionFrame(this, IsLegacy: false);
+        try
+        {
+            SetAmbient(new AmbientState(
+                frame,
+                asRoot ? null : previous?.ServiceProviderOverride));
+            return new ExecutionScope(
+                frame,
+                previous,
+                invocationState);
+        }
+        catch
+        {
+            if (invocationState != null)
+            {
+                RuntimeServices.RestoreAmbientInvocationState(invocationState);
+            }
+
+            throw;
+        }
+    }
+
+    private void Configure(bool isHosted, string? compiledAssemblyPath)
+    {
+        lock (_stateGate)
+        {
+            IsHosted = isHosted;
+            CompiledAssemblyPath = compiledAssemblyPath;
+        }
+    }
+
+    private static void SetAmbient(AmbientState? next)
+    {
+        var previousStore = Ambient.Value?.Frame?.Context.DescriptorStore;
+        Ambient.Value = next;
+        PropertyDescriptorStore.OnExecutionContextChanged(
+            previousStore,
+            next?.Frame?.Context.DescriptorStore);
+    }
+
+    private sealed record AmbientState(
+        ExecutionFrame? Frame,
+        ServiceContainer? ServiceProviderOverride);
+
+    private sealed record ExecutionFrame(
+        RuntimeExecutionContext Context,
+        bool IsLegacy);
+
+    private sealed class ExecutionScope : IDisposable
+    {
+        private readonly ExecutionFrame _frame;
+        private readonly AmbientState? _previous;
+        private readonly object? _invocationState;
+        private bool _disposed;
+
+        internal ExecutionScope(
+            ExecutionFrame frame,
+            AmbientState? previous,
+            object? invocationState)
+        {
+            _frame = frame;
+            _previous = previous;
+            _invocationState = invocationState;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (!ReferenceEquals(Ambient.Value?.Frame, _frame))
+            {
+                throw new InvalidOperationException(
+                    "Runtime execution frames must be exited in reverse entry order.");
+            }
+
+            SetAmbient(_previous);
+            if (_invocationState != null)
+            {
+                RuntimeServices.RestoreAmbientInvocationState(_invocationState);
+            }
+
+            _disposed = true;
+        }
     }
 }

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -34,6 +34,19 @@ public class RuntimeServices
 
     public static object[] GetEmptyScopes() => EmptyScopes;
 
+    private readonly record struct AmbientInvocationState(
+        object? CurrentThis,
+        object? CurrentLexicalSuperReceiver,
+        object[]? CurrentLexicalSuperScopes,
+        object?[]? CurrentArguments,
+        JsCallArguments? CurrentCallArguments,
+        object? CurrentNewTarget,
+        object? CurrentCallee,
+        Stack<object?[]?>? ConstructorArgStack,
+        Stack<GeneratedFunctionDirectCallState>? GeneratedFunctionDirectCallStack,
+        Stack<object?>? ConstructorNewTargetStack,
+        Stack<object?>? DerivedConstructorThisStack);
+
     private sealed class DerivedConstructorThisBinding
     {
         public object? Value = TemporalDeadZoneSentinel;
@@ -140,6 +153,57 @@ public class RuntimeServices
         var previous = _currentThis.Value;
         _currentThis.Value = value;
         return previous;
+    }
+
+    internal static object CaptureAndClearAmbientInvocationState()
+    {
+        var state = new AmbientInvocationState(
+            _currentThis.Value,
+            _currentLexicalSuperReceiver.Value,
+            _currentLexicalSuperScopes.Value,
+            _currentArguments.Value,
+            _currentCallArguments.Value,
+            _currentNewTarget.Value,
+            _currentCallee.Value,
+            _constructorArgStack,
+            _generatedFunctionDirectCallStack,
+            _constructorNewTargetStack,
+            _derivedConstructorThisStack);
+
+        _currentThis.Value = null;
+        _currentLexicalSuperReceiver.Value = null;
+        _currentLexicalSuperScopes.Value = null;
+        _currentArguments.Value = null;
+        _currentCallArguments.Value = null;
+        _currentNewTarget.Value = null;
+        _currentCallee.Value = null;
+        _constructorArgStack = null;
+        _generatedFunctionDirectCallStack = null;
+        _constructorNewTargetStack = null;
+        _derivedConstructorThisStack = null;
+        return state;
+    }
+
+    internal static void RestoreAmbientInvocationState(object state)
+    {
+        if (state is not AmbientInvocationState invocationState)
+        {
+            throw new ArgumentException(
+                "The invocation state was not created by this runtime.",
+                nameof(state));
+        }
+
+        _currentThis.Value = invocationState.CurrentThis;
+        _currentLexicalSuperReceiver.Value = invocationState.CurrentLexicalSuperReceiver;
+        _currentLexicalSuperScopes.Value = invocationState.CurrentLexicalSuperScopes;
+        _currentArguments.Value = invocationState.CurrentArguments;
+        _currentCallArguments.Value = invocationState.CurrentCallArguments;
+        _currentNewTarget.Value = invocationState.CurrentNewTarget;
+        _currentCallee.Value = invocationState.CurrentCallee;
+        _constructorArgStack = invocationState.ConstructorArgStack;
+        _generatedFunctionDirectCallStack = invocationState.GeneratedFunctionDirectCallStack;
+        _constructorNewTargetStack = invocationState.ConstructorNewTargetStack;
+        _derivedConstructorThisStack = invocationState.DerivedConstructorThisStack;
     }
 
     public static object? GetCurrentLexicalSuperReceiver()

--- a/tests/Jroc.Testing/InMemoryTestCompiler.cs
+++ b/tests/Jroc.Testing/InMemoryTestCompiler.cs
@@ -200,10 +200,10 @@ public static class InMemoryTestCompiler
             {
                 JavaScriptRuntime.Array.ResetPrototypeForTests();
                 EnvironmentProvider.SuppressExit = true;
+                Engine._serviceProviderOverride.Value = serviceProvider;
                 JavaScriptRuntime.Modules.CommonJS.ModuleContext.SetModuleContext(
                     Path.GetDirectoryName(entryPath) ?? string.Empty,
                     entryPath);
-                Engine._serviceProviderOverride.Value = serviceProvider;
 
                 var entryPoint = assembly.EntryPoint
                     ?? throw new InvalidOperationException("No entry point found in the generated assembly.");
@@ -221,7 +221,6 @@ public static class InMemoryTestCompiler
                     RuntimeServices.UnregisterModuleRequires(runtimeContext.RegisteredModuleRequires);
                 }
 
-                GlobalThis.ServiceProvider = null;
                 Engine._serviceProviderOverride.Value = null;
                 RuntimeServices.SetCurrentThis(null);
                 EnvironmentProvider.SuppressExit = false;

--- a/tests/Jroc.Tests/DebugSymbols/JavaScriptErrorStackTraceTests.cs
+++ b/tests/Jroc.Tests/DebugSymbols/JavaScriptErrorStackTraceTests.cs
@@ -217,7 +217,6 @@ public class JavaScriptErrorStackTraceTests
         var captured = new CapturingConsoleOutput();
         var capturedEnvironment = new JavaScriptRuntime.CapturingEnvironment();
 
-        JavaScriptRuntime.Modules.CommonJS.ModuleContext.SetModuleContext(modDir, file);
         JavaScriptRuntime.EnvironmentProvider.SuppressExit = true;
         var runtimeServices = JavaScriptRuntime.RuntimeServices.BuildServiceProvider();
         runtimeServices.RegisterInstance(new ConsoleOutputSinks
@@ -227,6 +226,7 @@ public class JavaScriptErrorStackTraceTests
         });
         runtimeServices.RegisterInstance<IEnvironment>(capturedEnvironment);
         JavaScriptRuntime.Engine._serviceProviderOverride.Value = runtimeServices;
+        JavaScriptRuntime.Modules.CommonJS.ModuleContext.SetModuleContext(modDir, file);
 
         try
         {

--- a/tests/Jroc.Tests/RuntimeExecutionContextTests.cs
+++ b/tests/Jroc.Tests/RuntimeExecutionContextTests.cs
@@ -1,0 +1,222 @@
+using JavaScriptRuntime;
+using JavaScriptRuntime.Modules.CommonJS;
+
+namespace Jroc.Tests;
+
+public sealed class RuntimeExecutionContextTests
+{
+    [Fact]
+    public void Enter_NestsAndRestoresThePreviousRealm()
+    {
+        var firstServices = RuntimeServices.BuildServiceProvider();
+        var secondServices = RuntimeServices.BuildServiceProvider();
+        var first = RuntimeExecutionContext.GetOrCreate(firstServices);
+        var second = RuntimeExecutionContext.GetOrCreate(secondServices);
+
+        Assert.Null(RuntimeExecutionContext.Current);
+
+        using (first.Enter())
+        {
+            Assert.Same(first, RuntimeExecutionContext.Current);
+            Assert.Same(firstServices, GlobalThis.ServiceProvider);
+
+            using (second.Enter())
+            {
+                Assert.Same(second, RuntimeExecutionContext.Current);
+                Assert.Same(secondServices, GlobalThis.ServiceProvider);
+            }
+
+            Assert.Same(first, RuntimeExecutionContext.Current);
+            Assert.Same(firstServices, GlobalThis.ServiceProvider);
+        }
+
+        Assert.Null(RuntimeExecutionContext.Current);
+        Assert.Null(GlobalThis.ServiceProvider);
+    }
+
+    [Fact]
+    public void Enter_RestoresAfterExceptionUnwinding()
+    {
+        var context = CreateContext();
+
+        _ = Assert.Throws<InvalidOperationException>(
+            new Action(() =>
+            {
+                using var scope = context.Enter();
+                throw new InvalidOperationException("expected");
+            }));
+
+        Assert.Null(RuntimeExecutionContext.Current);
+    }
+
+    [Fact]
+    public void Enter_RejectsOutOfOrderDisposal()
+    {
+        var first = CreateContext();
+        var second = CreateContext();
+        var firstScope = first.Enter();
+        var secondScope = second.Enter();
+
+        _ = Assert.Throws<InvalidOperationException>(firstScope.Dispose);
+        Assert.Same(second, RuntimeExecutionContext.Current);
+
+        secondScope.Dispose();
+        firstScope.Dispose();
+
+        Assert.Null(RuntimeExecutionContext.Current);
+    }
+
+    [Fact]
+    public async Task Enter_FlowsAcrossAsyncContinuations()
+    {
+        var context = CreateContext();
+
+        using (context.Enter())
+        {
+            await Task.Yield();
+            Assert.Same(context, RuntimeExecutionContext.Current);
+            Assert.Same(
+                context,
+                await Task.Run(() => RuntimeExecutionContext.Current));
+        }
+
+        Assert.Null(RuntimeExecutionContext.Current);
+    }
+
+    [Fact]
+    public async Task ParallelAgentsKeepIndependentExecutionFrames()
+    {
+        var first = CreateContext();
+        var second = CreateContext();
+        using var ready = new Barrier(2);
+
+        var firstTask = Task.Run(() =>
+        {
+            using var _ = first.EnterAsRoot();
+            ready.SignalAndWait();
+            Assert.Same(first, RuntimeExecutionContext.Current);
+            Assert.Same(first.Services, GlobalThis.ServiceProvider);
+        });
+        var secondTask = Task.Run(() =>
+        {
+            using var _ = second.EnterAsRoot();
+            ready.SignalAndWait();
+            Assert.Same(second, RuntimeExecutionContext.Current);
+            Assert.Same(second.Services, GlobalThis.ServiceProvider);
+        });
+
+        await Task.WhenAll(firstTask, secondTask);
+        Assert.Null(RuntimeExecutionContext.Current);
+    }
+
+    [Fact]
+    public void EnterAsRootSuppressesInheritedRuntimeAndInvocationState()
+    {
+        var parent = CreateContext();
+        var child = CreateContext();
+        var parentThis = new object();
+        var parentArguments = new object?[] { "parent" };
+        var parentNewTarget = new object();
+        var parentCallee = new object();
+
+        using (parent.Enter())
+        {
+            RuntimeServices.SetCurrentThis(parentThis);
+            RuntimeServices.SetCurrentArguments(parentArguments);
+            RuntimeServices.SetCurrentNewTarget(parentNewTarget);
+            RuntimeServices.SetCurrentCallee(parentCallee);
+            Engine._serviceProviderOverride.Value = parent.Services;
+
+            using (child.EnterAsRoot())
+            {
+                Assert.Same(child, RuntimeExecutionContext.Current);
+                Assert.Null(RuntimeServices.GetCurrentThis());
+                Assert.Null(RuntimeServices.GetCurrentArguments());
+                Assert.Null(RuntimeServices.GetCurrentNewTarget());
+                Assert.Null(RuntimeServices.GetCurrentCallee());
+                Assert.Null(Engine._serviceProviderOverride.Value);
+            }
+
+            Assert.Same(parent, RuntimeExecutionContext.Current);
+            Assert.Same(parentThis, RuntimeServices.GetCurrentThis());
+            Assert.Same(parentArguments, RuntimeServices.GetCurrentArguments());
+            Assert.Same(parentNewTarget, RuntimeServices.GetCurrentNewTarget());
+            Assert.Same(parentCallee, RuntimeServices.GetCurrentCallee());
+            Assert.Same(parent.Services, Engine._serviceProviderOverride.Value);
+
+            Engine._serviceProviderOverride.Value = null;
+            RuntimeServices.SetCurrentThis(null);
+            RuntimeServices.SetCurrentArguments(null);
+            RuntimeServices.SetCurrentNewTarget(null);
+            RuntimeServices.SetCurrentCallee(null);
+        }
+    }
+
+    [Fact]
+    public void ModuleLocationFollowsTheActiveFrame()
+    {
+        var first = CreateContext();
+        var second = CreateContext();
+
+        using (first.Enter())
+        {
+            ModuleContext.SetModuleContext("/first", "/first/main.js");
+            AssertModuleLocation("/first", "/first/main.js");
+
+            using (second.Enter())
+            {
+                ModuleContext.SetModuleContext("/second", "/second/main.js");
+                AssertModuleLocation("/second", "/second/main.js");
+            }
+
+            AssertModuleLocation("/first", "/first/main.js");
+        }
+    }
+
+    [Fact]
+    public void EachContextKeepsItsGlobalObjectIdentity()
+    {
+        var first = CreateContext();
+        var second = CreateContext();
+        object firstGlobal;
+
+        using (first.Enter())
+        {
+            firstGlobal = GlobalThis.globalThis;
+        }
+
+        using (second.Enter())
+        {
+            Assert.NotSame(firstGlobal, GlobalThis.globalThis);
+        }
+
+        using (first.Enter())
+        {
+            Assert.Same(firstGlobal, GlobalThis.globalThis);
+        }
+    }
+
+    [Fact]
+    public void DisposedRealmCannotBeEntered()
+    {
+        var context = CreateContext();
+        context.Realm.Dispose();
+
+        _ = Assert.Throws<ObjectDisposedException>(() => context.Enter());
+    }
+
+    private static RuntimeExecutionContext CreateContext()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        return RuntimeExecutionContext.GetOrCreate(services);
+    }
+
+    private static void AssertModuleLocation(
+        string expectedDirectory,
+        string expectedFilename)
+    {
+        var module = ModuleContext.CreateModuleContext();
+        Assert.Equal(expectedDirectory, module.__dirname);
+        Assert.Equal(expectedFilename, module.__filename);
+    }
+}


### PR DESCRIPTION
## Summary

- replace thread-local runtime discovery with balanced, async-flow-safe execution frames
- route realm services, globals, property descriptors, and module locations through the active frame
- suppress inherited JavaScript invocation state during root engine and hosted-runtime bootstrap
- preserve nested-frame restoration, hosted lifecycle behavior, and hot call paths without per-call frame allocation

## Validation

- `dotnet build jroc.sln --no-restore`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --filter 'FullyQualifiedName~RuntimeExecutionContextTests|FullyQualifiedName~RuntimeOwnershipTests|FullyQualifiedName~ServiceContainerTests|FullyQualifiedName~GlobalThisTests|FullyQualifiedName~PropertyDescriptorStoreTests|FullyQualifiedName~RuntimePrototypeIsolationTests|FullyQualifiedName~Jroc.Tests.Hosting|FullyQualifiedName~JavaScriptErrorStackTraceTests' --no-restore`

Fixes #1822
