### PR TITLE
feat(runtime): expose WeakRef global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime/test262: expose WeakRef as a first-class global constructor with
+  standard constructor/prototype metadata and `deref()` behavior. Weak-target
+  eligibility now correctly rejects registered symbols. Activates twenty
+  corresponding pinned test262 fixtures.
+
 - compiler/runtime/test262: add the ES2024 SuppressedError global with standard
   constructor/prototype metadata and ordered own `message`, `error`, and
   `suppressed` properties. Activates twenty corresponding pinned test262

--- a/docs/ECMA262/19/Section19_3.json
+++ b/docs/ECMA262/19/Section19_3.json
@@ -370,13 +370,14 @@
       },
       {
         "clause": "19.3.41",
-        "feature": "WeakRef constructible global baseline",
+        "feature": "WeakRef first-class global constructor",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-weakref",
         "testScripts": [
-          "tests/Jroc.Tests/WeakRef/JavaScript/WeakRef_Deref_KeptObjects.js"
+          "tests/Jroc.Test262.Tests/built-ins/WeakRef/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/ExecutionTests.cs"
         ],
-        "notes": "Supports `new WeakRef(target)` in construct positions plus `deref()` and kept-object behavior. jroc does not yet expose a full first-class `globalThis.WeakRef` constructor/prototype object, and deterministic collection in tests uses a host-opt-in non-standard global `gc()` helper."
+        "notes": "Exposes globalThis.WeakRef as a constructible function with the standard constructor/prototype metadata and deref() surface. Deterministic collection in tests still uses a host-opt-in non-standard global gc() helper, while custom newTarget prototypes and cross-realm construction remain limited."
       },
       {
         "clause": "19.3.42",

--- a/docs/ECMA262/19/Section19_3.md
+++ b/docs/ECMA262/19/Section19_3.md
@@ -4,7 +4,7 @@
 
 [Back to Section19](Section19.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-05-24T19:56:40Z
+> Last generated (UTC): 2026-08-15T05:05:31Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -119,7 +119,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| WeakRef constructible global baseline | Supported with Limitations | [`WeakRef_Deref_KeptObjects.js`](../../../tests/Jroc.Tests/WeakRef/JavaScript/WeakRef_Deref_KeptObjects.js) |  | Supports `new WeakRef(target)` in construct positions plus `deref()` and kept-object behavior. jroc does not yet expose a full first-class `globalThis.WeakRef` constructor/prototype object, and deterministic collection in tests uses a host-opt-in non-standard global `gc()` helper. |
+| WeakRef first-class global constructor | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/WeakRef/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/ExecutionTests.cs` |  | Exposes globalThis.WeakRef as a constructible function with the standard constructor/prototype metadata and deref() surface. Deterministic collection in tests still uses a host-opt-in non-standard global gc() helper, while custom newTarget prototypes and cross-realm construction remain limited. |
 
 ### 19.3.42 ([tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-weakset))
 

--- a/docs/ECMA262/26/Section26_1.json
+++ b/docs/ECMA262/26/Section26_1.json
@@ -24,37 +24,37 @@
     {
       "clause": "26.1.2",
       "title": "Properties of the WeakRef Constructor",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-constructor"
     },
     {
       "clause": "26.1.2.1",
       "title": "WeakRef.prototype",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-weak-ref.prototype"
     },
     {
       "clause": "26.1.3",
       "title": "Properties of the WeakRef Prototype Object",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-prototype-object"
     },
     {
       "clause": "26.1.3.1",
       "title": "WeakRef.prototype.constructor",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-weak-ref.prototype.constructor"
     },
     {
       "clause": "26.1.3.2",
       "title": "WeakRef.prototype.deref ( )",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-weak-ref.prototype.deref"
     },
     {
       "clause": "26.1.3.3",
       "title": "WeakRef.prototype [ %Symbol.toStringTag% ]",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-weak-ref.prototype-%symbol.tostringtag%"
     },
     {
@@ -79,14 +79,61 @@
   "support": {
     "entries": [
       {
-        "clause": "26.1",
-        "feature": "WeakRef constructor, deref(), and kept-object baseline",
+        "clause": "26.1.1.1",
+        "feature": "WeakRef construction and weak-target validation",
         "status": "Supported with Limitations",
-        "specUrl": "https://tc39.es/ecma262/#sec-weak-ref-objects",
+        "specUrl": "https://tc39.es/ecma262/#sec-weak-ref-target",
         "testScripts": [
-          "tests/Jroc.Tests/WeakRef/JavaScript/WeakRef_Deref_KeptObjects.js"
+          "tests/Jroc.Test262.Tests/built-ins/WeakRef/ExecutionTests.cs"
         ],
-        "notes": "Supports `new WeakRef(target)` in construct positions, `deref()`, and `%Symbol.toStringTag%` via instance-level descriptor wiring. `deref()` adds live targets to a host-kept set until the next cleanup checkpoint, and tests use a host-opt-in non-standard global `gc()` helper to force deterministic collection. jroc does not yet expose a full first-class `WeakRef` constructor/prototype object on `globalThis`."
+        "test262Paths": [
+          "test/built-ins/WeakRef/newtarget-prototype-is-not-object.js",
+          "test/built-ins/WeakRef/throws-when-target-cannot-be-held-weakly.js",
+          "test/built-ins/WeakRef/undefined-newtarget-throws.js"
+        ],
+        "notes": "Supports construction only with new, rejects primitives and registered symbols as targets, and uses the intrinsic WeakRef prototype when a newTarget prototype is not an object. Custom newTarget prototypes and cross-realm construction remain limited."
+      },
+      {
+        "clause": "26.1.2",
+        "feature": "WeakRef constructor function surface",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-constructor",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/WeakRef/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/WeakRef/constructor.js",
+          "test/built-ins/WeakRef/is-a-constructor.js",
+          "test/built-ins/WeakRef/length.js",
+          "test/built-ins/WeakRef/name.js",
+          "test/built-ins/WeakRef/prop-desc.js",
+          "test/built-ins/WeakRef/proto.js"
+        ],
+        "notes": "globalThis.WeakRef is a constructible function with standard name, length, global-property, and prototype descriptors."
+      },
+      {
+        "clause": "26.1.3",
+        "feature": "WeakRef.prototype and deref() surface",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-prototype-object",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/WeakRef/prototype/constructor.js",
+          "test/built-ins/WeakRef/prototype/prop-desc.js",
+          "test/built-ins/WeakRef/prototype/proto.js",
+          "test/built-ins/WeakRef/prototype/Symbol.toStringTag.js",
+          "test/built-ins/WeakRef/prototype/deref/custom-this.js",
+          "test/built-ins/WeakRef/prototype/deref/length.js",
+          "test/built-ins/WeakRef/prototype/deref/name.js",
+          "test/built-ins/WeakRef/prototype/deref/not-a-constructor.js",
+          "test/built-ins/WeakRef/prototype/deref/prop-desc.js",
+          "test/built-ins/WeakRef/prototype/deref/this-does-not-have-internal-target-throws.js",
+          "test/built-ins/WeakRef/prototype/deref/this-not-object-throws.js"
+        ],
+        "notes": "WeakRef.prototype inherits Object.prototype and owns constructor, deref, and @@toStringTag properties. deref is non-constructible, supports explicit receivers, and rejects incompatible receivers."
       }
     ]
   }

--- a/docs/ECMA262/26/Section26_1.md
+++ b/docs/ECMA262/26/Section26_1.md
@@ -4,7 +4,7 @@
 
 [Back to Section26](Section26.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-03-10T00:19:15Z
+> Last generated (UTC): 2026-08-15T05:05:31Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -16,23 +16,35 @@
 |---:|---|---|---|
 | 26.1.1 | The WeakRef Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref-constructor) |
 | 26.1.1.1 | WeakRef ( target ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref-target) |
-| 26.1.2 | Properties of the WeakRef Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-constructor) |
-| 26.1.2.1 | WeakRef.prototype | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref.prototype) |
-| 26.1.3 | Properties of the WeakRef Prototype Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-prototype-object) |
-| 26.1.3.1 | WeakRef.prototype.constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref.prototype.constructor) |
-| 26.1.3.2 | WeakRef.prototype.deref ( ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref.prototype.deref) |
-| 26.1.3.3 | WeakRef.prototype [ %Symbol.toStringTag% ] | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref.prototype-%symbol.tostringtag%) |
+| 26.1.2 | Properties of the WeakRef Constructor | Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-constructor) |
+| 26.1.2.1 | WeakRef.prototype | Supported | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref.prototype) |
+| 26.1.3 | Properties of the WeakRef Prototype Object | Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-prototype-object) |
+| 26.1.3.1 | WeakRef.prototype.constructor | Supported | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref.prototype.constructor) |
+| 26.1.3.2 | WeakRef.prototype.deref ( ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref.prototype.deref) |
+| 26.1.3.3 | WeakRef.prototype [ %Symbol.toStringTag% ] | Supported | [tc39.es](https://tc39.es/ecma262/#sec-weak-ref.prototype-%symbol.tostringtag%) |
 | 26.1.4 | WeakRef Abstract Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakref-abstract-operations) |
 | 26.1.4.1 | WeakRefDeref ( weakRef ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-weakrefderef) |
 | 26.1.5 | Properties of WeakRef Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-weak-ref-instances) |
 
 ## Support
 
-Feature-level support tracking with test script references.
+Feature-level support tracking with repo test references and optional test262 evidence.
 
-### 26.1 ([tc39.es](https://tc39.es/ecma262/#sec-weak-ref-objects))
+### 26.1.1.1 ([tc39.es](https://tc39.es/ecma262/#sec-weak-ref-target))
 
-| Feature name | Status | Test scripts | Notes |
-|---|---|---|---|
-| WeakRef constructor, deref(), and kept-object baseline | Supported with Limitations | [`WeakRef_Deref_KeptObjects.js`](../../../tests/Jroc.Tests/WeakRef/JavaScript/WeakRef_Deref_KeptObjects.js) | Supports `new WeakRef(target)` in construct positions, `deref()`, and `%Symbol.toStringTag%` via instance-level descriptor wiring. `deref()` adds live targets to a host-kept set until the next cleanup checkpoint, and tests use a host-opt-in non-standard global `gc()` helper to force deterministic collection. jroc does not yet expose a full first-class `WeakRef` constructor/prototype object on `globalThis`. |
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| WeakRef construction and weak-target validation | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/WeakRef/ExecutionTests.cs` | `test/built-ins/WeakRef/newtarget-prototype-is-not-object.js`<br>`test/built-ins/WeakRef/throws-when-target-cannot-be-held-weakly.js`<br>`test/built-ins/WeakRef/undefined-newtarget-throws.js` | Supports construction only with new, rejects primitives and registered symbols as targets, and uses the intrinsic WeakRef prototype when a newTarget prototype is not an object. Custom newTarget prototypes and cross-realm construction remain limited. |
+
+### 26.1.2 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-constructor))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| WeakRef constructor function surface | Supported | `tests/Jroc.Test262.Tests/built-ins/WeakRef/ExecutionTests.cs` | `test/built-ins/WeakRef/constructor.js`<br>`test/built-ins/WeakRef/is-a-constructor.js`<br>`test/built-ins/WeakRef/length.js`<br>`test/built-ins/WeakRef/name.js`<br>`test/built-ins/WeakRef/prop-desc.js`<br>`test/built-ins/WeakRef/proto.js` | globalThis.WeakRef is a constructible function with standard name, length, global-property, and prototype descriptors. |
+
+### 26.1.3 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-weak-ref-prototype-object))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| WeakRef.prototype and deref() surface | Supported | `tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/ExecutionTests.cs` | `test/built-ins/WeakRef/prototype/constructor.js`<br>`test/built-ins/WeakRef/prototype/prop-desc.js`<br>`test/built-ins/WeakRef/prototype/proto.js`<br>`test/built-ins/WeakRef/prototype/Symbol.toStringTag.js`<br>`test/built-ins/WeakRef/prototype/deref/custom-this.js`<br>`test/built-ins/WeakRef/prototype/deref/length.js`<br>`test/built-ins/WeakRef/prototype/deref/name.js`<br>`test/built-ins/WeakRef/prototype/deref/not-a-constructor.js`<br>`test/built-ins/WeakRef/prototype/deref/prop-desc.js`<br>`test/built-ins/WeakRef/prototype/deref/this-does-not-have-internal-target-throws.js`<br>`test/built-ins/WeakRef/prototype/deref/this-not-object-throws.js` | WeakRef.prototype inherits Object.prototype and owns constructor, deref, and @@toStringTag properties. deref is non-constructible, supports explicit receivers, and rejects incompatible receivers. |
 

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -178,6 +178,16 @@ namespace JavaScriptRuntime
             return new JavaScriptRuntime.WeakSet(iterable);
         };
 
+        private static readonly JsFuncNoScopes1 _weakRefConstructorValue = static (newTarget, target) =>
+        {
+            if (newTarget is null)
+            {
+                throw new TypeError("Constructor WeakRef requires 'new'");
+            }
+
+            return new JavaScriptRuntime.WeakRef(target);
+        };
+
         private static readonly JsFuncNoScopes1 _promiseConstructorValue = static (newTarget, executor) =>
         {
             if (newTarget is null)
@@ -491,6 +501,7 @@ namespace JavaScriptRuntime
             ConfigureCollectionIntrinsicSurface(_setConstructorValue, JavaScriptRuntime.Set.Prototype);
             ConfigureCollectionIntrinsicSurface(_weakMapConstructorValue, JavaScriptRuntime.WeakMap.Prototype);
             ConfigureCollectionIntrinsicSurface(_weakSetConstructorValue, JavaScriptRuntime.WeakSet.Prototype);
+            ConfigureWeakRefIntrinsicSurface();
             ConfigureCollectionConstructorMetadata(_mapConstructorValue, "Map");
             ConfigureCollectionConstructorMetadata(_setConstructorValue, "Set");
             ConfigureCollectionConstructorMetadata(_weakMapConstructorValue, "WeakMap");
@@ -1339,6 +1350,9 @@ namespace JavaScriptRuntime
             dict.TryAdd(nameof(GlobalThis.WeakSet), WeakSet);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.WeakSet), dict[nameof(GlobalThis.WeakSet)]);
 
+            dict.TryAdd(nameof(GlobalThis.WeakRef), WeakRef);
+            DefineNonEnumerableDataProperty(nameof(GlobalThis.WeakRef), dict[nameof(GlobalThis.WeakRef)]);
+
             dict.TryAdd(nameof(GlobalThis.Object), Object);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.Object), dict[nameof(GlobalThis.Object)]);
 
@@ -1641,6 +1655,8 @@ namespace JavaScriptRuntime
         public static Delegate WeakMap => _weakMapConstructorValue;
 
         public static Delegate WeakSet => _weakSetConstructorValue;
+
+        public static Delegate WeakRef => _weakRefConstructorValue;
 
         public static Func<object[], object?, object> Object => _objectConstructorValue;
 
@@ -2171,6 +2187,27 @@ namespace JavaScriptRuntime
         {
             ConfigureConstructorPrototypeSurface(constructorValue, prototypeValue);
             DefineSpeciesAccessorProperty(constructorValue);
+        }
+
+        private static void ConfigureWeakRefIntrinsicSurface()
+        {
+            ConfigureConstructorPrototypeSurface(_weakRefConstructorValue, JavaScriptRuntime.WeakRef.Prototype);
+            PropertyDescriptorStore.DefineOrUpdate(_weakRefConstructorValue, "length", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = false,
+                Value = 1d
+            });
+            PropertyDescriptorStore.DefineOrUpdate(_weakRefConstructorValue, "name", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = false,
+                Value = "WeakRef"
+            });
         }
 
         private static void DefineSpeciesAccessorProperty(object constructorValue)

--- a/src/JavaScriptRuntime/Symbol.cs
+++ b/src/JavaScriptRuntime/Symbol.cs
@@ -177,6 +177,14 @@ public sealed class Symbol
     public static bool IsWellKnown(string name)
         => GetWellKnown(name) != null;
 
+    internal static bool IsRegistered(Symbol symbol)
+    {
+        lock (_registryLock)
+        {
+            return _globalRegistryReverse.ContainsKey(symbol);
+        }
+    }
+
     // Useful for debugging, but keep ToString() JS-like.
     public string DebugId => _debugId;
 }

--- a/src/JavaScriptRuntime/TypeUtilities.cs
+++ b/src/JavaScriptRuntime/TypeUtilities.cs
@@ -27,11 +27,15 @@ namespace JavaScriptRuntime
         }
 
         /// <summary>
-        /// Best-effort runtime approximation of ECMA-262 CanBeHeldWeakly.
-        /// JROC currently treats non-null reference types (including symbols/functions) as weakly holdable.
+        /// ECMA-262 CanBeHeldWeakly accepts objects plus non-registered symbols.
         /// </summary>
         public static bool CanBeHeldWeakly(object? value)
         {
+            if (value is JavaScriptRuntime.Symbol symbol)
+            {
+                return !JavaScriptRuntime.Symbol.IsRegistered(symbol);
+            }
+
             return IsConstructorReturnOverride(value);
         }
 

--- a/src/JavaScriptRuntime/WeakRef.cs
+++ b/src/JavaScriptRuntime/WeakRef.cs
@@ -5,7 +5,12 @@ namespace JavaScriptRuntime
     [IntrinsicObject("WeakRef")]
     public sealed class WeakRef
     {
+        internal static readonly object Prototype = CreatePrototype();
         private readonly WeakReference<object> _target;
+
+        public WeakRef() : this(null)
+        {
+        }
 
         public WeakRef(object? target)
         {
@@ -36,7 +41,33 @@ namespace JavaScriptRuntime
 
         private void InitializeIntrinsicSurface()
         {
-            PropertyDescriptorStore.DefineOrUpdate(this, Symbol.toStringTag.DebugId, new JsPropertyDescriptor
+            PrototypeChain.SetPrototype(this, Prototype);
+        }
+
+        private static object CreatePrototype()
+        {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
+            var prototype = new JsObject();
+            Func<object[], object?[]?, object?> deref = PrototypeDeref;
+            Function.InitializeFunctionInstance(deref, 0d, "deref");
+            PropertyDescriptorStore.DefineOrUpdate(deref, "prototype", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = false,
+                Writable = false,
+                Value = null
+            });
+            PropertyDescriptorStore.DefineOrUpdate(prototype, "deref", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = true,
+                Value = deref
+            });
+            PropertyDescriptorStore.DefineOrUpdate(prototype, Symbol.toStringTag.DebugId, new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Data,
                 Enumerable = false,
@@ -44,6 +75,17 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = "WeakRef"
             });
+            return prototype;
+        }
+
+        private static object? PrototypeDeref(object[] scopes, object?[]? args)
+        {
+            if (RuntimeServices.GetCurrentThis() is not WeakRef weakRef)
+            {
+                throw new TypeError("WeakRef.prototype.deref called on incompatible receiver");
+            }
+
+            return weakRef.deref();
         }
     }
 }

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/ExecutionTests.cs
@@ -1,0 +1,37 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.WeakRef;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.WeakRef") { }
+
+    [Fact(DisplayName = "constructor.js")]
+    public Task constructor() => ExecutionTestFromFile("constructor");
+
+    [Fact(DisplayName = "is-a-constructor.js")]
+    public Task is_a_constructor() => ExecutionTestFromFile("is-a-constructor");
+
+    [Fact(DisplayName = "length.js")]
+    public Task length() => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "newtarget-prototype-is-not-object.js")]
+    public Task newtarget_prototype_is_not_object()
+        => ExecutionTestFromFile("newtarget-prototype-is-not-object");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+
+    [Fact(DisplayName = "proto.js")]
+    public Task proto() => ExecutionTestFromFile("proto");
+
+    [Fact(DisplayName = "throws-when-target-cannot-be-held-weakly.js")]
+    public Task throws_when_target_cannot_be_held_weakly()
+        => ExecutionTestFromFile("throws-when-target-cannot-be-held-weakly");
+
+    [Fact(DisplayName = "undefined-newtarget-throws.js")]
+    public Task undefined_newtarget_throws() => ExecutionTestFromFile("undefined-newtarget-throws");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/constructor.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref-constructor
+description: >
+  The WeakRef constructor is the %WeakRef% intrinsic object and the initial
+  value of the WeakRef property of the global object.
+features: [WeakRef]
+---*/
+
+assert.sameValue(
+  typeof WeakRef, 'function',
+  'typeof WeakRef is function'
+);

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/is-a-constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/is-a-constructor.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  The WeakRef constructor implements [[Construct]]
+info: |
+  IsConstructor ( argument )
+
+  The abstract operation IsConstructor takes argument argument (an ECMAScript language value).
+  It determines if argument is a function object with a [[Construct]] internal method.
+  It performs the following steps when called:
+
+  If Type(argument) is not Object, return false.
+  If argument has a [[Construct]] internal method, return true.
+  Return false.
+includes: [isConstructor.js]
+features: [Reflect.construct, WeakRef]
+---*/
+
+assert.sameValue(isConstructor(WeakRef), true, 'isConstructor(WeakRef) must return true');
+new WeakRef({})
+  

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref-target
+description: WeakRef.length property descriptor
+info: |
+  WeakRef ( target )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [WeakRef]
+---*/
+
+verifyProperty(WeakRef, 'length', {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref-target
+description: WeakRef.name property descriptor
+info: |
+  WeakRef ( value )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [WeakRef]
+---*/
+
+verifyProperty(WeakRef, 'name', {
+  value: 'WeakRef',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/newtarget-prototype-is-not-object.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/newtarget-prototype-is-not-object.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref-target
+description: >
+  [[Prototype]] defaults to %WeakRefPrototype% if NewTarget.prototype is not an object.
+info: |
+  WeakRef( target )
+
+  ...
+  3. Let weakRef be ? OrdinaryCreateFromConstructor(NewTarget,  "%WeakRefPrototype%", « [[Target]] »).
+  4. Perfom ! KeepDuringJob(target).
+  5. Set weakRef.[[Target]] to target.
+  6. Return weakRef.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [WeakRef, Reflect.construct, Symbol]
+---*/
+
+var wr;
+function newTarget() {}
+
+newTarget.prototype = undefined;
+wr = Reflect.construct(WeakRef, [{}], newTarget);
+assert.sameValue(Object.getPrototypeOf(wr), WeakRef.prototype, 'newTarget.prototype is undefined');
+
+newTarget.prototype = null;
+wr = Reflect.construct(WeakRef, [{}], newTarget);
+assert.sameValue(Object.getPrototypeOf(wr), WeakRef.prototype, 'newTarget.prototype is null');
+
+newTarget.prototype = true;
+wr = Reflect.construct(WeakRef, [{}], newTarget);
+assert.sameValue(Object.getPrototypeOf(wr), WeakRef.prototype, 'newTarget.prototype is a Boolean');
+
+newTarget.prototype = '';
+wr = Reflect.construct(WeakRef, [{}], newTarget);
+assert.sameValue(Object.getPrototypeOf(wr), WeakRef.prototype, 'newTarget.prototype is a String');
+
+newTarget.prototype = Symbol();
+wr = Reflect.construct(WeakRef, [{}], newTarget);
+assert.sameValue(Object.getPrototypeOf(wr), WeakRef.prototype, 'newTarget.prototype is a Symbol');
+
+newTarget.prototype = 1;
+wr = Reflect.construct(WeakRef, [{}], newTarget);
+assert.sameValue(Object.getPrototypeOf(wr), WeakRef.prototype, 'newTarget.prototype is a Number');

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/prop-desc.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref-constructor
+description: >
+  Property descriptor of WeakRef
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [WeakRef]
+---*/
+
+verifyProperty(this, 'WeakRef', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/proto.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/proto.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-weak-ref-constructor
+description: >
+  The prototype of WeakRef is Object.prototype
+info: |
+  The value of the [[Prototype]] internal slot of the WeakRef object is the
+  intrinsic object %FunctionPrototype%.
+features: [WeakRef]
+---*/
+
+assert.sameValue(
+  Object.getPrototypeOf(WeakRef),
+  Function.prototype,
+  'Object.getPrototypeOf(WeakRef) returns the value of `Function.prototype`'
+);

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/throws-when-target-cannot-be-held-weakly.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/throws-when-target-cannot-be-held-weakly.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref-target
+description: >
+  Throws a TypeError if target cannot be held weakly
+info: |
+  WeakRef ( _target_ )
+  2. If CanBeHeldWeakly(_target_) is *false*, throw a *TypeError* exception.
+features: [WeakRef]
+---*/
+
+assert.sameValue(
+  typeof WeakRef, 'function',
+  'typeof WeakRef is function'
+);
+
+assert.throws(TypeError, function() {
+  new WeakRef();
+}, 'implicit undefined');
+
+assert.throws(TypeError, function() {
+  new WeakRef(undefined);
+}, 'explicit undefined');
+
+assert.throws(TypeError, function() {
+  new WeakRef(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  new WeakRef(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  new WeakRef('Object');
+}, 'string');
+
+var s = Symbol.for('registered symbol');
+assert.throws(TypeError, function() {
+  new WeakRef(s);
+}, 'registered symbol');
+
+assert.throws(TypeError, function() {
+  new WeakRef(true);
+}, 'Boolean, true');
+
+assert.throws(TypeError, function() {
+  new WeakRef(false);
+}, 'Boolean, false');

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/undefined-newtarget-throws.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/JavaScript/undefined-newtarget-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref-target
+description: >
+  Throws a TypeError if NewTarget is undefined.
+info: |
+  WeakRef ( target )
+
+  1. If NewTarget is undefined, throw a TypeError exception.
+  2. If Type(target) is not Object, throw a TypeError exception.
+  ...
+features: [WeakRef]
+---*/
+
+assert.sameValue(
+  typeof WeakRef, 'function',
+  'typeof WeakRef is function'
+);
+
+assert.throws(TypeError, function() {
+  WeakRef();
+});
+
+assert.throws(TypeError, function() {
+  WeakRef({});
+});

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/ExecutionTests.cs
@@ -1,0 +1,20 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.WeakRef.prototype;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.WeakRef.prototype") { }
+
+    [Fact(DisplayName = "constructor.js")]
+    public Task constructor() => ExecutionTestFromFile("constructor");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+
+    [Fact(DisplayName = "proto.js")]
+    public Task proto() => ExecutionTestFromFile("proto");
+
+    [Fact(DisplayName = "Symbol.toStringTag.js")]
+    public Task symbol_to_string_tag() => ExecutionTestFromFile("Symbol.toStringTag");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/JavaScript/Symbol.toStringTag.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/JavaScript/Symbol.toStringTag.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref-@@tostringtag
+description: >
+    `Symbol.toStringTag` property descriptor
+info: |
+    The initial value of the @@toStringTag property is the String value
+    'WeakRef'.
+
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [WeakRef, Symbol, Symbol.toStringTag]
+---*/
+
+verifyProperty(WeakRef.prototype, Symbol.toStringTag, {
+  value: 'WeakRef',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/JavaScript/constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/JavaScript/constructor.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-weak-ref-prototype-object
+description: WeakRef.prototype.constructor
+info: |
+  WeakRef.prototype.constructor
+
+  Normative Optional
+
+  The initial value of WeakRef.prototype.constructor is the intrinsic object %WeakRef%.
+
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true }.
+
+  This section is to be treated identically to the "Annex B" of ECMA-262, but to be written in-line with the main specification.
+includes: [propertyHelper.js]
+features: [WeakRef]
+---*/
+
+var actual = WeakRef.prototype.hasOwnProperty('constructor');
+
+// If implemented, it should conform to the spec text
+if (actual) {
+  verifyProperty(WeakRef.prototype, 'constructor', {
+    value: WeakRef,
+    writable: true,
+    enumerable: false,
+    configurable: true
+  });
+}

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/JavaScript/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The property descriptor WeakRef.prototype
+esid: sec-weak-ref.prototype
+info: |
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: false }.
+features: [WeakRef]
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(WeakRef, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false
+});

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/JavaScript/proto.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/JavaScript/proto.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The prototype of WeakRef.prototype is Object.prototype
+esid: sec-properties-of-the-weak-ref-prototype-object
+info: |
+  The value of the [[Prototype]] internal slot of the WeakRef prototype object
+  is the intrinsic object %ObjectPrototype%.
+features: [WeakRef]
+---*/
+
+var proto = Object.getPrototypeOf(WeakRef.prototype);
+assert.sameValue(proto, Object.prototype);

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/ExecutionTests.cs
@@ -1,0 +1,30 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.WeakRef.prototype.deref;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.WeakRef.prototype.deref") { }
+
+    [Fact(DisplayName = "custom-this.js")]
+    public Task custom_this() => ExecutionTestFromFile("custom-this");
+
+    [Fact(DisplayName = "length.js")]
+    public Task length() => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "not-a-constructor.js")]
+    public Task not_a_constructor() => ExecutionTestFromFile("not-a-constructor");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+
+    [Fact(DisplayName = "this-does-not-have-internal-target-throws.js")]
+    public Task this_does_not_have_internal_target_throws()
+        => ExecutionTestFromFile("this-does-not-have-internal-target-throws");
+
+    [Fact(DisplayName = "this-not-object-throws.js")]
+    public Task this_not_object_throws() => ExecutionTestFromFile("this-not-object-throws");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/custom-this.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/custom-this.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref.prototype.deref
+description: Return target if weakRef.[[Target]] is not empty (applying custom this)
+info: |
+  WeakRef.prototype.deref ()
+
+  1. Let weakRef be the this value.
+  ...
+  4. Let target be the value of weakRef.[[Target]].
+  5. If target is not empty,
+    a. Perform ! KeepDuringJob(target).
+    b. Return target.
+  6. Return undefined.
+features: [WeakRef]
+---*/
+
+var target = {};
+var deref = WeakRef.prototype.deref;
+var wref = new WeakRef(target);
+
+assert.sameValue(deref.call(wref), target, 'returns target');
+assert.sameValue(deref.call(wref), target, '[[Target]] is not emptied #1');
+assert.sameValue(deref.call(wref), target, '[[Target]] is not emptied #2');
+assert.sameValue(deref.call(wref), target, '[[Target]] is not emptied #3');

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref.prototype.deref
+description: WeakRef.prototype.deref.length property descriptor
+info: |
+  WeakRef.prototype.deref ()
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [WeakRef]
+---*/
+
+verifyProperty(WeakRef.prototype.deref, 'length', {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref.prototype.deref
+description: WeakRef.prototype.deref.name property descriptor
+info: |
+  WeakRef.prototype.deref.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [WeakRef]
+---*/
+
+verifyProperty(WeakRef.prototype.deref, 'name', {
+  value: 'deref',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/not-a-constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  WeakRef.prototype.deref does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, WeakRef, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(WeakRef.prototype.deref),
+  false,
+  'isConstructor(WeakRef.prototype.deref) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let wr = new WeakRef({}); new wr.deref();
+});
+

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref.prototype.deref
+description: >
+  Property descriptor of WeakRef.prototype.deref
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [WeakRef]
+---*/
+
+assert.sameValue(typeof WeakRef.prototype.deref, 'function');
+
+verifyProperty(WeakRef.prototype, 'deref', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/this-does-not-have-internal-target-throws.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/this-does-not-have-internal-target-throws.js
@@ -1,0 +1,50 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref.prototype.deref
+description: Throws a TypeError if this does not have a [[Target]] internal slot
+info: |
+  WeakRef.prototype.deref ()
+
+  1. Let weakRef be the this value.
+  2. If Type(weakRef) is not Object, throw a TypeError exception.
+  3. If weakRef does not have a [[Target]] internal slot, throw a TypeError exception.
+  4. Let target be the value of weakRef.[[Target]].
+  5. If target is not empty,
+    a. Perform ! KeepDuringJob(target).
+    b. Return target.
+  6. Return undefined.
+features: [WeakSet, WeakMap, WeakRef, FinalizationRegistry]
+---*/
+
+assert.sameValue(typeof WeakRef.prototype.deref, 'function');
+
+var deref = WeakRef.prototype.deref;
+
+assert.throws(TypeError, function() {
+  deref.call({ ['[[Target]]']: {} });
+}, 'Ordinary object without [[Target]]');
+
+assert.throws(TypeError, function() {
+  deref.call(WeakRef.prototype);
+}, 'WeakRef.prototype does not have a [[Target]] internal slot');
+
+assert.throws(TypeError, function() {
+  deref.call(WeakRef);
+}, 'WeakRef does not have a [[Target]] internal slot');
+
+var finalizationRegistry = new FinalizationRegistry(function() {});
+assert.throws(TypeError, function() {
+  deref.call(finalizationRegistry);
+}, 'FinalizationRegistry instance');
+
+var wm = new WeakMap();
+assert.throws(TypeError, function() {
+  deref.call(wm);
+}, 'WeakMap instance');
+
+var ws = new WeakSet();
+assert.throws(TypeError, function() {
+  deref.call(ws);
+}, 'WeakSet instance');

--- a/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/this-not-object-throws.js
+++ b/tests/Jroc.Test262.Tests/built-ins/WeakRef/prototype/deref/JavaScript/this-not-object-throws.js
@@ -1,0 +1,52 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-weak-ref.prototype.deref
+description: Throws a TypeError if this is not an Object
+info: |
+  WeakRef.prototype.deref ()
+
+  1. Let weakRef be the this value.
+  2. If Type(weakRef) is not Object, throw a TypeError exception.
+  3. If weakRef does not have a [[Target]] internal slot, throw a TypeError exception.
+  4. Let target be the value of weakRef.[[Target]].
+  5. If target is not empty,
+    a. Perform ! KeepDuringJob(target).
+    b. Return target.
+  6. Return undefined.
+features: [WeakRef]
+---*/
+
+assert.sameValue(typeof WeakRef.prototype.deref, 'function');
+
+var deref = WeakRef.prototype.deref;
+
+assert.throws(TypeError, function() {
+  deref.call(undefined);
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  deref.call(null);
+}, 'null');
+
+assert.throws(TypeError, function() {
+  deref.call(true);
+}, 'true');
+
+assert.throws(TypeError, function() {
+  deref.call(false);
+}, 'false');
+
+assert.throws(TypeError, function() {
+  deref.call(1);
+}, 'number');
+
+assert.throws(TypeError, function() {
+  deref.call('object');
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  deref.call(s);
+}, 'symbol');


### PR DESCRIPTION
## Summary
- expose the existing WeakRef runtime as a first-class ES global with standard constructor/prototype metadata
- implement prototype-owned, non-constructible `deref()` dispatch and spec-correct weak-target eligibility for registered symbols
- port 20 byte-identical pinned test262 WeakRef fixtures and update §§19.3/26.1 documentation

## Validation
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --filter 'FullyQualifiedName~built_ins.WeakRef' --no-restore` (20 passed)
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --filter 'FullyQualifiedName~WeakRef' --no-restore` (2 passed)

Generator snapshots will be updated through the **Update generator snapshots** workflow.
