### PR TITLE
feat(runtime): expose DataView global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime/test262: expose DataView as a first-class global constructor with
+  standard constructor/prototype metadata and buffer, byteLength, and
+  byteOffset accessors. Activates twenty corresponding pinned test262 fixtures.
+
 - runtime/test262: expose FinalizationRegistry as a first-class global
   constructor with standard constructor/prototype metadata plus prototype-owned
   register() and unregister() methods. Activates twenty corresponding pinned

--- a/docs/ECMA262/19/Section19_3.json
+++ b/docs/ECMA262/19/Section19_3.json
@@ -54,7 +54,7 @@
     {
       "clause": "19.3.8",
       "title": "DataView ( . . . )",
-      "status": "Not Yet Supported",
+      "status": "Supported with Limitations",
       "specUrl": "https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-dataview"
     },
     {
@@ -363,6 +363,24 @@
           "test/built-ins/FinalizationRegistry/proto.js"
         ],
         "notes": "Exposes globalThis.FinalizationRegistry as a constructible function with the standard constructor/prototype metadata plus register(), unregister(), and @@toStringTag. Deterministic cleanup in tests still uses a host-opt-in non-standard gc() helper, while cleanup timing otherwise depends on .NET GC and event-loop checkpoints."
+      },
+      {
+        "clause": "19.3.8",
+        "feature": "DataView first-class global constructor",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-dataview",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/DataView/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/DataView/constructor.js",
+          "test/built-ins/DataView/is-a-constructor.js",
+          "test/built-ins/DataView/length.js",
+          "test/built-ins/DataView/name.js",
+          "test/built-ins/DataView/newtarget-undefined-throws.js",
+          "test/built-ins/DataView/proto.js"
+        ],
+        "notes": "Exposes globalThis.DataView as a constructible function with standard name, length, global-property, and prototype descriptors. BigInt/Float16 accessors, full prototype method exposure, custom newTarget prototypes, and detached-buffer behavior remain limited."
       },
       {
         "clause": "19.3.40",

--- a/docs/ECMA262/19/Section19_3.md
+++ b/docs/ECMA262/19/Section19_3.md
@@ -4,7 +4,7 @@
 
 [Back to Section19](Section19.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-08-15T06:08:55Z
+> Last generated (UTC): 2026-08-15T07:23:45Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -21,7 +21,7 @@
 | 19.3.5 | BigInt64Array ( . . . ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-bigint64array) |
 | 19.3.6 | BigUint64Array ( . . . ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-biguint64array) |
 | 19.3.7 | Boolean ( . . . ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-boolean) |
-| 19.3.8 | DataView ( . . . ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-dataview) |
+| 19.3.8 | DataView ( . . . ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-dataview) |
 | 19.3.9 | Date ( . . . ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-date) |
 | 19.3.10 | Error ( . . . ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-error) |
 | 19.3.11 | EvalError ( . . . ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-evalerror) |
@@ -66,6 +66,12 @@ Feature-level support tracking with repo test references and optional test262 ev
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | Global Boolean constructor is exposed as a callable function value (e.g., array.filter(Boolean)) | Supported with Limitations | [`PrimitiveConversion_Boolean_Callable.js`](../../../tests/Jroc.Tests/PrimitiveConversion/JavaScript/PrimitiveConversion_Boolean_Callable.js) |  | jroc supports calling Boolean(x) via primitive conversion lowering, and also supports using Boolean as a first-class function value by exposing it as JavaScriptRuntime.GlobalThis.Boolean (delegate). This is sufficient for common patterns like array.filter(Boolean), but does not implement full Boolean constructor/prototype semantics. |
+
+### 19.3.8 ([tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-dataview))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| DataView first-class global constructor | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/DataView/ExecutionTests.cs` | `test/built-ins/DataView/constructor.js`<br>`test/built-ins/DataView/is-a-constructor.js`<br>`test/built-ins/DataView/length.js`<br>`test/built-ins/DataView/name.js`<br>`test/built-ins/DataView/newtarget-undefined-throws.js`<br>`test/built-ins/DataView/proto.js` | Exposes globalThis.DataView as a constructible function with standard name, length, global-property, and prototype descriptors. BigInt/Float16 accessors, full prototype method exposure, custom newTarget prototypes, and detached-buffer behavior remain limited. |
 
 ### 19.3.12 ([tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-finalization-registry))
 

--- a/docs/ECMA262/25/Section25_3.json
+++ b/docs/ECMA262/25/Section25_3.json
@@ -66,13 +66,13 @@
     {
       "clause": "25.3.3",
       "title": "Properties of the DataView Constructor",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-dataview-constructor"
     },
     {
       "clause": "25.3.3.1",
       "title": "DataView.prototype",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview.prototype"
     },
     {
@@ -102,7 +102,7 @@
     {
       "clause": "25.3.4.4",
       "title": "DataView.prototype.constructor",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview.prototype.constructor"
     },
     {
@@ -240,7 +240,7 @@
     {
       "clause": "25.3.4.27",
       "title": "DataView.prototype [ %Symbol.toStringTag% ]",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-dataview.prototype-%symbol.tostringtag%"
     },
     {
@@ -258,21 +258,62 @@
         "status": "Supported with Limitations",
         "specUrl": "https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength",
         "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/DataView/ExecutionTests.cs",
           "tests/Jroc.Tests/TypedArray/JavaScript/DataView_ByteOffset_ByteLength.js",
           "tests/Jroc.Tests/TypedArray/JavaScript/DataView_BoundsChecks_RangeError.js",
           "tests/Jroc.Tests/TypedArray/JavaScript/DataView_InvalidByteOffset_ByteLength_Messages.js"
         ],
-        "notes": "Supports fixed-length ArrayBuffer-backed views with byteOffset/byteLength validation, distinct RangeError diagnostics for invalid byteOffset versus byteLength, and bounds checks. SharedArrayBuffer, resizable buffers, and detached buffer semantics are not implemented."
+        "test262Paths": [
+          "test/built-ins/DataView/newtarget-undefined-throws.js"
+        ],
+        "notes": "Supports a first-class DataView constructor plus fixed-length ArrayBuffer-backed views with byteOffset/byteLength validation, distinct RangeError diagnostics for invalid byteOffset versus byteLength, and bounds checks. SharedArrayBuffer, resizable buffers, custom newTarget prototypes, and detached buffer semantics are not implemented."
+      },
+      {
+        "clause": "25.3.3",
+        "feature": "DataView constructor function surface",
+        "status": "Supported",
+        "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-dataview-constructor",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/DataView/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/DataView/constructor.js",
+          "test/built-ins/DataView/is-a-constructor.js",
+          "test/built-ins/DataView/length.js",
+          "test/built-ins/DataView/name.js",
+          "test/built-ins/DataView/proto.js"
+        ],
+        "notes": "globalThis.DataView is a constructible function with standard name, length, and prototype metadata."
       },
       {
         "clause": "25.3.4",
-        "feature": "DataView prototype accessors",
+        "feature": "DataView prototype buffer accessors",
         "status": "Supported",
         "specUrl": "https://tc39.es/ecma262/#sec-properties-of-the-dataview-prototype-object",
         "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/DataView/prototype/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteLength/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteOffset/ExecutionTests.cs",
           "tests/Jroc.Tests/TypedArray/JavaScript/DataView_ByteOffset_ByteLength.js"
         ],
-        "notes": "buffer, byteOffset, and byteLength are exposed as runtime properties on JavaScriptRuntime.DataView."
+        "test262Paths": [
+          "test/built-ins/DataView/prototype/Symbol.toStringTag.js",
+          "test/built-ins/DataView/prototype/buffer/invoked-as-accessor.js",
+          "test/built-ins/DataView/prototype/buffer/length.js",
+          "test/built-ins/DataView/prototype/buffer/name.js",
+          "test/built-ins/DataView/prototype/buffer/prop-desc.js",
+          "test/built-ins/DataView/prototype/buffer/return-buffer.js",
+          "test/built-ins/DataView/prototype/byteLength/invoked-as-accessor.js",
+          "test/built-ins/DataView/prototype/byteLength/length.js",
+          "test/built-ins/DataView/prototype/byteLength/name.js",
+          "test/built-ins/DataView/prototype/byteLength/prop-desc.js",
+          "test/built-ins/DataView/prototype/byteOffset/invoked-as-accessor.js",
+          "test/built-ins/DataView/prototype/byteOffset/length.js",
+          "test/built-ins/DataView/prototype/byteOffset/name.js",
+          "test/built-ins/DataView/prototype/byteOffset/prop-desc.js"
+        ],
+        "notes": "DataView.prototype inherits Object.prototype and owns constructor, buffer, byteOffset, byteLength, and @@toStringTag properties. The accessors enforce DataView receivers and expose standard getter metadata."
       },
       {
         "clause": "25.3.4",

--- a/docs/ECMA262/25/Section25_3.md
+++ b/docs/ECMA262/25/Section25_3.md
@@ -4,7 +4,7 @@
 
 [Back to Section25](Section25.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-08-14T08:29:24Z
+> Last generated (UTC): 2026-08-15T07:23:46Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -23,13 +23,13 @@
 | 25.3.1.6 | SetViewValue ( view , requestIndex , isLittleEndian , type , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-setviewvalue) |
 | 25.3.2 | The DataView Constructor | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview-constructor) |
 | 25.3.2.1 | DataView ( buffer [ , byteOffset [ , byteLength ] ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength) |
-| 25.3.3 | Properties of the DataView Constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-dataview-constructor) |
-| 25.3.3.1 | DataView.prototype | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype) |
+| 25.3.3 | Properties of the DataView Constructor | Supported | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-dataview-constructor) |
+| 25.3.3.1 | DataView.prototype | Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype) |
 | 25.3.4 | Properties of the DataView Prototype Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-dataview-prototype-object) |
 | 25.3.4.1 | get DataView.prototype.buffer | Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-dataview.prototype.buffer) |
 | 25.3.4.2 | get DataView.prototype.byteLength | Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-dataview.prototype.bytelength) |
 | 25.3.4.3 | get DataView.prototype.byteOffset | Supported | [tc39.es](https://tc39.es/ecma262/#sec-get-dataview.prototype.byteoffset) |
-| 25.3.4.4 | DataView.prototype.constructor | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.constructor) |
+| 25.3.4.4 | DataView.prototype.constructor | Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.constructor) |
 | 25.3.4.5 | DataView.prototype.getBigInt64 ( byteOffset [ , littleEndian ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getbigint64) |
 | 25.3.4.6 | DataView.prototype.getBigUint64 ( byteOffset [ , littleEndian ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getbiguint64) |
 | 25.3.4.7 | DataView.prototype.getFloat16 ( byteOffset [ , littleEndian ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.getfloat16) |
@@ -52,7 +52,7 @@
 | 25.3.4.24 | DataView.prototype.setUint8 ( byteOffset , value ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setuint8) |
 | 25.3.4.25 | DataView.prototype.setUint16 ( byteOffset , value [ , littleEndian ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setuint16) |
 | 25.3.4.26 | DataView.prototype.setUint32 ( byteOffset , value [ , littleEndian ] ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype.setuint32) |
-| 25.3.4.27 | DataView.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype-%symbol.tostringtag%) |
+| 25.3.4.27 | DataView.prototype [ %Symbol.toStringTag% ] | Supported | [tc39.es](https://tc39.es/ecma262/#sec-dataview.prototype-%symbol.tostringtag%) |
 | 25.3.5 | Properties of DataView Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-dataview-instances) |
 
 ## Support
@@ -63,12 +63,18 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| DataView(buffer, byteOffset, byteLength) | Supported with Limitations | [`DataView_ByteOffset_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_ByteOffset_ByteLength.js)<br>[`DataView_BoundsChecks_RangeError.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_BoundsChecks_RangeError.js)<br>[`DataView_InvalidByteOffset_ByteLength_Messages.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_InvalidByteOffset_ByteLength_Messages.js) |  | Supports fixed-length ArrayBuffer-backed views with byteOffset/byteLength validation, distinct RangeError diagnostics for invalid byteOffset versus byteLength, and bounds checks. SharedArrayBuffer, resizable buffers, and detached buffer semantics are not implemented. |
+| DataView(buffer, byteOffset, byteLength) | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/DataView/ExecutionTests.cs`<br>[`DataView_ByteOffset_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_ByteOffset_ByteLength.js)<br>[`DataView_BoundsChecks_RangeError.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_BoundsChecks_RangeError.js)<br>[`DataView_InvalidByteOffset_ByteLength_Messages.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_InvalidByteOffset_ByteLength_Messages.js) | `test/built-ins/DataView/newtarget-undefined-throws.js` | Supports a first-class DataView constructor plus fixed-length ArrayBuffer-backed views with byteOffset/byteLength validation, distinct RangeError diagnostics for invalid byteOffset versus byteLength, and bounds checks. SharedArrayBuffer, resizable buffers, custom newTarget prototypes, and detached buffer semantics are not implemented. |
+
+### 25.3.3 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-dataview-constructor))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| DataView constructor function surface | Supported | `tests/Jroc.Test262.Tests/built-ins/DataView/ExecutionTests.cs` | `test/built-ins/DataView/constructor.js`<br>`test/built-ins/DataView/is-a-constructor.js`<br>`test/built-ins/DataView/length.js`<br>`test/built-ins/DataView/name.js`<br>`test/built-ins/DataView/proto.js` | globalThis.DataView is a constructible function with standard name, length, and prototype metadata. |
 
 ### 25.3.4 ([tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-dataview-prototype-object))
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
 | DataView integer and floating-point getters/setters | Supported with Limitations | [`DataView_SetGet_UintAndEndian.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_SetGet_UintAndEndian.js)<br>[`DataView_Float32_Float64_RoundTrip.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_Float32_Float64_RoundTrip.js) |  | Implements get/set for Int8, Uint8, Int16, Uint16, Int32, Uint32, Float32, and Float64 with optional littleEndian support (default big-endian). BigInt64, BigUint64, and Float16 remain unimplemented. |
-| DataView prototype accessors | Supported | [`DataView_ByteOffset_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_ByteOffset_ByteLength.js) |  | buffer, byteOffset, and byteLength are exposed as runtime properties on JavaScriptRuntime.DataView. |
+| DataView prototype buffer accessors | Supported | `tests/Jroc.Test262.Tests/built-ins/DataView/prototype/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteLength/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteOffset/ExecutionTests.cs`<br>[`DataView_ByteOffset_ByteLength.js`](../../../tests/Jroc.Tests/TypedArray/JavaScript/DataView_ByteOffset_ByteLength.js) | `test/built-ins/DataView/prototype/Symbol.toStringTag.js`<br>`test/built-ins/DataView/prototype/buffer/invoked-as-accessor.js`<br>`test/built-ins/DataView/prototype/buffer/length.js`<br>`test/built-ins/DataView/prototype/buffer/name.js`<br>`test/built-ins/DataView/prototype/buffer/prop-desc.js`<br>`test/built-ins/DataView/prototype/buffer/return-buffer.js`<br>`test/built-ins/DataView/prototype/byteLength/invoked-as-accessor.js`<br>`test/built-ins/DataView/prototype/byteLength/length.js`<br>`test/built-ins/DataView/prototype/byteLength/name.js`<br>`test/built-ins/DataView/prototype/byteLength/prop-desc.js`<br>`test/built-ins/DataView/prototype/byteOffset/invoked-as-accessor.js`<br>`test/built-ins/DataView/prototype/byteOffset/length.js`<br>`test/built-ins/DataView/prototype/byteOffset/name.js`<br>`test/built-ins/DataView/prototype/byteOffset/prop-desc.js` | DataView.prototype inherits Object.prototype and owns constructor, buffer, byteOffset, byteLength, and @@toStringTag properties. The accessors enforce DataView receivers and expose standard getter metadata. |
 

--- a/src/JavaScriptRuntime/DataView.cs
+++ b/src/JavaScriptRuntime/DataView.cs
@@ -5,6 +5,7 @@ namespace JavaScriptRuntime
     [IntrinsicObject("DataView")]
     public sealed class DataView
     {
+        internal static readonly object Prototype = new JsObject();
         private readonly ArrayBuffer _buffer;
         private readonly int _byteOffset;
         private readonly int _byteLength;
@@ -46,6 +47,8 @@ namespace JavaScriptRuntime
             {
                 throw new RangeError("Invalid DataView byteLength");
             }
+
+            PrototypeChain.SetPrototype(this, Prototype);
         }
 
         public ArrayBuffer buffer => _buffer;

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -195,6 +195,20 @@ namespace JavaScriptRuntime
             return new JavaScriptRuntime.FinalizationRegistry(cleanupCallback);
         };
 
+        private static readonly JsFuncNoScopes3 _dataViewConstructorValue = static (
+            newTarget,
+            buffer,
+            byteOffset,
+            byteLength) =>
+        {
+            if (newTarget is null)
+            {
+                throw new TypeError("Constructor DataView requires 'new'");
+            }
+
+            return new JavaScriptRuntime.DataView(buffer, byteOffset, byteLength);
+        };
+
         private static readonly JsFuncNoScopes1 _promiseConstructorValue = static (newTarget, executor) =>
         {
             if (newTarget is null)
@@ -921,6 +935,7 @@ namespace JavaScriptRuntime
             ConfigureConstructorPrototypeSurface(
                 _sharedArrayBufferConstructorValue,
                 _sharedArrayBufferPrototypeValue);
+            ConfigureDataViewIntrinsicSurface();
 
             JavaScriptRuntime.String.ConfigureIntrinsicSurface(_stringFunctionValue);
         }
@@ -1291,6 +1306,9 @@ namespace JavaScriptRuntime
             dict.TryAdd(nameof(GlobalThis.ArrayBuffer), ArrayBuffer);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.ArrayBuffer), dict[nameof(GlobalThis.ArrayBuffer)]);
 
+            dict.TryAdd(nameof(GlobalThis.DataView), DataView);
+            DefineNonEnumerableDataProperty(nameof(GlobalThis.DataView), dict[nameof(GlobalThis.DataView)]);
+
             dict.TryAdd(nameof(GlobalThis.Atomics), Atomics);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.Atomics), dict[nameof(GlobalThis.Atomics)]);
 
@@ -1609,6 +1627,8 @@ namespace JavaScriptRuntime
 
         public static Delegate SharedArrayBuffer => _sharedArrayBufferConstructorValue;
         public static Delegate ArrayBuffer => _arrayBufferConstructorValue;
+
+        public static Delegate DataView => _dataViewConstructorValue;
 
         public static object Atomics => _atomicsValue;
 
@@ -2237,6 +2257,64 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = "FinalizationRegistry"
             });
+        }
+
+        private static void ConfigureDataViewIntrinsicSurface()
+        {
+            ConfigureConstructorPrototypeSurface(_dataViewConstructorValue, JavaScriptRuntime.DataView.Prototype);
+            PropertyDescriptorStore.DefineOrUpdate(_dataViewConstructorValue, "length", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = false,
+                Value = 1d
+            });
+            PropertyDescriptorStore.DefineOrUpdate(_dataViewConstructorValue, "name", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = false,
+                Value = "DataView"
+            });
+            DefineDataViewAccessor("buffer", DataViewBufferGetter);
+            DefineDataViewAccessor("byteLength", DataViewByteLengthGetter);
+            DefineDataViewAccessor("byteOffset", DataViewByteOffsetGetter);
+            DefineIntrinsicToStringTagProperty(JavaScriptRuntime.DataView.Prototype, "DataView");
+        }
+
+        private static void DefineDataViewAccessor(
+            string propertyName,
+            Func<object[], object?[]?, object?> getter)
+        {
+            JavaScriptRuntime.Function.InitializeFunctionInstance(getter, 0d, $"get {propertyName}");
+            PropertyDescriptorStore.DefineOrUpdate(JavaScriptRuntime.DataView.Prototype, propertyName, new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Accessor,
+                Enumerable = false,
+                Configurable = true,
+                Get = getter
+            });
+        }
+
+        private static object? DataViewBufferGetter(object[] _, object?[]? __)
+            => GetDataViewThis("buffer").buffer;
+
+        private static object? DataViewByteLengthGetter(object[] _, object?[]? __)
+            => GetDataViewThis("byteLength").byteLength;
+
+        private static object? DataViewByteOffsetGetter(object[] _, object?[]? __)
+            => GetDataViewThis("byteOffset").byteOffset;
+
+        private static JavaScriptRuntime.DataView GetDataViewThis(string propertyName)
+        {
+            if (RuntimeServices.GetCurrentThis() is not JavaScriptRuntime.DataView dataView)
+            {
+                throw new TypeError($"get DataView.prototype.{propertyName} called on incompatible receiver");
+            }
+
+            return dataView;
         }
 
         private static void DefineSpeciesAccessorProperty(object constructorValue)

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/ExecutionTests.cs
@@ -1,0 +1,26 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.DataView;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.DataView") { }
+
+    [Fact(DisplayName = "constructor.js")]
+    public Task constructor() => ExecutionTestFromFile("constructor");
+
+    [Fact(DisplayName = "is-a-constructor.js")]
+    public Task is_a_constructor() => ExecutionTestFromFile("is-a-constructor");
+
+    [Fact(DisplayName = "length.js")]
+    public Task length() => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "newtarget-undefined-throws.js")]
+    public Task newtarget_undefined_throws() => ExecutionTestFromFile("newtarget-undefined-throws");
+
+    [Fact(DisplayName = "proto.js")]
+    public Task proto() => ExecutionTestFromFile("proto");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/JavaScript/constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/JavaScript/constructor.js
@@ -1,0 +1,11 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview-constructor
+description: >
+  The DataView constructor is the %DataView% intrinsic object and the initial
+  value of the DataView property of the global object.
+---*/
+
+assert.sameValue(typeof DataView, "function", "`typeof DataView` is `'function'`");

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/JavaScript/is-a-constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/JavaScript/is-a-constructor.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2020 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-ecmascript-standard-built-in-objects
+description: >
+  The DataView constructor implements [[Construct]]
+info: |
+  IsConstructor ( argument )
+
+  The abstract operation IsConstructor takes argument argument (an ECMAScript language value).
+  It determines if argument is a function object with a [[Construct]] internal method.
+  It performs the following steps when called:
+
+  If Type(argument) is not Object, return false.
+  If argument has a [[Construct]] internal method, return true.
+  Return false.
+includes: [isConstructor.js]
+features: [Reflect.construct, DataView, ArrayBuffer]
+---*/
+
+assert.sameValue(isConstructor(DataView), true, 'isConstructor(DataView) must return true');
+new DataView(new ArrayBuffer(16));
+  

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/JavaScript/length.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview-constructor
+description: >
+  The length property of DataView has the default value of 1
+info: |
+  DataView ( buffer [ , byteOffset [ , byteLength ] ] )
+
+  ECMAScript Standard Built-in Objects:
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in function
+  object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [DataView]
+---*/
+
+verifyProperty(DataView, "length", {
+    value: 1,
+    enumerable: false,
+    writable: false,
+    configurable: true,
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/JavaScript/name.js
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview-constructor
+description: >
+  The name property of DataView is "DataView"
+includes: [propertyHelper.js]
+---*/
+
+verifyProperty(DataView, "name", {
+  value: "DataView",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/JavaScript/newtarget-undefined-throws.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/JavaScript/newtarget-undefined-throws.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-dataview-buffer-byteoffset-bytelength
+description: >
+  Throws a TypeError if NewTarget is undefined.
+info: |
+  24.2.2.1 DataView (buffer, byteOffset, byteLength )
+
+  1. If NewTarget is undefined, throw a TypeError exception.
+  ...
+---*/
+
+var obj = {
+  valueOf: function() {
+    throw new Test262Error("NewTarget should be verified before byteOffset");
+  }
+};
+
+var buffer = new ArrayBuffer(1);
+
+assert.throws(TypeError, function() {
+  DataView(buffer, obj);
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/JavaScript/proto.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/JavaScript/proto.js
@@ -1,0 +1,13 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-properties-of-the-dataview-constructor
+description: >
+  The prototype of DataView is Function.prototype
+info: |
+  The value of the [[Prototype]] internal slot of the DataView constructor is
+  the intrinsic object %FunctionPrototype%.
+---*/
+
+assert.sameValue(Object.getPrototypeOf(DataView), Function.prototype);

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/ExecutionTests.cs
@@ -1,0 +1,11 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.DataView.prototype;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.DataView.prototype") { }
+
+    [Fact(DisplayName = "Symbol.toStringTag.js")]
+    public Task symbol_to_string_tag() => ExecutionTestFromFile("Symbol.toStringTag");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/JavaScript/Symbol.toStringTag.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/JavaScript/Symbol.toStringTag.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-dataview.prototype-@@tostringtag
+description: >
+    `Symbol.toStringTag` property descriptor
+info: |
+    The initial value of the @@toStringTag property is the String value
+    "DataView".
+
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.toStringTag]
+---*/
+
+assert.sameValue(
+  DataView.prototype[Symbol.toStringTag],
+  'DataView',
+  'The value of DataView.prototype[Symbol.toStringTag] is expected to be "DataView"'
+);
+
+verifyProperty(DataView.prototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/ExecutionTests.cs
@@ -1,0 +1,23 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.DataView.prototype.buffer;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.DataView.prototype.buffer") { }
+
+    [Fact(DisplayName = "invoked-as-accessor.js")]
+    public Task invoked_as_accessor() => ExecutionTestFromFile("invoked-as-accessor");
+
+    [Fact(DisplayName = "length.js")]
+    public Task length() => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+
+    [Fact(DisplayName = "return-buffer.js")]
+    public Task return_buffer() => ExecutionTestFromFile("return-buffer");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/JavaScript/invoked-as-accessor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/JavaScript/invoked-as-accessor.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-dataview.prototype.buffer
+description: >
+  Requires this value to have a [[DataView]] internal slot
+info: |
+  24.2.4.1 get DataView.prototype.buffer
+
+  1. Let O be the this value.
+  2. If Type(O) is not Object, throw a TypeError exception.
+  3. If O does not have a [[DataView]] internal slot, throw a TypeError
+  exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  DataView.prototype.buffer;
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/JavaScript/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-dataview.prototype.buffer
+description: >
+  get DataView.prototype.buffer.length is 0.
+info: |
+  get DataView.prototype.buffer
+
+  17 ECMAScript Standard Built-in Objects:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this
+    value is equal to the largest number of named arguments shown in the
+    subclause headings for the function description, including optional
+    parameters. However, rest parameters shown using the form “...name”
+    are not included in the default argument count.
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(DataView.prototype, "buffer");
+
+verifyProperty(desc.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/JavaScript/name.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-dataview.prototype.buffer
+description: >
+  get DataView.prototype.buffer
+
+  17 ECMAScript Standard Built-in Objects
+
+  Functions that are specified as get or set accessor functions of built-in
+  properties have "get " or "set " prepended to the property name string.
+
+includes: [propertyHelper.js]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(
+  DataView.prototype, 'buffer'
+);
+
+verifyProperty(descriptor.get, "name", {
+  value: "get buffer",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/JavaScript/prop-desc.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-dataview.prototype.buffer
+description: >
+  "buffer" property of DataView.prototype
+info: |
+  DataView.prototype.buffer is an accessor property whose set accessor function
+  is undefined.
+
+  Section 17: Every accessor property described in clauses 18 through 26 and in
+  Annex B.2 has the attributes {[[Enumerable]]: false, [[Configurable]]: true }
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(DataView.prototype, "buffer");
+
+assert.sameValue(desc.set, undefined);
+assert.sameValue(typeof desc.get, "function");
+
+verifyNotEnumerable(DataView.prototype, "buffer");
+verifyConfigurable(DataView.prototype, "buffer");

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/JavaScript/return-buffer.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/buffer/JavaScript/return-buffer.js
@@ -1,0 +1,19 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-dataview.prototype.buffer
+description: >
+  Return buffer from [[ViewedArrayBuffer]] internal slot
+info: |
+  24.2.4.1 get DataView.prototype.buffer
+
+  ...
+  5. Let buffer be the value of O's [[ViewedArrayBuffer]] internal slot.
+  6. Return buffer.
+---*/
+
+var buffer = new ArrayBuffer(1);
+var dv = new DataView(buffer, 0);
+
+assert.sameValue(dv.buffer, buffer);

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteLength/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteLength/ExecutionTests.cs
@@ -1,0 +1,20 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.DataView.prototype.byteLength;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.DataView.prototype.byteLength") { }
+
+    [Fact(DisplayName = "invoked-as-accessor.js")]
+    public Task invoked_as_accessor() => ExecutionTestFromFile("invoked-as-accessor");
+
+    [Fact(DisplayName = "length.js")]
+    public Task length() => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteLength/JavaScript/invoked-as-accessor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteLength/JavaScript/invoked-as-accessor.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-dataview.prototype.bytelength
+description: >
+  Requires this value to have a [[DataView]] internal slot
+info: |
+  24.2.4.2 get DataView.prototype.byteLength
+
+  1. Let O be the this value.
+  2. If Type(O) is not Object, throw a TypeError exception.
+  3. If O does not have a [[DataView]] internal slot, throw a TypeError
+  exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  DataView.prototype.byteLength;
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteLength/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteLength/JavaScript/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-dataview.prototype.bytelength
+description: >
+  get DataView.prototype.byteLength.length is 0.
+info: |
+  get DataView.prototype.byteLength
+
+  17 ECMAScript Standard Built-in Objects:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this
+    value is equal to the largest number of named arguments shown in the
+    subclause headings for the function description, including optional
+    parameters. However, rest parameters shown using the form “...name”
+    are not included in the default argument count.
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(DataView.prototype, "byteLength");
+
+verifyProperty(desc.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteLength/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteLength/JavaScript/name.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-dataview.prototype.bytelength
+description: >
+  get DataView.prototype.byteLength
+
+  17 ECMAScript Standard Built-in Objects
+
+  Functions that are specified as get or set accessor functions of built-in
+  properties have "get " or "set " prepended to the property name string.
+
+includes: [propertyHelper.js]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(
+  DataView.prototype, 'byteLength'
+);
+
+verifyProperty(descriptor.get, "name", {
+  value: "get byteLength",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteLength/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteLength/JavaScript/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-dataview.prototype.bytelength
+description: >
+  "byteLength" property of DataView.prototype
+info: |
+  24.2.4.2 get DataView.prototype.byteLength
+
+  DataView.prototype.byteLength is an accessor property whose set accessor
+  function is undefined.
+
+  Section 17: Every accessor property described in clauses 18 through 26 and in
+  Annex B.2 has the attributes {[[Enumerable]]: false, [[Configurable]]: true }
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(DataView.prototype, "byteLength");
+
+assert.sameValue(desc.set, undefined);
+assert.sameValue(typeof desc.get, "function");
+
+verifyNotEnumerable(DataView.prototype, "byteLength");
+verifyConfigurable(DataView.prototype, "byteLength");

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteOffset/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteOffset/ExecutionTests.cs
@@ -1,0 +1,20 @@
+using Jroc.Test262.Tests.built_ins;
+
+namespace Jroc.Test262.Tests.built_ins.DataView.prototype.byteOffset;
+
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.DataView.prototype.byteOffset") { }
+
+    [Fact(DisplayName = "invoked-as-accessor.js")]
+    public Task invoked_as_accessor() => ExecutionTestFromFile("invoked-as-accessor");
+
+    [Fact(DisplayName = "length.js")]
+    public Task length() => ExecutionTestFromFile("length");
+
+    [Fact(DisplayName = "name.js")]
+    public Task name() => ExecutionTestFromFile("name");
+
+    [Fact(DisplayName = "prop-desc.js")]
+    public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteOffset/JavaScript/invoked-as-accessor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteOffset/JavaScript/invoked-as-accessor.js
@@ -1,0 +1,20 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-dataview.prototype.byteoffset
+description: >
+  Requires this value to have a [[DataView]] internal slot
+info: |
+  24.2.4.3 get DataView.prototype.byteOffset
+
+  1. Let O be the this value.
+  2. If Type(O) is not Object, throw a TypeError exception.
+  3. If O does not have a [[DataView]] internal slot, throw a TypeError
+  exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  DataView.prototype.byteOffset;
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteOffset/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteOffset/JavaScript/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-dataview.prototype.byteoffset
+description: >
+  get DataView.prototype.byteOffset.length is 0.
+info: |
+  get DataView.prototype.byteOffset
+
+  17 ECMAScript Standard Built-in Objects:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this
+    value is equal to the largest number of named arguments shown in the
+    subclause headings for the function description, including optional
+    parameters. However, rest parameters shown using the form “...name”
+    are not included in the default argument count.
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(DataView.prototype, "byteOffset");
+
+verifyProperty(desc.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteOffset/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteOffset/JavaScript/name.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-dataview.prototype.byteoffset
+description: >
+  get DataView.prototype.byteOffset
+
+  17 ECMAScript Standard Built-in Objects
+
+  Functions that are specified as get or set accessor functions of built-in
+  properties have "get " or "set " prepended to the property name string.
+
+includes: [propertyHelper.js]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(
+  DataView.prototype, 'byteOffset'
+);
+
+verifyProperty(descriptor.get, "name", {
+  value: "get byteOffset",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteOffset/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/DataView/prototype/byteOffset/JavaScript/prop-desc.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-dataview.prototype.byteoffset
+description: >
+  "byteOffset" property of DataView.prototype
+info: |
+  DataView.prototype.byteOffset is an accessor property whose set accessor
+  function is undefined.
+
+  Section 17: Every accessor property described in clauses 18 through 26 and in
+  Annex B.2 has the attributes {[[Enumerable]]: false, [[Configurable]]: true }
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(DataView.prototype, "byteOffset");
+
+assert.sameValue(desc.set, undefined);
+assert.sameValue(typeof desc.get, "function");
+
+verifyNotEnumerable(DataView.prototype, "byteOffset");
+verifyConfigurable(DataView.prototype, "byteOffset");


### PR DESCRIPTION
## Summary
- expose `globalThis.DataView` with standard constructor and prototype metadata
- add prototype-owned `buffer`, `byteLength`, and `byteOffset` accessors with receiver validation
- port 20 byte-identical DataView test262 fixtures and update ECMA-262 coverage docs

## Validation
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --filter "FullyQualifiedName~built_ins.DataView" --no-restore`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --filter "FullyQualifiedName~TypedArray" --no-restore`
- `dotnet build src/Cli/Jroc.csproj -c Release --no-restore`