### PR TITLE
feat(runtime): expose FinalizationRegistry global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime/test262: expose FinalizationRegistry as a first-class global
+  constructor with standard constructor/prototype metadata plus prototype-owned
+  register() and unregister() methods. Activates twenty corresponding pinned
+  test262 fixtures.
+
 - runtime/test262: expose WeakRef as a first-class global constructor with
   standard constructor/prototype metadata and `deref()` behavior. Weak-target
   eligibility now correctly rejects registered symbols. Activates twenty

--- a/docs/ECMA262/19/Section19_3.json
+++ b/docs/ECMA262/19/Section19_3.json
@@ -346,14 +346,23 @@
       },
       {
         "clause": "19.3.12",
-        "feature": "FinalizationRegistry constructible global baseline",
+        "feature": "FinalizationRegistry first-class global constructor",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-finalization-registry",
         "testScripts": [
-          "tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Cleanup_Order.js",
-          "tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Unregister_Basic.js"
+          "tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/ExecutionTests.cs"
         ],
-        "notes": "Supports `new FinalizationRegistry(cleanupCallback)` in construct positions plus register/unregister/toStringTag baseline behavior. jroc does not yet expose a full first-class `globalThis.FinalizationRegistry` constructor/prototype object, and deterministic cleanup in tests uses a host-opt-in non-standard global `gc()` helper."
+        "test262Paths": [
+          "test/built-ins/FinalizationRegistry/constructor.js",
+          "test/built-ins/FinalizationRegistry/is-a-constructor.js",
+          "test/built-ins/FinalizationRegistry/length.js",
+          "test/built-ins/FinalizationRegistry/name.js",
+          "test/built-ins/FinalizationRegistry/prop-desc.js",
+          "test/built-ins/FinalizationRegistry/proto.js"
+        ],
+        "notes": "Exposes globalThis.FinalizationRegistry as a constructible function with the standard constructor/prototype metadata plus register(), unregister(), and @@toStringTag. Deterministic cleanup in tests still uses a host-opt-in non-standard gc() helper, while cleanup timing otherwise depends on .NET GC and event-loop checkpoints."
       },
       {
         "clause": "19.3.40",

--- a/docs/ECMA262/19/Section19_3.md
+++ b/docs/ECMA262/19/Section19_3.md
@@ -4,7 +4,7 @@
 
 [Back to Section19](Section19.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-08-15T05:05:31Z
+> Last generated (UTC): 2026-08-15T06:08:55Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -71,7 +71,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| FinalizationRegistry constructible global baseline | Supported with Limitations | [`FinalizationRegistry_Cleanup_Order.js`](../../../tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Cleanup_Order.js)<br>[`FinalizationRegistry_Unregister_Basic.js`](../../../tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Unregister_Basic.js) |  | Supports `new FinalizationRegistry(cleanupCallback)` in construct positions plus register/unregister/toStringTag baseline behavior. jroc does not yet expose a full first-class `globalThis.FinalizationRegistry` constructor/prototype object, and deterministic cleanup in tests uses a host-opt-in non-standard global `gc()` helper. |
+| FinalizationRegistry first-class global constructor | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/ExecutionTests.cs` | `test/built-ins/FinalizationRegistry/constructor.js`<br>`test/built-ins/FinalizationRegistry/is-a-constructor.js`<br>`test/built-ins/FinalizationRegistry/length.js`<br>`test/built-ins/FinalizationRegistry/name.js`<br>`test/built-ins/FinalizationRegistry/prop-desc.js`<br>`test/built-ins/FinalizationRegistry/proto.js` | Exposes globalThis.FinalizationRegistry as a constructible function with the standard constructor/prototype metadata plus register(), unregister(), and @@toStringTag. Deterministic cleanup in tests still uses a host-opt-in non-standard gc() helper, while cleanup timing otherwise depends on .NET GC and event-loop checkpoints. |
 
 ### 19.3.16 ([tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-function))
 

--- a/docs/ECMA262/26/Section26_2.json
+++ b/docs/ECMA262/26/Section26_2.json
@@ -24,43 +24,43 @@
     {
       "clause": "26.2.2",
       "title": "Properties of the FinalizationRegistry Constructor",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-constructor"
     },
     {
       "clause": "26.2.2.1",
       "title": "FinalizationRegistry.prototype",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-finalization-registry.prototype"
     },
     {
       "clause": "26.2.3",
       "title": "Properties of the FinalizationRegistry Prototype Object",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-prototype-object"
     },
     {
       "clause": "26.2.3.1",
       "title": "FinalizationRegistry.prototype.constructor",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-finalization-registry.prototype.constructor"
     },
     {
       "clause": "26.2.3.2",
       "title": "FinalizationRegistry.prototype.register ( target , heldValue [ , unregisterToken ] )",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-finalization-registry.prototype.register"
     },
     {
       "clause": "26.2.3.3",
       "title": "FinalizationRegistry.prototype.unregister ( unregisterToken )",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister"
     },
     {
       "clause": "26.2.3.4",
       "title": "FinalizationRegistry.prototype [ %Symbol.toStringTag% ]",
-      "status": "Supported with Limitations",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-finalization-registry.prototype-%symbol.tostringtag%"
     },
     {
@@ -74,14 +74,63 @@
     "entries": [
       {
         "clause": "26.2",
-        "feature": "FinalizationRegistry constructor, register/unregister, and cleanup callback baseline",
+        "feature": "FinalizationRegistry construction and cleanup callback",
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-finalization-registry-objects",
         "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/ExecutionTests.cs",
           "tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Cleanup_Order.js",
           "tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Unregister_Basic.js"
         ],
-        "notes": "Supports `new FinalizationRegistry(cleanupCallback)` in construct positions plus `register(target, heldValue, [unregisterToken])`, `unregister(token)`, and `%Symbol.toStringTag%`. Cleanup callbacks are queued through a host-managed finalization queue and become deterministic in tests when a host-opt-in non-standard global `gc()` helper forces collection. jroc does not yet expose a full first-class `FinalizationRegistry` constructor/prototype object on `globalThis`, and cleanup timing otherwise depends on .NET GC plus event-loop checkpoints."
+        "test262Paths": [
+          "test/built-ins/FinalizationRegistry/newtarget-prototype-is-not-object.js",
+          "test/built-ins/FinalizationRegistry/returns-new-object-from-constructor.js",
+          "test/built-ins/FinalizationRegistry/undefined-newtarget-throws.js"
+        ],
+        "notes": "Supports construction only with new and uses the intrinsic FinalizationRegistry prototype when a newTarget prototype is not an object. Cleanup callbacks are queued through a host-managed finalization queue and become deterministic when a host-opt-in non-standard gc() helper forces collection. Custom newTarget prototypes, cross-realm construction, and cleanup timing outside that helper remain limited."
+      },
+      {
+        "clause": "26.2.2",
+        "feature": "FinalizationRegistry constructor function surface",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-constructor",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/FinalizationRegistry/constructor.js",
+          "test/built-ins/FinalizationRegistry/is-a-constructor.js",
+          "test/built-ins/FinalizationRegistry/length.js",
+          "test/built-ins/FinalizationRegistry/name.js",
+          "test/built-ins/FinalizationRegistry/prop-desc.js",
+          "test/built-ins/FinalizationRegistry/proto.js"
+        ],
+        "notes": "globalThis.FinalizationRegistry is a constructible function with standard name, length, global-property, and prototype descriptors."
+      },
+      {
+        "clause": "26.2.3",
+        "feature": "FinalizationRegistry.prototype register/unregister surface",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-prototype-object",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/ExecutionTests.cs",
+          "tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Unregister_Basic.js"
+        ],
+        "test262Paths": [
+          "test/built-ins/FinalizationRegistry/prototype/constructor.js",
+          "test/built-ins/FinalizationRegistry/prototype/prop-desc.js",
+          "test/built-ins/FinalizationRegistry/prototype/proto.js",
+          "test/built-ins/FinalizationRegistry/prototype/Symbol.toStringTag.js",
+          "test/built-ins/FinalizationRegistry/prototype/register/custom-this.js",
+          "test/built-ins/FinalizationRegistry/prototype/register/length.js",
+          "test/built-ins/FinalizationRegistry/prototype/register/name.js",
+          "test/built-ins/FinalizationRegistry/prototype/register/not-a-constructor.js",
+          "test/built-ins/FinalizationRegistry/prototype/register/prop-desc.js",
+          "test/built-ins/FinalizationRegistry/prototype/register/this-does-not-have-internal-target-throws.js",
+          "test/built-ins/FinalizationRegistry/prototype/register/this-not-object-throws.js"
+        ],
+        "notes": "FinalizationRegistry.prototype inherits Object.prototype and owns constructor, register, unregister, and @@toStringTag properties. register and unregister are non-constructible, support explicit receivers, and reject incompatible receivers."
       }
     ]
   }

--- a/docs/ECMA262/26/Section26_2.md
+++ b/docs/ECMA262/26/Section26_2.md
@@ -4,7 +4,7 @@
 
 [Back to Section26](Section26.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-08-14T08:27:55Z
+> Last generated (UTC): 2026-08-15T06:08:55Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -16,13 +16,13 @@
 |---:|---|---|---|
 | 26.2.1 | The FinalizationRegistry Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry-constructor) |
 | 26.2.1.1 | FinalizationRegistry ( cleanupCallback ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry-cleanup-callback) |
-| 26.2.2 | Properties of the FinalizationRegistry Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-constructor) |
-| 26.2.2.1 | FinalizationRegistry.prototype | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype) |
-| 26.2.3 | Properties of the FinalizationRegistry Prototype Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-prototype-object) |
-| 26.2.3.1 | FinalizationRegistry.prototype.constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype.constructor) |
-| 26.2.3.2 | FinalizationRegistry.prototype.register ( target , heldValue [ , unregisterToken ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype.register) |
-| 26.2.3.3 | FinalizationRegistry.prototype.unregister ( unregisterToken ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister) |
-| 26.2.3.4 | FinalizationRegistry.prototype [ %Symbol.toStringTag% ] | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype-%symbol.tostringtag%) |
+| 26.2.2 | Properties of the FinalizationRegistry Constructor | Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-constructor) |
+| 26.2.2.1 | FinalizationRegistry.prototype | Supported | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype) |
+| 26.2.3 | Properties of the FinalizationRegistry Prototype Object | Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-prototype-object) |
+| 26.2.3.1 | FinalizationRegistry.prototype.constructor | Supported | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype.constructor) |
+| 26.2.3.2 | FinalizationRegistry.prototype.register ( target , heldValue [ , unregisterToken ] ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype.register) |
+| 26.2.3.3 | FinalizationRegistry.prototype.unregister ( unregisterToken ) | Supported | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister) |
+| 26.2.3.4 | FinalizationRegistry.prototype [ %Symbol.toStringTag% ] | Supported | [tc39.es](https://tc39.es/ecma262/#sec-finalization-registry.prototype-%symbol.tostringtag%) |
 | 26.2.4 | Properties of FinalizationRegistry Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-finalization-registry-instances) |
 
 ## Support
@@ -33,5 +33,17 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| FinalizationRegistry constructor, register/unregister, and cleanup callback baseline | Supported with Limitations | [`FinalizationRegistry_Cleanup_Order.js`](../../../tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Cleanup_Order.js)<br>[`FinalizationRegistry_Unregister_Basic.js`](../../../tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Unregister_Basic.js) |  | Supports `new FinalizationRegistry(cleanupCallback)` in construct positions plus `register(target, heldValue, [unregisterToken])`, `unregister(token)`, and `%Symbol.toStringTag%`. Cleanup callbacks are queued through a host-managed finalization queue and become deterministic in tests when a host-opt-in non-standard global `gc()` helper forces collection. jroc does not yet expose a full first-class `FinalizationRegistry` constructor/prototype object on `globalThis`, and cleanup timing otherwise depends on .NET GC plus event-loop checkpoints. |
+| FinalizationRegistry construction and cleanup callback | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/ExecutionTests.cs`<br>[`FinalizationRegistry_Cleanup_Order.js`](../../../tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Cleanup_Order.js)<br>[`FinalizationRegistry_Unregister_Basic.js`](../../../tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Unregister_Basic.js) | `test/built-ins/FinalizationRegistry/newtarget-prototype-is-not-object.js`<br>`test/built-ins/FinalizationRegistry/returns-new-object-from-constructor.js`<br>`test/built-ins/FinalizationRegistry/undefined-newtarget-throws.js` | Supports construction only with new and uses the intrinsic FinalizationRegistry prototype when a newTarget prototype is not an object. Cleanup callbacks are queued through a host-managed finalization queue and become deterministic when a host-opt-in non-standard gc() helper forces collection. Custom newTarget prototypes, cross-realm construction, and cleanup timing outside that helper remain limited. |
+
+### 26.2.2 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-constructor))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| FinalizationRegistry constructor function surface | Supported | `tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/ExecutionTests.cs` | `test/built-ins/FinalizationRegistry/constructor.js`<br>`test/built-ins/FinalizationRegistry/is-a-constructor.js`<br>`test/built-ins/FinalizationRegistry/length.js`<br>`test/built-ins/FinalizationRegistry/name.js`<br>`test/built-ins/FinalizationRegistry/prop-desc.js`<br>`test/built-ins/FinalizationRegistry/proto.js` | globalThis.FinalizationRegistry is a constructible function with standard name, length, global-property, and prototype descriptors. |
+
+### 26.2.3 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-finalization-registry-prototype-object))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| FinalizationRegistry.prototype register/unregister surface | Supported | `tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/ExecutionTests.cs`<br>[`FinalizationRegistry_Unregister_Basic.js`](../../../tests/Jroc.Tests/FinalizationRegistry/JavaScript/FinalizationRegistry_Unregister_Basic.js) | `test/built-ins/FinalizationRegistry/prototype/constructor.js`<br>`test/built-ins/FinalizationRegistry/prototype/prop-desc.js`<br>`test/built-ins/FinalizationRegistry/prototype/proto.js`<br>`test/built-ins/FinalizationRegistry/prototype/Symbol.toStringTag.js`<br>`test/built-ins/FinalizationRegistry/prototype/register/custom-this.js`<br>`test/built-ins/FinalizationRegistry/prototype/register/length.js`<br>`test/built-ins/FinalizationRegistry/prototype/register/name.js`<br>`test/built-ins/FinalizationRegistry/prototype/register/not-a-constructor.js`<br>`test/built-ins/FinalizationRegistry/prototype/register/prop-desc.js`<br>`test/built-ins/FinalizationRegistry/prototype/register/this-does-not-have-internal-target-throws.js`<br>`test/built-ins/FinalizationRegistry/prototype/register/this-not-object-throws.js` | FinalizationRegistry.prototype inherits Object.prototype and owns constructor, register, unregister, and @@toStringTag properties. register and unregister are non-constructible, support explicit receivers, and reject incompatible receivers. |
 

--- a/src/JavaScriptRuntime/FinalizationRegistry.cs
+++ b/src/JavaScriptRuntime/FinalizationRegistry.cs
@@ -6,6 +6,7 @@ namespace JavaScriptRuntime
     [IntrinsicObject("FinalizationRegistry")]
     public sealed class FinalizationRegistry
     {
+        internal static readonly object Prototype = CreatePrototype();
         private sealed class Registration
         {
             public Registration(object target, object? heldValue, object? unregisterToken)
@@ -31,6 +32,10 @@ namespace JavaScriptRuntime
         private readonly object _cleanupCallback;
         private readonly List<Registration> _registrations = new();
         private bool _trackedWithHost;
+
+        public FinalizationRegistry() : this(null)
+        {
+        }
 
         public FinalizationRegistry(object? cleanupCallback)
         {
@@ -150,7 +155,51 @@ namespace JavaScriptRuntime
 
         private void InitializeIntrinsicSurface()
         {
-            PropertyDescriptorStore.DefineOrUpdate(this, Symbol.toStringTag.DebugId, new JsPropertyDescriptor
+            PrototypeChain.SetPrototype(this, Prototype);
+        }
+
+        private static object CreatePrototype()
+        {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
+            var prototype = new JsObject();
+            Func<object[], object?[]?, object?> register = PrototypeRegister;
+            Func<object[], object?[]?, object?> unregister = PrototypeUnregister;
+            Function.InitializeFunctionInstance(register, 2d, "register");
+            Function.InitializeFunctionInstance(unregister, 1d, "unregister");
+            PropertyDescriptorStore.DefineOrUpdate(register, "prototype", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = false,
+                Writable = false,
+                Value = null
+            });
+            PropertyDescriptorStore.DefineOrUpdate(unregister, "prototype", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = false,
+                Writable = false,
+                Value = null
+            });
+            PropertyDescriptorStore.DefineOrUpdate(prototype, "register", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = true,
+                Value = register
+            });
+            PropertyDescriptorStore.DefineOrUpdate(prototype, "unregister", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = true,
+                Value = unregister
+            });
+            PropertyDescriptorStore.DefineOrUpdate(prototype, Symbol.toStringTag.DebugId, new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Data,
                 Enumerable = false,
@@ -158,6 +207,32 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = "FinalizationRegistry"
             });
+            return prototype;
+        }
+
+        private static object? PrototypeRegister(object[] _, object?[]? args)
+        {
+            if (RuntimeServices.GetCurrentThis() is not FinalizationRegistry finalizationRegistry)
+            {
+                throw new TypeError("FinalizationRegistry.prototype.register called on incompatible receiver");
+            }
+
+            args ??= [];
+            return finalizationRegistry.register(
+                args.Length > 0 ? args[0] : null,
+                args.Length > 1 ? args[1] : null,
+                args.Length > 2 ? args[2] : null);
+        }
+
+        private static object? PrototypeUnregister(object[] _, object?[]? args)
+        {
+            if (RuntimeServices.GetCurrentThis() is not FinalizationRegistry finalizationRegistry)
+            {
+                throw new TypeError("FinalizationRegistry.prototype.unregister called on incompatible receiver");
+            }
+
+            args ??= [];
+            return finalizationRegistry.unregister(args.Length > 0 ? args[0] : null);
         }
     }
 }

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -188,6 +188,16 @@ namespace JavaScriptRuntime
             return new JavaScriptRuntime.WeakRef(target);
         };
 
+        private static readonly JsFuncNoScopes1 _finalizationRegistryConstructorValue = static (newTarget, cleanupCallback) =>
+        {
+            if (newTarget is null)
+            {
+                throw new TypeError("Constructor FinalizationRegistry requires 'new'");
+            }
+
+            return new JavaScriptRuntime.FinalizationRegistry(cleanupCallback);
+        };
+
         private static readonly JsFuncNoScopes1 _promiseConstructorValue = static (newTarget, executor) =>
         {
             if (newTarget is null)
@@ -502,6 +512,7 @@ namespace JavaScriptRuntime
             ConfigureCollectionIntrinsicSurface(_weakMapConstructorValue, JavaScriptRuntime.WeakMap.Prototype);
             ConfigureCollectionIntrinsicSurface(_weakSetConstructorValue, JavaScriptRuntime.WeakSet.Prototype);
             ConfigureWeakRefIntrinsicSurface();
+            ConfigureFinalizationRegistryIntrinsicSurface();
             ConfigureCollectionConstructorMetadata(_mapConstructorValue, "Map");
             ConfigureCollectionConstructorMetadata(_setConstructorValue, "Set");
             ConfigureCollectionConstructorMetadata(_weakMapConstructorValue, "WeakMap");
@@ -1353,6 +1364,9 @@ namespace JavaScriptRuntime
             dict.TryAdd(nameof(GlobalThis.WeakRef), WeakRef);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.WeakRef), dict[nameof(GlobalThis.WeakRef)]);
 
+            dict.TryAdd(nameof(GlobalThis.FinalizationRegistry), FinalizationRegistry);
+            DefineNonEnumerableDataProperty(nameof(GlobalThis.FinalizationRegistry), dict[nameof(GlobalThis.FinalizationRegistry)]);
+
             dict.TryAdd(nameof(GlobalThis.Object), Object);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.Object), dict[nameof(GlobalThis.Object)]);
 
@@ -1657,6 +1671,8 @@ namespace JavaScriptRuntime
         public static Delegate WeakSet => _weakSetConstructorValue;
 
         public static Delegate WeakRef => _weakRefConstructorValue;
+
+        public static Delegate FinalizationRegistry => _finalizationRegistryConstructorValue;
 
         public static Func<object[], object?, object> Object => _objectConstructorValue;
 
@@ -2207,6 +2223,29 @@ namespace JavaScriptRuntime
                 Configurable = true,
                 Writable = false,
                 Value = "WeakRef"
+            });
+        }
+
+        private static void ConfigureFinalizationRegistryIntrinsicSurface()
+        {
+            ConfigureConstructorPrototypeSurface(
+                _finalizationRegistryConstructorValue,
+                JavaScriptRuntime.FinalizationRegistry.Prototype);
+            PropertyDescriptorStore.DefineOrUpdate(_finalizationRegistryConstructorValue, "length", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = false,
+                Value = 1d
+            });
+            PropertyDescriptorStore.DefineOrUpdate(_finalizationRegistryConstructorValue, "name", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = false,
+                Value = "FinalizationRegistry"
             });
         }
 

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/ExecutionTests.cs
@@ -1,0 +1,37 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.FinalizationRegistry;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.FinalizationRegistry") { }
+
+    [Fact(DisplayName = "constructor.js")]
+    public Task constructor() => ExecutionTestFromFile("constructor");
+
+    [Fact(DisplayName = "is-a-constructor.js")]
+    public Task is_a_constructor() => ExecutionTestFromFile("is-a-constructor");
+
+    [Fact(DisplayName = "length.js")]
+    public Task length() => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "newtarget-prototype-is-not-object.js")]
+    public Task newtarget_prototype_is_not_object()
+        => ExecutionTestFromFile("newtarget-prototype-is-not-object");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+
+    [Fact(DisplayName = "proto.js")]
+    public Task proto() => ExecutionTestFromFile("proto");
+
+    [Fact(DisplayName = "returns-new-object-from-constructor.js")]
+    public Task returns_new_object_from_constructor()
+        => ExecutionTestFromFile("returns-new-object-from-constructor");
+
+    [Fact(DisplayName = "undefined-newtarget-throws.js")]
+    public Task undefined_newtarget_throws() => ExecutionTestFromFile("undefined-newtarget-throws");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/constructor.js
@@ -1,0 +1,15 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry-constructor
+description: >
+  The FinalizationRegistry constructor is the %FinalizationRegistry% intrinsic object and the initial
+  value of the FinalizationRegistry property of the global object.
+features: [FinalizationRegistry]
+---*/
+
+assert.sameValue(
+  typeof FinalizationRegistry, 'function',
+  'typeof FinalizationRegistry is function'
+);

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/is-a-constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/is-a-constructor.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  The FinalizationRegistry constructor implements [[Construct]]
+info: |
+  IsConstructor ( argument )
+
+  The abstract operation IsConstructor takes argument argument (an ECMAScript language value).
+  It determines if argument is a function object with a [[Construct]] internal method.
+  It performs the following steps when called:
+
+  If Type(argument) is not Object, return false.
+  If argument has a [[Construct]] internal method, return true.
+  Return false.
+includes: [isConstructor.js]
+features: [Reflect.construct, FinalizationRegistry, arrow-function]
+---*/
+
+assert.sameValue(isConstructor(FinalizationRegistry), true, 'isConstructor(FinalizationRegistry) must return true');
+new FinalizationRegistry(() => {});
+  

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry-target
+description: FinalizationRegistry.length property descriptor
+info: |
+  FinalizationRegistry ( cleanupCallback )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [FinalizationRegistry]
+---*/
+
+verifyProperty(FinalizationRegistry, 'length', {
+  value: 1,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry-target
+description: FinalizationRegistry.name property descriptor
+info: |
+  FinalizationRegistry ( value )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [FinalizationRegistry]
+---*/
+
+verifyProperty(FinalizationRegistry, 'name', {
+  value: 'FinalizationRegistry',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/newtarget-prototype-is-not-object.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/newtarget-prototype-is-not-object.js
@@ -1,0 +1,58 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry-target
+description: >
+  [[Prototype]] defaults to %FinalizationRegistryPrototype% if NewTarget.prototype is not an object.
+info: |
+  FinalizationRegistry ( cleanupCallback )
+
+  ...
+  3. Let finalizationRegistry be ? OrdinaryCreateFromConstructor(NewTarget,  "%FinalizationRegistryPrototype%", « [[Realm]], [[CleanupCallback]], [[Cells]], [[IsFinalizationRegistryCleanupJobActive]] »).
+  ...
+  9. Return finalizationRegistry.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+
+  GetPrototypeFromConstructor ( constructor, intrinsicDefaultProto )
+
+  3. Let proto be ? Get(constructor, 'prototype').
+  4. If Type(proto) is not Object, then
+    a. Let realm be ? GetFunctionRealm(constructor).
+    b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+  5. Return proto.
+features: [FinalizationRegistry, Reflect.construct, Symbol]
+---*/
+
+var finalizationRegistry;
+function newTarget() {}
+function fn() {}
+
+newTarget.prototype = undefined;
+finalizationRegistry = Reflect.construct(FinalizationRegistry, [fn], newTarget);
+assert.sameValue(Object.getPrototypeOf(finalizationRegistry), FinalizationRegistry.prototype, 'newTarget.prototype is undefined');
+
+newTarget.prototype = null;
+finalizationRegistry = Reflect.construct(FinalizationRegistry, [fn], newTarget);
+assert.sameValue(Object.getPrototypeOf(finalizationRegistry), FinalizationRegistry.prototype, 'newTarget.prototype is null');
+
+newTarget.prototype = true;
+finalizationRegistry = Reflect.construct(FinalizationRegistry, [fn], newTarget);
+assert.sameValue(Object.getPrototypeOf(finalizationRegistry), FinalizationRegistry.prototype, 'newTarget.prototype is a Boolean');
+
+newTarget.prototype = '';
+finalizationRegistry = Reflect.construct(FinalizationRegistry, [fn], newTarget);
+assert.sameValue(Object.getPrototypeOf(finalizationRegistry), FinalizationRegistry.prototype, 'newTarget.prototype is a String');
+
+newTarget.prototype = Symbol();
+finalizationRegistry = Reflect.construct(FinalizationRegistry, [fn], newTarget);
+assert.sameValue(Object.getPrototypeOf(finalizationRegistry), FinalizationRegistry.prototype, 'newTarget.prototype is a Symbol');
+
+newTarget.prototype = 1;
+finalizationRegistry = Reflect.construct(FinalizationRegistry, [fn], newTarget);
+assert.sameValue(Object.getPrototypeOf(finalizationRegistry), FinalizationRegistry.prototype, 'newTarget.prototype is a Number');

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/prop-desc.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry-constructor
+description: >
+  Property descriptor of FinalizationRegistry
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [FinalizationRegistry]
+---*/
+
+verifyProperty(this, 'FinalizationRegistry', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/proto.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/proto.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-finalization-registry-constructor
+description: >
+  The prototype of FinalizationRegistry is Object.prototype
+info: |
+  The value of the [[Prototype]] internal slot of the FinalizationRegistry object is the
+  intrinsic object %FunctionPrototype%.
+features: [FinalizationRegistry]
+---*/
+
+assert.sameValue(
+  Object.getPrototypeOf(FinalizationRegistry),
+  Function.prototype,
+  'Object.getPrototypeOf(FinalizationRegistry) returns the value of `Function.prototype`'
+);

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/returns-new-object-from-constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/returns-new-object-from-constructor.js
@@ -1,0 +1,39 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry-target
+description: >
+  Returns a new ordinary object from the FinalizationRegistry constructor
+info: |
+  FinalizationRegistry ( cleanupCallback )
+
+  ...
+  3. Let finalizationRegistry be ? OrdinaryCreateFromConstructor(NewTarget,  "%FinalizationRegistryPrototype%", « [[Realm]], [[CleanupCallback]], [[Cells]], [[IsFinalizationRegistryCleanupJobActive]] »).
+  ...
+  9. Return finalizationRegistry.
+
+  OrdinaryCreateFromConstructor ( constructor, intrinsicDefaultProto [ , internalSlotsList ] )
+
+  ...
+  2. Let proto be ? GetPrototypeFromConstructor(constructor, intrinsicDefaultProto).
+  3. Return ObjectCreate(proto, internalSlotsList).
+features: [FinalizationRegistry, for-of]
+---*/
+
+var cleanupCallback = function() {};
+var finalizationRegistry = new FinalizationRegistry(cleanupCallback);
+
+assert.sameValue(Object.getPrototypeOf(finalizationRegistry), FinalizationRegistry.prototype);
+assert.notSameValue(finalizationRegistry, cleanupCallback, 'does not return the same function');
+assert.sameValue(finalizationRegistry instanceof FinalizationRegistry, true, 'instanceof');
+
+for (let key of Object.getOwnPropertyNames(finalizationRegistry)) {
+  assert(false, `should not set any own named properties: ${key}`);
+}
+
+for (let key of Object.getOwnPropertySymbols(finalizationRegistry)) {
+  assert(false, `should not set any own symbol properties: ${String(key)}`);
+}
+
+assert.sameValue(Object.getPrototypeOf(finalizationRegistry), FinalizationRegistry.prototype);

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/undefined-newtarget-throws.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/JavaScript/undefined-newtarget-throws.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry-target
+description: >
+  Throws a TypeError if NewTarget is undefined.
+info: |
+  FinalizationRegistry ( cleanupCallback )
+
+  1. If NewTarget is undefined, throw a TypeError exception.
+  2. If IsCallable(cleanupCallback) is false, throw a TypeError exception.
+  ...
+features: [FinalizationRegistry]
+---*/
+
+assert.sameValue(
+  typeof FinalizationRegistry, 'function',
+  'typeof FinalizationRegistry is function'
+);
+
+assert.throws(TypeError, function() {
+  FinalizationRegistry();
+});
+
+assert.throws(TypeError, function() {
+  FinalizationRegistry(function() {});
+});

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/ExecutionTests.cs
@@ -1,0 +1,20 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.FinalizationRegistry.prototype;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.FinalizationRegistry.prototype") { }
+
+    [Fact(DisplayName = "constructor.js")]
+    public Task constructor() => ExecutionTestFromFile("constructor");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+
+    [Fact(DisplayName = "proto.js")]
+    public Task proto() => ExecutionTestFromFile("proto");
+
+    [Fact(DisplayName = "Symbol.toStringTag.js")]
+    public Task symbol_to_string_tag() => ExecutionTestFromFile("Symbol.toStringTag");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/JavaScript/Symbol.toStringTag.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/JavaScript/Symbol.toStringTag.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry-@@tostringtag
+description: >
+    `Symbol.toStringTag` property descriptor
+info: |
+    The initial value of the @@toStringTag property is the String value
+    'FinalizationRegistry'.
+
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [FinalizationRegistry, Symbol, Symbol.toStringTag]
+---*/
+
+verifyProperty(FinalizationRegistry.prototype, Symbol.toStringTag, {
+  value: 'FinalizationRegistry',
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/JavaScript/constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/JavaScript/constructor.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry.prototype.constructor
+description: FinalizationRegistry.prototype.constructor property descriptor
+info: |
+  FinalizationRegistry.prototype.constructor
+
+  The initial value of FinalizationRegistry.prototype.constructor is the intrinsic
+  object %FinalizationRegistry%.
+
+  17 ECMAScript Standard Built-in Objects
+includes: [propertyHelper.js]
+features: [FinalizationRegistry]
+---*/
+
+verifyProperty(FinalizationRegistry.prototype, 'constructor', {
+  value: FinalizationRegistry,
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/JavaScript/prop-desc.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The property descriptor FinalizationRegistry.prototype
+esid: sec-finalization-registry.prototype
+info: |
+  This property has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: false }.
+features: [FinalizationRegistry]
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(FinalizationRegistry, 'prototype', {
+  writable: false,
+  enumerable: false,
+  configurable: false
+});

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/JavaScript/proto.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/JavaScript/proto.js
@@ -1,0 +1,14 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+description: The prototype of FinalizationRegistry.prototype is Object.prototype
+esid: sec-properties-of-the-finalization-registry-prototype-object
+info: |
+  The value of the [[Prototype]] internal slot of the FinalizationRegistry prototype object
+  is the intrinsic object %ObjectPrototype%.
+features: [FinalizationRegistry]
+---*/
+
+var proto = Object.getPrototypeOf(FinalizationRegistry.prototype);
+assert.sameValue(proto, Object.prototype);

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/ExecutionTests.cs
@@ -1,0 +1,30 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.FinalizationRegistry.prototype.register;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.FinalizationRegistry.prototype.register") { }
+
+    [Fact(DisplayName = "custom-this.js")]
+    public Task custom_this() => ExecutionTestFromFile("custom-this");
+
+    [Fact(DisplayName = "length.js")]
+    public Task length() => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "not-a-constructor.js")]
+    public Task not_a_constructor() => ExecutionTestFromFile("not-a-constructor");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+
+    [Fact(DisplayName = "this-does-not-have-internal-target-throws.js")]
+    public Task this_does_not_have_internal_target_throws()
+        => ExecutionTestFromFile("this-does-not-have-internal-target-throws");
+
+    [Fact(DisplayName = "this-not-object-throws.js")]
+    public Task this_not_object_throws() => ExecutionTestFromFile("this-not-object-throws");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/custom-this.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/custom-this.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry.prototype.register
+description: Return undefined (applying custom this)
+info: |
+  FinalizationRegistry.prototype.register ( target , holdings [, unregisterToken ] )
+
+  1. Let finalizationRegistry be the this value.
+  2. If Type(finalizationRegistry) is not Object, throw a TypeError exception.
+  3. If Type(target) is not Object, throw a TypeError exception.
+  4. If finalizationRegistry does not have a [[Cells]] internal slot, throw a TypeError exception.
+  5. If Type(unregisterToken) is not Object,
+    a. If unregisterToken is not undefined, throw a TypeError exception.
+    b. Set unregisterToken to empty.
+  6. Let cell be the Record { [[Target]] : target, [[Holdings]]: holdings, [[UnregisterToken]]: unregisterToken }.
+  7. Append cell to finalizationRegistry.[[Cells]].
+  8. Return undefined.
+features: [FinalizationRegistry]
+---*/
+
+var fn = function() {};
+var register = FinalizationRegistry.prototype.register;
+var finalizationRegistry = new FinalizationRegistry(fn);
+
+var target = {};
+assert.sameValue(register.call(finalizationRegistry, target), undefined);

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry.prototype.register
+description: FinalizationRegistry.prototype.register.length property descriptor
+info: |
+  FinalizationRegistry.prototype.register ( target , holdings [, unregisterToken ] )
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in
+  function object has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [FinalizationRegistry]
+---*/
+
+verifyProperty(FinalizationRegistry.prototype.register, 'length', {
+  value: 2,
+  enumerable: false,
+  writable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/name.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry.prototype.register
+description: FinalizationRegistry.prototype.register.name property descriptor
+info: |
+  FinalizationRegistry.prototype.register.name value and property descriptor
+
+  17 ECMAScript Standard Built-in Objects
+
+  Every built-in function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value
+  is a String. Unless otherwise specified, this value is the name that
+  is given to the function in this specification. For functions that
+  are specified as properties of objects, the name value is the
+  property name string used to access the function. [...]
+
+  Unless otherwise specified, the name property of a built-in function
+  object, if it exists, has the attributes { [[Writable]]: false,
+  [[Enumerable]]: false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [FinalizationRegistry]
+---*/
+
+verifyProperty(FinalizationRegistry.prototype.register, 'name', {
+  value: 'register',
+  enumerable: false,
+  writable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/not-a-constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/not-a-constructor.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  FinalizationRegistry.prototype.register does not implement [[Construct]], is not new-able
+info: |
+  ECMAScript Function Objects
+
+  Built-in function objects that are not identified as constructors do not
+  implement the [[Construct]] internal method unless otherwise specified in
+  the description of a particular function.
+
+  sec-evaluatenew
+
+  ...
+  7. If IsConstructor(constructor) is false, throw a TypeError exception.
+  ...
+includes: [isConstructor.js]
+features: [Reflect.construct, FinalizationRegistry, arrow-function]
+---*/
+
+assert.sameValue(
+  isConstructor(FinalizationRegistry.prototype.register),
+  false,
+  'isConstructor(FinalizationRegistry.prototype.register) must return false'
+);
+
+assert.throws(TypeError, () => {
+  let fr = new FinalizationRegistry(() => {}); new fr.register({});
+});
+

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/prop-desc.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry.prototype.register
+description: >
+  Property descriptor of FinalizationRegistry.prototype.register
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+features: [FinalizationRegistry]
+---*/
+
+assert.sameValue(typeof FinalizationRegistry.prototype.register, 'function');
+
+verifyProperty(FinalizationRegistry.prototype, 'register', {
+  enumerable: false,
+  writable: true,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/this-does-not-have-internal-target-throws.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/this-does-not-have-internal-target-throws.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry.prototype.register
+description: Throws a TypeError if this does not have a [[Cells]] internal slot
+info: |
+  FinalizationRegistry.prototype.register ( target , holdings [, unregisterToken ] )
+
+  1. Let finalizationRegistry be the this value.
+  2. If Type(finalizationRegistry) is not Object, throw a TypeError exception.
+  3. If Type(target) is not Object, throw a TypeError exception.
+  4. If finalizationRegistry does not have a [[Cells]] internal slot, throw a TypeError exception.
+  ...
+features: [WeakSet, WeakMap, FinalizationRegistry, WeakRef]
+---*/
+
+assert.sameValue(typeof FinalizationRegistry.prototype.register, 'function');
+
+var register = FinalizationRegistry.prototype.register;
+var target = {};
+
+assert.throws(TypeError, function() {
+  register.call({ ['[[Cells]]']: {} }, target);
+}, 'Ordinary object without [[Cells]]');
+
+assert.throws(TypeError, function() {
+  register.call(WeakRef.prototype, target);
+}, 'WeakRef.prototype does not have a [[Cells]] internal slot');
+
+assert.throws(TypeError, function() {
+  register.call(WeakRef, target);
+}, 'WeakRef does not have a [[Cells]] internal slot');
+
+var wr = new WeakRef({});
+assert.throws(TypeError, function() {
+  register.call(wr, target);
+}, 'WeakRef instance');
+
+var wm = new WeakMap();
+assert.throws(TypeError, function() {
+  register.call(wm, target);
+}, 'WeakMap instance');
+
+var ws = new WeakSet();
+assert.throws(TypeError, function() {
+  register.call(ws, target);
+}, 'WeakSet instance');

--- a/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/this-not-object-throws.js
+++ b/tests/Jroc.Test262.Tests/built-ins/FinalizationRegistry/prototype/register/JavaScript/this-not-object-throws.js
@@ -1,0 +1,51 @@
+// Copyright (C) 2019 Leo Balter. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-finalization-registry.prototype.register
+description: Throws a TypeError if this is not an Object
+info: |
+  FinalizationRegistry.prototype.register ( target , holdings [, unregisterToken ] )
+
+  1. Let finalizationRegistry be the this value.
+  2. If Type(finalizationRegistry) is not Object, throw a TypeError exception.
+  3. If Type(target) is not Object, throw a TypeError exception.
+  4. If finalizationRegistry does not have a [[Cells]] internal slot, throw a TypeError exception.
+  5. If Type(unregisterToken) is not Object,
+    a. If unregisterToken is not undefined, throw a TypeError exception.
+  ...
+features: [FinalizationRegistry]
+---*/
+
+assert.sameValue(typeof FinalizationRegistry.prototype.register, 'function');
+
+var register = FinalizationRegistry.prototype.register;
+
+assert.throws(TypeError, function() {
+  register.call(undefined, {});
+}, 'undefined');
+
+assert.throws(TypeError, function() {
+  register.call(null, {});
+}, 'null');
+
+assert.throws(TypeError, function() {
+  register.call(true, {});
+}, 'true');
+
+assert.throws(TypeError, function() {
+  register.call(false, {});
+}, 'false');
+
+assert.throws(TypeError, function() {
+  register.call(1, {});
+}, 'number');
+
+assert.throws(TypeError, function() {
+  register.call('object', {});
+}, 'string');
+
+var s = Symbol();
+assert.throws(TypeError, function() {
+  register.call(s, {});
+}, 'symbol');


### PR DESCRIPTION
## Summary
- expose `globalThis.FinalizationRegistry` with standard constructor and prototype metadata
- add prototype-owned `register` and `unregister` methods with receiver validation
- port 20 byte-identical FinalizationRegistry test262 fixtures and update ECMA-262 coverage docs

## Validation
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --filter "FullyQualifiedName~built_ins.FinalizationRegistry" --no-restore`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --filter "FullyQualifiedName~FinalizationRegistry" --no-restore`
- `dotnet build src/Cli/Jroc.csproj -c Release --no-restore`
- `node scripts/test262/runMvp.js --filter "built-ins/FinalizationRegistry" --limit 80` (88/94 cases pass; remaining failures are cross-realm/custom-newTarget coverage)