### PR TITLE
runtime: move module state into realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   register() and unregister() methods. Activates twenty corresponding pinned
   test262 fixtures.
 
+- runtime: move CommonJS and ESM graph state into `RuntimeRealm`, including
+  module instances, live bindings, namespace caches, `import.meta`,
+  module-scoped require delegates, and compiled assembly ownership. Active
+  module paths and require parent state now follow nested execution frames,
+  while realm disposal releases the complete module graph.
+
 - runtime/test262: expose WeakRef as a first-class global constructor with
   standard constructor/prototype metadata and `deref()` behavior. Weak-target
   eligibility now correctly rejects registered symbols. Activates twenty

--- a/docs/runtime/RuntimeModuleState.md
+++ b/docs/runtime/RuntimeModuleState.md
@@ -1,0 +1,27 @@
+# Runtime module state
+
+Each `RuntimeRealm` owns exactly one `RuntimeModuleState`. It is the lifetime
+boundary for all mutable CommonJS and ECMAScript module graph state:
+
+- CommonJS module instances, exports caches, parent/main relationships, and
+  Node module instances;
+- the compiled modules assembly and its lazily discovered module type map;
+- module-scoped require delegates used by dynamic import;
+- `import.meta` objects keyed by canonical URL;
+- ESM live binding cells and native namespace markers;
+- synthesized CommonJS namespace objects.
+
+Identical canonical module IDs can therefore exist concurrently in different
+realms without sharing exports, bindings, namespace identity, or
+`import.meta`. Immutable compiled metadata and the Node module type registry
+may still be discovered process-wide, but realm-created values are stored only
+in `RuntimeModuleState`.
+
+Module filename, directory, and the active CommonJS parent module belong to
+the current execution frame. Nested frame entry inherits those values and
+restores the previous values when its scope exits. Root entry starts without
+an active parent module.
+
+Disposing a realm clears its module state as one operation. Runtime shutdown
+does not unregister entries from process-wide dictionaries because no mutable
+module graph is process-owned.

--- a/docs/runtime/RuntimeOwnership.md
+++ b/docs/runtime/RuntimeOwnership.md
@@ -6,6 +6,7 @@ JROC runtime state has three explicit lifetime owners:
 RuntimeAgentCluster
   -> RuntimeAgent
       -> RuntimeRealm
+          -> RuntimeModuleState
           -> ServiceContainer
           -> RuntimeExecutionContext (while entered)
 ```
@@ -16,6 +17,9 @@ RuntimeAgentCluster
   more realms.
 - `RuntimeRealm` owns one JavaScript object graph and exactly one runtime
   `ServiceContainer`.
+- `RuntimeModuleState` owns the realm's CommonJS and ESM graph, including
+  module instances, live binding cells, namespace identities, `import.meta`,
+  module-scoped require delegates, and the compiled module assembly.
 
 The child keeps a reference to its parent so services can receive the correct
 owner through constructor injection. Parents keep their children only while
@@ -41,6 +45,8 @@ issues move that state under these owners.
 - A cluster may reference its active agents.
 - An agent may reference its cluster and active realms.
 - A realm may reference its agent and service container.
+- A realm owns one module state object; no mutable module graph is
+  process-wide.
 - An entered execution context is the only ambient pointer to a realm and
   agent; thread identity is not an ownership boundary.
 - Realm services may receive any of the three owners through constructor

--- a/src/JavaScriptRuntime/DependencyInjection/ServiceContainer.cs
+++ b/src/JavaScriptRuntime/DependencyInjection/ServiceContainer.cs
@@ -40,6 +40,7 @@ public class ServiceContainer
             _singletons[typeof(RuntimeAgentCluster)] = realm.Agent.Cluster;
             _singletons[typeof(RuntimeAgent)] = realm.Agent;
             _singletons[typeof(RuntimeRealm)] = realm;
+            _singletons[typeof(Modules.RuntimeModuleState)] = realm.ModuleState;
         }
     }
 
@@ -301,6 +302,7 @@ public class ServiceContainer
         _singletons[typeof(RuntimeAgentCluster)] = _owningRealm.Agent.Cluster;
         _singletons[typeof(RuntimeAgent)] = _owningRealm.Agent;
         _singletons[typeof(RuntimeRealm)] = _owningRealm;
+        _singletons[typeof(Modules.RuntimeModuleState)] = _owningRealm.ModuleState;
     }
 
     private void ThrowIfOwningRealmDisposed()
@@ -316,7 +318,8 @@ public class ServiceContainer
         if (_owningRealm != null
             && (serviceType == typeof(RuntimeAgentCluster)
                 || serviceType == typeof(RuntimeAgent)
-                || serviceType == typeof(RuntimeRealm)))
+                || serviceType == typeof(RuntimeRealm)
+                || serviceType == typeof(Modules.RuntimeModuleState)))
         {
             throw new InvalidOperationException(
                 $"Runtime ownership service '{serviceType.Name}' cannot be replaced or removed.");

--- a/src/JavaScriptRuntime/Engine/Engine.cs
+++ b/src/JavaScriptRuntime/Engine/Engine.cs
@@ -51,8 +51,6 @@ public class Engine
                 }
                 finally
                 {
-                    RuntimeServices.UnregisterModuleRequires(
-                        runtimeContext.RegisteredModuleRequires);
                     if (serviceProvider.TryResolve<AsyncContextRuntime>(
                             out var asyncContext)
                         && asyncContext != null)
@@ -103,7 +101,7 @@ public class Engine
         _ = serviceProvider.Resolve<NodeEventLoopPump>();
 
         // Provide the compiled modules assembly for runtime dependency/module resolution.
-        serviceProvider.Resolve<LocalModulesAssembly>().ModulesAssembly = modulesAssembly;
+        serviceProvider.Resolve<RuntimeRealm>().ModuleState.ModulesAssembly = modulesAssembly;
 
         return serviceProvider;
     }

--- a/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
+++ b/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
@@ -511,11 +511,6 @@ internal sealed class JsRuntimeInstance : IDisposable
         {
             FailPendingOperations();
 
-            if (_serviceProvider?.TryResolve<RuntimeExecutionContext>(out var runtimeContext) == true && runtimeContext != null)
-            {
-                RuntimeServices.UnregisterModuleRequires(runtimeContext.RegisteredModuleRequires);
-            }
-
             executionScope?.Dispose();
             _exports = null;
             _eventLoop = null;

--- a/src/JavaScriptRuntime/Modules/CommonJS/Require.cs
+++ b/src/JavaScriptRuntime/Modules/CommonJS/Require.cs
@@ -4,35 +4,51 @@ using System.Dynamic;
 using System.Reflection;
 using System.Linq;
 using Jroc.Runtime;
+using JavaScriptRuntime.Modules.Shared;
 
 namespace JavaScriptRuntime.Modules.CommonJS
 {
-    using JavaScriptRuntime.Modules.Shared;
-
     internal sealed class Require
     {
-        // Registry and instance cache; resolved lazily via [Node.NodeModule] attributes
-        private readonly Dictionary<string, Type> _registry = new(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, object> _instances = new(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, Module> _modules = new(StringComparer.OrdinalIgnoreCase);
-        private readonly HashSet<string> _notFound = new(StringComparer.OrdinalIgnoreCase);
+        private readonly RuntimeModuleState _state;
 
-        private readonly Assembly? _localModulesAssembly;
+        private Dictionary<string, Type> _registry => _state.NodeModuleRegistry;
 
-        // Mapping emitted by the compiler: logical module id -> CLR type name.
-        // Populated lazily from assembly attributes.
-        private Dictionary<string, (string CanonicalId, string TypeName)>? _compiledModuleTypeMap;
-        
-        // Track the current parent module for establishing parent-child relationships
-        private Module? _currentParentModule;
+        private Dictionary<string, object> _instances => _state.Instances;
 
-        // Node semantics: require.main should refer to the main module.
-        private Module? _mainModule;
+        private Dictionary<string, Module> _modules => _state.CommonJsModules;
 
-        public Require(LocalModulesAssembly localModulesAssembly)
+        private HashSet<string> _notFound => _state.MissingNodeModules;
+
+        private Assembly? _localModulesAssembly => _state.ModulesAssembly;
+
+        private Dictionary<string, (string CanonicalId, string TypeName)>? _compiledModuleTypeMap
         {
-            // Preload local modules from the provided assembly
-            _localModulesAssembly = localModulesAssembly.ModulesAssembly;
+            get => _state.CompiledModuleTypeMap;
+            set => _state.CompiledModuleTypeMap = value;
+        }
+
+        private Module? _currentParentModule
+        {
+            get => RuntimeExecutionContext.Current?.GetCurrentParentModule();
+            set
+            {
+                var context = RuntimeExecutionContext.Current
+                    ?? throw new InvalidOperationException(
+                        "Active require state requires a runtime execution frame.");
+                context.SetCurrentParentModule(value);
+            }
+        }
+
+        private Module? _mainModule
+        {
+            get => _state.MainModule;
+            set => _state.MainModule = value;
+        }
+
+        public Require(RuntimeModuleState state)
+        {
+            _state = state;
         }
 
         internal void SetMainModule(Module mainModule)
@@ -108,7 +124,9 @@ namespace JavaScriptRuntime.Modules.CommonJS
         public object? RequireModule(string specifier)
         {
             if (string.IsNullOrWhiteSpace(specifier))
-                throw new ReferenceError("require specifier must be a non-empty string"); 
+            {
+                throw new ReferenceError("require specifier must be a non-empty string");
+            }
 
             var isNodeBuiltinSpecifier = IsNodeBuiltinSpecifier(specifier);
             var key = Normalize(specifier);

--- a/src/JavaScriptRuntime/Modules/ESM/EsModuleLinker.cs
+++ b/src/JavaScriptRuntime/Modules/ESM/EsModuleLinker.cs
@@ -4,13 +4,6 @@ using JavaScriptRuntime.Modules.Shared;
 
 namespace JavaScriptRuntime.Modules.ESM
 {
-    internal sealed class EsModuleLinkerState
-    {
-        internal ConcurrentDictionary<string, ConcurrentDictionary<string, EsModuleBinding>> BindingsByModule { get; } = new();
-
-        internal ConditionalWeakTable<object, ModuleNamespaceMarker> ModuleNamespaces { get; } = new();
-    }
-
     internal sealed class ModuleNamespaceMarker
     {
     }
@@ -76,13 +69,13 @@ namespace JavaScriptRuntime.Modules.ESM
     /// </summary>
     public static class EsModuleLinker
     {
-        private static EsModuleLinkerState State
-            => GlobalThis.ServiceProvider?.Resolve<EsModuleLinkerState>()
+        private static RuntimeModuleState State
+            => RuntimeExecutionContext.Current?.Realm.ModuleState
                ?? throw new InvalidOperationException(
                    "ES module linking requires an active JavaScript runtime.");
 
         private static ConcurrentDictionary<string, EsModuleBinding> GetModuleBindings(string moduleId)
-            => State.BindingsByModule.GetOrAdd(
+            => State.EsModuleBindings.GetOrAdd(
                 moduleId,
                 static _ => new ConcurrentDictionary<string, EsModuleBinding>(StringComparer.Ordinal));
 
@@ -109,7 +102,7 @@ namespace JavaScriptRuntime.Modules.ESM
                 ObjectRuntime.defineProperty(exports, "__esModule", descriptor);
             }
 
-            State.ModuleNamespaces.GetValue(exports, static _ => new ModuleNamespaceMarker());
+            State.EsModuleNamespaces.GetValue(exports, static _ => new ModuleNamespaceMarker());
         }
 
         /// <summary>
@@ -119,11 +112,8 @@ namespace JavaScriptRuntime.Modules.ESM
         /// </summary>
         internal static bool IsModuleNamespace(object value)
         {
-            var services = GlobalThis.ServiceProvider;
-            return services != null
-                && services.TryResolve<EsModuleLinkerState>(out var state)
-                && state != null
-                && state.ModuleNamespaces.TryGetValue(value, out _);
+            return RuntimeExecutionContext.Current?.Realm.ModuleState
+                .EsModuleNamespaces.TryGetValue(value, out _) == true;
         }
 
         /// <summary>

--- a/src/JavaScriptRuntime/Modules/RuntimeModuleState.cs
+++ b/src/JavaScriptRuntime/Modules/RuntimeModuleState.cs
@@ -1,0 +1,62 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using JavaScriptRuntime.Modules.CommonJS;
+using JavaScriptRuntime.Modules.ESM;
+using Assembly = System.Reflection.Assembly;
+
+namespace JavaScriptRuntime.Modules;
+
+internal sealed class RuntimeModuleState : IDisposable
+{
+    internal Dictionary<string, Type> NodeModuleRegistry { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    internal Dictionary<string, object> Instances { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    internal Dictionary<string, Module> CommonJsModules { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    internal HashSet<string> MissingNodeModules { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    internal ConcurrentDictionary<string, JsObject> ImportMetaByUrl { get; } =
+        new(StringComparer.Ordinal);
+
+    internal ConcurrentDictionary<string, RequireDelegate> RequireByModuleId { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    internal ConcurrentDictionary<string, ConcurrentDictionary<string, EsModuleBinding>> EsModuleBindings { get; } =
+        new(StringComparer.Ordinal);
+
+    internal ConditionalWeakTable<object, ModuleNamespaceMarker> EsModuleNamespaces { get; } = new();
+
+    internal ConditionalWeakTable<object, object> CommonJsNamespaceCache { get; } = new();
+
+    internal Assembly? ModulesAssembly { get; set; }
+
+    internal Dictionary<string, (string CanonicalId, string TypeName)>?
+        CompiledModuleTypeMap
+    {
+        get;
+        set;
+    }
+
+    internal Module? MainModule { get; set; }
+
+    public void Dispose()
+    {
+        NodeModuleRegistry.Clear();
+        Instances.Clear();
+        CommonJsModules.Clear();
+        MissingNodeModules.Clear();
+        ImportMetaByUrl.Clear();
+        RequireByModuleId.Clear();
+        EsModuleBindings.Clear();
+        EsModuleNamespaces.Clear();
+        CommonJsNamespaceCache.Clear();
+        ModulesAssembly = null;
+        CompiledModuleTypeMap = null;
+        MainModule = null;
+    }
+}

--- a/src/JavaScriptRuntime/Modules/Shared/EsModuleInterop.cs
+++ b/src/JavaScriptRuntime/Modules/Shared/EsModuleInterop.cs
@@ -1,12 +1,13 @@
-using System.Runtime.CompilerServices;
-
 namespace JavaScriptRuntime.Modules.Shared
 {
     internal static class EsModuleInterop
     {
         private const string EsModuleProperty = "__esModule";
-        private const string NamespaceCacheProperty = "__jroc_esm_namespace";
-        private static readonly ConditionalWeakTable<object, object> NamespaceSideCache = new();
+
+        private static RuntimeModuleState State
+            => RuntimeExecutionContext.Current?.Realm.ModuleState
+                ?? throw new InvalidOperationException(
+                    "ES module interop requires an active JavaScript runtime.");
 
         public static object ToDynamicImportResult(object? exports)
         {
@@ -73,37 +74,12 @@ namespace JavaScriptRuntime.Modules.Shared
 
         private static bool TryGetCachedNamespace(object exports, out object? namespaceObject)
         {
-            namespaceObject = null;
-            if (ObjectRuntime.hasOwn(exports, NamespaceCacheProperty))
-            {
-                namespaceObject = JavaScriptRuntime.ObjectRuntime.GetProperty(exports, NamespaceCacheProperty);
-                if (namespaceObject is not null && namespaceObject is not JsNull)
-                {
-                    return true;
-                }
-            }
-
-            return NamespaceSideCache.TryGetValue(exports, out namespaceObject);
+            return State.CommonJsNamespaceCache.TryGetValue(exports, out namespaceObject);
         }
 
         private static object CacheNamespace(object exports, object namespaceObject)
         {
-            if (ObjectRuntime.hasOwn(exports, NamespaceCacheProperty))
-            {
-                return JavaScriptRuntime.ObjectRuntime.GetProperty(exports, NamespaceCacheProperty) ?? namespaceObject;
-            }
-
-            if (ObjectRuntime.isExtensible(exports))
-            {
-                ObjectRuntime.defineProperty(
-                    exports,
-                    NamespaceCacheProperty,
-                    CreateDataDescriptor(namespaceObject, enumerable: false, configurable: false, writable: false));
-
-                return namespaceObject;
-            }
-
-            return NamespaceSideCache.GetValue(exports, _ => namespaceObject);
+            return State.CommonJsNamespaceCache.GetValue(exports, _ => namespaceObject);
         }
 
         private static object CreatePrimitiveNamespace(object? exports)
@@ -123,18 +99,7 @@ namespace JavaScriptRuntime.Modules.Shared
         {
             return key == "default"
                 || key == "module.exports"
-                || key == EsModuleProperty
-                || key == NamespaceCacheProperty;
-        }
-
-        private static object CreateDataDescriptor(object? value, bool enumerable, bool configurable, bool writable)
-        {
-            var descriptor = new JsObject();
-            descriptor.SetValue("value", value);
-            descriptor.SetBoolean("enumerable", enumerable);
-            descriptor.SetBoolean("configurable", configurable);
-            descriptor.SetBoolean("writable", writable);
-            return descriptor;
+                || key == EsModuleProperty;
         }
     }
 }

--- a/src/JavaScriptRuntime/Modules/Shared/LocalModulesAssembly.cs
+++ b/src/JavaScriptRuntime/Modules/Shared/LocalModulesAssembly.cs
@@ -1,8 +1,0 @@
-using System.Reflection;
-
-namespace JavaScriptRuntime.Modules.Shared;
-
-class LocalModulesAssembly
-{
-    public Assembly? ModulesAssembly { get; set; }
-}

--- a/src/JavaScriptRuntime/RuntimeExecutionContext.cs
+++ b/src/JavaScriptRuntime/RuntimeExecutionContext.cs
@@ -8,8 +8,9 @@ internal sealed class RuntimeExecutionContext
     private static readonly AsyncLocal<AmbientState?> Ambient = new();
 
     private readonly object _stateGate = new();
-    private readonly List<KeyValuePair<string, RequireDelegate>> _registeredModuleRequires = [];
     private GlobalThis? _globalObject;
+    private string _moduleDirectory = string.Empty;
+    private string _moduleFilename = string.Empty;
 
     private RuntimeExecutionContext(
         RuntimeRealm realm,
@@ -48,13 +49,6 @@ internal sealed class RuntimeExecutionContext
     internal bool IsHosted { get; private set; }
 
     internal string? CompiledAssemblyPath { get; private set; }
-
-    internal string ModuleDirectory { get; private set; } = string.Empty;
-
-    internal string ModuleFilename { get; private set; } = string.Empty;
-
-    internal IReadOnlyList<KeyValuePair<string, RequireDelegate>> RegisteredModuleRequires
-        => _registeredModuleRequires;
 
     internal static RuntimeExecutionContext GetOrCreate(
         ServiceContainer services,
@@ -118,9 +112,10 @@ internal sealed class RuntimeExecutionContext
 
         var frame = services == null
             ? null
-            : new ExecutionFrame(
+            : CreateFrame(
                 GetOrCreate(services),
-                IsLegacy: true);
+                isLegacy: true,
+                inheritActiveModuleState: true);
         SetAmbient(new AmbientState(
             frame,
             current?.ServiceProviderOverride));
@@ -131,19 +126,53 @@ internal sealed class RuntimeExecutionContext
         ArgumentNullException.ThrowIfNull(directory);
         ArgumentNullException.ThrowIfNull(filename);
 
+        if (Ambient.Value?.Frame is { } frame
+            && ReferenceEquals(frame.Context, this))
+        {
+            frame.ModuleDirectory = directory;
+            frame.ModuleFilename = filename;
+            return;
+        }
+
         lock (_stateGate)
         {
-            ModuleDirectory = directory;
-            ModuleFilename = filename;
+            _moduleDirectory = directory;
+            _moduleFilename = filename;
         }
     }
 
     internal (string Directory, string Filename) GetModuleLocation()
     {
+        if (Ambient.Value?.Frame is { } frame
+            && ReferenceEquals(frame.Context, this))
+        {
+            return (frame.ModuleDirectory, frame.ModuleFilename);
+        }
+
         lock (_stateGate)
         {
-            return (ModuleDirectory, ModuleFilename);
+            return (_moduleDirectory, _moduleFilename);
         }
+    }
+
+    internal Module? GetCurrentParentModule()
+    {
+        var frame = Ambient.Value?.Frame;
+        return frame != null && ReferenceEquals(frame.Context, this)
+            ? frame.CurrentParentModule
+            : null;
+    }
+
+    internal void SetCurrentParentModule(Module? module)
+    {
+        var frame = Ambient.Value?.Frame;
+        if (frame == null || !ReferenceEquals(frame.Context, this))
+        {
+            throw new InvalidOperationException(
+                "Active require state requires a runtime execution frame.");
+        }
+
+        frame.CurrentParentModule = module;
     }
 
     internal GlobalThis GetOrCreateGlobalObject()
@@ -152,12 +181,6 @@ internal sealed class RuntimeExecutionContext
         {
             return _globalObject ??= new GlobalThis();
         }
-    }
-
-    internal void TrackModuleRequire(string moduleId, RequireDelegate require)
-    {
-        _registeredModuleRequires.Add(
-            new KeyValuePair<string, RequireDelegate>(moduleId, require));
     }
 
     private IDisposable EnterCore(bool asRoot)
@@ -174,7 +197,10 @@ internal sealed class RuntimeExecutionContext
             invocationState = RuntimeServices.CaptureAndClearAmbientInvocationState();
         }
 
-        var frame = new ExecutionFrame(this, IsLegacy: false);
+        var frame = CreateFrame(
+            this,
+            isLegacy: false,
+            inheritActiveModuleState: !asRoot);
         try
         {
             SetAmbient(new AmbientState(
@@ -214,13 +240,55 @@ internal sealed class RuntimeExecutionContext
             next?.Frame?.Context.DescriptorStore);
     }
 
+    private static ExecutionFrame CreateFrame(
+        RuntimeExecutionContext context,
+        bool isLegacy,
+        bool inheritActiveModuleState)
+    {
+        var (directory, filename) = context.GetModuleLocation();
+        var frame = new ExecutionFrame(
+            context,
+            isLegacy,
+            directory,
+            filename);
+        if (inheritActiveModuleState
+            && Ambient.Value?.Frame is { } current
+            && ReferenceEquals(current.Context, context))
+        {
+            frame.CurrentParentModule = current.CurrentParentModule;
+        }
+
+        return frame;
+    }
+
     private sealed record AmbientState(
         ExecutionFrame? Frame,
         ServiceContainer? ServiceProviderOverride);
 
-    private sealed record ExecutionFrame(
-        RuntimeExecutionContext Context,
-        bool IsLegacy);
+    private sealed class ExecutionFrame
+    {
+        internal ExecutionFrame(
+            RuntimeExecutionContext context,
+            bool isLegacy,
+            string moduleDirectory,
+            string moduleFilename)
+        {
+            Context = context;
+            IsLegacy = isLegacy;
+            ModuleDirectory = moduleDirectory;
+            ModuleFilename = moduleFilename;
+        }
+
+        internal RuntimeExecutionContext Context { get; }
+
+        internal bool IsLegacy { get; }
+
+        internal string ModuleDirectory { get; set; }
+
+        internal string ModuleFilename { get; set; }
+
+        internal Module? CurrentParentModule { get; set; }
+    }
 
     private sealed class ExecutionScope : IDisposable
     {

--- a/src/JavaScriptRuntime/RuntimeOwnership.cs
+++ b/src/JavaScriptRuntime/RuntimeOwnership.cs
@@ -194,11 +194,14 @@ internal sealed class RuntimeRealm : IDisposable
     internal RuntimeRealm(RuntimeAgent agent)
     {
         Agent = agent;
+        ModuleState = new Modules.RuntimeModuleState();
         Services = new ServiceContainer();
         Services.AttachOwningRealm(this);
     }
 
     internal RuntimeAgent Agent { get; }
+
+    internal Modules.RuntimeModuleState ModuleState { get; }
 
     internal ServiceContainer Services { get; }
 
@@ -225,6 +228,7 @@ internal sealed class RuntimeRealm : IDisposable
             }
 
             _state = RuntimeOwnershipState.Disposing;
+            ModuleState.Dispose();
             DisposalOrder = Agent.Cluster.NextDisposalOrder();
             _state = RuntimeOwnershipState.Disposed;
         }

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -22,8 +22,6 @@ public class RuntimeServices
     [ThreadStatic] private static Stack<GeneratedFunctionDirectCallState>? _generatedFunctionDirectCallStack;
     [ThreadStatic] private static Stack<object?>? _constructorNewTargetStack;
     [ThreadStatic] private static Stack<object?>? _derivedConstructorThisStack;
-    private static readonly ConcurrentDictionary<string, JsObject> _importMetaByUrl = new(StringComparer.Ordinal);
-    private static readonly ConcurrentDictionary<string, JavaScriptRuntime.Modules.CommonJS.RequireDelegate> _requireByModuleId = new(StringComparer.OrdinalIgnoreCase);
     private static readonly ConditionalWeakTable<Type, LazyClassMetadataSlot> _lazyClassMetadata = new();
     private static readonly ConcurrentDictionary<ClassConstructorCacheKey, JsClassConstructorObject> _classConstructorValues = new();
 
@@ -1603,7 +1601,7 @@ public class RuntimeServices
     public static object GetImportMeta(object? moduleIdOrPath)
     {
         var url = GetImportMetaUrl(moduleIdOrPath);
-        var meta = _importMetaByUrl.GetOrAdd(url, static key =>
+        var meta = GetCurrentModuleState().ImportMetaByUrl.GetOrAdd(url, static key =>
         {
             var meta = new JsObject();
             if (!string.IsNullOrEmpty(key))
@@ -1696,20 +1694,7 @@ public class RuntimeServices
             return;
         }
 
-        _requireByModuleId[moduleId] = require;
-        if (GlobalThis.ServiceProvider?.TryResolve<RuntimeExecutionContext>(out var runtimeContext) == true
-            && runtimeContext != null)
-        {
-            runtimeContext.TrackModuleRequire(moduleId, require);
-        }
-    }
-
-    internal static void UnregisterModuleRequires(IEnumerable<KeyValuePair<string, Modules.CommonJS.RequireDelegate>> moduleRequires)
-    {
-        foreach (var moduleRequire in moduleRequires)
-        {
-            ((ICollection<KeyValuePair<string, Modules.CommonJS.RequireDelegate>>)_requireByModuleId).Remove(moduleRequire);
-        }
+        GetCurrentModuleState().RequireByModuleId[moduleId] = require;
     }
 
     /// <summary>
@@ -1722,8 +1707,15 @@ public class RuntimeServices
             return null;
         }
 
-        return _requireByModuleId.TryGetValue(moduleId, out var require) ? require : null;
+        return GetCurrentModuleState().RequireByModuleId.TryGetValue(moduleId, out var require)
+            ? require
+            : null;
     }
+
+    private static Modules.RuntimeModuleState GetCurrentModuleState()
+        => RuntimeExecutionContext.Current?.Realm.ModuleState
+            ?? throw new InvalidOperationException(
+                "Module state requires an active JavaScript runtime.");
 
     /// <summary>
     /// Creates the backing object for a JavaScript object literal.
@@ -1802,8 +1794,6 @@ public class RuntimeServices
         container.Register<EngineCore.IIOScheduler, EngineCore.NodeSchedulerState>();
         container.Register<EngineCore.IFinalizationRegistryHost, EngineCore.FinalizationRegistryHost>();
         container.Register<Modules.CommonJS.Require>();
-        container.Register<Modules.ESM.EsModuleLinkerState>();
-        container.Register<Modules.Shared.LocalModulesAssembly>();
         container.RegisterInstance<IPropertyDescriptorStore>(new PropertyDescriptorStore());
         container.Register<IEnvironment, DefaultEnvironment>();
         container.Register<Node.IChildProcessLauncher, Node.DefaultChildProcessLauncher>();

--- a/tests/Jroc.Testing/InMemoryTestCompiler.cs
+++ b/tests/Jroc.Testing/InMemoryTestCompiler.cs
@@ -215,12 +215,6 @@ public static class InMemoryTestCompiler
             }
             finally
             {
-                if (serviceProvider.TryResolve<RuntimeExecutionContext>(out var runtimeContext)
-                    && runtimeContext != null)
-                {
-                    RuntimeServices.UnregisterModuleRequires(runtimeContext.RegisteredModuleRequires);
-                }
-
                 Engine._serviceProviderOverride.Value = null;
                 RuntimeServices.SetCurrentThis(null);
                 EnvironmentProvider.SuppressExit = false;

--- a/tests/Jroc.Tests/CommonJS/ModuleObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/CommonJS/ModuleObjectRepresentationTests.cs
@@ -26,6 +26,7 @@ public class ModuleObjectRepresentationTests
     [Fact]
     public void DynamicImport_CjsNamespace_IsJsObject_AndPreservesLiveAccessors()
     {
+        using var scope = EnterRealm();
         var exports = new JsObject();
         ObjectRuntime.SetProperty(exports, "value", 1d);
 
@@ -43,11 +44,11 @@ public class ModuleObjectRepresentationTests
         Assert.Equal(2d, ObjectRuntime.GetProperty(jsNamespace, "value"));
         Assert.True(PropertyDescriptorStore.TryGetOwn(jsNamespace, "value", out var valueDescriptor));
         Assert.Equal(JsPropertyDescriptorKind.Accessor, valueDescriptor.Kind);
-        Assert.True(PropertyDescriptorStore.TryGetOwn(exports, "__jroc_esm_namespace", out var cacheDescriptor));
-        Assert.Same(jsNamespace, Assert.IsType<JsObject>(cacheDescriptor.Value));
-        Assert.False(cacheDescriptor.Enumerable);
-        Assert.False(cacheDescriptor.Configurable);
-        Assert.False(cacheDescriptor.Writable);
+        Assert.False(
+            PropertyDescriptorStore.TryGetOwn(
+                exports,
+                "__jroc_esm_namespace",
+                out _));
     }
 
     [Fact]
@@ -58,5 +59,11 @@ public class ModuleObjectRepresentationTests
         var jsNamespace = Assert.IsType<JsObject>(namespaceObject);
         Assert.Equal(42d, ObjectRuntime.GetProperty(jsNamespace, "default"));
         Assert.Equal(42d, ObjectRuntime.GetProperty(jsNamespace, "module.exports"));
+    }
+
+    private static IDisposable EnterRealm()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        return RuntimeExecutionContext.GetOrCreate(services).Enter();
     }
 }

--- a/tests/Jroc.Tests/CommonJS/RequireAdapterLazinessTests.cs
+++ b/tests/Jroc.Tests/CommonJS/RequireAdapterLazinessTests.cs
@@ -1,6 +1,6 @@
 using JavaScriptRuntime;
+using JavaScriptRuntime.Modules;
 using JavaScriptRuntime.Modules.CommonJS;
-using JavaScriptRuntime.Modules.Shared;
 
 namespace Jroc.Tests.CommonJS;
 
@@ -9,7 +9,7 @@ public sealed class RequireAdapterLazinessTests
     [Fact]
     public void ModuleConstruction_DoesNotMaterializeRequireAdapter()
     {
-        var requireService = new Require(new LocalModulesAssembly());
+        var requireService = new Require(new RuntimeModuleState());
         var requireTarget = new RequireFunctionTarget(requireService, "entry");
 
         _ = new Module(
@@ -27,7 +27,7 @@ public sealed class RequireAdapterLazinessTests
     [Fact]
     public void FirstRequireValueRead_CreatesOneStableAdapterWithMainMetadata()
     {
-        var requireService = new Require(new LocalModulesAssembly());
+        var requireService = new Require(new RuntimeModuleState());
         var requireTarget = new RequireFunctionTarget(requireService, "entry");
         var module = new Module(
             "entry",

--- a/tests/Jroc.Tests/ObjectRuntimeOrdinaryObjectTests.cs
+++ b/tests/Jroc.Tests/ObjectRuntimeOrdinaryObjectTests.cs
@@ -241,6 +241,8 @@ public sealed class ObjectRuntimeOrdinaryObjectTests
     [Fact]
     public void RuntimeCreatedOrdinaryRecords_AreJsObjects()
     {
+        var services = RuntimeServices.BuildServiceProvider();
+        using var scope = RuntimeExecutionContext.GetOrCreate(services).Enter();
         var moduleId = $"module-{Guid.NewGuid():N}.js";
         var importMeta = Assert.IsType<JsObject>(RuntimeServices.GetImportMeta(moduleId));
         var revocable = Assert.IsType<JsObject>(

--- a/tests/Jroc.Tests/RuntimeModuleStateTests.cs
+++ b/tests/Jroc.Tests/RuntimeModuleStateTests.cs
@@ -1,0 +1,222 @@
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using JavaScriptRuntime;
+using JavaScriptRuntime.Modules.CommonJS;
+using JavaScriptRuntime.Modules.ESM;
+using JavaScriptRuntime.Modules.Shared;
+using AssemblyName = System.Reflection.AssemblyName;
+
+namespace Jroc.Tests;
+
+public sealed class RuntimeModuleStateTests
+{
+    [Fact]
+    public async Task ParallelRealmsKeepIdenticalModuleIdsIndependent()
+    {
+        var first = CreateContext();
+        var second = CreateContext();
+        using var ready = new Barrier(2);
+
+        var firstTask = Task.Run(() =>
+        {
+            using var scope = first.EnterAsRoot();
+            var meta = RuntimeServices.GetImportMeta("shared.js");
+            RequireDelegate require = static _ => "first";
+            RuntimeServices.RegisterModuleRequire("shared.js", require);
+            ready.SignalAndWait();
+
+            Assert.Same(require, RuntimeServices.GetRequireForModule("shared.js"));
+            return meta;
+        });
+        var secondTask = Task.Run(() =>
+        {
+            using var scope = second.EnterAsRoot();
+            var meta = RuntimeServices.GetImportMeta("shared.js");
+            RequireDelegate require = static _ => "second";
+            RuntimeServices.RegisterModuleRequire("shared.js", require);
+            ready.SignalAndWait();
+
+            Assert.Same(require, RuntimeServices.GetRequireForModule("shared.js"));
+            return meta;
+        });
+
+        var metas = await Task.WhenAll(firstTask, secondTask);
+        Assert.NotSame(metas[0], metas[1]);
+
+        first.Realm.Dispose();
+
+        using (second.Enter())
+        {
+            Assert.Equal(
+                "second",
+                RuntimeServices.GetRequireForModule("shared.js")!("ignored"));
+            Assert.Same(metas[1], RuntimeServices.GetImportMeta("shared.js"));
+        }
+    }
+
+    [Fact]
+    public void EsmBindingsWithIdenticalIdsRemainRealmLocal()
+    {
+        var first = CreateContext();
+        var second = CreateContext();
+        var firstExports = new JsObject();
+        var secondExports = new JsObject();
+
+        using (first.Enter())
+        {
+            EsModuleLinker.MarkEsModule(firstExports);
+            EsModuleLinker.RegisterLocalExport(firstExports, "shared.js", "value");
+            EsModuleLinker.SetLocalExport("shared.js", "value", 1d);
+        }
+
+        using (second.Enter())
+        {
+            EsModuleLinker.MarkEsModule(secondExports);
+            EsModuleLinker.RegisterLocalExport(secondExports, "shared.js", "value");
+            EsModuleLinker.SetLocalExport("shared.js", "value", 2d);
+        }
+
+        Assert.Equal(1d, ObjectRuntime.GetProperty(firstExports, "value"));
+        Assert.Equal(2d, ObjectRuntime.GetProperty(secondExports, "value"));
+    }
+
+    [Fact]
+    public void CommonJsNamespaceCacheIsRealmLocal()
+    {
+        var first = CreateContext();
+        var second = CreateContext();
+        var exports = new JsObject();
+        ObjectRuntime.SetProperty(exports, "value", 1d);
+        JavaScriptRuntime.Object.preventExtensions(exports);
+        object firstNamespace;
+        object secondNamespace;
+
+        using (first.Enter())
+        {
+            firstNamespace = EsModuleInterop.ToDynamicImportResult(exports);
+            Assert.Same(
+                firstNamespace,
+                EsModuleInterop.ToDynamicImportResult(exports));
+        }
+
+        using (second.Enter())
+        {
+            secondNamespace = EsModuleInterop.ToDynamicImportResult(exports);
+            Assert.Same(
+                secondNamespace,
+                EsModuleInterop.ToDynamicImportResult(exports));
+        }
+
+        Assert.NotSame(firstNamespace, secondNamespace);
+    }
+
+    [Fact]
+    public void NestedFramesRestoreModuleLocationAndActiveRequireState()
+    {
+        var context = CreateContext();
+        var outerModule = new Module(
+            "outer",
+            "/outer/main.js",
+            parent: null,
+            static _ => null);
+        var innerModule = new Module(
+            "inner",
+            "/inner/main.js",
+            parent: null,
+            static _ => null);
+
+        using (context.Enter())
+        {
+            context.SetCurrentParentModule(outerModule);
+            ModuleContext.SetModuleContext("/outer", "/outer/main.js");
+
+            using (context.Enter())
+            {
+                Assert.Same(outerModule, context.GetCurrentParentModule());
+                AssertModuleLocation("/outer", "/outer/main.js");
+                context.SetCurrentParentModule(innerModule);
+                ModuleContext.SetModuleContext("/inner", "/inner/main.js");
+            }
+
+            Assert.Same(outerModule, context.GetCurrentParentModule());
+            AssertModuleLocation("/outer", "/outer/main.js");
+        }
+    }
+
+    [Fact]
+    public void RealmDisposalReleasesTheModuleGraph()
+    {
+        var context = CreateContext();
+        var exports = new JsObject();
+        var commonJsExports = new JsObject();
+
+        using (context.Enter())
+        {
+            context.Realm.ModuleState.ModulesAssembly = typeof(RuntimeModuleStateTests).Assembly;
+            _ = RuntimeServices.GetImportMeta("shared.js");
+            RuntimeServices.RegisterModuleRequire("shared.js", static _ => null);
+            EsModuleLinker.MarkEsModule(exports);
+            _ = EsModuleInterop.ToDynamicImportResult(commonJsExports);
+        }
+
+        context.Realm.Dispose();
+
+        Assert.Null(context.Realm.ModuleState.ModulesAssembly);
+        Assert.Empty(context.Realm.ModuleState.ImportMetaByUrl);
+        Assert.Empty(context.Realm.ModuleState.RequireByModuleId);
+        Assert.Empty(context.Realm.ModuleState.EsModuleBindings);
+        Assert.False(
+            context.Realm.ModuleState.EsModuleNamespaces.TryGetValue(
+                exports,
+                out _));
+        Assert.False(
+            context.Realm.ModuleState.CommonJsNamespaceCache.TryGetValue(
+                commonJsExports,
+                out _));
+    }
+
+    [Fact]
+    public void RealmDisposalDoesNotRetainCollectibleModuleAssembly()
+    {
+        var assemblyReference = CreateDisposedRealmWithCollectibleAssembly();
+
+        for (var attempt = 0; attempt < 10 && assemblyReference.IsAlive; attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        Assert.False(assemblyReference.IsAlive);
+    }
+
+    private static RuntimeExecutionContext CreateContext()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        return RuntimeExecutionContext.GetOrCreate(services);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateDisposedRealmWithCollectibleAssembly()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName($"CollectibleModule_{Guid.NewGuid():N}"),
+            AssemblyBuilderAccess.RunAndCollect);
+        var module = assembly.DefineDynamicModule("main");
+        _ = module.DefineType("Modules.Entry").CreateType();
+        var reference = new WeakReference(assembly);
+        var context = CreateContext();
+        context.Realm.ModuleState.ModulesAssembly = assembly;
+        context.Realm.Dispose();
+        return reference;
+    }
+
+    private static void AssertModuleLocation(
+        string expectedDirectory,
+        string expectedFilename)
+    {
+        var module = ModuleContext.CreateModuleContext();
+        Assert.Equal(expectedDirectory, module.__dirname);
+        Assert.Equal(expectedFilename, module.__filename);
+    }
+}

--- a/tests/Jroc.Tests/RuntimeOwnershipTests.cs
+++ b/tests/Jroc.Tests/RuntimeOwnershipTests.cs
@@ -1,5 +1,6 @@
 using JavaScriptRuntime;
 using JavaScriptRuntime.DependencyInjection;
+using JavaScriptRuntime.Modules;
 
 namespace Jroc.Tests;
 
@@ -16,6 +17,7 @@ public sealed class RuntimeOwnershipTests
         Assert.Same(realm, realm.Services.Resolve<RuntimeRealm>());
         Assert.Same(agent, realm.Services.Resolve<RuntimeAgent>());
         Assert.Same(cluster, realm.Services.Resolve<RuntimeAgentCluster>());
+        Assert.Same(realm.ModuleState, realm.Services.Resolve<RuntimeModuleState>());
         Assert.Equal(1, agent.RealmCount);
         Assert.Equal(1, cluster.AgentCount);
 
@@ -150,12 +152,15 @@ public sealed class RuntimeOwnershipTests
             () => services.Replace(new RuntimeAgentCluster()));
         Assert.Throws<InvalidOperationException>(
             () => services.Remove<RuntimeRealm>());
+        Assert.Throws<InvalidOperationException>(
+            () => services.Replace(new RuntimeModuleState()));
 
         services.Clear();
 
         Assert.Same(realm, services.Resolve<RuntimeRealm>());
         Assert.Same(realm.Agent, services.Resolve<RuntimeAgent>());
         Assert.Same(realm.Agent.Cluster, services.Resolve<RuntimeAgentCluster>());
+        Assert.Same(realm.ModuleState, services.Resolve<RuntimeModuleState>());
 
         realm.Agent.Cluster.Dispose();
     }


### PR DESCRIPTION
## Summary

- add realm-owned `RuntimeModuleState` for CommonJS and ESM graph identity
- move module instances, live binding cells, namespace caches, `import.meta`,
  require delegates, and compiled assembly ownership out of process-wide state
- move module location and active require parent state onto nested execution
  frames
- release the entire module graph during realm disposal instead of unregistering
  static entries during runtime shutdown

## Validation

- `dotnet build jroc.sln --no-restore`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --filter 'FullyQualifiedName~Jroc.Tests.Import|FullyQualifiedName~Jroc.Tests.CommonJS|FullyQualifiedName~Jroc.Tests.Hosting|FullyQualifiedName~RuntimeModuleStateTests|FullyQualifiedName~RuntimeExecutionContextTests|FullyQualifiedName~RuntimeOwnershipTests|FullyQualifiedName~ServiceContainerTests|FullyQualifiedName~ModuleLoaderTests|FullyQualifiedName~NodeModuleResolverTests' --no-restore`

Fixes #1823
