### PR TITLE
feat(runtime): support SuppressedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- compiler/runtime/test262: add the ES2024 SuppressedError global with standard
+  constructor/prototype metadata and ordered own `message`, `error`, and
+  `suppressed` properties. Activates twenty corresponding pinned test262
+  fixtures.
+
 - runtime/test262: add the ES2021 AggregateError global, iterable error-list
   construction, standard constructor/prototype metadata, and message-property
   behavior. Activates twenty corresponding pinned test262 fixtures.

--- a/docs/ECMA262/20/Section20_5.json
+++ b/docs/ECMA262/20/Section20_5.json
@@ -239,12 +239,72 @@
     },
     {
       "clause": "20.5.8",
+      "title": "SuppressedError Objects",
+      "status": "Supported with Limitations",
+      "specUrl": "https://tc39.es/ecma262/#sec-suppressed-error-objects"
+    },
+    {
+      "clause": "20.5.8.1",
+      "title": "The SuppressedError Constructor",
+      "status": "Supported with Limitations",
+      "specUrl": "https://tc39.es/ecma262/#sec-suppressederror-constructor"
+    },
+    {
+      "clause": "20.5.8.1.1",
+      "title": "SuppressedError ( error , suppressed , message [ , options ] )",
+      "status": "Supported with Limitations",
+      "specUrl": "https://tc39.es/ecma262/#sec-suppressederror-constructor"
+    },
+    {
+      "clause": "20.5.8.2",
+      "title": "Properties of the SuppressedError Constructor",
+      "status": "Supported",
+      "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-suppressederror-constructors"
+    },
+    {
+      "clause": "20.5.8.2.1",
+      "title": "SuppressedError.prototype",
+      "status": "Supported",
+      "specUrl": "https://tc39.es/ecma262/#sec-suppressederror.prototype"
+    },
+    {
+      "clause": "20.5.8.3",
+      "title": "Properties of the SuppressedError Prototype Object",
+      "status": "Supported",
+      "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-suppressederror-prototype-objects"
+    },
+    {
+      "clause": "20.5.8.3.1",
+      "title": "SuppressedError.prototype.constructor",
+      "status": "Supported",
+      "specUrl": "https://tc39.es/ecma262/#sec-suppressederror.prototype.constructor"
+    },
+    {
+      "clause": "20.5.8.3.2",
+      "title": "SuppressedError.prototype.message",
+      "status": "Supported",
+      "specUrl": "https://tc39.es/ecma262/#sec-suppressederror.prototype.message"
+    },
+    {
+      "clause": "20.5.8.3.3",
+      "title": "SuppressedError.prototype.name",
+      "status": "Supported",
+      "specUrl": "https://tc39.es/ecma262/#sec-suppressederror.prototype.name"
+    },
+    {
+      "clause": "20.5.8.4",
+      "title": "Properties of SuppressedError Instances",
+      "status": "Supported with Limitations",
+      "specUrl": "https://tc39.es/ecma262/#sec-properties-of-suppressederror-instances"
+    },
+    {
+      "clause": "20.5.9",
       "title": "Abstract Operations for Error Objects",
       "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-abstract-operations-for-error-objects"
     },
     {
-      "clause": "20.5.8.1",
+      "clause": "20.5.9.1",
       "title": "InstallErrorCause ( O , options )",
       "status": "Not Yet Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-installerrorcause"
@@ -399,6 +459,62 @@
           "test/built-ins/AggregateError/prototype/proto.js"
         ],
         "notes": "AggregateError.prototype inherits Error.prototype and provides the standard constructor, message, and name properties without an own errors property."
+      },
+      {
+        "clause": "20.5.8.1.1",
+        "feature": "SuppressedError constructor and own error properties",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-suppressederror-constructor",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/SuppressedError/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/SuppressedError/message-method-prop-cast.js",
+          "test/built-ins/SuppressedError/message-method-prop.js",
+          "test/built-ins/SuppressedError/message-tostring-abrupt-symbol.js",
+          "test/built-ins/SuppressedError/message-tostring-abrupt.js",
+          "test/built-ins/SuppressedError/message-undefined-no-prop.js",
+          "test/built-ins/SuppressedError/newtarget-is-undefined.js",
+          "test/built-ins/SuppressedError/newtarget-proto-fallback.js",
+          "test/built-ins/SuppressedError/newtarget-proto.js",
+          "test/built-ins/SuppressedError/order-of-args-evaluation.js"
+        ],
+        "notes": "SuppressedError preserves message coercion order and creates writable, non-enumerable own error and suppressed properties after an own message property when supplied. Error cause options and custom newTarget prototypes remain limited."
+      },
+      {
+        "clause": "20.5.8.2",
+        "feature": "SuppressedError constructor function surface",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-suppressederror-constructors",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/SuppressedError/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/SuppressedError/is-a-constructor.js",
+          "test/built-ins/SuppressedError/length.js",
+          "test/built-ins/SuppressedError/name.js",
+          "test/built-ins/SuppressedError/prop-desc.js",
+          "test/built-ins/SuppressedError/proto.js"
+        ],
+        "notes": "The global is a constructible function with the standard global property, name, length, prototype descriptor, and Error constructor prototype."
+      },
+      {
+        "clause": "20.5.8.3",
+        "feature": "SuppressedError.prototype surface",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-suppressederror-prototype-objects",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/SuppressedError/prototype/constructor.js",
+          "test/built-ins/SuppressedError/prototype/errors-absent-on-prototype.js",
+          "test/built-ins/SuppressedError/prototype/message.js",
+          "test/built-ins/SuppressedError/prototype/name.js",
+          "test/built-ins/SuppressedError/prototype/prop-desc.js",
+          "test/built-ins/SuppressedError/prototype/proto.js"
+        ],
+        "notes": "SuppressedError.prototype inherits Error.prototype and provides the standard constructor, message, and name properties without own error or suppressed properties."
       }
     ]
   }

--- a/docs/ECMA262/20/Section20_5.md
+++ b/docs/ECMA262/20/Section20_5.md
@@ -4,7 +4,7 @@
 
 [Back to Section20](Section20.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-08-14T23:17:53Z
+> Last generated (UTC): 2026-08-15T04:49:21Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -52,8 +52,18 @@
 | 20.5.7.3.2 | AggregateError.prototype.message | Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype.message) |
 | 20.5.7.3.3 | AggregateError.prototype.name | Supported | [tc39.es](https://tc39.es/ecma262/#sec-aggregate-error.prototype.name) |
 | 20.5.7.4 | Properties of AggregateError Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-aggregate-error-instances) |
-| 20.5.8 | Abstract Operations for Error Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-error-objects) |
-| 20.5.8.1 | InstallErrorCause ( O , options ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-installerrorcause) |
+| 20.5.8 | SuppressedError Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-suppressed-error-objects) |
+| 20.5.8.1 | The SuppressedError Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-suppressederror-constructor) |
+| 20.5.8.1.1 | SuppressedError ( error , suppressed , message [ , options ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-suppressederror-constructor) |
+| 20.5.8.2 | Properties of the SuppressedError Constructor | Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-suppressederror-constructors) |
+| 20.5.8.2.1 | SuppressedError.prototype | Supported | [tc39.es](https://tc39.es/ecma262/#sec-suppressederror.prototype) |
+| 20.5.8.3 | Properties of the SuppressedError Prototype Object | Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-suppressederror-prototype-objects) |
+| 20.5.8.3.1 | SuppressedError.prototype.constructor | Supported | [tc39.es](https://tc39.es/ecma262/#sec-suppressederror.prototype.constructor) |
+| 20.5.8.3.2 | SuppressedError.prototype.message | Supported | [tc39.es](https://tc39.es/ecma262/#sec-suppressederror.prototype.message) |
+| 20.5.8.3.3 | SuppressedError.prototype.name | Supported | [tc39.es](https://tc39.es/ecma262/#sec-suppressederror.prototype.name) |
+| 20.5.8.4 | Properties of SuppressedError Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-suppressederror-instances) |
+| 20.5.9 | Abstract Operations for Error Objects | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations-for-error-objects) |
+| 20.5.9.1 | InstallErrorCause ( O , options ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-installerrorcause) |
 
 ## Support
 
@@ -125,4 +135,22 @@ Feature-level support tracking with repo test references and optional test262 ev
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | AggregateError.prototype surface | Supported | `tests/Jroc.Test262.Tests/built-ins/AggregateError/prototype/ExecutionTests.cs` | `test/built-ins/AggregateError/prototype/constructor.js`<br>`test/built-ins/AggregateError/prototype/errors-absent-on-prototype.js`<br>`test/built-ins/AggregateError/prototype/message.js`<br>`test/built-ins/AggregateError/prototype/name.js`<br>`test/built-ins/AggregateError/prototype/prop-desc.js`<br>`test/built-ins/AggregateError/prototype/proto.js` | AggregateError.prototype inherits Error.prototype and provides the standard constructor, message, and name properties without an own errors property. |
+
+### 20.5.8.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-suppressederror-constructor))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| SuppressedError constructor and own error properties | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/SuppressedError/ExecutionTests.cs` | `test/built-ins/SuppressedError/message-method-prop-cast.js`<br>`test/built-ins/SuppressedError/message-method-prop.js`<br>`test/built-ins/SuppressedError/message-tostring-abrupt-symbol.js`<br>`test/built-ins/SuppressedError/message-tostring-abrupt.js`<br>`test/built-ins/SuppressedError/message-undefined-no-prop.js`<br>`test/built-ins/SuppressedError/newtarget-is-undefined.js`<br>`test/built-ins/SuppressedError/newtarget-proto-fallback.js`<br>`test/built-ins/SuppressedError/newtarget-proto.js`<br>`test/built-ins/SuppressedError/order-of-args-evaluation.js` | SuppressedError preserves message coercion order and creates writable, non-enumerable own error and suppressed properties after an own message property when supplied. Error cause options and custom newTarget prototypes remain limited. |
+
+### 20.5.8.2 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-suppressederror-constructors))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| SuppressedError constructor function surface | Supported | `tests/Jroc.Test262.Tests/built-ins/SuppressedError/ExecutionTests.cs` | `test/built-ins/SuppressedError/is-a-constructor.js`<br>`test/built-ins/SuppressedError/length.js`<br>`test/built-ins/SuppressedError/name.js`<br>`test/built-ins/SuppressedError/prop-desc.js`<br>`test/built-ins/SuppressedError/proto.js` | The global is a constructible function with the standard global property, name, length, prototype descriptor, and Error constructor prototype. |
+
+### 20.5.8.3 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-suppressederror-prototype-objects))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| SuppressedError.prototype surface | Supported | `tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/ExecutionTests.cs` | `test/built-ins/SuppressedError/prototype/constructor.js`<br>`test/built-ins/SuppressedError/prototype/errors-absent-on-prototype.js`<br>`test/built-ins/SuppressedError/prototype/message.js`<br>`test/built-ins/SuppressedError/prototype/name.js`<br>`test/built-ins/SuppressedError/prototype/prop-desc.js`<br>`test/built-ins/SuppressedError/prototype/proto.js` | SuppressedError.prototype inherits Error.prototype and provides the standard constructor, message, and name properties without own error or suppressed properties. |
 

--- a/src/Compiler/IR/BuiltInErrorTypes.cs
+++ b/src/Compiler/IR/BuiltInErrorTypes.cs
@@ -15,6 +15,7 @@ internal static class BuiltInErrorTypes
         ["TypeError"] = typeof(global::JavaScriptRuntime.TypeError),
         ["URIError"] = typeof(global::JavaScriptRuntime.URIError),
         ["AggregateError"] = typeof(global::JavaScriptRuntime.AggregateError),
+        ["SuppressedError"] = typeof(global::JavaScriptRuntime.SuppressedError),
     };
 
     public static bool IsBuiltInErrorTypeName(string name) => NameToClrType.ContainsKey(name);

--- a/src/Compiler/IR/HIR/HIRBuilder.cs
+++ b/src/Compiler/IR/HIR/HIRBuilder.cs
@@ -3960,7 +3960,10 @@ partial class HIRMethodBuilder
                     return true;
                 }
 
-                if (isBuiltInError && newArgExprs.Count > 2)
+                var maximumBuiltInErrorArguments = string.Equals(calleeName, "SuppressedError", StringComparison.Ordinal)
+                    ? 3
+                    : 2;
+                if (isBuiltInError && newArgExprs.Count > maximumBuiltInErrorArguments)
                 {
                     return false;
                 }

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionCall.cs
@@ -295,17 +295,18 @@ public sealed partial class HIRToLIRLowerer
                     {
                         case JavaScriptRuntime.IntrinsicCallKind.BuiltInError:
                             {
-                                if (string.Equals(intrinsicInfo.Name, "AggregateError", StringComparison.Ordinal))
+                                if (string.Equals(intrinsicInfo.Name, "AggregateError", StringComparison.Ordinal)
+                                    || string.Equals(intrinsicInfo.Name, "SuppressedError", StringComparison.Ordinal))
                                 {
-                                    if (!TryEvaluateCallArguments(callExpr.Arguments, callExpr.Arguments.Length, out var aggregateErrorArgs))
+                                    if (!TryLowerCallArgumentsToArgsArray(callExpr.Arguments, out var specialErrorArgs))
                                     {
                                         return false;
                                     }
 
-                                    _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStatic(
-                                        "AggregateError",
+                                    _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStaticWithArgsArray(
+                                        intrinsicInfo.Name,
                                         nameof(JavaScriptRuntime.AggregateError.Construct),
-                                        aggregateErrorArgs,
+                                        specialErrorArgs,
                                         resultTempVar));
                                     DefineTempStorage(resultTempVar, GetBuiltInErrorStorage(intrinsicInfo.Name));
                                     return true;

--- a/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionNew.cs
+++ b/src/Compiler/IR/LIR/HIRToLIRLowerer.ExpressionNew.cs
@@ -84,18 +84,19 @@ public sealed partial class HIRToLIRLowerer
         // PL3.3a: built-in Error types
         if (BuiltInErrorTypes.IsBuiltInErrorTypeName(ctorName))
         {
-            if (string.Equals(ctorName, "AggregateError", StringComparison.Ordinal))
+            if (string.Equals(ctorName, "AggregateError", StringComparison.Ordinal)
+                || string.Equals(ctorName, "SuppressedError", StringComparison.Ordinal))
             {
-                if (!TryEvaluateCallArguments(newExpr.Arguments, newExpr.Arguments.Count, out var aggregateErrorArgs))
+                if (!TryLowerCallArgumentsToArgsArray(newExpr.Arguments, out var errorArgs))
                 {
                     return false;
                 }
 
                 resultTempVar = CreateTempVariable();
-                _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStatic(
-                    "AggregateError",
+                _methodBodyIR.Instructions.Add(new LIRCallIntrinsicStaticWithArgsArray(
+                    ctorName,
                     nameof(JavaScriptRuntime.AggregateError.Construct),
-                    aggregateErrorArgs,
+                    errorArgs,
                     resultTempVar));
                 DefineTempStorage(resultTempVar, GetBuiltInErrorStorage(ctorName));
                 return true;

--- a/src/JavaScriptRuntime/Error.cs
+++ b/src/JavaScriptRuntime/Error.cs
@@ -235,4 +235,54 @@ namespace JavaScriptRuntime
             });
         }
     }
+
+    [IntrinsicObject("SuppressedError", IntrinsicCallKind.BuiltInError)]
+    public class SuppressedError : Error
+    {
+        public object? ErrorValue { get; }
+        public object? SuppressedValue { get; }
+
+        public SuppressedError(object? error, object? suppressed, string? message)
+            : base(message)
+        {
+            Name = "SuppressedError";
+            ErrorValue = error;
+            SuppressedValue = suppressed;
+            InitializeIntrinsicSurface(GlobalThis.SuppressedErrorPrototypeValue);
+        }
+
+        public static SuppressedError Construct(object?[] args)
+        {
+            var errorValue = args.Length > 0 ? args[0] : null;
+            var suppressedValue = args.Length > 1 ? args[1] : null;
+            var hasMessage = args.Length > 2 && args[2] is not null;
+            var message = hasMessage ? CoerceMessage(args[2]) : null;
+            var error = new SuppressedError(errorValue, suppressedValue, message);
+
+            if (hasMessage)
+            {
+                error.InstallDataProperty("message", message);
+            }
+            else
+            {
+                PropertyDescriptorStore.Delete(error, "message");
+            }
+
+            error.InstallDataProperty("error", errorValue);
+            error.InstallDataProperty("suppressed", suppressedValue);
+            return error;
+        }
+
+        private void InstallDataProperty(string name, object? value)
+        {
+            PropertyDescriptorStore.DefineOrUpdate(this, name, new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = true,
+                Value = value
+            });
+        }
+    }
 }

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -290,6 +290,9 @@ namespace JavaScriptRuntime
         private static readonly Func<object[], object?[], object?> _aggregateErrorConstructorValue = static (_, args) =>
             JavaScriptRuntime.AggregateError.Construct(args ?? System.Array.Empty<object?>());
 
+        private static readonly Func<object[], object?[], object?> _suppressedErrorConstructorValue = static (_, args) =>
+            JavaScriptRuntime.SuppressedError.Construct(args ?? System.Array.Empty<object?>());
+
         private static readonly Func<object[], object?[], object?> _iteratorConstructorValue = static (_, __) =>
             throw new TypeError("Iterator is not directly constructible in jroc.");
 
@@ -308,6 +311,7 @@ namespace JavaScriptRuntime
         private static readonly object _typeErrorPrototypeValue = new JsObject();
         private static readonly object _uriErrorPrototypeValue = new JsObject();
         private static readonly object _aggregateErrorPrototypeValue = new JsObject();
+        private static readonly object _suppressedErrorPrototypeValue = new JsObject();
 
         // Minimal Object.prototype object used for descriptor/prototype-heavy libraries.
         // NOTE: We intentionally do not enable PrototypeChain here; Object.create/setPrototypeOf
@@ -689,6 +693,7 @@ namespace JavaScriptRuntime
             ConfigureErrorIntrinsicSurface(_typeErrorConstructorValue, _typeErrorPrototypeValue, "TypeError", parentPrototype: _errorPrototypeValue);
             ConfigureErrorIntrinsicSurface(_uriErrorConstructorValue, _uriErrorPrototypeValue, "URIError", parentPrototype: _errorPrototypeValue);
             ConfigureAggregateErrorIntrinsicSurface();
+            ConfigureSuppressedErrorIntrinsicSurface();
 
             PropertyDescriptorStore.DefineOrUpdate(_booleanPrototypeValue, "constructor", new JsPropertyDescriptor
             {
@@ -1379,6 +1384,9 @@ namespace JavaScriptRuntime
             dict.TryAdd(nameof(GlobalThis.AggregateError), AggregateError);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.AggregateError), dict[nameof(GlobalThis.AggregateError)]);
 
+            dict.TryAdd(nameof(GlobalThis.SuppressedError), SuppressedError);
+            DefineNonEnumerableDataProperty(nameof(GlobalThis.SuppressedError), dict[nameof(GlobalThis.SuppressedError)]);
+
             dict.TryAdd(nameof(GlobalThis.Iterator), Iterator);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.Iterator), dict[nameof(GlobalThis.Iterator)]);
 
@@ -1668,6 +1676,8 @@ namespace JavaScriptRuntime
         public static Func<object[], object?[], object?> URIError => _uriErrorConstructorValue;
 
         public static Func<object[], object?[], object?> AggregateError => _aggregateErrorConstructorValue;
+
+        public static Func<object[], object?[], object?> SuppressedError => _suppressedErrorConstructorValue;
 
         public static Func<object[], object?[], object?> Iterator => _iteratorConstructorValue;
 
@@ -2307,6 +2317,7 @@ namespace JavaScriptRuntime
         internal static object TypeErrorPrototypeValue => _typeErrorPrototypeValue;
         internal static object URIErrorPrototypeValue => _uriErrorPrototypeValue;
         internal static object AggregateErrorPrototypeValue => _aggregateErrorPrototypeValue;
+        internal static object SuppressedErrorPrototypeValue => _suppressedErrorPrototypeValue;
         private static Func<object[], object?[], object?> CreateErrorConstructorValue(Func<string?, object> factory)
         {
             return (_, args) =>
@@ -2396,6 +2407,33 @@ namespace JavaScriptRuntime
             });
         }
 
+        private static void ConfigureSuppressedErrorIntrinsicSurface()
+        {
+            ConfigureErrorIntrinsicSurface(
+                _suppressedErrorConstructorValue,
+                _suppressedErrorPrototypeValue,
+                "SuppressedError",
+                _errorPrototypeValue);
+            PrototypeChain.SetPrototype(_suppressedErrorConstructorValue, _errorConstructorValue);
+
+            PropertyDescriptorStore.DefineOrUpdate(_suppressedErrorConstructorValue, "length", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = false,
+                Value = 3d
+            });
+            PropertyDescriptorStore.DefineOrUpdate(_suppressedErrorConstructorValue, "prototype", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = false,
+                Writable = false,
+                Value = _suppressedErrorPrototypeValue
+            });
+        }
+
         internal static void AssignBuiltInErrorPrototype(JavaScriptRuntime.Error error)
         {
             ArgumentNullException.ThrowIfNull(error);
@@ -2410,6 +2448,7 @@ namespace JavaScriptRuntime
                 JavaScriptRuntime.TypeError => _typeErrorPrototypeValue,
                 JavaScriptRuntime.URIError => _uriErrorPrototypeValue,
                 JavaScriptRuntime.AggregateError => _aggregateErrorPrototypeValue,
+                JavaScriptRuntime.SuppressedError => _suppressedErrorPrototypeValue,
                 _ => _errorPrototypeValue
             };
 

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/ExecutionTests.cs
@@ -1,0 +1,50 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.SuppressedError;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.SuppressedError") { }
+
+    [Fact(DisplayName = "is-a-constructor.js")]
+    public Task is_a_constructor() => ExecutionTestFromFile("is-a-constructor");
+
+    [Fact(DisplayName = "length.js")]
+    public Task length() => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "message-method-prop-cast.js")]
+    public Task message_method_prop_cast() => ExecutionTestFromFile("message-method-prop-cast");
+
+    [Fact(DisplayName = "message-method-prop.js")]
+    public Task message_method_prop() => ExecutionTestFromFile("message-method-prop");
+
+    [Fact(DisplayName = "message-tostring-abrupt.js")]
+    public Task message_tostring_abrupt() => ExecutionTestFromFile("message-tostring-abrupt");
+
+    [Fact(DisplayName = "message-tostring-abrupt-symbol.js")]
+    public Task message_tostring_abrupt_symbol() => ExecutionTestFromFile("message-tostring-abrupt-symbol");
+
+    [Fact(DisplayName = "message-undefined-no-prop.js")]
+    public Task message_undefined_no_prop() => ExecutionTestFromFile("message-undefined-no-prop");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "newtarget-is-undefined.js")]
+    public Task newtarget_is_undefined() => ExecutionTestFromFile("newtarget-is-undefined");
+
+    [Fact(DisplayName = "newtarget-proto-fallback.js")]
+    public Task newtarget_proto_fallback() => ExecutionTestFromFile("newtarget-proto-fallback");
+
+    [Fact(DisplayName = "newtarget-proto.js")]
+    public Task newtarget_proto() => ExecutionTestFromFile("newtarget-proto");
+
+    [Fact(DisplayName = "order-of-args-evaluation.js")]
+    public Task order_of_args_evaluation() => ExecutionTestFromFile("order-of-args-evaluation");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+
+    [Fact(DisplayName = "proto.js")]
+    public Task proto() => ExecutionTestFromFile("proto");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/is-a-constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/is-a-constructor.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  The SuppressedError constructor implements [[Construct]]
+info: |
+  IsConstructor ( argument )
+
+  The abstract operation IsConstructor takes argument argument (an ECMAScript language value).
+  It determines if argument is a function object with a [[Construct]] internal method.
+  It performs the following steps when called:
+
+  If Type(argument) is not Object, return false.
+  If argument has a [[Construct]] internal method, return true.
+  Return false.
+includes: [isConstructor.js]
+features: [Reflect.construct, explicit-resource-management]
+---*/
+
+assert.sameValue(isConstructor(SuppressedError), true, 'isConstructor(SuppressedError) must return true');
+new SuppressedError();
+

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-suppressederror-constructors
+description: SuppressedError.length property descriptor
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError, 'length', {
+  value: 3,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/message-method-prop-cast.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/message-method-prop-cast.js
@@ -1,0 +1,69 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Cast ToString values of message in the created method property
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+
+  CreateMethodProperty ( O, P, V )
+
+  ...
+  3. Let newDesc be the PropertyDescriptor { [[Value]]: V, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.
+  4. Return ? O.[[DefineOwnProperty]](P, newDesc).
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+var case1 = new SuppressedError(undefined, undefined, 42);
+
+verifyProperty(case1, 'message', {
+  value: '42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var case2 = new SuppressedError(undefined, undefined, false);
+
+verifyProperty(case2, 'message', {
+  value: 'false',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var case3 = new SuppressedError(undefined, undefined, true);
+
+verifyProperty(case3, 'message', {
+  value: 'true',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var case4 = new SuppressedError(undefined, undefined, { toString() { return 'string'; }});
+
+verifyProperty(case4, 'message', {
+  value: 'string',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});
+
+var case5 = new SuppressedError(undefined, undefined, null);
+
+verifyProperty(case5, 'message', {
+  value: 'null',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/message-method-prop.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/message-method-prop.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Creates a method property for message
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+
+  CreateMethodProperty ( O, P, V )
+
+  ...
+  3. Let newDesc be the PropertyDescriptor { [[Value]]: V, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }.
+  4. Return ? O.[[DefineOwnProperty]](P, newDesc).
+features: [explicit-resource-management]
+includes: [propertyHelper.js]
+---*/
+
+var obj = new SuppressedError(undefined, undefined, '42');
+
+verifyProperty(obj, 'message', {
+  value: '42',
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/message-tostring-abrupt-symbol.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/message-tostring-abrupt-symbol.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Abrupt completions of ToString(Symbol message)
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+features: [explicit-resource-management, Symbol, Symbol.toPrimitive]
+---*/
+
+var case1 = Symbol();
+
+assert.throws(TypeError, () => {
+  new SuppressedError(undefined, undefined, case1);
+}, 'toPrimitive');
+
+var case2 = {
+  [Symbol.toPrimitive]() {
+    return Symbol();
+  },
+  toString() {
+    throw new Test262Error();
+  },
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(TypeError, () => {
+  new SuppressedError(undefined, undefined, case2);
+}, 'from ToPrimitive');

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/message-tostring-abrupt.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/message-tostring-abrupt.js
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Abrupt completions of ToString(message)
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+features: [explicit-resource-management, Symbol.toPrimitive]
+---*/
+
+var case1 = {
+  [Symbol.toPrimitive]() {
+    throw new Test262Error();
+  },
+  toString() {
+    throw 'toString called';
+  },
+  valueOf() {
+    throw 'valueOf called';
+  }
+};
+
+assert.throws(Test262Error, () => {
+  new SuppressedError(undefined, undefined, case1);
+}, 'toPrimitive');
+
+var case2 = {
+  [Symbol.toPrimitive]: undefined,
+  toString() {
+    throw new Test262Error();
+  },
+  valueOf() {
+    throw 'valueOf called';
+  }
+};
+
+assert.throws(Test262Error, () => {
+  new SuppressedError(undefined, undefined, case2);
+}, 'toString');
+
+var case3 = {
+  [Symbol.toPrimitive]: undefined,
+  toString: undefined,
+  valueOf() {
+    throw new Test262Error();
+  }
+};
+
+assert.throws(Test262Error, () => {
+  new SuppressedError(undefined, undefined, case3);
+}, 'valueOf');

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/message-undefined-no-prop.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/message-undefined-no-prop.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  If message is undefined, no property will be set to the new instance
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  ...
+  5. If message is not undefined, then
+    a. Let msg be ? ToString(message).
+    b. Perform ! CreateMethodProperty(O, "message", msg).
+  6. Return O.
+features: [explicit-resource-management]
+---*/
+
+var case1 = new SuppressedError(undefined, undefined, undefined);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(case1, 'message'),
+  false,
+  'explicit'
+);
+
+var case2 = new SuppressedError([]);
+
+assert.sameValue(
+  Object.prototype.hasOwnProperty.call(case2, 'message'),
+  false,
+  'implicit'
+);

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/name.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-suppressederror-constructor
+description: SuppressedError.name property descriptor
+info: |
+  Properties of the SuppressedError Constructor
+
+  - has a name property whose value is the String value "SuppressedError".
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError, 'name', {
+  value: 'SuppressedError',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/newtarget-is-undefined.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/newtarget-is-undefined.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  NewTarget is undefined
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
+
+features: [explicit-resource-management]
+---*/
+
+var obj = SuppressedError();
+
+assert.sameValue(Object.getPrototypeOf(obj), SuppressedError.prototype);
+assert(obj instanceof SuppressedError);

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/newtarget-proto-fallback.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/newtarget-proto-fallback.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Fallback to the NewTarget's [[Prototype]] if the prototype property is not an object
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
+  2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%SuppressedError.prototype%", « [[ErrorData]], [[AggregateErrors]] »).
+  ...
+  6. Return O.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  ...
+  3. Let proto be ? Get(constructor, "prototype").
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  Return proto.
+features: [explicit-resource-management, Symbol]
+---*/
+
+const values = [
+  undefined,
+  null,
+  42,
+  false,
+  true,
+  Symbol(),
+  'string',
+  SuppressedError.prototype,
+];
+
+const NewTarget = new Function();
+
+for (const value of values) {
+  const NewTargetProxy = new Proxy(NewTarget, {
+    get(t, p) {
+      if (p === 'prototype') {
+        return value;
+      }
+      return t[p];
+    }
+  });
+
+  const error = Reflect.construct(SuppressedError, [], NewTargetProxy);
+  assert.sameValue(Object.getPrototypeOf(error), SuppressedError.prototype);
+}

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/newtarget-proto.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/newtarget-proto.js
@@ -1,0 +1,35 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Default prototype is the %SuppressedError.prototype%"
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
+  2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%SuppressedError.prototype%", « [[ErrorData]], [[AggregateErrors]] »).
+  ...
+  6. Return O.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  ...
+  3. Let proto be ? Get(constructor, "prototype").
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  Return proto.
+features: [explicit-resource-management]
+---*/
+
+var obj = new SuppressedError();
+
+assert.sameValue(Object.getPrototypeOf(obj), SuppressedError.prototype);

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/order-of-args-evaluation.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/order-of-args-evaluation.js
@@ -1,0 +1,44 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-constructor
+description: >
+  Process arguments in superclass-then-subclass order
+info: |
+  SuppressedError ( error, suppressed, message )
+
+  3. If message is not undefined, then
+    a. Let messageString be ? ToString(message).
+    b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "message", messageString).
+  4. Perform CreateNonEnumerableDataPropertyOrThrow(O, "error", error).
+  5. Perform CreateNonEnumerableDataPropertyOrThrow(O, "suppressed", suppressed).
+
+features: [explicit-resource-management, Symbol.iterator]
+---*/
+
+let messageStringified = false;
+const message = {
+  toString() {
+    messageStringified = true;
+    return '';
+  }
+};
+const error = {};
+const suppressed = {};
+
+const e = new SuppressedError(error, suppressed, message);
+
+assert.sameValue(messageStringified, true);
+const keys = Object.getOwnPropertyNames(e);
+
+// Allow implementation-defined properties before "message" and after "suppressed".
+
+const messageIndex = keys.indexOf("message");
+assert.notSameValue(messageIndex, -1, "Expected 'message' to be defined");
+
+const errorIndex = keys.indexOf("error");
+assert.sameValue(errorIndex, messageIndex + 1, "Expected 'error' to be defined after 'message'");
+
+const suppressedIndex = keys.indexOf("suppressed");
+assert.sameValue(suppressedIndex, errorIndex + 1, "Expected 'suppressed' to be defined after 'error'");

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/prop-desc.js
@@ -1,0 +1,26 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror-objects
+description: >
+  Property descriptor of SuppressedError
+info: |
+  SuppressedError Objects
+
+  ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof SuppressedError, 'function');
+
+verifyProperty(this, 'SuppressedError', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/proto.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/JavaScript/proto.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The prototype of SuppressedError constructor is Error
+esid: sec-properties-of-the-suppressederror-constructors
+info: |
+  Properties of the SuppressedError Constructor
+
+  - has a [[Prototype]] internal slot whose value is the intrinsic object %Error%.
+features: [explicit-resource-management]
+---*/
+
+var proto = Object.getPrototypeOf(SuppressedError);
+
+assert.sameValue(proto, Error);

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/ExecutionTests.cs
@@ -1,0 +1,26 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.SuppressedError.prototype;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.SuppressedError.prototype") { }
+
+    [Fact(DisplayName = "constructor.js")]
+    public Task constructor() => ExecutionTestFromFile("constructor");
+
+    [Fact(DisplayName = "errors-absent-on-prototype.js")]
+    public Task errors_absent_on_prototype() => ExecutionTestFromFile("errors-absent-on-prototype");
+
+    [Fact(DisplayName = "message.js")]
+    public Task message() => ExecutionTestFromFile("message");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+
+    [Fact(DisplayName = "proto.js")]
+    public Task proto() => ExecutionTestFromFile("proto");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/JavaScript/constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/JavaScript/constructor.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-suppressederror.prototype.constructor
+description: >
+  The `SuppressedError.prototype.constructor` property descriptor.
+info: |
+  The initial value of SuppressedError.prototype.constructor is the intrinsic
+  object %SuppressedError%.
+
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described (...) has the attributes { [[Writable]]: true,
+    [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError.prototype, 'constructor', {
+  value: SuppressedError,
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/JavaScript/errors-absent-on-prototype.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/JavaScript/errors-absent-on-prototype.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-suppressederror-prototype-objects
+description: >
+  The SuppressedError prototype object isn't an SuppressedError instance.
+info: |
+  Properties of the SuppressedError Prototype Object
+
+  The SuppressedError prototype object:
+    ...
+    - is not an Error instance or an SuppressedError instance and does not have an
+      [[ErrorData]] internal slot.
+    ...
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(SuppressedError.prototype.hasOwnProperty("error"), false);
+assert.sameValue(SuppressedError.prototype.hasOwnProperty("suppressed"), false);

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/JavaScript/message.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/JavaScript/message.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error.prototype.message
+description: >
+  The `SuppressedError.prototype.message` property descriptor.
+info: |
+  The initial value of the message property of the prototype for a given SuppressedError
+  constructor is the empty String.
+
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described (...) has the attributes { [[Writable]]: true,
+    [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError.prototype, 'message', {
+  value: '',
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/JavaScript/name.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error.prototype.name
+description: >
+  The `SuppressedError.prototype.name` property descriptor.
+info: |
+  The initial value of SuppressedError.prototype.name is "SuppressedError".
+
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described (...) has the attributes { [[Writable]]: true,
+    [[Enumerable]]: false, [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+verifyProperty(SuppressedError.prototype, 'name', {
+  value: 'SuppressedError',
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/JavaScript/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-aggregate-error.prototype
+description: >
+  Property descriptor of SuppressedError.prototype
+info: |
+  SuppressedError.prototype
+
+  The initial value of SuppressedError.prototype is the intrinsic object %AggregateErrorPrototype%.
+
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }.
+includes: [propertyHelper.js]
+features: [explicit-resource-management]
+---*/
+
+assert.sameValue(typeof SuppressedError.prototype, 'object');
+
+verifyProperty(SuppressedError, 'prototype', {
+  enumerable: false,
+  writable: false,
+  configurable: false
+});

--- a/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/JavaScript/proto.js
+++ b/tests/Jroc.Test262.Tests/built-ins/SuppressedError/prototype/JavaScript/proto.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2023 Ron Buckton. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-suppressederror-prototype-objects
+description: The prototype of SuppressedError.prototype constructor is Error.prototype
+info: |
+  Properties of the SuppressedError Prototype Object
+
+  - has a [[Prototype]] internal slot whose value is the intrinsic object %Error.prototype%.
+features: [explicit-resource-management]
+---*/
+
+var proto = Object.getPrototypeOf(SuppressedError.prototype);
+
+assert.sameValue(proto, Error.prototype);


### PR DESCRIPTION
## Summary
- add the ES2024 `SuppressedError` global, constructor/prototype surface, and ordered own `message`, `error`, and `suppressed` properties
- port 20 byte-identical pinned test262 fixtures across constructor and prototype behavior
- document §20.5 support and limitations

## Validation
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --filter 'FullyQualifiedName~AggregateError|FullyQualifiedName~SuppressedError' --no-restore` (40 passed)

Generator snapshots will be updated through the **Update generator snapshots** workflow.
