### PR TITLE
runtime/test262: expose ArrayBuffer intrinsic surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime/test262: expose ArrayBuffer as a first-class global constructor with
+  standard constructor/prototype metadata, `isView`, and receiver-checked
+  `byteLength`, `maxByteLength`, and `resizable` accessors. Activates twenty
+  corresponding pinned test262 fixtures.
+
 - runtime/test262: expose DataView as a first-class global constructor with
   standard constructor/prototype metadata and buffer, byteLength, and
   byteOffset accessors. Activates twenty corresponding pinned test262 fixtures.

--- a/docs/ECMA262/19/Section19_3.json
+++ b/docs/ECMA262/19/Section19_3.json
@@ -383,6 +383,25 @@
         "notes": "Exposes globalThis.DataView as a constructible function with standard name, length, global-property, and prototype descriptors. BigInt/Float16 accessors, full prototype method exposure, custom newTarget prototypes, and detached-buffer behavior remain limited."
       },
       {
+        "clause": "19.3.3",
+        "feature": "ArrayBuffer first-class global constructor",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-arraybuffer",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/ArrayBuffer/length.js",
+          "test/built-ins/ArrayBuffer/name.js",
+          "test/built-ins/ArrayBuffer/prop-desc.js",
+          "test/built-ins/ArrayBuffer/newtarget-prototype-is-not-object.js",
+          "test/built-ins/ArrayBuffer/prototype/constructor.js",
+          "test/built-ins/ArrayBuffer/prototype/Symbol.toStringTag.js"
+        ],
+        "notes": "Exposes globalThis.ArrayBuffer as a constructible function with standard constructor/prototype metadata and isView(). Custom newTarget prototypes, species, detachment, transfer, and complete resizable-buffer semantics remain limited."
+      },
+      {
         "clause": "19.3.40",
         "feature": "WeakMap constructor and core prototype methods",
         "status": "Supported with Limitations",

--- a/docs/ECMA262/19/Section19_3.md
+++ b/docs/ECMA262/19/Section19_3.md
@@ -4,7 +4,7 @@
 
 [Back to Section19](Section19.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-08-15T07:23:45Z
+> Last generated (UTC): 2026-08-15T08:03:05Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -60,6 +60,12 @@
 ## Support
 
 Feature-level support tracking with repo test references and optional test262 evidence.
+
+### 19.3.3 ([tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-arraybuffer))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| ArrayBuffer first-class global constructor | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/ExecutionTests.cs` | `test/built-ins/ArrayBuffer/length.js`<br>`test/built-ins/ArrayBuffer/name.js`<br>`test/built-ins/ArrayBuffer/prop-desc.js`<br>`test/built-ins/ArrayBuffer/newtarget-prototype-is-not-object.js`<br>`test/built-ins/ArrayBuffer/prototype/constructor.js`<br>`test/built-ins/ArrayBuffer/prototype/Symbol.toStringTag.js` | Exposes globalThis.ArrayBuffer as a constructible function with standard constructor/prototype metadata and isView(). Custom newTarget prototypes, species, detachment, transfer, and complete resizable-buffer semantics remain limited. |
 
 ### 19.3.7 ([tc39.es](https://tc39.es/ecma262/#sec-constructor-properties-of-the-global-object-boolean))
 

--- a/docs/ECMA262/25/Section25_1.json
+++ b/docs/ECMA262/25/Section25_1.json
@@ -240,7 +240,7 @@
     {
       "clause": "25.1.6.10",
       "title": "ArrayBuffer.prototype [ %Symbol.toStringTag% ]",
-      "status": "Not Yet Supported",
+      "status": "Supported",
       "specUrl": "https://tc39.es/ecma262/#sec-arraybuffer.prototype-%symbol.tostringtag%"
     },
     {
@@ -277,6 +277,28 @@
           "tests/Jroc.Tests/TypedArray/JavaScript/ArrayBuffer_IsView_DataView.js"
         ],
         "notes": "Recognizes DataView and the current Int32Array typed-array surface as ArrayBuffer views. Broader TypedArray families and shared ArrayBuffer-backed view infrastructure remain follow-up work for issue #774."
+      },
+      {
+        "clause": "25.1.4",
+        "feature": "ArrayBuffer first-class constructor and prototype metadata",
+        "status": "Supported with Limitations",
+        "specUrl": "https://tc39.es/ecma262/#sec-arraybuffer-constructor",
+        "testScripts": [
+          "tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/ExecutionTests.cs",
+          "tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/resizable/ExecutionTests.cs"
+        ],
+        "test262Paths": [
+          "test/built-ins/ArrayBuffer/length.js",
+          "test/built-ins/ArrayBuffer/name.js",
+          "test/built-ins/ArrayBuffer/prop-desc.js",
+          "test/built-ins/ArrayBuffer/newtarget-prototype-is-not-object.js",
+          "test/built-ins/ArrayBuffer/prototype/constructor.js",
+          "test/built-ins/ArrayBuffer/prototype/Symbol.toStringTag.js"
+        ],
+        "notes": "Exposes globalThis.ArrayBuffer as a constructible function with standard name, length, global-property, and prototype descriptors. ArrayBuffer.prototype has receiver-checked byteLength, maxByteLength, resizable, and @@toStringTag properties. Species, custom newTarget prototypes, detachment, transfer, and resizable-buffer operations remain limited."
       },
       {
         "clause": "25.1.6",

--- a/docs/ECMA262/25/Section25_1.md
+++ b/docs/ECMA262/25/Section25_1.md
@@ -4,7 +4,7 @@
 
 [Back to Section25](Section25.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-08-14T08:29:24Z
+> Last generated (UTC): 2026-08-15T08:03:05Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -52,13 +52,19 @@
 | 25.1.6.7 | ArrayBuffer.prototype.slice ( start , end ) | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice) |
 | 25.1.6.8 | ArrayBuffer.prototype.transfer ( [ newLength ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfer) |
 | 25.1.6.9 | ArrayBuffer.prototype.transferToFixedLength ( [ newLength ] ) | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype.transfertofixedlength) |
-| 25.1.6.10 | ArrayBuffer.prototype [ %Symbol.toStringTag% ] | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype-%symbol.tostringtag%) |
+| 25.1.6.10 | ArrayBuffer.prototype [ %Symbol.toStringTag% ] | Supported | [tc39.es](https://tc39.es/ecma262/#sec-arraybuffer.prototype-%symbol.tostringtag%) |
 | 25.1.7 | Properties of ArrayBuffer Instances | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-properties-of-the-arraybuffer-instances) |
 | 25.1.8 | Resizable ArrayBuffer Guidelines | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-resizable-arraybuffer-guidelines) |
 
 ## Support
 
 Feature-level support tracking with repo test references and optional test262 evidence.
+
+### 25.1.4 ([tc39.es](https://tc39.es/ecma262/#sec-arraybuffer-constructor))
+
+| Feature name | Status | Test scripts | test262 evidence | Notes |
+|---|---|---|---|---|
+| ArrayBuffer first-class constructor and prototype metadata | Supported with Limitations | `tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/ExecutionTests.cs`<br>`tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/resizable/ExecutionTests.cs` | `test/built-ins/ArrayBuffer/length.js`<br>`test/built-ins/ArrayBuffer/name.js`<br>`test/built-ins/ArrayBuffer/prop-desc.js`<br>`test/built-ins/ArrayBuffer/newtarget-prototype-is-not-object.js`<br>`test/built-ins/ArrayBuffer/prototype/constructor.js`<br>`test/built-ins/ArrayBuffer/prototype/Symbol.toStringTag.js` | Exposes globalThis.ArrayBuffer as a constructible function with standard name, length, global-property, and prototype descriptors. ArrayBuffer.prototype has receiver-checked byteLength, maxByteLength, resizable, and @@toStringTag properties. Species, custom newTarget prototypes, detachment, transfer, and resizable-buffer operations remain limited. |
 
 ### 25.1.4.1 ([tc39.es](https://tc39.es/ecma262/#sec-arraybuffer-length))
 

--- a/src/JavaScriptRuntime/ArrayBuffer.cs
+++ b/src/JavaScriptRuntime/ArrayBuffer.cs
@@ -5,6 +5,7 @@ namespace JavaScriptRuntime
     [IntrinsicObject("ArrayBuffer")]
     public class ArrayBuffer
     {
+        internal static readonly object Prototype = new JsObject();
         private byte[] _bytes;
         private readonly int _maxByteLength;
         private readonly bool _isResizable;
@@ -13,6 +14,7 @@ namespace JavaScriptRuntime
         {
             _bytes = System.Array.Empty<byte>();
             _maxByteLength = 0;
+            InitializeIntrinsicSurface();
         }
 
         public ArrayBuffer(object? length)
@@ -22,6 +24,7 @@ namespace JavaScriptRuntime
                 ? System.Array.Empty<byte>()
                 : new byte[byteLength];
             _maxByteLength = byteLength;
+            InitializeIntrinsicSurface();
         }
 
         public ArrayBuffer(object? length, object? options)
@@ -45,16 +48,19 @@ namespace JavaScriptRuntime
 
                 _maxByteLength = maxByteLength;
                 _isResizable = true;
+                InitializeIntrinsicSurface();
                 return;
             }
 
             _maxByteLength = byteLength;
+            InitializeIntrinsicSurface();
         }
 
         internal ArrayBuffer(byte[] bytes, bool cloneBuffer)
         {
             _bytes = cloneBuffer ? (byte[])bytes.Clone() : bytes;
             _maxByteLength = _bytes.Length;
+            InitializeIntrinsicSurface();
         }
 
         public double byteLength => _bytes.Length;
@@ -120,6 +126,14 @@ namespace JavaScriptRuntime
 
         internal byte[] RawBytes => _bytes;
         internal bool IsResizable => _isResizable;
+
+        private void InitializeIntrinsicSurface()
+        {
+            if (GetType() == typeof(ArrayBuffer))
+            {
+                PrototypeChain.SetPrototype(this, Prototype);
+            }
+        }
 
         private static int CoerceByteLength(object? value)
         {

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -356,7 +356,6 @@ namespace JavaScriptRuntime
         private static readonly object _bigIntPrototypeValue = new JsObject();
         private static readonly object _symbolPrototypeValue = new JsObject();
         private static readonly object _promisePrototypeValue = new JsObject();
-        private static readonly object _arrayBufferPrototypeValue = new JsObject();
         private static readonly object _sharedArrayBufferPrototypeValue = new JsObject();
         private static readonly Func<object[], object?[]?, object?> _symbolFunctionValue = SymbolCall;
 
@@ -394,6 +393,8 @@ namespace JavaScriptRuntime
             static (_, args) => args != null && args.Length > 1
                 ? new ArrayBuffer(args[0], args[1])
                 : new ArrayBuffer(args != null && args.Length > 0 ? args[0] : null);
+        private static readonly Func<object[], object?, bool> _arrayBufferIsViewValue =
+            static (_, value) => JavaScriptRuntime.ArrayBuffer.isView(value);
         private static readonly Func<object[], object?[], object?> _sharedArrayBufferConstructorValue =
             static (_, args) => new SharedArrayBuffer(args != null && args.Length > 0 ? args[0] : null);
         private static readonly Func<object[], object?[], object?> _int16ArrayConstructorValue =
@@ -931,7 +932,7 @@ namespace JavaScriptRuntime
             ConfigureTypedArrayInstancePrototype(_uint32ArrayConstructorValue, _uint32ArrayPrototypeValue);
             ConfigureTypedArrayInstancePrototype(_uint16ArrayConstructorValue, _uint16ArrayPrototypeValue);
             JavaScriptRuntime.Uint8Array.ConfigureIntrinsicSurface(_uint8ArrayConstructorValue);
-            ConfigureConstructorPrototypeSurface(_arrayBufferConstructorValue, _arrayBufferPrototypeValue);
+            ConfigureArrayBufferIntrinsicSurface();
             ConfigureConstructorPrototypeSurface(
                 _sharedArrayBufferConstructorValue,
                 _sharedArrayBufferPrototypeValue);
@@ -2282,6 +2283,41 @@ namespace JavaScriptRuntime
             DefineDataViewAccessor("byteLength", DataViewByteLengthGetter);
             DefineDataViewAccessor("byteOffset", DataViewByteOffsetGetter);
             DefineIntrinsicToStringTagProperty(JavaScriptRuntime.DataView.Prototype, "DataView");
+        }
+
+        private static void ConfigureArrayBufferIntrinsicSurface()
+        {
+            ConfigureConstructorPrototypeSurface(_arrayBufferConstructorValue, JavaScriptRuntime.ArrayBuffer.Prototype);
+            PropertyDescriptorStore.DefineOrUpdate(_arrayBufferConstructorValue, "length", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data, Enumerable = false, Configurable = true, Writable = false, Value = 1d
+            });
+            PropertyDescriptorStore.DefineOrUpdate(_arrayBufferConstructorValue, "name", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data, Enumerable = false, Configurable = true, Writable = false, Value = "ArrayBuffer"
+            });
+            DefineBuiltinFunctionProperty(_arrayBufferConstructorValue, "isView", _arrayBufferIsViewValue, 1d);
+            DefineArrayBufferAccessor("byteLength", static buffer => buffer.byteLength);
+            DefineArrayBufferAccessor("maxByteLength", static buffer => buffer.maxByteLength);
+            DefineArrayBufferAccessor("resizable", static buffer => buffer.resizable);
+            DefineIntrinsicToStringTagProperty(JavaScriptRuntime.ArrayBuffer.Prototype, "ArrayBuffer");
+        }
+
+        private static void DefineArrayBufferAccessor(string propertyName, Func<JavaScriptRuntime.ArrayBuffer, object?> read)
+        {
+            Func<object[], object?[]?, object?> getter = (_, __) =>
+            {
+                if (RuntimeServices.GetCurrentThis() is not JavaScriptRuntime.ArrayBuffer buffer)
+                {
+                    throw new TypeError($"get ArrayBuffer.prototype.{propertyName} called on incompatible receiver");
+                }
+                return read(buffer);
+            };
+            JavaScriptRuntime.Function.InitializeFunctionInstance(getter, 0d, $"get {propertyName}");
+            PropertyDescriptorStore.DefineOrUpdate(JavaScriptRuntime.ArrayBuffer.Prototype, propertyName, new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Accessor, Enumerable = false, Configurable = true, Get = getter
+            });
         }
 
         private static void DefineDataViewAccessor(

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/ExecutionTests.cs
@@ -1,0 +1,10 @@
+using Jroc.Test262.Tests.built_ins;
+namespace Jroc.Test262.Tests.built_ins.ArrayBuffer;
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.ArrayBuffer") { }
+    [Fact(DisplayName = "length.js")] public Task length() => ExecutionTestFromFile("length");
+    [Fact(DisplayName = "name.js")] public Task name() => ExecutionTestFromFile("name");
+    [Fact(DisplayName = "prop-desc.js")] public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+    [Fact(DisplayName = "newtarget-prototype-is-not-object.js")] public Task newtarget_prototype_is_not_object() => ExecutionTestFromFile("newtarget-prototype-is-not-object");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/JavaScript/length.js
@@ -1,0 +1,33 @@
+// Copyright (C) 2017 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-constructor
+description: >
+  ArrayBuffer.length is 1.
+info: |
+  ArrayBuffer ( length )
+
+  ECMAScript Standard Built-in Objects:
+
+  Every built-in function object, including constructors, has a length
+  property whose value is an integer. Unless otherwise specified, this
+  value is equal to the largest number of named arguments shown in the
+  subclause headings for the function description. Optional parameters
+  (which are indicated with brackets: [ ]) or rest parameters (which
+  are shown using the form «...name») are not included in the default
+  argument count.
+
+  Unless otherwise specified, the length property of a built-in function
+  object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+  [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [ArrayBuffer]
+---*/
+
+verifyProperty(ArrayBuffer, "length", {
+  value: 1,
+  enumerable: false,
+  writable: false,
+  configurable: true,
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/JavaScript/name.js
@@ -1,0 +1,28 @@
+// Copyright (C) 2017 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-constructor
+description: >
+  ArrayBuffer.name is "ArrayBuffer".
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every built-in Function object, including constructors, that is not
+  identified as an anonymous function has a name property whose value is a
+  String.
+
+  Unless otherwise specified, the name property of a built-in Function object,
+  if it exists, has the attributes { [[Writable]]: false, [[Enumerable]]:
+  false, [[Configurable]]: true }.
+
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(ArrayBuffer.name, "ArrayBuffer");
+
+verifyProperty(ArrayBuffer, "name", {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/JavaScript/newtarget-prototype-is-not-object.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/JavaScript/newtarget-prototype-is-not-object.js
@@ -1,0 +1,48 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-length
+description: >
+  [[Prototype]] defaults to %ArrayBufferPrototype% if NewTarget.prototype is not an object.
+info: |
+  ArrayBuffer( length )
+
+  ArrayBuffer called with argument length performs the following steps:
+
+  ...
+  6. Return AllocateArrayBuffer(NewTarget, byteLength).
+
+  AllocateArrayBuffer( constructor, byteLength )
+    1. Let obj be OrdinaryCreateFromConstructor(constructor, "%ArrayBufferPrototype%",
+       «[[ArrayBufferData]], [[ArrayBufferByteLength]]» ).
+    2. ReturnIfAbrupt(obj).
+    ...
+features: [Reflect.construct, Symbol]
+---*/
+
+function newTarget() {}
+
+newTarget.prototype = undefined;
+var arrayBuffer = Reflect.construct(ArrayBuffer, [1], newTarget);
+assert.sameValue(Object.getPrototypeOf(arrayBuffer), ArrayBuffer.prototype, "newTarget.prototype is undefined");
+
+newTarget.prototype = null;
+var arrayBuffer = Reflect.construct(ArrayBuffer, [2], newTarget);
+assert.sameValue(Object.getPrototypeOf(arrayBuffer), ArrayBuffer.prototype, "newTarget.prototype is null");
+
+newTarget.prototype = true;
+var arrayBuffer = Reflect.construct(ArrayBuffer, [3], newTarget);
+assert.sameValue(Object.getPrototypeOf(arrayBuffer), ArrayBuffer.prototype, "newTarget.prototype is a Boolean");
+
+newTarget.prototype = "";
+var arrayBuffer = Reflect.construct(ArrayBuffer, [4], newTarget);
+assert.sameValue(Object.getPrototypeOf(arrayBuffer), ArrayBuffer.prototype, "newTarget.prototype is a String");
+
+newTarget.prototype = Symbol();
+var arrayBuffer = Reflect.construct(ArrayBuffer, [5], newTarget);
+assert.sameValue(Object.getPrototypeOf(arrayBuffer), ArrayBuffer.prototype, "newTarget.prototype is a Symbol");
+
+newTarget.prototype = 1;
+var arrayBuffer = Reflect.construct(ArrayBuffer, [6], newTarget);
+assert.sameValue(Object.getPrototypeOf(arrayBuffer), ArrayBuffer.prototype, "newTarget.prototype is a Number");

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/JavaScript/prop-desc.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2017 Rick Waldron. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer-constructor
+description: >
+  Property descriptor of ArrayBuffer
+info: |
+  17 ECMAScript Standard Built-in Objects:
+
+  Every other data property described in clauses 18 through 26 and in Annex B.2
+  has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+  [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(typeof ArrayBuffer, "function", "`typeof ArrayBuffer` is `'function'`");
+
+verifyProperty(this, "ArrayBuffer", {
+  writable: true,
+  enumerable: false,
+  configurable: true,
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/ExecutionTests.cs
@@ -1,0 +1,8 @@
+using Jroc.Test262.Tests.built_ins;
+namespace Jroc.Test262.Tests.built_ins.ArrayBuffer.prototype;
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.ArrayBuffer.prototype") { }
+    [Fact(DisplayName = "constructor.js")] public Task constructor() => ExecutionTestFromFile("constructor");
+    [Fact(DisplayName = "Symbol.toStringTag.js")] public Task symbol_to_string_tag() => ExecutionTestFromFile("Symbol.toStringTag");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/JavaScript/Symbol.toStringTag.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/JavaScript/Symbol.toStringTag.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-arraybuffer.prototype-@@tostringtag
+description: >
+    `Symbol.toStringTag` property descriptor
+info: |
+    The initial value of the @@toStringTag property is the String value
+    "ArrayBuffer".
+
+    This property has the attributes { [[Writable]]: false, [[Enumerable]]:
+    false, [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [Symbol.toStringTag]
+---*/
+
+assert.sameValue(ArrayBuffer.prototype[Symbol.toStringTag], 'ArrayBuffer');
+
+verifyProperty(ArrayBuffer.prototype, Symbol.toStringTag, {
+  writable: false,
+  enumerable: false,
+  configurable: true,
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/JavaScript/constructor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/JavaScript/constructor.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-arraybuffer.prototype.constructor
+description: >
+  The `ArrayBuffer.prototype.constructor` property descriptor.
+info: |
+  The initial value of ArrayBuffer.prototype.constructor is the intrinsic
+  object %ArrayBuffer%.
+
+  17 ECMAScript Standard Built-in Objects:
+    Every other data property described in clauses 18 through 26 and in
+    Annex B.2 has the attributes { [[Writable]]: true, [[Enumerable]]: false,
+    [[Configurable]]: true } unless otherwise specified.
+includes: [propertyHelper.js]
+---*/
+
+assert.sameValue(ArrayBuffer.prototype.constructor, ArrayBuffer);
+
+verifyProperty(ArrayBuffer.prototype, "constructor", {
+  writable: true,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/ExecutionTests.cs
@@ -1,0 +1,11 @@
+using Jroc.Test262.Tests.built_ins;
+namespace Jroc.Test262.Tests.built_ins.ArrayBuffer.prototype.byteLength;
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.ArrayBuffer.prototype.byteLength") { }
+    [Fact(DisplayName = "invoked-as-accessor.js")] public Task invoked_as_accessor() => ExecutionTestFromFile("invoked-as-accessor");
+    [Fact(DisplayName = "length.js")] public Task length() => ExecutionTestFromFile("length");
+    [Fact(DisplayName = "name.js")] public Task name() => ExecutionTestFromFile("name");
+    [Fact(DisplayName = "prop-desc.js")] public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+    [Fact(DisplayName = "return-bytelength.js")] public Task return_bytelength() => ExecutionTestFromFile("return-bytelength");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/JavaScript/invoked-as-accessor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/JavaScript/invoked-as-accessor.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.bytelength
+description: Requires this value to have a [[ArrayBufferData]] internal slot
+info: |
+  24.1.4.1 get ArrayBuffer.prototype.byteLength
+
+  1. Let O be the this value.
+  2. If Type(O) is not Object, throw a TypeError exception.
+  3. If O does not have an [[ArrayBufferData]] internal slot, throw a TypeError
+  exception.
+  ...
+---*/
+
+assert.throws(TypeError, function() {
+  ArrayBuffer.prototype.byteLength;
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/JavaScript/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2015 André Bargull. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-get-arraybuffer.prototype.bytelength
+description: >
+  get ArrayBuffer.prototype.byteLength.length is 0.
+info: |
+  get ArrayBuffer.prototype.byteLength
+
+  17 ECMAScript Standard Built-in Objects:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this
+    value is equal to the largest number of named arguments shown in the
+    subclause headings for the function description, including optional
+    parameters. However, rest parameters shown using the form “...name”
+    are not included in the default argument count.
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "byteLength");
+
+verifyProperty(desc.get, "length", {
+  value: 0,
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/JavaScript/name.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.bytelength
+description: >
+  get ArrayBuffer.prototype.byteLength
+
+  17 ECMAScript Standard Built-in Objects
+
+  Functions that are specified as get or set accessor functions of built-in
+  properties have "get " or "set " prepended to the property name string.
+
+includes: [propertyHelper.js]
+---*/
+
+var descriptor = Object.getOwnPropertyDescriptor(
+  ArrayBuffer.prototype, 'byteLength'
+);
+
+verifyProperty(descriptor.get, "name", {
+  value: "get byteLength",
+  writable: false,
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/JavaScript/prop-desc.js
@@ -1,0 +1,22 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.bytelength
+description: >
+  "byteLength" property of ArrayBuffer.prototype
+info: |
+  ArrayBuffer.prototype.byteLength is an accessor property whose set accessor
+  function is undefined.
+
+  Section 17: Every accessor property described in clauses 18 through 26 and in
+  Annex B.2 has the attributes {[[Enumerable]]: false, [[Configurable]]: true }
+includes: [propertyHelper.js]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, "byteLength");
+
+assert.sameValue(desc.set, undefined);
+assert.sameValue(typeof desc.get, "function");
+
+verifyNotEnumerable(ArrayBuffer.prototype, "byteLength");
+verifyConfigurable(ArrayBuffer.prototype, "byteLength");

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/JavaScript/return-bytelength.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/byteLength/JavaScript/return-bytelength.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2016 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.bytelength
+description: Return value from [[ByteLength]] internal slot
+info: |
+  24.1.4.1 get ArrayBuffer.prototype.byteLength
+
+  ...
+  5. Let length be the value of O's [[ArrayBufferByteLength]] internal slot.
+  6. Return length.
+---*/
+
+var ab1 = new ArrayBuffer(0);
+assert.sameValue(ab1.byteLength, 0);
+
+var ab2 = new ArrayBuffer(42);
+assert.sameValue(ab2.byteLength, 42);

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/ExecutionTests.cs
@@ -1,0 +1,11 @@
+using Jroc.Test262.Tests.built_ins;
+namespace Jroc.Test262.Tests.built_ins.ArrayBuffer.prototype.maxByteLength;
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.ArrayBuffer.prototype.maxByteLength") { }
+    [Fact(DisplayName = "invoked-as-accessor.js")] public Task invoked_as_accessor() => ExecutionTestFromFile("invoked-as-accessor");
+    [Fact(DisplayName = "length.js")] public Task length() => ExecutionTestFromFile("length");
+    [Fact(DisplayName = "name.js")] public Task name() => ExecutionTestFromFile("name");
+    [Fact(DisplayName = "prop-desc.js")] public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+    [Fact(DisplayName = "return-maxbytelength-non-resizable.js")] public Task return_maxbytelength_non_resizable() => ExecutionTestFromFile("return-maxbytelength-non-resizable");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/JavaScript/invoked-as-accessor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/JavaScript/invoked-as-accessor.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.maxbytelength
+description: Requires this value to have a [[ArrayBufferData]] internal slot
+info: |
+  get ArrayBuffer.prototype.maxByteLength
+
+  1. Let O be the this value.
+  2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+  [...]
+features: [resizable-arraybuffer]
+---*/
+
+assert.throws(TypeError, function() {
+  ArrayBuffer.prototype.maxByteLength;
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/JavaScript/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.maxbytelength
+description: >
+  get ArrayBuffer.prototype.maxByteLength.length is 0.
+info: |
+  get ArrayBuffer.prototype.maxByteLength
+
+  17 ECMAScript Standard Built-in Objects:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this
+    value is equal to the largest number of named arguments shown in the
+    subclause headings for the function description, including optional
+    parameters. However, rest parameters shown using the form “...name”
+    are not included in the default argument count.
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [resizable-arraybuffer]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'maxByteLength');
+
+verifyProperty(desc.get, 'length', {
+  value: 0,
+  enumerable: false,
+  writable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/JavaScript/name.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.maxbytelength
+description: >
+  get ArrayBuffer.prototype.maxByteLength
+
+  17 ECMAScript Standard Built-in Objects
+
+  Functions that are specified as get or set accessor functions of built-in
+  properties have "get " or "set " prepended to the property name string.
+
+includes: [propertyHelper.js]
+features: [resizable-arraybuffer]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'maxByteLength');
+
+verifyProperty(desc.get, 'name', {
+  value: 'get maxByteLength',
+  enumerable: false,
+  writable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/JavaScript/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.maxbytelength
+description: >
+  "maxByteLength" property of ArrayBuffer.prototype
+info: |
+  ArrayBuffer.prototype.maxByteLength is an accessor property whose set
+  accessor function is undefined.
+
+  Section 17: Every accessor property described in clauses 18 through 26 and in
+  Annex B.2 has the attributes {[[Enumerable]]: false, [[Configurable]]: true }
+includes: [propertyHelper.js]
+features: [resizable-arraybuffer]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'maxByteLength');
+
+assert.sameValue(desc.set, undefined);
+assert.sameValue(typeof desc.get, 'function');
+
+verifyProperty(ArrayBuffer.prototype, 'maxByteLength', {
+  enumerable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/JavaScript/return-maxbytelength-non-resizable.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/maxByteLength/JavaScript/return-maxbytelength-non-resizable.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.maxbytelength
+description: Return value from [[ArrayBufferByteLength]] internal slot
+info: |
+  24.1.4.1 get ArrayBuffer.prototype.maxByteLength
+
+  1. Let O be the this value.
+  2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+  3. If IsSharedArrayBuffer(O) is true, throw a TypeError exception.
+  4. If IsDetachedBuffer(O) is true, return +0𝔽.
+  5. If IsResizableArrayBuffer(O) is true, then
+     [...]
+  6. Else,
+     a. Let length be O.[[ArrayBufferByteLength]].
+  7. Return 𝔽(length).
+features: [resizable-arraybuffer]
+---*/
+
+var ab1 = new ArrayBuffer(0);
+assert.sameValue(ab1.maxByteLength, 0);
+
+var ab2 = new ArrayBuffer(42);
+assert.sameValue(ab2.maxByteLength, 42);

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/resizable/ExecutionTests.cs
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/resizable/ExecutionTests.cs
@@ -1,0 +1,10 @@
+using Jroc.Test262.Tests.built_ins;
+namespace Jroc.Test262.Tests.built_ins.ArrayBuffer.prototype.resizable;
+public class ExecutionTests : DiskExecutionTestsBase
+{
+    public ExecutionTests() : base("built_ins.ArrayBuffer.prototype.resizable") { }
+    [Fact(DisplayName = "invoked-as-accessor.js")] public Task invoked_as_accessor() => ExecutionTestFromFile("invoked-as-accessor");
+    [Fact(DisplayName = "length.js")] public Task length() => ExecutionTestFromFile("length");
+    [Fact(DisplayName = "name.js")] public Task name() => ExecutionTestFromFile("name");
+    [Fact(DisplayName = "prop-desc.js")] public Task prop_desc() => ExecutionTestFromFile("prop-desc");
+}

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/resizable/JavaScript/invoked-as-accessor.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/resizable/JavaScript/invoked-as-accessor.js
@@ -1,0 +1,17 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.resizable
+description: Requires this value to have a [[ArrayBufferData]] internal slot
+info: |
+  get ArrayBuffer.prototype.resizable
+
+  1. Let O be the this value.
+  2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
+  [...]
+features: [resizable-arraybuffer]
+---*/
+
+assert.throws(TypeError, function() {
+  ArrayBuffer.prototype.resizable;
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/resizable/JavaScript/length.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/resizable/JavaScript/length.js
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.resizable
+description: >
+  get ArrayBuffer.prototype.resizable.length is 0.
+info: |
+  get ArrayBuffer.prototype.resizeable
+
+  17 ECMAScript Standard Built-in Objects:
+    Every built-in Function object, including constructors, has a length
+    property whose value is an integer. Unless otherwise specified, this
+    value is equal to the largest number of named arguments shown in the
+    subclause headings for the function description, including optional
+    parameters. However, rest parameters shown using the form “...name”
+    are not included in the default argument count.
+
+    Unless otherwise specified, the length property of a built-in Function
+    object has the attributes { [[Writable]]: false, [[Enumerable]]: false,
+    [[Configurable]]: true }.
+includes: [propertyHelper.js]
+features: [resizable-arraybuffer]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'resizable');
+
+verifyProperty(desc.get, 'length', {
+  value: 0,
+  enumerable: false,
+  writable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/resizable/JavaScript/name.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/resizable/JavaScript/name.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.resizable
+description: >
+  get ArrayBuffer.prototype.resizable
+
+  17 ECMAScript Standard Built-in Objects
+
+  Functions that are specified as get or set accessor functions of built-in
+  properties have "get " or "set " prepended to the property name string.
+
+includes: [propertyHelper.js]
+features: [resizable-arraybuffer]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'resizable');
+
+verifyProperty(desc.get, 'name', {
+  value: 'get resizable',
+  enumerable: false,
+  writable: false,
+  configurable: true
+});

--- a/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/resizable/JavaScript/prop-desc.js
+++ b/tests/Jroc.Test262.Tests/built-ins/ArrayBuffer/prototype/resizable/JavaScript/prop-desc.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-get-arraybuffer.prototype.resizable
+description: >
+  "resizable" property of ArrayBuffer.prototype
+info: |
+  ArrayBuffer.prototype.resizable is an accessor property whose set accessor
+  function is undefined.
+
+  Section 17: Every accessor property described in clauses 18 through 26 and in
+  Annex B.2 has the attributes {[[Enumerable]]: false, [[Configurable]]: true }
+includes: [propertyHelper.js]
+features: [resizable-arraybuffer]
+---*/
+
+var desc = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'resizable');
+
+assert.sameValue(desc.set, undefined);
+assert.sameValue(typeof desc.get, 'function');
+
+verifyProperty(ArrayBuffer.prototype, 'resizable', {
+  enumerable: false,
+  configurable: true
+});


### PR DESCRIPTION
## Summary

- Expose ArrayBuffer as a first-class global constructor with standard prototype metadata and `isView`.
- Add receiver-checked `byteLength`, `maxByteLength`, `resizable`, and @@toStringTag prototype properties.
- Port 20 exact ArrayBuffer test262 fixtures and document remaining limitations.

## Validation

- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --filter 'FullyQualifiedName~built_ins.ArrayBuffer' --no-restore`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --filter 'FullyQualifiedName~TypedArray' --no-restore`
- `dotnet build src/Cli/Jroc.csproj -c Release --no-restore`
