### PR TITLE
runtime: make globals and intrinsics realm-owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,44 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   `byteLength`, `maxByteLength`, and `resizable` accessors. Activates twenty
   corresponding pinned test262 fixtures.
 
+- runtime: make globals, intrinsics, descriptors, and prototypes realm-owned
+  (issue #1824). Every `RuntimeRealm` now owns a `RuntimeIntrinsics` graph that
+  holds the whole ECMA-262 Realm Record `[[Intrinsics]]` surface:
+  `Object.prototype` and every other built-in prototype (`Function`, `Array`,
+  `String`, `Number`, `Boolean`, `BigInt`, `Symbol`, the `Error` family, `Map`,
+  `Set`, `WeakMap`, `WeakSet`, `WeakRef`, `FinalizationRegistry`, `Promise`,
+  `RegExp`, `Date`, `DataView`, `ArrayBuffer`/`SharedArrayBuffer`, the typed
+  arrays, the iterator/generator/async-function prototypes and the Node `URL`
+  prototypes), the `JSON`/`Intl`/`Atomics` namespace objects, the
+  `BuiltinDelegateFunctionAdapter` identities behind every built-in constructor
+  and method, the global built-in function values exposed by
+  `GlobalThis.GetFunctionValue`, the intrinsic descriptor baseline for
+  non-`JsObject` targets, and the `[[Prototype]]` fallback slots for values that
+  are not `JsObject` instances. Two realms therefore observe distinct global,
+  constructor, prototype, and built-in function identities, and descriptor or
+  prototype mutation in one realm is invisible to the other. Only immutable CLR
+  metadata (the static delegates, method handles, and the `Type` handles used as
+  markers for `Math`, `Reflect`, `Date`, `AbortController`, `AbortSignal`, and
+  the `Intl` constructors) stays process-wide.
+- runtime: remove the process-wide `PrototypeChain._enabled` behavior switch.
+  Prototype-chain semantics are now always active (`Enabled`/`Enable()` remain
+  as no-op/always-true compatibility shims); the switch previously let one
+  realm's intrinsic bootstrap permanently change `__proto__` and
+  prototype-lookup behavior observed by every other realm/program sharing the
+  process.
+- runtime: intrinsic bootstrap (`GlobalThis.InitializeIntrinsics`) and every
+  lazily created intrinsic now run exactly once per realm under per-slot
+  initialization coordination, so concurrent realm creation is deterministic and
+  realms cannot corrupt each other's intrinsic surface. A second thread blocks
+  until an intrinsic is fully wired instead of observing a half-built prototype,
+  a failed initializer leaves the slot retryable, and the built-in adapter
+  initialization lock is a leaf lock (required intrinsics are materialized before
+  it is taken), so intrinsic creation and built-in function initialization can no
+  longer deadlock on inverted lock order. `RuntimeIntrinsics.Current` always
+  answers with the ambient realm, and context-less callers get one deterministic
+  process-default graph. Realm disposal releases the realm's intrinsic object
+  graph, adapter identities, and global function values.
+
 - runtime/test262: expose DataView as a first-class global constructor with
   standard constructor/prototype metadata and buffer, byteLength, and
   byteOffset accessors. Activates twenty corresponding pinned test262 fixtures.

--- a/docs/compiler/PrototypeChainSupport.md
+++ b/docs/compiler/PrototypeChainSupport.md
@@ -420,6 +420,19 @@ We have a few choices for how broadly to apply prototype-aware lowering.
 - Pros: easiest to implement, safest.
 - Cons: pessimizes unrelated hot paths.
 
+> **Implementation note (2026):** `PrototypeChain` originally implemented this
+> option with a process-wide `_enabled` switch flipped on by the compiler's
+> `Enable()` prologue call. Because intrinsic bootstrap itself always wires
+> prototype relationships (for example `Function.prototype -> Object.prototype`),
+> the switch was effectively always on shortly after the first realm in a
+> process started, and a second realm sharing the process could observe
+> prototype-aware behavior (e.g. `__proto__` semantics) it never opted into.
+> As part of making intrinsics realm-owned (GitHub issue #1824), the switch was
+> removed: `PrototypeChain` now always implements prototype-chain semantics.
+> `PrototypeChain.Enable()`/`Enabled` remain as no-op/always-true compatibility
+> shims for existing call sites and the compiler's prologue call; no runtime
+> behavior depends on them anymore.
+
 ### 10.2 Option 2: Per-scope / per-function switch (better)
 
 - Track a flag on the symbol table scope: `PrototypeSensitive`.

--- a/docs/runtime/RuntimeOwnership.md
+++ b/docs/runtime/RuntimeOwnership.md
@@ -6,6 +6,7 @@ JROC runtime state has three explicit lifetime owners:
 RuntimeAgentCluster
   -> RuntimeAgent
       -> RuntimeRealm
+          -> RuntimeIntrinsics
           -> RuntimeModuleState
           -> ServiceContainer
           -> RuntimeExecutionContext (while entered)
@@ -17,6 +18,18 @@ RuntimeAgentCluster
   more realms.
 - `RuntimeRealm` owns one JavaScript object graph and exactly one runtime
   `ServiceContainer`.
+- `RuntimeIntrinsics` owns the realm's well-known intrinsic object graph
+  (ECMA-262 Realm Record `[[Intrinsics]]`). That includes `Object.prototype` and
+  every other built-in prototype, the `JSON`/`Intl`/`Atomics` namespace objects,
+  the `BuiltinDelegateFunctionAdapter` identity of every built-in constructor and
+  method, the global built-in function values returned by
+  `GlobalThis.GetFunctionValue`, the intrinsic descriptor baseline for
+  non-`JsObject` targets, and the `[[Prototype]]` fallback slots for values that
+  are not `JsObject` instances. `GlobalThis` is constructed with its owning
+  realm's `RuntimeIntrinsics` and wires prototype chains, built-in methods, and
+  constructor linkage against it once per realm instead of once per process. See
+  [`RuntimeIntrinsics.cs`](../../src/JavaScriptRuntime/RuntimeIntrinsics.cs) for
+  the slot list and lifecycle.
 - `RuntimeModuleState` owns the realm's CommonJS and ESM graph, including
   module instances, live binding cells, namespace identities, `import.meta`,
   module-scoped require delegates, and the compiled module assembly.
@@ -33,10 +46,70 @@ retain the same realm owner. After realm disposal, its service container and
 any child scopes reject further use.
 
 The factory currently creates an isolated cluster, agent, realm, and service
-container for each `RuntimeServices.BuildServiceProvider()` call. Existing
-globals, modules, schedulers, caches, ambient execution state, `Engine`, and
-hosting lifecycle still use their prior implementations; subsequent migration
-issues move that state under these owners.
+container for each `RuntimeServices.BuildServiceProvider()` call. Template
+objects, materialized class constructors, and captured-scope constructor caches
+still use their prior implementations; subsequent migration issues (tracked by
+#1805, in particular #1825) move that state under these owners.
+
+## Intrinsic ownership
+
+Every JavaScript object that a realm can observe as a global, constructor,
+prototype, or built-in function is created for that realm alone:
+
+- Built-in prototypes are lazily created realm intrinsic slots. The thread that
+  wins a slot runs its initializer and resolves the slot reentrantly to the
+  object under construction, so the mutually recursive intrinsic bootstrap
+  cycles ECMA-262 requires (for example `Function.prototype.apply` being a
+  function object whose `[[Prototype]]` is `Function.prototype`) resolve instead
+  of recursing. Every other thread blocks until the initializer has completed
+  and therefore never observes a half-wired intrinsic; a failed initializer
+  leaves the slot empty so the next resolution retries.
+- The realm's one-time global bootstrap is itself an intrinsic slot
+  (`RuntimeIntrinsicSlot.RealmBootstrap`), so bootstrap and lazy slot creation
+  share a single coordination protocol instead of nesting two locks. Primitive
+  and error prototype accessors resolve through the already-resolved
+  `RuntimeIntrinsics` after a volatile bootstrap-state check, so they take no
+  lock once the realm is bootstrapped.
+- Lock order is `intrinsic slot gate` → `BuiltinDelegateFunctionAdapter`
+  initialization lock. The adapter lock is a leaf: `Function` materializes
+  `%Function.prototype%` and `%Object.prototype%` *before* acquiring it, so an
+  intrinsic initializer that configures built-in function objects can never
+  invert against a thread that already holds an adapter lock.
+- `RuntimeIntrinsics.Current` always answers with the ambient realm, so repeated
+  resolutions inside one operation cannot switch graphs when another realm is
+  created. Context-less callers get one deterministic process-default graph that
+  is never a live realm's graph.
+- Built-in function objects are `BuiltinDelegateFunctionAdapter` instances
+  resolved from the realm's adapter cache. The delegates, method handles, and
+  invoke metadata behind them are immutable CLR metadata and stay process-wide;
+  only the JavaScript-visible wrapper is realm-owned.
+- `JsObject` stores its own descriptors and `[[Prototype]]` inline, so those are
+  realm-correct once the object itself is realm-owned. Values that are not
+  `JsObject` instances (`Map`, `Set`, `RegExp`, `Date`, `Promise` instances and
+  the `Type` handles used as constructor markers) resolve their descriptor
+  baseline and `[[Prototype]]` link through the realm's
+  `IntrinsicDescriptors`/`PrototypeSlots` tables.
+- Post-bootstrap descriptor writes continue to go through
+  `PropertyDescriptorStore`'s per-realm overlay (`HasSharedIntrinsicBaseline`),
+  so descriptor definition, redefinition, and deletion are realm-local.
+- Realm disposal clears the realm's intrinsic slots, adapter cache, and global
+  function values, so a disposed realm's object graph becomes collectible.
+
+### Residual process-wide CLR metadata
+
+`Math`, `Reflect`, `Date`, `AbortController`, `AbortSignal`,
+`Intl.NumberFormat`, and `Intl.Segmenter` are represented by CLR `Type` handles
+rather than JavaScript objects. The handle itself is immutable CLR metadata and
+is explicitly allowed to be process-wide; all observable state hanging off it
+(own property descriptors including `prototype`, and its `[[Prototype]]` link)
+is realm-owned, so mutating any of it in one realm is invisible in another.
+Replacing those markers with realm-owned constructor objects is the
+`Type`-to-constructor materialization work tracked by #1825.
+
+`RegExp`'s well-known-symbol fast-path flag and `Array`'s prototype-mutation
+version counter remain process-wide. Both are monotonic de-optimization hints
+that only ever disable a fast path, hold no realm-created object, and cannot
+change observable semantics.
 
 ## Reference rules
 
@@ -44,7 +117,7 @@ issues move that state under these owners.
   agent, or cluster.
 - A cluster may reference its active agents.
 - An agent may reference its cluster and active realms.
-- A realm may reference its agent and service container.
+- A realm may reference its agent, intrinsics graph, and service container.
 - A realm owns one module state object; no mutable module graph is
   process-wide.
 - An entered execution context is the only ambient pointer to a realm and

--- a/src/JavaScriptRuntime/Array.cs
+++ b/src/JavaScriptRuntime/Array.cs
@@ -12,13 +12,43 @@ namespace JavaScriptRuntime
     [IntrinsicObject("Array", IntrinsicCallKind.ArrayConstruct)]
     public class Array : JsObject, IExoticJsObject, IJavaScriptArray, IDictionary<string, object?>
     {
-        private static readonly ThreadLocal<JsObject?> _threadPrototypeOverrides = new(() => null);
         [ThreadStatic]
         private static bool _defaultPrototypeChainHasIndexedProperties;
         [ThreadStatic]
         private static long _observedPrototypeMutationVersion;
+        [ThreadStatic]
+        private static long _observedPrototypeIntrinsicsId;
         private static long _prototypeMutationVersion;
-        internal static readonly JsObject ImmutablePrototype = CreatePrototype();
+
+        /// <summary>
+        /// This realm's immutable <c>%Array.prototype%</c> template. Realm-owned
+        /// (issue #1824); <see cref="Prototype"/> is the mutable copy handed to
+        /// running code.
+        /// </summary>
+        internal static JsObject ImmutablePrototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.ArrayImmutablePrototype,
+                static () => new JsObject(),
+                static prototype =>
+                {
+                    using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
+                    // Wired here rather than only from GlobalThis's bootstrap so the
+                    // template is complete no matter which realm-owned intrinsic is
+                    // materialized first: Prototype copies this object, and a copy taken
+                    // before the [[Prototype]] link and "constructor" existed would lose
+                    // Object.prototype's methods and Array.prototype.constructor.
+                    PrototypeChain.SetPrototype(prototype, GlobalThis.ObjectPrototypeValue);
+                    ConfigurePrototype(prototype);
+                    PropertyDescriptorStore.DefineOrUpdate(prototype, "constructor", new JsPropertyDescriptor
+                    {
+                        Kind = JsPropertyDescriptorKind.Data,
+                        Enumerable = false,
+                        Configurable = true,
+                        Writable = true,
+                        Value = GlobalThis.Array
+                    });
+                });
         private static readonly object Hole = new();
         private const int MaxDenseGap = 1024;
         private const int MinNumericStorageCapacity = 32;
@@ -48,52 +78,38 @@ namespace JavaScriptRuntime
         private void ClearCapacityHint()
             => _holeCount &= int.MinValue;
 
+        /// <summary>
+        /// This realm's live <c>Array.prototype</c>. Realm-owned (issue #1824): it used
+        /// to be a per-thread copy, which meant two realms sharing a thread also shared
+        /// every <c>Array.prototype</c> mutation.
+        /// </summary>
         internal static JsObject Prototype
-        {
-            get
-            {
-                var prototype = _threadPrototypeOverrides.Value;
-                if (prototype != null)
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.ArrayPrototype,
+                static () => new JsObject(),
+                static prototype =>
                 {
-                    return prototype;
-                }
-
-                prototype = CreateThreadPrototypeOverride();
-                _threadPrototypeOverrides.Value = prototype;
-                RefreshDefaultPrototypeChainState();
-                return prototype;
-            }
-        }
-
-        private static JsObject CreatePrototype()
-        {
-            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
-
-            var prototype = new JsObject();
-            ConfigurePrototype(prototype);
-            return prototype;
-        }
+                    CopyImmutablePrototypeSurface(prototype);
+                    RefreshDefaultPrototypeChainState();
+                });
 
         internal static void ResetPrototypeForTests()
         {
-            _threadPrototypeOverrides.Value = null;
             _defaultPrototypeChainHasIndexedProperties = false;
+            _observedPrototypeIntrinsicsId = 0;
             _observedPrototypeMutationVersion = Volatile.Read(ref _prototypeMutationVersion);
         }
 
-        private static JsObject CreateThreadPrototypeOverride()
+        private static void CopyImmutablePrototypeSurface(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var prototype = new JsObject();
             PropertyDescriptorStore.CopyOwnProperties(ImmutablePrototype, prototype);
 
             if (PrototypeChain.TryGetPrototype(ImmutablePrototype, out var parentPrototype))
             {
                 PrototypeChain.InitializePrototype(prototype, parentPrototype);
             }
-
-            return prototype;
         }
 
         private static void ConfigurePrototype(JsObject prototype)
@@ -2091,7 +2107,8 @@ namespace JavaScriptRuntime
         private static bool DefaultPrototypeChainAllowsDenseWrites()
         {
             var mutationVersion = Volatile.Read(ref _prototypeMutationVersion);
-            if (_observedPrototypeMutationVersion != mutationVersion)
+            if (_observedPrototypeMutationVersion != mutationVersion
+                || _observedPrototypeIntrinsicsId != RuntimeIntrinsics.Current.Id)
             {
                 RefreshDefaultPrototypeChainState();
             }
@@ -2113,6 +2130,7 @@ namespace JavaScriptRuntime
                 {
                     _defaultPrototypeChainHasIndexedProperties = hasIndexedProperties;
                     _observedPrototypeMutationVersion = afterScan;
+                    _observedPrototypeIntrinsicsId = RuntimeIntrinsics.Current.Id;
                     return;
                 }
             }

--- a/src/JavaScriptRuntime/ArrayBuffer.cs
+++ b/src/JavaScriptRuntime/ArrayBuffer.cs
@@ -5,7 +5,8 @@ namespace JavaScriptRuntime
     [IntrinsicObject("ArrayBuffer")]
     public class ArrayBuffer
     {
-        internal static readonly object Prototype = new JsObject();
+        internal static object Prototype
+            => RuntimeIntrinsics.Current.ArrayBufferPrototype;
         private byte[] _bytes;
         private readonly int _maxByteLength;
         private readonly bool _isResizable;

--- a/src/JavaScriptRuntime/AsyncFunction.cs
+++ b/src/JavaScriptRuntime/AsyncFunction.cs
@@ -4,18 +4,29 @@ namespace JavaScriptRuntime;
 
 public static class AsyncFunction
 {
-    internal static readonly object Prototype = CreatePrototype();
     private static readonly Func<object[], object?[], object?> ConstructorValue = static (_, args) =>
         CreateDynamicAsyncFunction(args);
 
-    static AsyncFunction()
+    /// <summary>Realm-owned <c>%AsyncFunction.prototype%</c> (issue #1824).</summary>
+    internal static object Prototype
+        => RuntimeIntrinsics.Current.GetOrCreate(
+            RuntimeIntrinsicSlot.AsyncFunctionPrototype,
+            static () => new JsObject(),
+            static prototype => InitializePrototype(prototype));
+
+    /// <summary>
+    /// Wires this realm's <c>%AsyncFunction%</c> surface. Runs once per realm from the
+    /// intrinsic slot initializer (issue #1824) rather than once per process from a
+    /// static constructor.
+    /// </summary>
+    private static void InitializePrototype(JsObject prototype)
     {
         using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
         Function.InitializeFunctionInstance(ConstructorValue);
         Function.MarkConstructible(ConstructorValue);
         PrototypeChain.SetPrototype(ConstructorValue, GlobalThis.Function);
-        PrototypeChain.SetPrototype(Prototype, Function.Prototype);
+        PrototypeChain.SetPrototype(prototype, Function.Prototype);
 
         DefineDataProperty(
             ConstructorValue,
@@ -32,13 +43,13 @@ public static class AsyncFunction
         DefineDataProperty(
             ConstructorValue,
             "prototype",
-            Prototype,
+            prototype,
             writable: false,
             configurable: false);
 
-        DefineDataProperty(Prototype, "constructor", ConstructorValue);
+        DefineDataProperty(prototype, "constructor", ConstructorValue);
         DefineDataProperty(
-            Prototype,
+            prototype,
             Symbol.toStringTag.DebugId,
             "AsyncFunction",
             writable: false,
@@ -155,13 +166,6 @@ public static class AsyncFunction
 
     public static object InitializeFunctionInstance(object functionValue, double length, string? name, bool requiresInvocationContext, bool hasRestrictedProperties)
         => InitializeFunctionInstance<object>(functionValue, length, name, requiresInvocationContext, hasRestrictedProperties);
-
-    private static object CreatePrototype()
-    {
-        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
-
-        return new JsObject();
-    }
 
     private static object CreateDynamicAsyncFunction(object?[]? args)
     {

--- a/src/JavaScriptRuntime/AsyncGeneratorFunction.cs
+++ b/src/JavaScriptRuntime/AsyncGeneratorFunction.cs
@@ -5,25 +5,12 @@ namespace JavaScriptRuntime;
 public static class AsyncGeneratorFunction
 {
     private static readonly Func<object[], object?[]?, object?> _constructor = AsyncGeneratorFunctionConstructor;
-    private static readonly JsObject Prototype = CreatePrototype();
-
-    static AsyncGeneratorFunction()
-    {
-        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
-
-        JavaScriptRuntime.Function.InitializeFunctionInstance(_constructor, 1d, "AsyncGeneratorFunction", requiresInvocationContext: false);
-        JavaScriptRuntime.Function.MarkConstructible(_constructor);
-        PrototypeChain.SetPrototype(_constructor, GlobalThis.Function);
-        PropertyDescriptorStore.DefineOrUpdate(_constructor, "prototype", new JsPropertyDescriptor
-        {
-            Kind = JsPropertyDescriptorKind.Data,
-            Enumerable = false,
-            Configurable = false,
-            Writable = false,
-            Value = Prototype
-        });
-        AsyncGeneratorObject.ConfigurePrototype(Prototype);
-    }
+    /// <summary>Realm-owned <c>%AsyncGeneratorFunction.prototype%</c> (issue #1824).</summary>
+    internal static JsObject Prototype
+        => RuntimeIntrinsics.Current.GetOrCreate(
+            RuntimeIntrinsicSlot.AsyncGeneratorFunctionPrototype,
+            static () => new JsObject(),
+            static prototype => InitializePrototype(prototype));
 
     public static object InitializeFunctionObject(object functionObject)
     {
@@ -35,11 +22,15 @@ public static class AsyncGeneratorFunction
         return functionObject;
     }
 
-    private static JsObject CreatePrototype()
+    /// <summary>
+    /// Wires this realm's <c>%AsyncGeneratorFunction%</c> surface. Runs once per realm
+    /// from the intrinsic slot initializer (issue #1824) rather than once per process
+    /// from a static constructor.
+    /// </summary>
+    private static void InitializePrototype(JsObject prototype)
     {
         using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-        var prototype = new JsObject();
         PrototypeChain.SetPrototype(prototype, JavaScriptRuntime.Function.Prototype);
         PropertyDescriptorStore.DefineOrUpdate(prototype, "constructor", new JsPropertyDescriptor
         {
@@ -49,7 +40,19 @@ public static class AsyncGeneratorFunction
             Writable = true,
             Value = _constructor
         });
-        return prototype;
+
+        JavaScriptRuntime.Function.InitializeFunctionInstance(_constructor, 1d, "AsyncGeneratorFunction", requiresInvocationContext: false);
+        JavaScriptRuntime.Function.MarkConstructible(_constructor);
+        PrototypeChain.SetPrototype(_constructor, GlobalThis.Function);
+        PropertyDescriptorStore.DefineOrUpdate(_constructor, "prototype", new JsPropertyDescriptor
+        {
+            Kind = JsPropertyDescriptorKind.Data,
+            Enumerable = false,
+            Configurable = false,
+            Writable = false,
+            Value = prototype
+        });
+        AsyncGeneratorObject.ConfigurePrototype(prototype);
     }
 
     private static object? AsyncGeneratorFunctionConstructor(object[] scopes, object?[]? args)

--- a/src/JavaScriptRuntime/AsyncGeneratorObject.cs
+++ b/src/JavaScriptRuntime/AsyncGeneratorObject.cs
@@ -11,7 +11,19 @@ namespace JavaScriptRuntime;
 /// </summary>
 public sealed class AsyncGeneratorObject : IJavaScriptAsyncIterator
 {
-    internal static readonly object PrototypeObject = CreatePrototype();
+    /// <summary>Realm-owned <c>%AsyncGeneratorPrototype%</c> (issue #1824).</summary>
+    internal static object PrototypeObject
+        => RuntimeIntrinsics.Current.GetOrCreate(
+            RuntimeIntrinsicSlot.AsyncGeneratorPrototype,
+            static () => new JsObject(),
+            static prototype =>
+            {
+                PrototypeChain.SetPrototype(prototype, AsyncIterator.Prototype);
+
+                // Touching the realm's %AsyncGeneratorFunction.prototype% installs this
+                // object's own methods through ConfigurePrototype below.
+                _ = AsyncGeneratorFunction.Prototype;
+            });
     private readonly object[] _scopes;
 
     public AsyncGeneratorObject(object[] scopes)
@@ -19,13 +31,6 @@ public sealed class AsyncGeneratorObject : IJavaScriptAsyncIterator
         _scopes = scopes ?? throw new ArgumentNullException(nameof(scopes));
         PrototypeChain.SetPrototype(this, PrototypeObject);
         GetLeafScope().ThisValue = RuntimeServices.GetCurrentThis();
-    }
-
-    private static object CreatePrototype()
-    {
-        var prototype = new JsObject();
-        PrototypeChain.SetPrototype(prototype, AsyncIterator.Prototype);
-        return prototype;
     }
 
     internal static void ConfigurePrototype(

--- a/src/JavaScriptRuntime/AsyncIterator.cs
+++ b/src/JavaScriptRuntime/AsyncIterator.cs
@@ -4,7 +4,11 @@ namespace JavaScriptRuntime;
 
 public static class AsyncIterator
 {
-    internal static readonly object Prototype = CreatePrototype();
+    /// <summary>Realm-owned <c>%AsyncIteratorPrototype%</c> (issue #1824).</summary>
+    internal static object Prototype
+        => RuntimeIntrinsics.Current.GetOrCreate(
+            RuntimeIntrinsicSlot.AsyncIteratorPrototype,
+            static () => new JsObject());
 
     internal static void ConfigureIntrinsicSurface(object asyncIteratorConstructorValue)
     {
@@ -24,13 +28,6 @@ public static class AsyncIterator
         {
             PrototypeChain.SetPrototype(iterator, Prototype);
         }
-    }
-
-    private static object CreatePrototype()
-    {
-        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
-
-        return new JsObject();
     }
 
     private static void DefineDataProperty(object target, string key, object? value)

--- a/src/JavaScriptRuntime/BuiltinDelegateFunctionAdapter.cs
+++ b/src/JavaScriptRuntime/BuiltinDelegateFunctionAdapter.cs
@@ -1,33 +1,18 @@
 namespace JavaScriptRuntime;
 
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
-
 /// <summary>
 /// Explicit adapter for runtime-owned built-in CLR delegates.
 /// Compiled JavaScript functions never use this representation.
 /// </summary>
+/// <remarks>
+/// The adapter is the JavaScript-visible identity of a built-in function, so it is
+/// realm-owned (issue #1824): <see cref="FromDelegate"/> resolves the stable adapter
+/// from <see cref="RuntimeIntrinsics.BuiltinAdapters"/> of the ambient realm. Only the
+/// immutable CLR metadata behind it (the static delegate, its method handle and its
+/// <see cref="Closure.DelegateInvokeMetadata"/>) stays process-wide.
+/// </remarks>
 public sealed class BuiltinDelegateFunctionAdapter : JsFunctionObject
 {
-    private sealed class StaticAdapterCache
-    {
-        public ConcurrentDictionary<
-            (RuntimeMethodHandle Method, Type DelegateType),
-            BuiltinDelegateFunctionAdapter> Adapters { get; } = new();
-    }
-
-    private sealed class AdapterMethodCache
-    {
-        public ConcurrentDictionary<
-            (RuntimeMethodHandle Method, Type DelegateType),
-            BuiltinDelegateFunctionAdapter> Adapters { get; } = new();
-    }
-
-    private static readonly ConditionalWeakTable<Type, StaticAdapterCache> StaticAdapters = new();
-    private static readonly ConditionalWeakTable<object, AdapterMethodCache> InstanceAdapters = new();
-    private static readonly ConcurrentQueue<
-        WeakReference<BuiltinDelegateFunctionAdapter>> DeferredFunctionPrototypes = new();
-
     private readonly object[] _scopes;
     private readonly Closure.DelegateInvokeMetadata _invokeMetadata;
     private readonly object _initializationLock = new();
@@ -69,26 +54,6 @@ public sealed class BuiltinDelegateFunctionAdapter : JsFunctionObject
 
     public override bool RequiresInvocationContext => _requiresInvocationContext;
 
-    internal static void DeferFunctionPrototypeInitialization(
-        BuiltinDelegateFunctionAdapter adapter)
-    {
-        DeferredFunctionPrototypes.Enqueue(new WeakReference<BuiltinDelegateFunctionAdapter>(
-            adapter));
-    }
-
-    internal static void CompleteDeferredFunctionPrototypeInitialization(
-        JsObject functionPrototype)
-    {
-        while (DeferredFunctionPrototypes.TryDequeue(out var reference))
-        {
-            if (reference.TryGetTarget(out var adapter)
-                && PrototypeChain.GetPrototypeOrNull(adapter) == null)
-            {
-                PrototypeChain.InitializePrototype(adapter, functionPrototype);
-            }
-        }
-    }
-
     public static BuiltinDelegateFunctionAdapter FromDelegate(Delegate target)
     {
         ArgumentNullException.ThrowIfNull(target);
@@ -103,42 +68,16 @@ public sealed class BuiltinDelegateFunctionAdapter : JsFunctionObject
             return new BuiltinDelegateFunctionAdapter(target);
         }
 
-        if (target.Target == null)
-        {
-            var declaringType = target.Method.DeclaringType
-                ?? throw new InvalidOperationException(
-                    "Runtime-owned static delegates require a declaring type.");
-            var cache = StaticAdapters.GetOrCreateValue(declaringType);
-            return cache.Adapters.GetOrAdd(
-                (target.Method.MethodHandle, target.GetType()),
-                _ => new BuiltinDelegateFunctionAdapter(target));
-        }
-
-        var instanceCache = InstanceAdapters.GetOrCreateValue(target.Target);
-        return instanceCache.Adapters.GetOrAdd(
-            (target.Method.MethodHandle, target.GetType()),
-            _ => new BuiltinDelegateFunctionAdapter(target));
+        return RuntimeIntrinsics.Current.BuiltinAdapters.GetOrAdd(
+            target,
+            static resolved => new BuiltinDelegateFunctionAdapter(resolved));
     }
 
     internal static bool HasStableAdapterForTests(Delegate target)
     {
         ArgumentNullException.ThrowIfNull(target);
-        if (target.GetInvocationList().Length != 1)
-        {
-            return false;
-        }
-
-        if (target.Target == null)
-        {
-            return target.Method.DeclaringType is { } declaringType
-                && StaticAdapters.TryGetValue(declaringType, out var staticCache)
-                && staticCache.Adapters.ContainsKey(
-                    (target.Method.MethodHandle, target.GetType()));
-        }
-
-        return InstanceAdapters.TryGetValue(target.Target, out var instanceCache)
-            && instanceCache.Adapters.ContainsKey(
-                (target.Method.MethodHandle, target.GetType()));
+        return target.GetInvocationList().Length == 1
+            && RuntimeIntrinsics.Current.BuiltinAdapters.Contains(target);
     }
 
     internal static object? WrapJavaScriptVisibleValue(object? value)

--- a/src/JavaScriptRuntime/DataView.cs
+++ b/src/JavaScriptRuntime/DataView.cs
@@ -5,7 +5,11 @@ namespace JavaScriptRuntime
     [IntrinsicObject("DataView")]
     public sealed class DataView
     {
-        internal static readonly object Prototype = new JsObject();
+        /// <summary>Realm-owned <c>DataView.prototype</c> (issue #1824).</summary>
+        internal static object Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.DataViewPrototype,
+                static () => new JsObject());
         private readonly ArrayBuffer _buffer;
         private readonly int _byteOffset;
         private readonly int _byteLength;

--- a/src/JavaScriptRuntime/Date.cs
+++ b/src/JavaScriptRuntime/Date.cs
@@ -18,7 +18,11 @@ namespace JavaScriptRuntime
     [IntrinsicObject("Date", IntrinsicCallKind.DateToString)]
     public class Date
     {
-        internal static readonly object Prototype = new JsObject();
+        /// <summary>Realm-owned <c>Date.prototype</c> (issue #1824).</summary>
+        internal static object Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.DatePrototype,
+                static () => new JsObject());
 
         private static readonly Regex DateOnlyRegex = new(
             @"^(?<year>[+-]?\d{4,6})(?:-(?<month>\d{2})(?:-(?<day>\d{2}))?)?$",

--- a/src/JavaScriptRuntime/FinalizationRegistry.cs
+++ b/src/JavaScriptRuntime/FinalizationRegistry.cs
@@ -6,7 +6,12 @@ namespace JavaScriptRuntime
     [IntrinsicObject("FinalizationRegistry")]
     public sealed class FinalizationRegistry
     {
-        internal static readonly object Prototype = CreatePrototype();
+        /// <summary>Realm-owned <c>FinalizationRegistry.prototype</c> intrinsic (issue #1824).</summary>
+        internal static object Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.FinalizationRegistryPrototype,
+                static () => new JsObject(),
+                static prototype => InitializePrototype(prototype));
         private sealed class Registration
         {
             public Registration(object target, object? heldValue, object? unregisterToken)
@@ -158,11 +163,10 @@ namespace JavaScriptRuntime
             PrototypeChain.SetPrototype(this, Prototype);
         }
 
-        private static object CreatePrototype()
+        private static void InitializePrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var prototype = new JsObject();
             Func<object[], object?[]?, object?> register = PrototypeRegister;
             Func<object[], object?[]?, object?> unregister = PrototypeUnregister;
             Function.InitializeFunctionInstance(register, 2d, "register");
@@ -207,7 +211,6 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = "FinalizationRegistry"
             });
-            return prototype;
         }
 
         private static object? PrototypeRegister(object[] _, object?[]? args)

--- a/src/JavaScriptRuntime/Function.cs
+++ b/src/JavaScriptRuntime/Function.cs
@@ -17,29 +17,35 @@ public static class Function
     private static readonly Func<object[], object?[], object?> _restrictedPropertyThrower =
         static (_, _) => throw new TypeError("Cannot access restricted function property");
 
-    internal static readonly JsObject Prototype;
-    internal static readonly JsObject RestrictedPropertiesPrototype;
+    /// <summary>
+    /// This realm's <c>%Function.prototype%</c>. Realm-owned (issue #1824): the object
+    /// is published into the realm's intrinsic slot before its own methods are wired,
+    /// because <c>Function.prototype.apply</c> and friends are themselves function
+    /// objects whose [[Prototype]] is <c>%Function.prototype%</c>.
+    /// </summary>
+    internal static JsObject Prototype
+        => RuntimeIntrinsics.Current.GetOrCreate(
+            RuntimeIntrinsicSlot.FunctionPrototype,
+            static () => new JsObject(),
+            static prototype => InitializePrototypeSurface(prototype));
 
-    static Function()
-    {
-        Prototype = CreatePrototype();
-        RestrictedPropertiesPrototype = CreateRestrictedPropertiesPrototype();
-        BuiltinDelegateFunctionAdapter
-            .CompleteDeferredFunctionPrototypeInitialization(Prototype);
-    }
+    internal static JsObject RestrictedPropertiesPrototype
+        => RuntimeIntrinsics.Current.GetOrCreate(
+            RuntimeIntrinsicSlot.FunctionRestrictedPropertiesPrototype,
+            static () => new JsObject(),
+            static prototype => InitializeRestrictedPropertiesPrototype(prototype));
 
-    private static JsObject CreatePrototype()
+    private static void InitializePrototypeSurface(JsObject prototype)
     {
         using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-        var prototype = new JsObject();
+        PrototypeChain.SetPrototype(prototype, GlobalThis.ObjectPrototypeValue);
         DefinePrototypeMethod(prototype, "apply", (Func<object[], object?[]?, object?>)PrototypeApply, 2);
         DefinePrototypeMethod(prototype, "call", (Func<object[], object?[]?, object?>)PrototypeCall, 1);
         DefinePrototypeMethod(prototype, "bind", (Func<object[], object?[]?, object?>)PrototypeBind, 1);
         DefinePrototypeMethod(prototype, "toString", (Func<object[], object?[]?, object?>)PrototypeToString, 0);
         DefineRestrictedProperty(prototype, "caller");
         DefineRestrictedProperty(prototype, "arguments");
-        return prototype;
     }
 
     private static void DefinePrototypeMethod(JsObject prototype, string name, Func<object[], object?[]?, object?> method, double length)
@@ -91,14 +97,13 @@ public static class Function
         return method;
     }
 
-    private static JsObject CreateRestrictedPropertiesPrototype()
+    private static void InitializeRestrictedPropertiesPrototype(JsObject prototype)
     {
         using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-        var prototype = new JsObject();
+        PrototypeChain.SetPrototype(prototype, Prototype);
         DefineRestrictedProperty(prototype, "caller");
         DefineRestrictedProperty(prototype, "arguments");
-        return prototype;
     }
 
     private static void DefineRestrictedProperty(object target, string propertyName)
@@ -119,28 +124,55 @@ public static class Function
             BuiltinDelegateFunctionAdapter.NormalizeJavaScriptObject(
                 functionValue);
 
+        // Resolved before the adapter lock: see MaterializeFunctionIntrinsics.
+        var prototype = MaterializeFunctionIntrinsics(ordinaryPrototypeRequired: false);
+
         if (functionValue is BuiltinDelegateFunctionAdapter adapter)
         {
             lock (adapter.InitializationLock)
             {
                 using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
-                ConfigureCallableObjectCore(functionValue, hasRestrictedProperties);
+                ConfigureCallableObjectCore(functionValue, prototype, hasRestrictedProperties);
             }
             return;
         }
 
-        ConfigureCallableObjectCore(functionValue, hasRestrictedProperties);
+        ConfigureCallableObjectCore(functionValue, prototype, hasRestrictedProperties);
     }
 
     private static void ConfigureCallableObjectCore(
         object functionValue,
+        JsObject prototype,
         bool hasRestrictedProperties)
     {
-        PrototypeChain.SetPrototype(functionValue, Prototype);
+        PrototypeChain.SetPrototype(functionValue, prototype);
         if (hasRestrictedProperties)
         {
             DefineRestrictedFunctionProperties(functionValue);
         }
+    }
+
+    /// <summary>
+    /// Materializes every intrinsic a <see cref="BuiltinDelegateFunctionAdapter.InitializationLock"/>
+    /// scope needs, before that lock is taken.
+    /// </summary>
+    /// <remarks>
+    /// The adapter lock is a leaf in the runtime's lock order (intrinsic slot gate →
+    /// adapter lock). Resolving <c>%Function.prototype%</c> or <c>%Object.prototype%</c>
+    /// while holding an adapter lock would invert that order against an intrinsic
+    /// initializer that configures built-in function objects, which is a deadlock.
+    /// </remarks>
+    private static JsObject MaterializeFunctionIntrinsics(bool ordinaryPrototypeRequired)
+    {
+        var prototype = Prototype;
+        if (ordinaryPrototypeRequired)
+        {
+            // EnsureOrdinaryFunctionPrototype allocates through
+            // ObjectRuntime.CreateOrdinaryObject, which needs %Object.prototype%.
+            _ = GlobalThis.ObjectPrototypeValue;
+        }
+
+        return prototype;
     }
 
     internal static void DefineRestrictedFunctionProperties(object functionValue)
@@ -358,37 +390,30 @@ public static class Function
                 BuiltinDelegateFunctionAdapter.NormalizeJavaScriptObject(
                     functionValue);
 
+            // Resolved before the adapter lock: see MaterializeFunctionIntrinsics.
+            var prototype = MaterializeFunctionIntrinsics(ordinaryPrototypeRequired: false);
+
             if (functionObject is BuiltinDelegateFunctionAdapter adapter)
             {
                 lock (adapter.InitializationLock)
                 {
                     using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
-                    InitializeFunctionPrototype(functionObject);
+                    InitializeFunctionPrototype(functionObject, prototype);
                 }
             }
             else
             {
-                InitializeFunctionPrototype(functionObject);
+                InitializeFunctionPrototype(functionObject, prototype);
             }
 
             return functionValue;
         }
 
-        private static void InitializeFunctionPrototype(object functionObject)
+        private static void InitializeFunctionPrototype(object functionObject, JsObject prototype)
         {
-            if (Prototype is null)
-            {
-                if (functionObject is BuiltinDelegateFunctionAdapter adapter)
-                {
-                    BuiltinDelegateFunctionAdapter
-                        .DeferFunctionPrototypeInitialization(adapter);
-                }
-                return;
-            }
-
             if (PrototypeChain.GetPrototypeOrNull(functionObject) == null)
             {
-                PrototypeChain.SetPrototype(functionObject, Prototype);
+                PrototypeChain.SetPrototype(functionObject, prototype);
             }
         }
 
@@ -418,6 +443,9 @@ public static class Function
                 BuiltinDelegateFunctionAdapter.NormalizeJavaScriptObject(
                     functionValue);
 
+            // Resolved before the adapter lock: see MaterializeFunctionIntrinsics.
+            var prototype = MaterializeFunctionIntrinsics(ordinaryPrototypeRequired: true);
+
             if (functionObject is BuiltinDelegateFunctionAdapter adapter)
             {
                 lock (adapter.InitializationLock)
@@ -425,6 +453,7 @@ public static class Function
                     using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
                     InitializeFunctionInstanceCore(
                         functionObject,
+                        prototype,
                         length,
                         name,
                         requiresInvocationContext,
@@ -435,6 +464,7 @@ public static class Function
             {
                 InitializeFunctionInstanceCore(
                     functionObject,
+                    prototype,
                     length,
                     name,
                     requiresInvocationContext,
@@ -446,12 +476,13 @@ public static class Function
 
         private static void InitializeFunctionInstanceCore(
             object functionObject,
+            JsObject prototype,
             double length,
             string? name,
             bool requiresInvocationContext,
             bool hasRestrictedProperties)
         {
-            InitializeFunctionPrototype(functionObject);
+            InitializeFunctionPrototype(functionObject, prototype);
             if (hasRestrictedProperties)
             {
                 DefineRestrictedFunctionProperties(functionObject);
@@ -505,6 +536,9 @@ public static class Function
                     functionValue);
             if (functionObject is BuiltinDelegateFunctionAdapter adapter)
             {
+                // Resolved before the adapter lock: see MaterializeFunctionIntrinsics.
+                _ = MaterializeFunctionIntrinsics(ordinaryPrototypeRequired: true);
+
                 lock (adapter.InitializationLock)
                 {
                     using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();

--- a/src/JavaScriptRuntime/GeneratorObject.cs
+++ b/src/JavaScriptRuntime/GeneratorObject.cs
@@ -20,8 +20,19 @@ public sealed class GeneratorObject : IJavaScriptIterator
     // Per ECMA-262, gen.constructor is the same function object for all generator instances.
     private static readonly Func<object[], object?[]?, object?> _generatorFunctionConstructor =
         static (_, args) => CreateDynamicGeneratorFunction(args);
-    private static readonly object Prototype = CreatePrototype();
-    private static readonly object GeneratorFunctionPrototype = CreateGeneratorFunctionPrototype();
+    /// <summary>Realm-owned <c>%GeneratorPrototype%</c> (issue #1824).</summary>
+    private static object Prototype
+        => RuntimeIntrinsics.Current.GetOrCreate(
+            RuntimeIntrinsicSlot.GeneratorPrototype,
+            static () => new JsObject(),
+            static prototype => InitializePrototype(prototype));
+
+    /// <summary>Realm-owned <c>%GeneratorFunction.prototype%</c> (issue #1824).</summary>
+    private static object GeneratorFunctionPrototype
+        => RuntimeIntrinsics.Current.GetOrCreate(
+            RuntimeIntrinsicSlot.GeneratorFunctionPrototype,
+            static () => new JsObject(),
+            static prototype => InitializeGeneratorFunctionPrototype(prototype));
 
     private readonly CompiledContinuation _step;
     private readonly object[] _scopes;
@@ -41,9 +52,29 @@ public sealed class GeneratorObject : IJavaScriptIterator
     internal static object GeneratorFunctionPrototypeObject => GeneratorFunctionPrototype;
     internal static object GeneratorPrototypeObject => Prototype;
 
-    static GeneratorObject()
+    private static void InitializePrototype(JsObject prototype)
     {
         using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
+        PrototypeChain.SetPrototype(prototype, Iterator.Prototype);
+        DefineDataProperty(prototype, "constructor", _generatorFunctionConstructor);
+        DefineDataProperty(prototype, "next", (Func<object[], object?[]?, object?>)PrototypeNext);
+        DefineDataProperty(prototype, "return", (Func<object[], object?[]?, object?>)PrototypeReturn);
+        DefineDataProperty(prototype, "throw", (Func<object[], object?[]?, object?>)PrototypeThrow);
+        DefineDataProperty(prototype, Symbol.toStringTag.DebugId, "Generator");
+    }
+
+    /// <summary>
+    /// Wires this realm's <c>%GeneratorFunction%</c> constructor surface. Runs once per
+    /// realm from the intrinsic slot initializer (issue #1824) rather than once per
+    /// process from a static constructor.
+    /// </summary>
+    private static void InitializeGeneratorFunctionPrototype(JsObject prototype)
+    {
+        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
+        PrototypeChain.SetPrototype(prototype, Function.Prototype);
+        DefineDataProperty(prototype, "constructor", _generatorFunctionConstructor);
 
         Function.InitializeFunctionInstance(_generatorFunctionConstructor, 1d, "GeneratorFunction", requiresInvocationContext: false);
         Function.MarkConstructible(_generatorFunctionConstructor);
@@ -54,32 +85,8 @@ public sealed class GeneratorObject : IJavaScriptIterator
             Enumerable = false,
             Configurable = false,
             Writable = false,
-            Value = GeneratorFunctionPrototype
+            Value = prototype
         });
-    }
-
-    private static object CreatePrototype()
-    {
-        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
-
-        var prototype = new JsObject();
-        PrototypeChain.SetPrototype(prototype, Iterator.Prototype);
-        DefineDataProperty(prototype, "constructor", _generatorFunctionConstructor);
-        DefineDataProperty(prototype, "next", (Func<object[], object?[]?, object?>)PrototypeNext);
-        DefineDataProperty(prototype, "return", (Func<object[], object?[]?, object?>)PrototypeReturn);
-        DefineDataProperty(prototype, "throw", (Func<object[], object?[]?, object?>)PrototypeThrow);
-        DefineDataProperty(prototype, Symbol.toStringTag.DebugId, "Generator");
-        return prototype;
-    }
-
-    private static object CreateGeneratorFunctionPrototype()
-    {
-        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
-
-        var prototype = new JsObject();
-        PrototypeChain.SetPrototype(prototype, Function.Prototype);
-        DefineDataProperty(prototype, "constructor", _generatorFunctionConstructor);
-        return prototype;
     }
 
     private static object CreateDynamicGeneratorFunction(object?[]? args)

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -15,15 +15,101 @@ namespace JavaScriptRuntime
     public class GlobalThis : JsObject, IDictionary<string, object?>
     {
         private static readonly ThreadLocal<GlobalThis?> _fallbackGlobalObject = new(() => null);
-        private static readonly ConcurrentDictionary<string, BuiltinDelegateFunctionAdapter>
-            _globalFunctionValues = new(StringComparer.Ordinal);
 
         private static readonly JavaScriptRuntime.Console _defaultConsole = new(new ConsoleOutputSinks());
         private static readonly JavaScriptRuntime.Node.Process _defaultProcess = new(new DefaultEnvironment());
 
-        public GlobalThis()
+        private readonly RuntimeIntrinsics _intrinsics;
+        private readonly object _seedGate = new();
+        private volatile bool _seeded;
+        private int _seedingThreadId;
+
+        /// <summary>
+        /// Cached bootstrap delegate: <see cref="Bootstrap"/> runs on every
+        /// <c>globalThis</c> resolution, so the instance method group must not be
+        /// converted to a new delegate each time.
+        /// </summary>
+        private Action? _initializeIntrinsics;
+
+        /// <summary>
+        /// The realm-owned intrinsic object graph backing this global object's
+        /// well-known prototypes/namespace objects (ECMA-262 [[Intrinsics]]).
+        /// </summary>
+        internal RuntimeIntrinsics Intrinsics => _intrinsics;
+
+        public GlobalThis() : this(RuntimeIntrinsics.Current)
         {
-            SeedGlobalObjectIfMissing();
+            Bootstrap();
+        }
+
+        internal GlobalThis(RuntimeIntrinsics intrinsics)
+        {
+            _intrinsics = intrinsics ?? throw new ArgumentNullException(nameof(intrinsics));
+        }
+
+        /// <summary>
+        /// Wires this realm's intrinsic object graph and seeds the global object's
+        /// well-known bindings. Idempotent and safe to call from any thread: the realm
+        /// wiring runs exactly once per realm inside
+        /// <see cref="RuntimeIntrinsics.EnsureBootstrapped"/> (concurrent callers block
+        /// until it is complete), and the binding seed runs exactly once per instance.
+        /// </summary>
+        /// <remarks>
+        /// Split out from the constructor so callers that publish the instance ambiently
+        /// (<see cref="RuntimeExecutionContext"/>) can record the reference *before*
+        /// running the wiring pass: bootstrap reenters
+        /// <c>GlobalThis.globalThis</c>/<c>GetOrCreateGlobalObject()</c> (for example via
+        /// <see cref="Function.MarkConstructible"/> creating an ordinary function
+        /// prototype), and without publishing first that reentrant lookup would
+        /// recursively construct another instance. Reentrant calls made while this thread
+        /// is building the intrinsic graph return immediately with the graph under
+        /// construction, which is also what keeps the bootstrap out of the runtime's lock
+        /// order (no intrinsic initializer ever waits on a bootstrap gate).
+        /// </remarks>
+        internal void Bootstrap()
+        {
+            if (!_intrinsics.IsBootstrapped)
+            {
+                _intrinsics.EnsureBootstrapped(_initializeIntrinsics ??= InitializeIntrinsics);
+            }
+
+            SeedOnce();
+        }
+
+        private void SeedOnce()
+        {
+            if (_seeded)
+            {
+                return;
+            }
+
+            if (Volatile.Read(ref _seedingThreadId) == Environment.CurrentManagedThreadId
+                || RuntimeIntrinsics.IsInitializingOnCurrentThread)
+            {
+                // Reentrant lookup from this instance's own seed pass, or from an
+                // intrinsic initializer: the caller is part of the bootstrap and must
+                // observe the object under construction instead of waiting for itself.
+                return;
+            }
+
+            lock (_seedGate)
+            {
+                if (_seeded)
+                {
+                    return;
+                }
+
+                Volatile.Write(ref _seedingThreadId, Environment.CurrentManagedThreadId);
+                try
+                {
+                    SeedGlobalObjectIfMissing();
+                    _seeded = true;
+                }
+                finally
+                {
+                    Volatile.Write(ref _seedingThreadId, 0);
+                }
+            }
         }
 
         // Some ECMAScript globals are callable (e.g., Boolean(x)). When used in expression position
@@ -334,41 +420,42 @@ namespace JavaScriptRuntime
             arg is JavaScriptRuntime.Error;
 
         // Minimal Error.prototype object. Libraries may attach properties here.
-        private static readonly object _errorPrototypeValue = new JsObject();
-        private static readonly object _evalErrorPrototypeValue = new JsObject();
-        private static readonly object _rangeErrorPrototypeValue = new JsObject();
-        private static readonly object _referenceErrorPrototypeValue = new JsObject();
-        private static readonly object _syntaxErrorPrototypeValue = new JsObject();
-        private static readonly object _typeErrorPrototypeValue = new JsObject();
-        private static readonly object _uriErrorPrototypeValue = new JsObject();
-        private static readonly object _aggregateErrorPrototypeValue = new JsObject();
-        private static readonly object _suppressedErrorPrototypeValue = new JsObject();
+        // Realm-owned: see RuntimeIntrinsics.
+        private object _errorPrototypeValue => _intrinsics.ErrorPrototype;
+        private object _evalErrorPrototypeValue => _intrinsics.EvalErrorPrototype;
+        private object _rangeErrorPrototypeValue => _intrinsics.RangeErrorPrototype;
+        private object _referenceErrorPrototypeValue => _intrinsics.ReferenceErrorPrototype;
+        private object _syntaxErrorPrototypeValue => _intrinsics.SyntaxErrorPrototype;
+        private object _typeErrorPrototypeValue => _intrinsics.TypeErrorPrototype;
+        private object _uriErrorPrototypeValue => _intrinsics.URIErrorPrototype;
+        private object _aggregateErrorPrototypeValue => _intrinsics.AggregateErrorPrototype;
+        private object _suppressedErrorPrototypeValue => _intrinsics.SuppressedErrorPrototype;
 
-        // Minimal Object.prototype object used for descriptor/prototype-heavy libraries.
-        // NOTE: We intentionally do not enable PrototypeChain here; Object.create/setPrototypeOf
-        // opt into prototype semantics as needed.
-        private static readonly object _objectPrototypeValue = new JsObject();
-        private static readonly object _jsonValue = new JsObject();
-        private static readonly object _intlValue = new JsObject();
-        private static readonly object _atomicsValue = new JsObject();
-        private static readonly object _numberPrototypeValue = new JsObject();
-        private static readonly object _booleanPrototypeValue = new JsObject();
-        private static readonly object _bigIntPrototypeValue = new JsObject();
-        private static readonly object _symbolPrototypeValue = new JsObject();
-        private static readonly object _promisePrototypeValue = new JsObject();
+        // Realm-owned Object.prototype (issue #1824). Every other intrinsic prototype
+        // chains up to it, so it must be created per realm together with them.
+        private object _objectPrototypeValue => _intrinsics.ObjectPrototype;
+        private object _jsonValue => _intrinsics.Json;
+        private object _intlValue => _intrinsics.Intl;
+        private object _atomicsValue => _intrinsics.Atomics;
+        private object _numberPrototypeValue => _intrinsics.NumberPrototype;
+        private object _booleanPrototypeValue => _intrinsics.BooleanPrototype;
+        private object _bigIntPrototypeValue => _intrinsics.BigIntPrototype;
+        private object _symbolPrototypeValue => _intrinsics.SymbolPrototype;
+        private object _promisePrototypeValue => _intrinsics.GlobalPromisePrototype;
         private static readonly Func<object[], object?[]?, object?> _symbolFunctionValue = SymbolCall;
 
         // TypedArray intrinsic constructor and prototype
         private static readonly Func<object[], object?[], object?> _typedArrayConstructorValue = static (_, __) =>
             throw new TypeError("%TypedArray% is not directly constructible in jroc.");
-        private static readonly object _typedArrayPrototypeValue = new JsObject();
-        private static readonly object _float64ArrayPrototypeValue = new JsObject();
-        private static readonly object _float32ArrayPrototypeValue = new JsObject();
-        private static readonly object _int32ArrayPrototypeValue = new JsObject();
-        private static readonly object _int16ArrayPrototypeValue = new JsObject();
-        private static readonly object _int8ArrayPrototypeValue = new JsObject();
-        private static readonly object _uint32ArrayPrototypeValue = new JsObject();
-        private static readonly object _uint16ArrayPrototypeValue = new JsObject();
+        // Realm-owned: see RuntimeIntrinsics.
+        private object _typedArrayPrototypeValue => _intrinsics.TypedArrayPrototype;
+        private object _float64ArrayPrototypeValue => _intrinsics.Float64ArrayPrototype;
+        private object _float32ArrayPrototypeValue => _intrinsics.Float32ArrayPrototype;
+        private object _int32ArrayPrototypeValue => _intrinsics.Int32ArrayPrototype;
+        private object _int16ArrayPrototypeValue => _intrinsics.Int16ArrayPrototype;
+        private object _int8ArrayPrototypeValue => _intrinsics.Int8ArrayPrototype;
+        private object _uint32ArrayPrototypeValue => _intrinsics.Uint32ArrayPrototype;
+        private object _uint16ArrayPrototypeValue => _intrinsics.Uint16ArrayPrototype;
         private static readonly Func<object[], object?[]?, object?> _typedArraySortValue = TypedArrayPrototypeSort;
         private static readonly Func<object[], object?[]?, object?> _typedArrayToSortedValue = TypedArrayPrototypeToSorted;
         private static readonly Func<object[], object?[]?, object?> _typedArrayWithValue = TypedArrayPrototypeWith;
@@ -413,10 +500,26 @@ namespace JavaScriptRuntime
         private static readonly Func<object[], object?[], object?> _bigUint64ArrayConstructorValue = 
             static (_, __) => throw new NotSupportedException("The BigUint64Array constructor is not yet supported in jroc.");
 
-        static GlobalThis()
+        private void InitializeIntrinsics()
         {
-            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+            // Runs once per realm inside the realm-bootstrap slot (issue #1824): every
+            // intrinsic object is realm-owned, and the slot protocol both serializes
+            // concurrent bootstraps of the same realm and keeps this pass and the lazy
+            // slot creation it triggers inside a single lock order. Bootstrap runs once
+            // per realm and never on a script's hot path.
 
+            // Every realm establishes the intrinsic descriptor baseline for its own
+            // intrinsic graph: the objects being written are this realm's objects and
+            // the descriptor baseline for non-JsObject targets is realm-owned too
+            // (PropertyDescriptorStore._intrinsicStore).
+            using var intrinsicBaselineScope =
+                PropertyDescriptorStore.BeginIntrinsicInitialization();
+
+            InitializeIntrinsicsCore();
+        }
+
+        private void InitializeIntrinsicsCore()
+        {
             PrototypeChain.SetPrototype(JavaScriptRuntime.Function.Prototype, _objectPrototypeValue);
             PrototypeChain.SetPrototype(JavaScriptRuntime.Function.RestrictedPropertiesPrototype, JavaScriptRuntime.Function.Prototype);
             DefineIntrinsicToStringTagProperty(Math, "Math");
@@ -428,7 +531,7 @@ namespace JavaScriptRuntime
             DefineIntrinsicConstantDataProperty(Math, "PI", JavaScriptRuntime.Math.PI);
             DefineIntrinsicConstantDataProperty(Math, "SQRT1_2", JavaScriptRuntime.Math.SQRT1_2);
             DefineIntrinsicConstantDataProperty(Math, "SQRT2", JavaScriptRuntime.Math.SQRT2);
-            DefineIntrinsicToStringTagProperty(JSON, "JSON");
+            DefineIntrinsicToStringTagProperty(_jsonValue, "JSON");
             DefineIntrinsicToStringTagProperty(Reflect, "Reflect");
             DefineIntrinsicToStringTagProperty(_intlValue, "Intl");
             DefineIntrinsicDataProperty(_intlValue, "NumberFormat", typeof(JavaScriptRuntime.IntlNumberFormat));
@@ -969,7 +1072,7 @@ namespace JavaScriptRuntime
             DefineIntrinsicConstantDataProperty(constructorValue, "BYTES_PER_ELEMENT", bytesPerElement);
         }
 
-        private static void ConfigureTypedArrayInstancePrototype(object constructorValue, object prototypeValue)
+        private void ConfigureTypedArrayInstancePrototype(object constructorValue, object prototypeValue)
         {
             PrototypeChain.SetPrototype(prototypeValue, _typedArrayPrototypeValue);
             PropertyDescriptorStore.DefineOrUpdate(constructorValue, "prototype", new JsPropertyDescriptor
@@ -1152,8 +1255,13 @@ namespace JavaScriptRuntime
             var obj = _fallbackGlobalObject.Value;
             if (obj == null)
             {
-                obj = new GlobalThis();
+                // Publish before bootstrapping (see GlobalThis.Bootstrap remarks): a
+                // reentrant globalThis/GetOrCreateGlobalObject() lookup that happens
+                // during this realm's own bootstrap must observe this instance
+                // instead of recursively constructing another one.
+                obj = new GlobalThis(RuntimeIntrinsics.Current);
                 _fallbackGlobalObject.Value = obj;
+                obj.Bootstrap();
             }
             return obj;
         }
@@ -1307,7 +1415,7 @@ namespace JavaScriptRuntime
             dict.TryAdd(nameof(GlobalThis.DataView), DataView);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.DataView), dict[nameof(GlobalThis.DataView)]);
 
-            dict.TryAdd(nameof(GlobalThis.Atomics), Atomics);
+            dict.TryAdd(nameof(GlobalThis.Atomics), _atomicsValue);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.Atomics), dict[nameof(GlobalThis.Atomics)]);
 
             dict.TryAdd(nameof(GlobalThis.Array), Array);
@@ -1376,10 +1484,10 @@ namespace JavaScriptRuntime
             dict.TryAdd(nameof(GlobalThis.Object), Object);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.Object), dict[nameof(GlobalThis.Object)]);
 
-            dict.TryAdd(nameof(GlobalThis.JSON), JSON);
+            dict.TryAdd(nameof(GlobalThis.JSON), _jsonValue);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.JSON), dict[nameof(GlobalThis.JSON)]);
 
-            dict.TryAdd(nameof(GlobalThis.Intl), Intl);
+            dict.TryAdd(nameof(GlobalThis.Intl), _intlValue);
             DefineNonEnumerableDataProperty(nameof(GlobalThis.Intl), dict[nameof(GlobalThis.Intl)]);
 
             dict.TryAdd(nameof(GlobalThis.RegExp), RegExp);
@@ -1509,10 +1617,16 @@ namespace JavaScriptRuntime
             }
         }
 
+        /// <summary>
+        /// Returns this realm's built-in function object for a global function such as
+        /// <c>setTimeout</c> or <c>parseInt</c>. Realm-owned (issue #1824): the delegate
+        /// behind it is immutable CLR metadata, but the JavaScript-visible function
+        /// object identity belongs to the realm.
+        /// </summary>
         public static JsFunctionObject GetFunctionValue(string name)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(name);
-            return _globalFunctionValues.GetOrAdd(
+            return RuntimeIntrinsics.Current.GlobalFunctionValues.GetOrAdd(
                 name,
                 static functionName =>
                 {
@@ -1628,7 +1742,7 @@ namespace JavaScriptRuntime
 
         public static Delegate DataView => _dataViewConstructorValue;
 
-        public static object Atomics => _atomicsValue;
+        public static object Atomics => BootstrappedIntrinsics().Atomics;
 
         /// <summary>
         /// ECMAScript global Array constructor value (placeholder).
@@ -1684,9 +1798,9 @@ namespace JavaScriptRuntime
 
         public static Func<object[], object?, object> Object => _objectConstructorValue;
 
-        public static object JSON => _jsonValue;
+        public static object JSON => BootstrappedIntrinsics().Json;
 
-        public static object Intl => _intlValue;
+        public static object Intl => BootstrappedIntrinsics().Intl;
 
         public static Delegate Symbol => _symbolFunctionValue;
 
@@ -1727,9 +1841,25 @@ namespace JavaScriptRuntime
 
         public static Type AbortSignal => typeof(JavaScriptRuntime.AbortSignal);
 
-        public static Delegate URL => JavaScriptRuntime.Node.Url.URLConstructorValue;
+        public static Delegate URL
+        {
+            get
+            {
+                // Materializes this realm's URL.prototype, which wires the constructor
+                // surface for this realm (issue #1824).
+                _ = JavaScriptRuntime.Node.URL.Prototype;
+                return JavaScriptRuntime.Node.Url.URLConstructorValue;
+            }
+        }
 
-        public static Delegate URLSearchParams => JavaScriptRuntime.Node.Url.URLSearchParamsConstructorValue;
+        public static Delegate URLSearchParams
+        {
+            get
+            {
+                _ = JavaScriptRuntime.Node.URLSearchParams.Prototype;
+                return JavaScriptRuntime.Node.Url.URLSearchParamsConstructorValue;
+            }
+        }
 
         /// <summary>
         /// ECMAScript global Infinity value (+∞).
@@ -2182,7 +2312,7 @@ namespace JavaScriptRuntime
             };
         }
 
-        private static void ConfigurePromiseIntrinsicSurface(object constructorValue, object prototypeValue)
+        private void ConfigurePromiseIntrinsicSurface(object constructorValue, object prototypeValue)
         {
             ConfigureBuiltinFunctionObject(constructorValue);
             JavaScriptRuntime.Function.MarkConstructible(constructorValue);
@@ -2207,13 +2337,13 @@ namespace JavaScriptRuntime
             });
         }
 
-        private static void ConfigureCollectionIntrinsicSurface(object constructorValue, object prototypeValue)
+        private void ConfigureCollectionIntrinsicSurface(object constructorValue, object prototypeValue)
         {
             ConfigureConstructorPrototypeSurface(constructorValue, prototypeValue);
             DefineSpeciesAccessorProperty(constructorValue);
         }
 
-        private static void ConfigureWeakRefIntrinsicSurface()
+        private void ConfigureWeakRefIntrinsicSurface()
         {
             ConfigureConstructorPrototypeSurface(_weakRefConstructorValue, JavaScriptRuntime.WeakRef.Prototype);
             PropertyDescriptorStore.DefineOrUpdate(_weakRefConstructorValue, "length", new JsPropertyDescriptor
@@ -2234,7 +2364,7 @@ namespace JavaScriptRuntime
             });
         }
 
-        private static void ConfigureFinalizationRegistryIntrinsicSurface()
+        private void ConfigureFinalizationRegistryIntrinsicSurface()
         {
             ConfigureConstructorPrototypeSurface(
                 _finalizationRegistryConstructorValue,
@@ -2257,7 +2387,7 @@ namespace JavaScriptRuntime
             });
         }
 
-        private static void ConfigureDataViewIntrinsicSurface()
+        private void ConfigureDataViewIntrinsicSurface()
         {
             ConfigureConstructorPrototypeSurface(_dataViewConstructorValue, JavaScriptRuntime.DataView.Prototype);
             PropertyDescriptorStore.DefineOrUpdate(_dataViewConstructorValue, "length", new JsPropertyDescriptor
@@ -2401,7 +2531,7 @@ namespace JavaScriptRuntime
             });
         }
 
-        private static void ConfigureConstructorPrototypeSurface(object constructorValue, object prototypeValue)
+        private void ConfigureConstructorPrototypeSurface(object constructorValue, object prototypeValue)
         {
             ConfigureBuiltinFunctionObject(constructorValue);
             JavaScriptRuntime.Function.MarkConstructible(constructorValue);
@@ -2445,7 +2575,7 @@ namespace JavaScriptRuntime
             });
         }
 
-        private static void ConfigureErrorSubclassIntrinsicSurface(object constructorValue, object prototypeValue, string name)
+        private void ConfigureErrorSubclassIntrinsicSurface(object constructorValue, object prototypeValue, string name)
         {
             ConfigureBuiltinFunctionObject(constructorValue);
             JavaScriptRuntime.Function.MarkConstructible(constructorValue);
@@ -2503,36 +2633,67 @@ namespace JavaScriptRuntime
             return false;
         }
 
-        internal static object ObjectPrototypeValue => _objectPrototypeValue;
+        internal static object ObjectPrototypeValue => RuntimeIntrinsics.Current.ObjectPrototype;
+
+        /// <summary>
+        /// Resolves the ambient realm's intrinsic graph for callers that need it fully
+        /// wired (primitive/error prototypes get their properties from the realm
+        /// bootstrap, not from a per-slot initializer).
+        /// </summary>
+        /// <remarks>
+        /// The common case is a volatile read of the realm's bootstrap state followed by
+        /// the intrinsic slot's lock-free fast path: no global-object lock, and no
+        /// per-access execution-context lock, is taken on these hot accessors.
+        /// </remarks>
+        private static RuntimeIntrinsics BootstrappedIntrinsics()
+        {
+            var intrinsics = RuntimeIntrinsics.Current;
+            return intrinsics.IsBootstrapped
+                ? intrinsics
+                : EnsureRealmBootstrapped(intrinsics);
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(
+            System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static RuntimeIntrinsics EnsureRealmBootstrapped(RuntimeIntrinsics intrinsics)
+        {
+            // Materializing the global object performs (or waits for) this realm's
+            // one-time bootstrap; the graph itself is then read through the intrinsics.
+            _ = GetOrCreateGlobalObject();
+            return intrinsics;
+        }
 
         internal static object GetTypedArrayInstancePrototype(TypedArrayBase typedArray)
-            => typedArray switch
+        {
+            var current = BootstrappedIntrinsics();
+            return typedArray switch
             {
-                JavaScriptRuntime.Float64Array => _float64ArrayPrototypeValue,
-                JavaScriptRuntime.Float32Array => _float32ArrayPrototypeValue,
-                JavaScriptRuntime.Int32Array => _int32ArrayPrototypeValue,
-                JavaScriptRuntime.Int16Array => _int16ArrayPrototypeValue,
-                JavaScriptRuntime.Int8Array => _int8ArrayPrototypeValue,
-                JavaScriptRuntime.Uint32Array => _uint32ArrayPrototypeValue,
-                JavaScriptRuntime.Uint16Array => _uint16ArrayPrototypeValue,
+                JavaScriptRuntime.Float64Array => current.Float64ArrayPrototype,
+                JavaScriptRuntime.Float32Array => current.Float32ArrayPrototype,
+                JavaScriptRuntime.Int32Array => current.Int32ArrayPrototype,
+                JavaScriptRuntime.Int16Array => current.Int16ArrayPrototype,
+                JavaScriptRuntime.Int8Array => current.Int8ArrayPrototype,
+                JavaScriptRuntime.Uint32Array => current.Uint32ArrayPrototype,
+                JavaScriptRuntime.Uint16Array => current.Uint16ArrayPrototype,
                 JavaScriptRuntime.Uint8Array => JavaScriptRuntime.Uint8Array.Prototype,
                 JavaScriptRuntime.Uint8ClampedArray => JavaScriptRuntime.Uint8ClampedArray.Prototype,
-                _ => _typedArrayPrototypeValue
+                _ => current.TypedArrayPrototype
             };
-        internal static object NumberPrototypeValue => _numberPrototypeValue;
-        internal static object BooleanPrototypeValue => _booleanPrototypeValue;
-        internal static object BigIntPrototypeValue => _bigIntPrototypeValue;
-        internal static object SymbolPrototypeValue => _symbolPrototypeValue;
+        }
+        internal static object NumberPrototypeValue => BootstrappedIntrinsics().NumberPrototype;
+        internal static object BooleanPrototypeValue => BootstrappedIntrinsics().BooleanPrototype;
+        internal static object BigIntPrototypeValue => BootstrappedIntrinsics().BigIntPrototype;
+        internal static object SymbolPrototypeValue => BootstrappedIntrinsics().SymbolPrototype;
         internal static object DatePrototypeValue => JavaScriptRuntime.Date.Prototype;
-        internal static object ErrorPrototypeValue => _errorPrototypeValue;
-        internal static object EvalErrorPrototypeValue => _evalErrorPrototypeValue;
-        internal static object RangeErrorPrototypeValue => _rangeErrorPrototypeValue;
-        internal static object ReferenceErrorPrototypeValue => _referenceErrorPrototypeValue;
-        internal static object SyntaxErrorPrototypeValue => _syntaxErrorPrototypeValue;
-        internal static object TypeErrorPrototypeValue => _typeErrorPrototypeValue;
-        internal static object URIErrorPrototypeValue => _uriErrorPrototypeValue;
-        internal static object AggregateErrorPrototypeValue => _aggregateErrorPrototypeValue;
-        internal static object SuppressedErrorPrototypeValue => _suppressedErrorPrototypeValue;
+        internal static object ErrorPrototypeValue => BootstrappedIntrinsics().ErrorPrototype;
+        internal static object EvalErrorPrototypeValue => BootstrappedIntrinsics().EvalErrorPrototype;
+        internal static object RangeErrorPrototypeValue => BootstrappedIntrinsics().RangeErrorPrototype;
+        internal static object ReferenceErrorPrototypeValue => BootstrappedIntrinsics().ReferenceErrorPrototype;
+        internal static object SyntaxErrorPrototypeValue => BootstrappedIntrinsics().SyntaxErrorPrototype;
+        internal static object TypeErrorPrototypeValue => BootstrappedIntrinsics().TypeErrorPrototype;
+        internal static object URIErrorPrototypeValue => BootstrappedIntrinsics().URIErrorPrototype;
+        internal static object AggregateErrorPrototypeValue => BootstrappedIntrinsics().AggregateErrorPrototype;
+        internal static object SuppressedErrorPrototypeValue => BootstrappedIntrinsics().SuppressedErrorPrototype;
         private static Func<object[], object?[], object?> CreateErrorConstructorValue(Func<string?, object> factory)
         {
             return (_, args) =>
@@ -2595,7 +2756,7 @@ namespace JavaScriptRuntime
             });
         }
 
-        private static void ConfigureAggregateErrorIntrinsicSurface()
+        private void ConfigureAggregateErrorIntrinsicSurface()
         {
             ConfigureErrorIntrinsicSurface(
                 _aggregateErrorConstructorValue,
@@ -2622,7 +2783,7 @@ namespace JavaScriptRuntime
             });
         }
 
-        private static void ConfigureSuppressedErrorIntrinsicSurface()
+        private void ConfigureSuppressedErrorIntrinsicSurface()
         {
             ConfigureErrorIntrinsicSurface(
                 _suppressedErrorConstructorValue,
@@ -2653,18 +2814,20 @@ namespace JavaScriptRuntime
         {
             ArgumentNullException.ThrowIfNull(error);
 
+            var current = BootstrappedIntrinsics();
+
             // Keep this aligned with the explicitly exposed built-in error constructor values above.
             var prototype = error switch
             {
-                JavaScriptRuntime.EvalError => _evalErrorPrototypeValue,
-                JavaScriptRuntime.RangeError => _rangeErrorPrototypeValue,
-                JavaScriptRuntime.ReferenceError => _referenceErrorPrototypeValue,
-                JavaScriptRuntime.SyntaxError => _syntaxErrorPrototypeValue,
-                JavaScriptRuntime.TypeError => _typeErrorPrototypeValue,
-                JavaScriptRuntime.URIError => _uriErrorPrototypeValue,
-                JavaScriptRuntime.AggregateError => _aggregateErrorPrototypeValue,
-                JavaScriptRuntime.SuppressedError => _suppressedErrorPrototypeValue,
-                _ => _errorPrototypeValue
+                JavaScriptRuntime.EvalError => current.EvalErrorPrototype,
+                JavaScriptRuntime.RangeError => current.RangeErrorPrototype,
+                JavaScriptRuntime.ReferenceError => current.ReferenceErrorPrototype,
+                JavaScriptRuntime.SyntaxError => current.SyntaxErrorPrototype,
+                JavaScriptRuntime.TypeError => current.TypeErrorPrototype,
+                JavaScriptRuntime.URIError => current.URIErrorPrototype,
+                JavaScriptRuntime.AggregateError => current.AggregateErrorPrototype,
+                JavaScriptRuntime.SuppressedError => current.SuppressedErrorPrototype,
+                _ => current.ErrorPrototype
             };
 
             PrototypeChain.SetPrototype(error, prototype);
@@ -2680,7 +2843,7 @@ namespace JavaScriptRuntime
             var symbol = args != null && args.Length > 0
                 ? (global::JavaScriptRuntime.Symbol)global::JavaScriptRuntime.Symbol.Call(args[0])
                 : (global::JavaScriptRuntime.Symbol)global::JavaScriptRuntime.Symbol.Call();
-            PrototypeChain.SetPrototype(symbol, _symbolPrototypeValue);
+            PrototypeChain.SetPrototype(symbol, SymbolPrototypeValue);
             return symbol;
         }
     }

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -2412,7 +2412,7 @@ namespace JavaScriptRuntime
             DefineIntrinsicToStringTagProperty(JavaScriptRuntime.DataView.Prototype, "DataView");
         }
 
-        private static void ConfigureArrayBufferIntrinsicSurface()
+        private void ConfigureArrayBufferIntrinsicSurface()
         {
             ConfigureConstructorPrototypeSurface(_arrayBufferConstructorValue, JavaScriptRuntime.ArrayBuffer.Prototype);
             PropertyDescriptorStore.DefineOrUpdate(_arrayBufferConstructorValue, "length", new JsPropertyDescriptor
@@ -2430,7 +2430,7 @@ namespace JavaScriptRuntime
             DefineIntrinsicToStringTagProperty(JavaScriptRuntime.ArrayBuffer.Prototype, "ArrayBuffer");
         }
 
-        private static void ConfigureSharedArrayBufferIntrinsicSurface()
+        private void ConfigureSharedArrayBufferIntrinsicSurface()
         {
             ConfigureConstructorPrototypeSurface(
                 _sharedArrayBufferConstructorValue,

--- a/src/JavaScriptRuntime/Iterator.cs
+++ b/src/JavaScriptRuntime/Iterator.cs
@@ -6,8 +6,18 @@ namespace JavaScriptRuntime;
 
 public static class Iterator
 {
-    internal static readonly object Prototype = CreatePrototype();
-    internal static readonly object HelperPrototype = CreateHelperPrototype();
+    /// <summary>Realm-owned <c>%IteratorPrototype%</c> (issue #1824).</summary>
+    internal static object Prototype
+        => RuntimeIntrinsics.Current.GetOrCreate(
+            RuntimeIntrinsicSlot.IteratorPrototype,
+            static () => new JsObject());
+
+    /// <summary>Realm-owned <c>%IteratorHelperPrototype%</c> (issue #1824).</summary>
+    internal static object HelperPrototype
+        => RuntimeIntrinsics.Current.GetOrCreate(
+            RuntimeIntrinsicSlot.IteratorHelperPrototype,
+            static () => new JsObject(),
+            static prototype => PrototypeChain.SetPrototype(prototype, Prototype));
 
     internal static void ConfigureIntrinsicSurface(object iteratorConstructorValue)
     {
@@ -68,22 +78,6 @@ public static class Iterator
         var wrapped = ObjectRuntime.GetIterator(value);
         InitializeIteratorSurface(wrapped);
         return wrapped;
-    }
-
-    private static object CreatePrototype()
-    {
-        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
-
-        return new JsObject();
-    }
-
-    private static object CreateHelperPrototype()
-    {
-        using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
-
-        var prototype = new JsObject();
-        PrototypeChain.SetPrototype(prototype, Prototype);
-        return prototype;
     }
 
     private static void DefineDataProperty(object target, string key, object? value)

--- a/src/JavaScriptRuntime/Map.cs
+++ b/src/JavaScriptRuntime/Map.cs
@@ -8,17 +8,26 @@ namespace JavaScriptRuntime
     public sealed class Map : IEnumerable<object[]>
     {
         private static readonly Func<object[], object?[]?, object?> _prototypeEntriesValue = PrototypeEntries;
-        internal static readonly JsObject IteratorPrototype = CreateIteratorPrototype();
-        internal static readonly JsObject Prototype = CreatePrototype();
+        /// <summary>Realm-owned <c>Map Iterator prototype</c> intrinsic (issue #1824).</summary>
+        internal static JsObject IteratorPrototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.MapIteratorPrototype,
+                static () => new JsObject(),
+                static prototype => InitializeIteratorPrototype(prototype));
+        /// <summary>Realm-owned <c>Map.prototype</c> intrinsic (issue #1824).</summary>
+        internal static JsObject Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.MapPrototype,
+                static () => new JsObject(),
+                static exp => InitializePrototype(exp));
         private static readonly object NullKeySentinel = new object();
         private readonly List<object[]> _entries = new List<object[]>(); // [key, value] pairs
         private readonly Dictionary<object, int> _keyIndex = new Dictionary<object, int>(new SameValueZeroKeyComparer());
 
-        private static JsObject CreatePrototype()
+        private static void InitializePrototype(JsObject exp)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var exp = new JsObject();
             DefinePrototypeMethod(exp, "set", PrototypeSet);
             DefinePrototypeMethod(exp, "get", PrototypeGet);
             DefinePrototypeMethod(exp, "has", PrototypeHas);
@@ -53,14 +62,12 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = "Map"
             });
-            return exp;
         }
 
-        private static JsObject CreateIteratorPrototype()
+        private static void InitializeIteratorPrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var prototype = new JsObject();
             PrototypeChain.SetPrototype(prototype, Iterator.Prototype);
             PropertyDescriptorStore.DefineOrUpdate(prototype, Symbol.toStringTag.DebugId, new JsPropertyDescriptor
             {
@@ -70,7 +77,6 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = "Map Iterator"
             });
-            return prototype;
         }
 
         private static void DefinePrototypeMethod(JsObject prototype, string name, Func<object[], object?[]?, object?> method)

--- a/src/JavaScriptRuntime/Node/Url.cs
+++ b/src/JavaScriptRuntime/Node/Url.cs
@@ -12,21 +12,43 @@ namespace JavaScriptRuntime.Node
 
         internal static readonly JsFuncNoScopes1 URLSearchParamsConstructorValue = CreateUrlSearchParamsConstructorValue();
 
-        static Url()
+        // Constructor surfaces are wired once per realm from the matching realm-owned
+        // prototype slot (issue #1824) instead of once per process from a static ctor.
+        internal static void ConfigureUrlConstructorSurface(object prototypeValue)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            ConfigureConstructorSurface(URLConstructorValue, global::JavaScriptRuntime.Node.URL.Prototype);
-            ConfigureConstructorSurface(URLSearchParamsConstructorValue, global::JavaScriptRuntime.Node.URLSearchParams.Prototype);
+            ConfigureConstructorSurface(URLConstructorValue, prototypeValue);
         }
 
-        public object URL =>
-            BuiltinDelegateFunctionAdapter.FromDelegate(
-                URLConstructorValue);
+        internal static void ConfigureUrlSearchParamsConstructorSurface(object prototypeValue)
+        {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-        public object URLSearchParams =>
-            BuiltinDelegateFunctionAdapter.FromDelegate(
-                URLSearchParamsConstructorValue);
+            ConfigureConstructorSurface(URLSearchParamsConstructorValue, prototypeValue);
+        }
+
+        public object URL
+        {
+            get
+            {
+                // Materializes this realm's URL.prototype, which also wires the
+                // constructor surface for this realm (issue #1824).
+                _ = global::JavaScriptRuntime.Node.URL.Prototype;
+                return BuiltinDelegateFunctionAdapter.FromDelegate(
+                    URLConstructorValue);
+            }
+        }
+
+        public object URLSearchParams
+        {
+            get
+            {
+                _ = global::JavaScriptRuntime.Node.URLSearchParams.Prototype;
+                return BuiltinDelegateFunctionAdapter.FromDelegate(
+                    URLSearchParamsConstructorValue);
+            }
+        }
 
         public string fileURLToPath(object input)
         {
@@ -121,7 +143,16 @@ namespace JavaScriptRuntime.Node
 
     public sealed class URL
     {
-        internal static readonly object Prototype = CreatePrototype();
+        /// <summary>Realm-owned <c>URL.prototype</c> (issue #1824).</summary>
+        internal static object Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.UrlPrototype,
+                static () => new JsObject(),
+                static prototype =>
+                {
+                    InitializePrototype(prototype);
+                    Url.ConfigureUrlConstructorSurface(prototype);
+                });
 
         private readonly URLSearchParams _searchParams;
 
@@ -299,11 +330,10 @@ namespace JavaScriptRuntime.Node
             return text.StartsWith("#", StringComparison.Ordinal) ? text : "#" + text;
         }
 
-        private static object CreatePrototype()
+        private static void InitializePrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var prototype = new JsObject();
             DefinePrototypeMethod(prototype, "toJSON", PrototypeToJson);
             DefinePrototypeMethod(prototype, "toString", PrototypeToString);
             PropertyDescriptorStore.DefineOrUpdate(prototype, global::JavaScriptRuntime.Symbol.toStringTag.DebugId, new JsPropertyDescriptor
@@ -314,7 +344,6 @@ namespace JavaScriptRuntime.Node
                 Writable = false,
                 Value = "URL"
             });
-            return prototype;
         }
 
         private static void DefinePrototypeMethod(object prototype, string name, Func<object[], object?[]?, object?> method)
@@ -350,7 +379,17 @@ namespace JavaScriptRuntime.Node
     public sealed class URLSearchParams
     {
         private static readonly Func<object[], object?[]?, object?> PrototypeEntriesValue = PrototypeEntries;
-        internal static readonly object Prototype = CreatePrototype();
+
+        /// <summary>Realm-owned <c>URLSearchParams.prototype</c> (issue #1824).</summary>
+        internal static object Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.UrlSearchParamsPrototype,
+                static () => new JsObject(),
+                static prototype =>
+                {
+                    InitializePrototype(prototype);
+                    Url.ConfigureUrlSearchParamsConstructorSurface(prototype);
+                });
 
         private readonly List<KeyValuePair<string, string>> _entries;
 
@@ -650,11 +689,10 @@ namespace JavaScriptRuntime.Node
             }
         }
 
-        private static object CreatePrototype()
+        private static void InitializePrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var prototype = new JsObject();
             DefinePrototypeMethod(prototype, "append", PrototypeAppend);
             DefinePrototypeMethod(prototype, "delete", PrototypeDelete);
             DefinePrototypeMethod(prototype, "entries", PrototypeEntriesValue);
@@ -690,7 +728,6 @@ namespace JavaScriptRuntime.Node
                 Writable = false,
                 Value = "URLSearchParams"
             });
-            return prototype;
         }
 
         private static void DefinePrototypeMethod(object prototype, string name, Func<object[], object?[]?, object?> method)

--- a/src/JavaScriptRuntime/Promise.cs
+++ b/src/JavaScriptRuntime/Promise.cs
@@ -12,7 +12,12 @@ public sealed class Promise : IJavaScriptPromise
     private static readonly Func<object[], object?[]?, object?> PrototypeThenValue = PrototypeThen;
     private static readonly Func<object[], object?[]?, object?> PrototypeCatchValue = PrototypeCatch;
     private static readonly Func<object[], object?[]?, object?> PrototypeFinallyValue = PrototypeFinally;
-    internal static readonly object Prototype = CreatePrototype();
+    /// <summary>Realm-owned <c>Promise.prototype</c> intrinsic (issue #1824).</summary>
+    internal static object Prototype
+        => RuntimeIntrinsics.Current.GetOrCreate(
+            RuntimeIntrinsicSlot.PromisePrototype,
+            static () => new JsObject(),
+            static prototype => InitializePrototype(prototype));
 
     // Nested types
     private enum State { Pending, Fulfilled, Rejected }
@@ -53,11 +58,10 @@ public sealed class Promise : IJavaScriptPromise
 
     private readonly List<Reaction> _reactions = new();
 
-    private static object CreatePrototype()
+    private static void InitializePrototype(JsObject prototype)
     {
         using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-        var prototype = new JsObject();
         Function.InitializeFunctionInstance(PrototypeThenValue, 2d, "then");
         Function.MarkUndefinedPrototype(PrototypeThenValue);
         Function.InitializeFunctionInstance(PrototypeCatchValue, 1d, "catch");
@@ -76,7 +80,6 @@ public sealed class Promise : IJavaScriptPromise
             Writable = false,
             Value = "Promise"
         });
-        return prototype;
     }
 
     private static void DefineDataProperty(object target, string key, object? value)

--- a/src/JavaScriptRuntime/PropertyDescriptorStore.cs
+++ b/src/JavaScriptRuntime/PropertyDescriptorStore.cs
@@ -126,7 +126,12 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
         public JsPropertyDescriptor Descriptor { get; init; }
     }
 
-    private sealed class IntrinsicPropertyDescriptorStore : IPropertyDescriptorStore
+    /// <summary>
+    /// Intrinsic descriptor baseline for targets that are not <see cref="JsObject"/>
+    /// instances (<see cref="JsObject"/> keeps its baseline inline). Realm-owned:
+    /// see <see cref="RuntimeIntrinsics.IntrinsicDescriptors"/>.
+    /// </summary>
+    internal sealed class IntrinsicPropertyDescriptorStore : IPropertyDescriptorStore
     {
         private readonly ConditionalWeakTable<object, DescriptorSlot> _slots = new();
 
@@ -259,7 +264,12 @@ internal sealed class PropertyDescriptorStore : IPropertyDescriptorStore
         }
     }
 
-    private static readonly IntrinsicPropertyDescriptorStore _intrinsicStore = new();
+    // The intrinsic baseline is realm-owned (issue #1824): it stores descriptors
+    // whose values are realm-created JavaScript objects (for example
+    // `typeof(Date).prototype`), so a process-wide table would let the realm that
+    // bootstrapped last overwrite every earlier realm's constructor surface.
+    private static IntrinsicPropertyDescriptorStore _intrinsicStore
+        => RuntimeIntrinsics.Current.IntrinsicDescriptors;
     private static readonly ThreadLocal<PropertyDescriptorStore?> _defaultRuntimeStore = new(() => null);
     private static readonly ThreadLocal<int> _intrinsicInitializationDepth = new(() => 0);
 

--- a/src/JavaScriptRuntime/PrototypeChain.cs
+++ b/src/JavaScriptRuntime/PrototypeChain.cs
@@ -1,41 +1,47 @@
 using System;
-using System.Runtime.CompilerServices;
 
 namespace JavaScriptRuntime;
 
 /// <summary>
-/// Minimal runtime feature gate and storage for ECMAScript-like [[Prototype]] chains.
-///
-/// This is intentionally opt-in: JROC emits a prologue call to <see cref="Enable"/> only
-/// when the compiler detects prototype-related usage (or when forced via compiler options).
+/// Storage for ECMAScript-like [[Prototype]] chains.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Prototype-chain support used to be gated behind a process-wide <c>_enabled</c>
+/// switch that the compiler flipped on via <see cref="Enable"/> only when it detected
+/// prototype-related usage in the compiled program. That switch was process-global:
+/// once any realm's intrinsic bootstrap (which always wires prototype relationships
+/// such as <c>Function.prototype -&gt; Object.prototype</c>) flipped it on, every other
+/// realm/program sharing the process silently paid for (and observed, e.g. via
+/// <c>__proto__</c> semantics in <c>ObjectRuntime.Operations</c>) full prototype-chain
+/// behavior even if its own compiled code never opted in. Prototype-chain semantics are
+/// now always active; <see cref="Enable"/>/<see cref="Enabled"/> remain as no-op/true
+/// compatibility shims for existing call sites and compiler-emitted prologue calls.
+/// </para>
+/// <para>
+/// <see cref="JsObject"/> stores its [[Prototype]] inline, so it is realm-correct by
+/// construction (every intrinsic <see cref="JsObject"/> is realm-owned; see
+/// <see cref="RuntimeIntrinsics"/>). Everything else — <c>Map</c>, <c>Set</c>,
+/// <c>RegExp</c>, <c>Date</c>, <c>Promise</c> instances and the <see cref="Type"/>
+/// objects used as constructor identities — uses the realm's fallback slot table
+/// (<see cref="RuntimeIntrinsics.PrototypeSlots"/>). That table has to be realm-owned:
+/// a shared <c>Date</c> constructor identity whose [[Prototype]] link lived in a
+/// process-wide table would otherwise resolve to whichever realm bootstrapped last.
+/// </para>
+/// </remarks>
 public static class PrototypeChain
 {
-    private sealed class PrototypeSlot
-    {
-        public object? Prototype;
-    }
+    /// <summary>Always <see langword="true"/>; retained as a compatibility shim (see remarks).</summary>
+    public static bool Enabled => true;
 
-    private static readonly ConditionalWeakTable<object, PrototypeSlot> _fallbackSlots = new();
-
-    // Volatile ensures other threads observe the enabled flag without additional locking.
-    private static volatile bool _enabled;
-
-    public static bool Enabled => _enabled;
-
+    /// <summary>No-op; retained as a compatibility shim (see remarks) for existing call sites
+    /// and compiler-emitted prologue calls.</summary>
     public static void Enable()
     {
-        _enabled = true;
     }
 
     public static bool TryGetPrototype(object obj, out object? prototype)
     {
-        if (!_enabled)
-        {
-            prototype = null;
-            return false;
-        }
-
         if (obj == null) throw new ArgumentNullException(nameof(obj));
         obj = BuiltinDelegateFunctionAdapter.NormalizeJavaScriptObject(obj);
 
@@ -44,7 +50,7 @@ public static class PrototypeChain
             return jsObject.TryGetInlinePrototype(out prototype);
         }
 
-        if (_fallbackSlots.TryGetValue(obj, out var slot))
+        if (RuntimeIntrinsics.Current.PrototypeSlots.TryGetValue(obj, out var slot))
         {
             prototype = slot.Prototype;
             return true;
@@ -59,11 +65,6 @@ public static class PrototypeChain
         if (obj == null) throw new ArgumentNullException(nameof(obj));
         obj = BuiltinDelegateFunctionAdapter.NormalizeJavaScriptObject(obj);
 
-        if (!_enabled)
-        {
-            return null;
-        }
-
         if (obj is JsObject jsObject)
         {
             return jsObject.TryGetInlinePrototype(out var prototype)
@@ -71,7 +72,9 @@ public static class PrototypeChain
                 : null;
         }
 
-        return _fallbackSlots.TryGetValue(obj, out var slot) ? slot.Prototype : null;
+        return RuntimeIntrinsics.Current.PrototypeSlots.TryGetValue(obj, out var slot)
+            ? slot.Prototype
+            : null;
     }
 
     public static void SetPrototype(object obj, object? prototype)
@@ -95,16 +98,13 @@ public static class PrototypeChain
             BuiltinDelegateFunctionAdapter.WrapJavaScriptVisibleValue(
                 prototype);
 
-        // If someone calls SetPrototype directly, treat it as explicit opt-in.
-        Enable();
-
         if (obj is JsObject jsObject)
         {
             jsObject.SetInlinePrototype(prototype);
             return;
         }
 
-        var slot = _fallbackSlots.GetOrCreateValue(obj);
+        var slot = RuntimeIntrinsics.Current.PrototypeSlots.GetOrCreateValue(obj);
         slot.Prototype = prototype;
     }
 }

--- a/src/JavaScriptRuntime/RegExp.cs
+++ b/src/JavaScriptRuntime/RegExp.cs
@@ -31,7 +31,12 @@ namespace JavaScriptRuntime
         private static readonly Func<object?, object?, object> ReplaceSymbolDelegate = ReplaceSymbolMethod;
         private static readonly Func<object?, object> SearchSymbolDelegate = SearchSymbolMethod;
         private static readonly Func<object?, object?, object> SplitSymbolDelegate = SplitSymbolMethod;
-        internal static readonly JsObject Prototype = CreatePrototype();
+        /// <summary>Realm-owned <c>RegExp.prototype</c> intrinsic (issue #1824).</summary>
+        internal static JsObject Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.RegExpPrototype,
+                static () => new JsObject(),
+                static prototype => InitializePrototype(prototype));
         private static WellKnownSymbolFastPathFlags _prototypeWellKnownSymbolFastPathFlags = WellKnownSymbolFastPathFlags.All;
         private readonly Regex _regex;
         private readonly bool _global;
@@ -375,17 +380,15 @@ namespace JavaScriptRuntime
             return JavaScriptRuntime.String.SplitWithRegExp(DotNet2JSConversions.ToString(input) ?? string.Empty, regExp, limit);
         }
 
-        private static JsObject CreatePrototype()
+        private static void InitializePrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var prototype = new JsObject();
             DefineSymbolMethod(prototype, MatchSymbolPropertyKey, MatchSymbolDelegate);
             DefineSymbolMethod(prototype, ReplaceSymbolPropertyKey, ReplaceSymbolDelegate);
             DefineSymbolMethod(prototype, SearchSymbolPropertyKey, SearchSymbolDelegate);
             DefineSymbolMethod(prototype, SplitSymbolPropertyKey, SplitSymbolDelegate);
             DefinePrototypeMethod(prototype, "toString", (Func<object[], object?[]?, object?>)PrototypeToString);
-            return prototype;
         }
 
         private static void DefinePrototypeMethod(object target, string key, object? value)

--- a/src/JavaScriptRuntime/RuntimeExecutionContext.cs
+++ b/src/JavaScriptRuntime/RuntimeExecutionContext.cs
@@ -177,10 +177,30 @@ internal sealed class RuntimeExecutionContext
 
     internal GlobalThis GetOrCreateGlobalObject()
     {
-        lock (_stateGate)
+        var instance = Volatile.Read(ref _globalObject);
+        if (instance == null)
         {
-            return _globalObject ??= new GlobalThis();
+            lock (_stateGate)
+            {
+                instance = _globalObject;
+                if (instance == null)
+                {
+                    // Publish before bootstrapping (see GlobalThis.Bootstrap remarks): a
+                    // reentrant globalThis/GetOrCreateGlobalObject() lookup that happens
+                    // during this realm's own intrinsic bootstrap must observe this
+                    // instance instead of recursively constructing another one.
+                    instance = new GlobalThis(Realm.Intrinsics);
+                    Volatile.Write(ref _globalObject, instance);
+                }
+            }
         }
+
+        // Deliberately outside _stateGate: bootstrap materializes intrinsics and must not
+        // pull this context lock into the intrinsic lock order. Bootstrap is idempotent,
+        // blocks concurrent callers until the realm graph is wired, and returns
+        // immediately for the thread that is running the bootstrap.
+        instance.Bootstrap();
+        return instance;
     }
 
     private IDisposable EnterCore(bool asRoot)

--- a/src/JavaScriptRuntime/RuntimeIntrinsics.cs
+++ b/src/JavaScriptRuntime/RuntimeIntrinsics.cs
@@ -1,0 +1,674 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace JavaScriptRuntime;
+
+/// <summary>
+/// Identifies a well-known intrinsic object slot inside a realm's
+/// <see cref="RuntimeIntrinsics"/> graph (ECMA-262 Realm Record [[Intrinsics]]).
+/// </summary>
+internal enum RuntimeIntrinsicSlot
+{
+    /// <summary>
+    /// Pseudo-slot for the realm's one-time global bootstrap (see
+    /// <see cref="RuntimeIntrinsics.EnsureBootstrapped"/>). Modelling the bootstrap as a
+    /// slot keeps it inside the same publication/waiting protocol as every other
+    /// intrinsic, so it can never invert the lock order against a lazily materialized
+    /// prototype.
+    /// </summary>
+    RealmBootstrap,
+    ObjectPrototype,
+    FunctionPrototype,
+    FunctionRestrictedPropertiesPrototype,
+    ArrayImmutablePrototype,
+    ArrayPrototype,
+    StringPrototype,
+    StringIteratorPrototype,
+    NumberPrototype,
+    BooleanPrototype,
+    BigIntPrototype,
+    SymbolPrototype,
+    ErrorPrototype,
+    EvalErrorPrototype,
+    RangeErrorPrototype,
+    ReferenceErrorPrototype,
+    SyntaxErrorPrototype,
+    TypeErrorPrototype,
+    URIErrorPrototype,
+    AggregateErrorPrototype,
+    SuppressedErrorPrototype,
+    Json,
+    Intl,
+    Atomics,
+    GlobalPromisePrototype,
+    PromisePrototype,
+    ArrayBufferPrototype,
+    SharedArrayBufferPrototype,
+    TypedArrayPrototype,
+    Float64ArrayPrototype,
+    Float32ArrayPrototype,
+    Int32ArrayPrototype,
+    Int16ArrayPrototype,
+    Int8ArrayPrototype,
+    Uint32ArrayPrototype,
+    Uint16ArrayPrototype,
+    Uint8ArrayPrototype,
+    Uint8ClampedArrayPrototype,
+    MapPrototype,
+    MapIteratorPrototype,
+    SetPrototype,
+    SetIteratorPrototype,
+    WeakMapPrototype,
+    WeakSetPrototype,
+    WeakRefPrototype,
+    FinalizationRegistryPrototype,
+    DataViewPrototype,
+    DatePrototype,
+    RegExpPrototype,
+    IteratorPrototype,
+    IteratorHelperPrototype,
+    AsyncIteratorPrototype,
+    GeneratorPrototype,
+    GeneratorFunctionPrototype,
+    AsyncGeneratorPrototype,
+    AsyncGeneratorFunctionPrototype,
+    AsyncFunctionPrototype,
+    UrlPrototype,
+    UrlSearchParamsPrototype,
+
+    Count
+}
+
+/// <summary>
+/// Realm-owned graph of well-known intrinsic objects. Mirrors the ECMA-262 Realm
+/// Record's [[Intrinsics]] slot: every <see cref="RuntimeRealm"/> owns exactly one
+/// <see cref="RuntimeIntrinsics"/> instance, and every JavaScript object reachable
+/// from it (<c>Object.prototype</c>, every other built-in prototype, every built-in
+/// function object, and every intrinsic property descriptor whose value is one of
+/// those objects) is created for that realm alone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Slot creation is coordinated per slot. The thread that wins a slot runs the factory
+/// and the initializer while every other thread waits for the fully initialized object,
+/// so a half-wired intrinsic is never handed to a second thread. The winning thread
+/// itself resolves the slot reentrantly to the object under construction, because the
+/// mutually recursive intrinsic bootstrap cycles that ECMA-262 requires (for example
+/// <c>Function.prototype.apply</c> being a function object whose own [[Prototype]] is
+/// <c>Function.prototype</c>) must resolve against the partially wired object instead of
+/// recursing forever. A failed initializer leaves the slot empty, so the next resolution
+/// retries from scratch instead of publishing a permanently half-built object.
+/// </para>
+/// <para>
+/// Lock order for the whole runtime (acquire left to right, never right to left):
+/// <c>intrinsic slot gate</c> → <see cref="BuiltinDelegateFunctionAdapter.InitializationLock"/>.
+/// The adapter lock is a leaf: any intrinsic an adapter-lock scope needs must be
+/// materialized before the lock is taken (see <see cref="Function.InitializeFunctionInstance{T}(T)"/>).
+/// The realm bootstrap is itself a slot (<see cref="RuntimeIntrinsicSlot.RealmBootstrap"/>),
+/// so bootstrap and lazy slot creation share one protocol rather than two nested locks.
+/// </para>
+/// <para>
+/// Besides the object slots this type owns the three realm-scoped side tables that
+/// used to be process-wide and therefore leaked realm-created JavaScript objects
+/// across realms:
+/// <list type="bullet">
+/// <item><description><see cref="BuiltinAdapters"/> — the stable
+/// <see cref="BuiltinDelegateFunctionAdapter"/> identity for each runtime-owned
+/// built-in delegate. The delegates themselves are immutable CLR metadata and stay
+/// static; only the JavaScript-visible wrapper is realm-owned.</description></item>
+/// <item><description><see cref="PrototypeSlots"/> — [[Prototype]] links for
+/// JavaScript values that are not <see cref="JsObject"/> instances (for example
+/// <c>Map</c>, <c>Set</c>, <c>RegExp</c>, <c>Date</c>, <c>Promise</c> and the
+/// <see cref="System.Type"/> objects used as constructor identities).</description></item>
+/// <item><description><see cref="IntrinsicDescriptors"/> — the intrinsic descriptor
+/// baseline for those same non-<see cref="JsObject"/> targets.</description></item>
+/// </list>
+/// </para>
+/// <para>
+/// <see cref="Current"/> always resolves the ambient realm through
+/// <see cref="RuntimeExecutionContext"/>; the ambient realm wins even when other realms
+/// exist, so repeated resolutions inside one operation can never switch graphs. Only a
+/// context-less caller (runtime unit tests that poke intrinsics directly) falls back to
+/// a single deterministic process-default graph.
+/// </para>
+/// </remarks>
+internal sealed class RuntimeIntrinsics
+{
+    private const int MaxWaitChainLength = 64;
+
+    private static readonly TimeSpan WaitSlice = TimeSpan.FromMilliseconds(20);
+
+    private static readonly object _processDefaultGate = new();
+
+    /// <summary>
+    /// Wait-for graph used to detect intrinsic initialization cycles that span threads.
+    /// Maps a blocked thread to the slot it is blocked on.
+    /// </summary>
+    private static readonly ConcurrentDictionary<int, SlotEntry> _blockedThreads = new();
+
+    private static RuntimeIntrinsics? _processDefault;
+    private static long _nextId;
+
+    [ThreadStatic]
+    private static int _initializationDepth;
+
+    private readonly object _slotTableGate = new();
+    private readonly SlotEntry?[] _slots = new SlotEntry?[(int)RuntimeIntrinsicSlot.Count];
+
+    /// <summary>
+    /// Fully initialized slot values. Only written after the slot's initializer has
+    /// completed, so the lock-free read path can never observe a half-built object.
+    /// </summary>
+    private readonly object?[] _published = new object?[(int)RuntimeIntrinsicSlot.Count];
+
+    internal RuntimeIntrinsics()
+    {
+        Id = Interlocked.Increment(ref _nextId);
+    }
+
+    /// <summary>
+    /// Process-unique identifier, usable as a realm-change marker by callers that must
+    /// not keep the intrinsic graph alive (see <c>Array</c>'s cached prototype-chain state).
+    /// </summary>
+    internal long Id { get; }
+
+    /// <summary>
+    /// Per-realm stable adapter identities for runtime-owned built-in delegates.
+    /// </summary>
+    internal BuiltinAdapterCache BuiltinAdapters { get; } = new();
+
+    /// <summary>
+    /// Per-realm [[Prototype]] storage for values that are not <see cref="JsObject"/>
+    /// instances (<see cref="JsObject"/> stores its own prototype inline).
+    /// </summary>
+    internal ConditionalWeakTable<object, PrototypeSlot> PrototypeSlots { get; } = new();
+
+    /// <summary>
+    /// Per-realm intrinsic descriptor baseline for non-<see cref="JsObject"/> targets.
+    /// </summary>
+    internal PropertyDescriptorStore.IntrinsicPropertyDescriptorStore IntrinsicDescriptors { get; } = new();
+
+    /// <summary>
+    /// Per-realm built-in function values exposed by <see cref="GlobalThis"/>
+    /// (<c>setTimeout</c>, <c>parseInt</c>, ...).
+    /// </summary>
+    internal ConcurrentDictionary<string, JsFunctionObject> GlobalFunctionValues { get; } =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// The intrinsic graph for the ambient realm, or the process default graph when
+    /// no realm is active (runtime unit tests that poke intrinsics directly).
+    /// </summary>
+    /// <remarks>
+    /// The ambient realm always wins: there is no "only one realm exists" shortcut,
+    /// because such a shortcut changes answer the moment a second realm appears and can
+    /// therefore hand two different graphs to one logical operation.
+    /// </remarks>
+    internal static RuntimeIntrinsics Current
+    {
+        get
+        {
+            // Cheap ambient fast path: one AsyncLocal read.
+            var context = RuntimeExecutionContext.Current;
+            return context != null
+                ? context.Realm.Intrinsics
+                : ResolveWithoutAmbientFrame();
+        }
+    }
+
+    /// <summary>
+    /// True when this realm's global bootstrap has completed, or is running on the
+    /// calling thread (the bootstrapping thread must observe the graph under
+    /// construction instead of waiting for itself).
+    /// </summary>
+    internal bool IsBootstrapped
+        => Volatile.Read(ref _published[(int)RuntimeIntrinsicSlot.RealmBootstrap]) != null
+            || IsInitializingSlotOnCurrentThread(RuntimeIntrinsicSlot.RealmBootstrap);
+
+    /// <summary>
+    /// True while the calling thread is inside an intrinsic factory/initializer. Such a
+    /// thread must never block on a bootstrap gate: it is already part of the graph
+    /// being built and has to keep making progress.
+    /// </summary>
+    internal static bool IsInitializingOnCurrentThread => _initializationDepth > 0;
+
+    internal object ObjectPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.ObjectPrototype, static () => new JsObject());
+
+    internal object ErrorPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.ErrorPrototype, static () => new JsObject());
+
+    internal object EvalErrorPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.EvalErrorPrototype, static () => new JsObject());
+
+    internal object RangeErrorPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.RangeErrorPrototype, static () => new JsObject());
+
+    internal object ReferenceErrorPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.ReferenceErrorPrototype, static () => new JsObject());
+
+    internal object SyntaxErrorPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.SyntaxErrorPrototype, static () => new JsObject());
+
+    internal object TypeErrorPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.TypeErrorPrototype, static () => new JsObject());
+
+    internal object URIErrorPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.URIErrorPrototype, static () => new JsObject());
+
+    internal object AggregateErrorPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.AggregateErrorPrototype, static () => new JsObject());
+
+    internal object SuppressedErrorPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.SuppressedErrorPrototype, static () => new JsObject());
+
+    internal object Json
+        => GetOrCreate(RuntimeIntrinsicSlot.Json, static () => new JsObject());
+
+    internal object Intl
+        => GetOrCreate(RuntimeIntrinsicSlot.Intl, static () => new JsObject());
+
+    internal object Atomics
+        => GetOrCreate(RuntimeIntrinsicSlot.Atomics, static () => new JsObject());
+
+    internal object NumberPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.NumberPrototype, static () => new JsObject());
+
+    internal object BooleanPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.BooleanPrototype, static () => new JsObject());
+
+    internal object BigIntPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.BigIntPrototype, static () => new JsObject());
+
+    internal object SymbolPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.SymbolPrototype, static () => new JsObject());
+
+    internal object GlobalPromisePrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.GlobalPromisePrototype, static () => new JsObject());
+
+    internal object ArrayBufferPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.ArrayBufferPrototype, static () => new JsObject());
+
+    internal object SharedArrayBufferPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.SharedArrayBufferPrototype, static () => new JsObject());
+
+    internal object TypedArrayPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.TypedArrayPrototype, static () => new JsObject());
+
+    internal object Float64ArrayPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.Float64ArrayPrototype, static () => new JsObject());
+
+    internal object Float32ArrayPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.Float32ArrayPrototype, static () => new JsObject());
+
+    internal object Int32ArrayPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.Int32ArrayPrototype, static () => new JsObject());
+
+    internal object Int16ArrayPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.Int16ArrayPrototype, static () => new JsObject());
+
+    internal object Int8ArrayPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.Int8ArrayPrototype, static () => new JsObject());
+
+    internal object Uint32ArrayPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.Uint32ArrayPrototype, static () => new JsObject());
+
+    internal object Uint16ArrayPrototype
+        => GetOrCreate(RuntimeIntrinsicSlot.Uint16ArrayPrototype, static () => new JsObject());
+
+    /// <summary>
+    /// Returns the intrinsic in <paramref name="slot"/>, creating it on first use.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="create"/> must only allocate the bare object and must not resolve
+    /// other intrinsics: the result is published to the owning thread before
+    /// <paramref name="initialize"/> runs, so nested lookups of the same slot from within
+    /// <paramref name="initialize"/> observe the object under construction instead of
+    /// recursing.
+    /// </para>
+    /// <para>
+    /// Other threads block until <paramref name="initialize"/> has completed and never
+    /// observe the object under construction. If <paramref name="initialize"/> throws,
+    /// the slot is reset to empty so the next resolution retries instead of publishing a
+    /// permanently half-built intrinsic.
+    /// </para>
+    /// </remarks>
+    internal T GetOrCreate<T>(
+        RuntimeIntrinsicSlot slot,
+        Func<T> create,
+        Action<T>? initialize = null)
+        where T : class
+    {
+        var index = (int)slot;
+        if (Volatile.Read(ref _published[index]) is T ready)
+        {
+            return ready;
+        }
+
+        var entry = GetOrAddEntry(index);
+        var threadId = Environment.CurrentManagedThreadId;
+
+        lock (entry.Gate)
+        {
+            while (true)
+            {
+                if (entry.Status == SlotStatus.Initialized)
+                {
+                    return (T)entry.Value!;
+                }
+
+                if (entry.Status == SlotStatus.Empty)
+                {
+                    entry.Status = SlotStatus.Initializing;
+                    entry.OwnerThreadId = threadId;
+                    break;
+                }
+
+                // The owning thread resolves reentrantly; that is how the ECMA-262
+                // intrinsic bootstrap cycles terminate without exposing the object under
+                // construction to another thread.
+                if (entry.OwnerThreadId == threadId)
+                {
+                    if (entry.Value is T underConstruction)
+                    {
+                        return underConstruction;
+                    }
+
+                    throw new InvalidOperationException(
+                        $"Intrinsic slot '{slot}' was resolved reentrantly from its own factory. "
+                        + "Factories must only allocate the bare object; move dependent work into the initializer.");
+                }
+
+                if (WouldDeadlock(entry, threadId))
+                {
+                    throw new InvalidOperationException(
+                        $"Cross-thread intrinsic initialization cycle detected while resolving slot '{slot}'.");
+                }
+
+                Wait(entry, threadId);
+            }
+        }
+
+        return RunInitializer(entry, index, create, initialize);
+    }
+
+    /// <summary>
+    /// Runs this realm's one-time global bootstrap, blocking concurrent callers until it
+    /// has completed. Reentrant calls from the bootstrapping thread are no-ops.
+    /// </summary>
+    internal void EnsureBootstrapped(Action bootstrap)
+    {
+        ArgumentNullException.ThrowIfNull(bootstrap);
+        if (IsBootstrapped)
+        {
+            return;
+        }
+
+        GetOrCreate(
+            RuntimeIntrinsicSlot.RealmBootstrap,
+            static () => new object(),
+            _ => bootstrap());
+    }
+
+    /// <summary>
+    /// True while <paramref name="slot"/> is being initialized by the calling thread.
+    /// </summary>
+    internal bool IsInitializingSlotOnCurrentThread(RuntimeIntrinsicSlot slot)
+    {
+        var entry = Volatile.Read(ref _slots[(int)slot]);
+        return entry != null
+            && Volatile.Read(ref entry.OwnerThreadId) == Environment.CurrentManagedThreadId;
+    }
+
+    /// <summary>
+    /// Releases the realm's intrinsic object graph (ECMA-262 realms are dropped whole).
+    /// </summary>
+    internal void Dispose()
+    {
+        lock (_slotTableGate)
+        {
+            System.Array.Clear(_slots);
+            System.Array.Clear(_published);
+        }
+
+        BuiltinAdapters.Clear();
+        GlobalFunctionValues.Clear();
+    }
+
+    private SlotEntry GetOrAddEntry(int index)
+    {
+        var existing = Volatile.Read(ref _slots[index]);
+        if (existing != null)
+        {
+            return existing;
+        }
+
+        var candidate = new SlotEntry();
+        return Interlocked.CompareExchange(ref _slots[index], candidate, null) ?? candidate;
+    }
+
+    private T RunInitializer<T>(
+        SlotEntry entry,
+        int index,
+        Func<T> create,
+        Action<T>? initialize)
+        where T : class
+    {
+        T value;
+        _initializationDepth++;
+        try
+        {
+            value = create();
+
+            lock (entry.Gate)
+            {
+                entry.Value = value;
+                Monitor.PulseAll(entry.Gate);
+            }
+
+            initialize?.Invoke(value);
+        }
+        catch
+        {
+            lock (entry.Gate)
+            {
+                entry.Value = null;
+                entry.Status = SlotStatus.Empty;
+                entry.OwnerThreadId = 0;
+                Monitor.PulseAll(entry.Gate);
+            }
+
+            throw;
+        }
+        finally
+        {
+            _initializationDepth--;
+        }
+
+        lock (entry.Gate)
+        {
+            entry.Status = SlotStatus.Initialized;
+            entry.OwnerThreadId = 0;
+            Monitor.PulseAll(entry.Gate);
+        }
+
+        // Only published once the initializer completed, and only while this entry is
+        // still the realm's live entry for the slot (a realm disposed mid-initialization
+        // must stay dropped).
+        lock (_slotTableGate)
+        {
+            if (ReferenceEquals(_slots[index], entry))
+            {
+                Volatile.Write(ref _published[index], value);
+            }
+        }
+
+        return value;
+    }
+
+    private static void Wait(SlotEntry entry, int threadId)
+    {
+        _blockedThreads[threadId] = entry;
+        try
+        {
+            // Bounded so the cycle check above is re-evaluated periodically: a wait-for
+            // edge that only appears after this thread blocked is then still noticed.
+            Monitor.Wait(entry.Gate, WaitSlice);
+        }
+        finally
+        {
+            _blockedThreads.TryRemove(threadId, out _);
+        }
+    }
+
+    /// <summary>
+    /// Walks the wait-for graph from <paramref name="target"/>'s owner and reports
+    /// whether blocking on it would close a cycle back to <paramref name="threadId"/>.
+    /// </summary>
+    private static bool WouldDeadlock(SlotEntry target, int threadId)
+    {
+        var current = target;
+        for (var hop = 0; hop < MaxWaitChainLength; hop++)
+        {
+            var owner = Volatile.Read(ref current.OwnerThreadId);
+            if (owner == 0)
+            {
+                return false;
+            }
+
+            if (owner == threadId)
+            {
+                return true;
+            }
+
+            if (!_blockedThreads.TryGetValue(owner, out var next))
+            {
+                return false;
+            }
+
+            current = next;
+        }
+
+        // Pathologically long chain: treat as a cycle rather than risk blocking forever.
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static RuntimeIntrinsics ResolveWithoutAmbientFrame()
+    {
+        var context = RuntimeExecutionContext.CurrentOrOverride;
+        if (context != null)
+        {
+            return context.Realm.Intrinsics;
+        }
+
+        var processDefault = Volatile.Read(ref _processDefault);
+        if (processDefault != null)
+        {
+            return processDefault;
+        }
+
+        lock (_processDefaultGate)
+        {
+            processDefault = _processDefault;
+            if (processDefault == null)
+            {
+                processDefault = new RuntimeIntrinsics();
+                Volatile.Write(ref _processDefault, processDefault);
+            }
+
+            return processDefault;
+        }
+    }
+
+    private enum SlotStatus
+    {
+        Empty,
+        Initializing,
+        Initialized
+    }
+
+    /// <summary>
+    /// Coordination state for a single intrinsic slot.
+    /// </summary>
+    private sealed class SlotEntry
+    {
+        internal readonly object Gate = new();
+
+        /// <summary>
+        /// The slot's object. Visible to other threads only once
+        /// <see cref="Status"/> is <see cref="SlotStatus.Initialized"/>, except for a
+        /// thread whose wait would close an initialization cycle.
+        /// </summary>
+        internal object? Value;
+
+        internal SlotStatus Status;
+
+        internal int OwnerThreadId;
+    }
+
+    /// <summary>
+    /// [[Prototype]] storage for a single non-<see cref="JsObject"/> target.
+    /// </summary>
+    internal sealed class PrototypeSlot
+    {
+        internal object? Prototype;
+    }
+
+    /// <summary>
+    /// Realm-owned stable adapter identities for runtime-owned built-in delegates.
+    /// Keyed by immutable CLR metadata (declaring type / delegate target instance plus
+    /// method handle and delegate type); only the produced adapter is realm-created.
+    /// </summary>
+    internal sealed class BuiltinAdapterCache
+    {
+        private sealed class Entries
+        {
+            internal ConcurrentDictionary<
+                (RuntimeMethodHandle Method, Type DelegateType),
+                BuiltinDelegateFunctionAdapter> Adapters { get; } = new();
+        }
+
+        private readonly ConditionalWeakTable<Type, Entries> _staticAdapters = new();
+        private readonly ConditionalWeakTable<object, Entries> _instanceAdapters = new();
+
+        internal BuiltinDelegateFunctionAdapter GetOrAdd(
+            Delegate target,
+            Func<Delegate, BuiltinDelegateFunctionAdapter> factory)
+        {
+            var entries = target.Target == null
+                ? _staticAdapters.GetOrCreateValue(
+                    target.Method.DeclaringType
+                        ?? throw new InvalidOperationException(
+                            "Runtime-owned static delegates require a declaring type."))
+                : _instanceAdapters.GetOrCreateValue(target.Target);
+
+            return entries.Adapters.GetOrAdd(
+                (target.Method.MethodHandle, target.GetType()),
+                _ => factory(target));
+        }
+
+        internal bool Contains(Delegate target)
+        {
+            if (target.Target == null)
+            {
+                return target.Method.DeclaringType is { } declaringType
+                    && _staticAdapters.TryGetValue(declaringType, out var staticEntries)
+                    && staticEntries.Adapters.ContainsKey(
+                        (target.Method.MethodHandle, target.GetType()));
+            }
+
+            return _instanceAdapters.TryGetValue(target.Target, out var instanceEntries)
+                && instanceEntries.Adapters.ContainsKey(
+                    (target.Method.MethodHandle, target.GetType()));
+        }
+
+        internal void Clear()
+        {
+            _staticAdapters.Clear();
+            _instanceAdapters.Clear();
+        }
+    }
+}

--- a/src/JavaScriptRuntime/RuntimeOwnership.cs
+++ b/src/JavaScriptRuntime/RuntimeOwnership.cs
@@ -195,6 +195,7 @@ internal sealed class RuntimeRealm : IDisposable
     {
         Agent = agent;
         ModuleState = new Modules.RuntimeModuleState();
+        Intrinsics = new RuntimeIntrinsics();
         Services = new ServiceContainer();
         Services.AttachOwningRealm(this);
     }
@@ -202,6 +203,12 @@ internal sealed class RuntimeRealm : IDisposable
     internal RuntimeAgent Agent { get; }
 
     internal Modules.RuntimeModuleState ModuleState { get; }
+
+    /// <summary>
+    /// The realm's well-known intrinsic object graph (ECMA-262 Realm Record
+    /// [[Intrinsics]]). See <see cref="RuntimeIntrinsics"/> for scope/limitations.
+    /// </summary>
+    internal RuntimeIntrinsics Intrinsics { get; }
 
     internal ServiceContainer Services { get; }
 
@@ -229,6 +236,7 @@ internal sealed class RuntimeRealm : IDisposable
 
             _state = RuntimeOwnershipState.Disposing;
             ModuleState.Dispose();
+            Intrinsics.Dispose();
             DisposalOrder = Agent.Cluster.NextDisposalOrder();
             _state = RuntimeOwnershipState.Disposed;
         }

--- a/src/JavaScriptRuntime/Set.cs
+++ b/src/JavaScriptRuntime/Set.cs
@@ -8,16 +8,25 @@ namespace JavaScriptRuntime
     public sealed class Set : IEnumerable<object>
     {
         private static readonly Func<object[], object?[]?, object?> _prototypeValuesValue = PrototypeValues;
-        internal static readonly JsObject IteratorPrototype = CreateIteratorPrototype();
-        internal static readonly JsObject Prototype = CreatePrototype();
+        /// <summary>Realm-owned <c>Set Iterator prototype</c> intrinsic (issue #1824).</summary>
+        internal static JsObject IteratorPrototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.SetIteratorPrototype,
+                static () => new JsObject(),
+                static prototype => InitializeIteratorPrototype(prototype));
+        /// <summary>Realm-owned <c>Set.prototype</c> intrinsic (issue #1824).</summary>
+        internal static JsObject Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.SetPrototype,
+                static () => new JsObject(),
+                static exp => InitializePrototype(exp));
         private readonly List<object> _items = new List<object>();
         private readonly HashSet<object> _set = new HashSet<object>();
 
-        private static JsObject CreatePrototype()
+        private static void InitializePrototype(JsObject exp)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var exp = new JsObject();
             DefinePrototypeMethod(exp, "add", PrototypeAdd);
             DefinePrototypeMethod(exp, "has", PrototypeHas);
             DefinePrototypeMethod(exp, "delete", PrototypeDelete);
@@ -56,14 +65,12 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = "Set"
             });
-            return exp;
         }
 
-        private static JsObject CreateIteratorPrototype()
+        private static void InitializeIteratorPrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var prototype = new JsObject();
             PrototypeChain.SetPrototype(prototype, Iterator.Prototype);
             PropertyDescriptorStore.DefineOrUpdate(prototype, Symbol.toStringTag.DebugId, new JsPropertyDescriptor
             {
@@ -73,7 +80,6 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = "Set Iterator"
             });
-            return prototype;
         }
 
         private static void DefinePrototypeMethod(JsObject prototype, string name, Func<object[], object?[]?, object?> method)

--- a/src/JavaScriptRuntime/SharedArrayBuffer.cs
+++ b/src/JavaScriptRuntime/SharedArrayBuffer.cs
@@ -3,7 +3,8 @@ namespace JavaScriptRuntime
     [IntrinsicObject("SharedArrayBuffer")]
     public sealed class SharedArrayBuffer : ArrayBuffer
     {
-        internal static readonly object SharedPrototype = new JsObject();
+        internal static object SharedPrototype
+            => RuntimeIntrinsics.Current.SharedArrayBufferPrototype;
 
         public SharedArrayBuffer()
         {

--- a/src/JavaScriptRuntime/String.cs
+++ b/src/JavaScriptRuntime/String.cs
@@ -23,8 +23,18 @@ namespace JavaScriptRuntime
         private static SubstringCacheEntry[]? substringCache;
         [ThreadStatic]
         private static int substringCacheNextIndex;
-        internal static readonly JsObject Prototype = CreatePrototype();
-        internal static readonly JsObject StringIteratorPrototype = CreateStringIteratorPrototype();
+        /// <summary>Realm-owned <c>String.prototype</c> intrinsic (issue #1824).</summary>
+        internal static JsObject Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.StringPrototype,
+                static () => new JsObject(),
+                static prototype => InitializePrototype(prototype));
+        /// <summary>Realm-owned <c>String Iterator prototype</c> intrinsic (issue #1824).</summary>
+        internal static JsObject StringIteratorPrototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.StringIteratorPrototype,
+                static () => new JsObject(),
+                static prototype => InitializeStringIteratorPrototype(prototype));
 
         private readonly struct SubstringCacheEntry
         {
@@ -42,11 +52,10 @@ namespace JavaScriptRuntime
             public string? Result { get; }
         }
 
-        private static JsObject CreatePrototype()
+        private static void InitializePrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var prototype = new JsObject();
 
             DefinePrototypeMethod(prototype, "at", (Func<object[], object?[]?, object?>)PrototypeAt, 1);
             DefinePrototypeMethod(prototype, "charAt", (Func<object[], object?[]?, object?>)PrototypeCharAt, 1);
@@ -102,14 +111,12 @@ namespace JavaScriptRuntime
                 Value = "String"
             });
 
-            return prototype;
         }
 
-        private static JsObject CreateStringIteratorPrototype()
+        private static void InitializeStringIteratorPrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var prototype = new JsObject();
             DefinePrototypeMethod(prototype, "next", (Func<object[], object?[]?, object?>)StringIteratorPrototypeNext, 0);
             DefinePrototypeMethod(prototype, IteratorSymbolPropertyKey, (Func<object[], object?[]?, object?>)StringIteratorPrototypeIterator, 0, "[Symbol.iterator]");
             PropertyDescriptorStore.DefineOrUpdate(prototype, ToStringTagSymbolPropertyKey, new JsPropertyDescriptor
@@ -120,7 +127,6 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = "String Iterator"
             });
-            return prototype;
         }
 
         private static void DefinePrototypeMethod(object target, string key, object? value, double length, string? functionNameOverride = null)

--- a/src/JavaScriptRuntime/Uint8Array.cs
+++ b/src/JavaScriptRuntime/Uint8Array.cs
@@ -6,13 +6,19 @@ namespace JavaScriptRuntime
     public sealed class Uint8Array : TypedArrayBase
     {
         private const int ElementSize = 1;
-        internal static readonly JsObject Prototype = CreatePrototype();
+        /// <summary>Realm-owned <c>Uint8Array.prototype</c> (issue #1824). The constructor surface is
+        /// wired per realm from this slot instead of from a process-wide static ctor.</summary>
+        internal static JsObject Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.Uint8ArrayPrototype,
+                static () => new JsObject(),
+                static prototype => InitializePrototype(prototype));
 
-        static Uint8Array()
+        private static void InitializePrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            PrototypeChain.SetPrototype(Prototype, GlobalThis.ObjectPrototypeValue);
+            PrototypeChain.SetPrototype(prototype, GlobalThis.ObjectPrototypeValue);
 
             PropertyDescriptorStore.DefineOrUpdate(typeof(Uint8Array), "prototype", new JsPropertyDescriptor
             {
@@ -20,10 +26,10 @@ namespace JavaScriptRuntime
                 Enumerable = false,
                 Configurable = false,
                 Writable = false,
-                Value = Prototype
+                Value = prototype
             });
 
-            PropertyDescriptorStore.DefineOrUpdate(Prototype, "constructor", new JsPropertyDescriptor
+            PropertyDescriptorStore.DefineOrUpdate(prototype, "constructor", new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Data,
                 Enumerable = false,
@@ -285,13 +291,6 @@ namespace JavaScriptRuntime
 
         protected override TypedArrayBase CreateSameType(ArrayBuffer buffer, int byteOffset, int length)
             => new Uint8Array(buffer, byteOffset, length);
-
-        private static JsObject CreatePrototype()
-        {
-            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
-
-            return new JsObject();
-        }
 
         private static object? ConstructorFromHex(object[] _, object?[]? args)
             => fromHex(GetArgument(args, 0));

--- a/src/JavaScriptRuntime/Uint8ClampedArray.cs
+++ b/src/JavaScriptRuntime/Uint8ClampedArray.cs
@@ -6,13 +6,19 @@ namespace JavaScriptRuntime
     public sealed class Uint8ClampedArray : TypedArrayBase
     {
         private const int ElementSize = 1;
-        internal static readonly JsObject Prototype = CreatePrototype();
+        /// <summary>Realm-owned <c>Uint8ClampedArray.prototype</c> (issue #1824). The constructor surface is
+        /// wired per realm from this slot instead of from a process-wide static ctor.</summary>
+        internal static JsObject Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.Uint8ClampedArrayPrototype,
+                static () => new JsObject(),
+                static prototype => InitializePrototype(prototype));
 
-        static Uint8ClampedArray()
+        private static void InitializePrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            PrototypeChain.SetPrototype(Prototype, GlobalThis.ObjectPrototypeValue);
+            PrototypeChain.SetPrototype(prototype, GlobalThis.ObjectPrototypeValue);
 
             PropertyDescriptorStore.DefineOrUpdate(typeof(Uint8ClampedArray), "prototype", new JsPropertyDescriptor
             {
@@ -20,10 +26,10 @@ namespace JavaScriptRuntime
                 Enumerable = false,
                 Configurable = false,
                 Writable = false,
-                Value = Prototype
+                Value = prototype
             });
 
-            PropertyDescriptorStore.DefineOrUpdate(Prototype, "constructor", new JsPropertyDescriptor
+            PropertyDescriptorStore.DefineOrUpdate(prototype, "constructor", new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Data,
                 Enumerable = false,
@@ -119,13 +125,6 @@ namespace JavaScriptRuntime
 
         protected override TypedArrayBase CreateSameType(ArrayBuffer buffer, int byteOffset, int length)
             => new Uint8ClampedArray(buffer, byteOffset, length);
-
-        private static JsObject CreatePrototype()
-        {
-            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
-
-            return new JsObject();
-        }
 
         private void InitializeIntrinsicSurface()
             => PrototypeChain.SetPrototype(this, Prototype);

--- a/src/JavaScriptRuntime/WeakMap.cs
+++ b/src/JavaScriptRuntime/WeakMap.cs
@@ -6,7 +6,12 @@ namespace JavaScriptRuntime
     [IntrinsicObject("WeakMap")]
     public sealed class WeakMap
     {
-        internal static readonly object Prototype = CreatePrototype();
+        /// <summary>Realm-owned <c>WeakMap.prototype</c> intrinsic (issue #1824).</summary>
+        internal static object Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.WeakMapPrototype,
+                static () => new JsObject(),
+                static prototype => InitializePrototype(prototype));
         // ConditionalWeakTable allows keys to be garbage collected when no other references exist
         private readonly ConditionalWeakTable<object, object> _table = new ConditionalWeakTable<object, object>();
 
@@ -147,11 +152,10 @@ namespace JavaScriptRuntime
             return _table.Remove(key!);
         }
 
-        private static object CreatePrototype()
+        private static void InitializePrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var prototype = new JsObject();
             DefinePrototypeMethod(prototype, "delete", PrototypeDelete);
             DefinePrototypeMethod(prototype, "get", PrototypeGet);
             DefinePrototypeMethod(prototype, "has", PrototypeHas);
@@ -164,7 +168,6 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = "WeakMap"
             });
-            return prototype;
         }
 
         private static void DefinePrototypeMethod(object prototype, string name, Func<object[], object?[]?, object?> method)

--- a/src/JavaScriptRuntime/WeakRef.cs
+++ b/src/JavaScriptRuntime/WeakRef.cs
@@ -5,7 +5,12 @@ namespace JavaScriptRuntime
     [IntrinsicObject("WeakRef")]
     public sealed class WeakRef
     {
-        internal static readonly object Prototype = CreatePrototype();
+        /// <summary>Realm-owned <c>WeakRef.prototype</c> intrinsic (issue #1824).</summary>
+        internal static object Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.WeakRefPrototype,
+                static () => new JsObject(),
+                static prototype => InitializePrototype(prototype));
         private readonly WeakReference<object> _target;
 
         public WeakRef() : this(null)
@@ -44,11 +49,10 @@ namespace JavaScriptRuntime
             PrototypeChain.SetPrototype(this, Prototype);
         }
 
-        private static object CreatePrototype()
+        private static void InitializePrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var prototype = new JsObject();
             Func<object[], object?[]?, object?> deref = PrototypeDeref;
             Function.InitializeFunctionInstance(deref, 0d, "deref");
             PropertyDescriptorStore.DefineOrUpdate(deref, "prototype", new JsPropertyDescriptor
@@ -75,7 +79,6 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = "WeakRef"
             });
-            return prototype;
         }
 
         private static object? PrototypeDeref(object[] scopes, object?[]? args)

--- a/src/JavaScriptRuntime/WeakSet.cs
+++ b/src/JavaScriptRuntime/WeakSet.cs
@@ -6,7 +6,12 @@ namespace JavaScriptRuntime
     [IntrinsicObject("WeakSet")]
     public sealed class WeakSet
     {
-        internal static readonly object Prototype = CreatePrototype();
+        /// <summary>Realm-owned <c>WeakSet.prototype</c> intrinsic (issue #1824).</summary>
+        internal static object Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.WeakSetPrototype,
+                static () => new JsObject(),
+                static prototype => InitializePrototype(prototype));
         // Use ConditionalWeakTable with a dummy value to track membership
         // The presence of a key in the table indicates it's in the set
         private readonly ConditionalWeakTable<object, object> _table = new ConditionalWeakTable<object, object>();
@@ -102,11 +107,10 @@ namespace JavaScriptRuntime
             return _table.Remove(value!);
         }
 
-        private static object CreatePrototype()
+        private static void InitializePrototype(JsObject prototype)
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            var prototype = new JsObject();
             DefinePrototypeMethod(prototype, "add", PrototypeAdd);
             DefinePrototypeMethod(prototype, "delete", PrototypeDelete);
             DefinePrototypeMethod(prototype, "has", PrototypeHas);
@@ -118,7 +122,6 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = "WeakSet"
             });
-            return prototype;
         }
 
         private static void DefinePrototypeMethod(object prototype, string name, Func<object[], object?[]?, object?> method)

--- a/tests/Jroc.Testing/Test262/Test262HostRuntimeIntrinsics.cs
+++ b/tests/Jroc.Testing/Test262/Test262HostRuntimeIntrinsics.cs
@@ -201,10 +201,25 @@ public static class Test262HostRuntimeIntrinsics
     {
         return ToMessage(name) switch
         {
-            "%AsyncFunction%" => GetStaticFieldValue(typeof(AsyncFunction), "ConstructorValue"),
-            "%GeneratorFunction%" => GetStaticFieldValue(typeof(GeneratorObject), "_generatorFunctionConstructor"),
+            // Touch the realm-owned intrinsic prototype first: it is the slot whose
+            // initializer wires this realm's %AsyncFunction%/%GeneratorFunction%
+            // constructor surface (issue #1824). Ordinary JavaScript reaches these
+            // constructors through Object.getPrototypeOf(fn).constructor, which
+            // materializes the same slot; only this reflection shortcut needs the hint.
+            "%AsyncFunction%" => EnsureRealmIntrinsic(
+                AsyncFunction.Prototype,
+                GetStaticFieldValue(typeof(AsyncFunction), "ConstructorValue")),
+            "%GeneratorFunction%" => EnsureRealmIntrinsic(
+                GeneratorObject.GeneratorFunctionPrototypeObject,
+                GetStaticFieldValue(typeof(GeneratorObject), "_generatorFunctionConstructor")),
             var unsupported => throw CreateTest262Error($"Unsupported intrinsic {unsupported}")
         };
+    }
+
+    private static object EnsureRealmIntrinsic(object realmPrototype, object constructorValue)
+    {
+        _ = realmPrototype;
+        return constructorValue;
     }
 
     private static object GetStaticFieldValue(Type type, string fieldName)

--- a/tests/Jroc.Tests/Array/RuntimePrototypeIsolationTests.cs
+++ b/tests/Jroc.Tests/Array/RuntimePrototypeIsolationTests.cs
@@ -117,8 +117,13 @@ public class RuntimePrototypeIsolationTests
             });
     }
 
+    /// <summary>
+    /// Each realm owns its own fully populated <c>Array.prototype</c> (issue #1824);
+    /// serially switching realms must never hand a realm another realm's prototype and
+    /// must never lose the intrinsic method surface.
+    /// </summary>
     [Fact]
-    public void ArrayPrototypeThreadOverride_RetainsIntrinsicDescriptorsAcrossSerialRuntimeStores()
+    public void ArrayPrototype_IsRealmOwnedAndFullyPopulatedAcrossSerialRuntimeStores()
     {
         JavaScriptRuntime.Array.ResetPrototypeForTests();
 
@@ -131,13 +136,14 @@ public class RuntimePrototypeIsolationTests
             var firstPrototype = ObjectRuntime.GetItem(GlobalThis.Array, "prototype")
                 ?? throw new InvalidOperationException("Array.prototype was not configured.");
             Assert.NotNull(ObjectRuntime.GetItem(firstPrototype, "push"));
+            Assert.NotNull(ObjectRuntime.GetItem(new JavaScriptRuntime.Array(), "push"));
 
             GlobalThis.ServiceProvider = null;
             GlobalThis.ServiceProvider = secondRuntime;
 
             var secondPrototype = ObjectRuntime.GetItem(GlobalThis.Array, "prototype")
                 ?? throw new InvalidOperationException("Array.prototype was not configured.");
-            Assert.Same(firstPrototype, secondPrototype);
+            Assert.NotSame(firstPrototype, secondPrototype);
             Assert.NotNull(ObjectRuntime.GetItem(secondPrototype, "push"));
             Assert.NotNull(ObjectRuntime.GetItem(new JavaScriptRuntime.Array(), "push"));
         }
@@ -177,7 +183,7 @@ public class RuntimePrototypeIsolationTests
 
             var secondPrototype = ObjectRuntime.GetItem(GlobalThis.Array, "prototype")
                 ?? throw new InvalidOperationException("Array.prototype was not configured.");
-            Assert.Same(arrayPrototype, secondPrototype);
+            Assert.NotSame(arrayPrototype, secondPrototype);
             Assert.Null(JavaScriptRuntime.Object.getOwnPropertyDescriptor(secondPrototype, "assignSourceLeak"));
             Assert.Null(JavaScriptRuntime.Object.getOwnPropertyDescriptor(secondPrototype, "assignTargetLeak"));
         }

--- a/tests/Jroc.Tests/RuntimeIntrinsicConcurrencyTests.cs
+++ b/tests/Jroc.Tests/RuntimeIntrinsicConcurrencyTests.cs
@@ -1,0 +1,482 @@
+using JavaScriptRuntime;
+using JavaScriptRuntime.DependencyInjection;
+
+namespace Jroc.Tests;
+
+/// <summary>
+/// Concurrency regressions for the realm-owned intrinsic graph (GitHub issue #1824).
+/// Covers the four hazards the lazy graph introduces: a half-initialized intrinsic
+/// escaping to a second thread, a lock inversion between the intrinsic graph and
+/// <see cref="BuiltinDelegateFunctionAdapter.InitializationLock"/>, an unstable
+/// <see cref="RuntimeIntrinsics.Current"/> answer, and an unbootstrapped realm being
+/// observed through the primitive prototype accessors.
+/// </summary>
+public sealed class RuntimeIntrinsicConcurrencyTests
+{
+    private static readonly TimeSpan DeadlockTimeout = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan SignalTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan BlockedProbe = TimeSpan.FromMilliseconds(500);
+
+    private static readonly Func<object[], object?[]?, object?> LockInversionTarget =
+        static (_, _) => null;
+
+    /// <summary>
+    /// Slot used by the tests that drive <see cref="RuntimeIntrinsics.GetOrCreate"/>
+    /// directly. The runtime itself never materializes it in these realms.
+    /// </summary>
+    private const RuntimeIntrinsicSlot TestSlot = RuntimeIntrinsicSlot.UrlSearchParamsPrototype;
+
+    [Fact]
+    public async Task SimultaneousFirstAccess_BlocksUntilTheInitializerCompleted()
+    {
+        var intrinsics = new RuntimeIntrinsics();
+        using var initializerEntered = new ManualResetEventSlim();
+        using var releaseInitializer = new ManualResetEventSlim();
+
+        var owner = Task.Run(() => intrinsics.GetOrCreate(
+            TestSlot,
+            static () => new JsObject(),
+            prototype =>
+            {
+                initializerEntered.Set();
+                Assert.True(releaseInitializer.Wait(SignalTimeout));
+                prototype["state"] = "ready";
+            }));
+
+        Assert.True(initializerEntered.Wait(SignalTimeout));
+
+        var waiter = Task.Run(() => intrinsics.GetOrCreate(
+            TestSlot,
+            static () => new JsObject(),
+            static _ => throw new InvalidOperationException(
+                "A second thread must not run the initializer for an owned slot.")));
+
+        await Task.Delay(BlockedProbe);
+        Assert.False(
+            waiter.IsCompleted,
+            "A second thread observed an intrinsic before its initializer completed.");
+
+        releaseInitializer.Set();
+
+        var owned = await Guarded(owner, "The owning thread never completed the initializer.");
+        var observed = await Guarded(waiter, "The waiting thread never observed the intrinsic.");
+
+        Assert.Same(owned, observed);
+        Assert.Equal("ready", observed["state"]);
+    }
+
+    [Fact]
+    public async Task SimultaneousFirstAccessToALazyPrototype_SharesOneFullyWiredInstance()
+    {
+        const int threadCount = 8;
+        var services = RuntimeServices.BuildServiceProvider();
+        var context = RuntimeExecutionContext.GetOrCreate(services);
+        using var scope = context.EnterAsRoot();
+        using var ready = new Barrier(threadCount);
+
+        var tasks = new Task<(object ArrayPrototype, object StringPrototype, object MapPrototype)>[threadCount];
+        for (var index = 0; index < threadCount; index++)
+        {
+            tasks[index] = Task.Run(() =>
+            {
+                ready.SignalAndWait();
+
+                var arrayPrototype = JavaScriptRuntime.Array.Prototype;
+                var stringPrototype = JavaScriptRuntime.String.Prototype;
+                var mapPrototype = JavaScriptRuntime.Map.Prototype;
+
+                // Asserted at the moment of first observation: a half-built prototype
+                // would be missing its method surface.
+                AssertFullyWired(arrayPrototype, "map", "push", "filter");
+                AssertFullyWired(stringPrototype, "slice", "indexOf", "replace");
+                AssertFullyWired(mapPrototype, "get", "set", "has");
+
+                return ((object)arrayPrototype, (object)stringPrototype, (object)mapPrototype);
+            });
+        }
+
+        var results = await GuardedAll(tasks, "Concurrent lazy prototype creation deadlocked.");
+
+        foreach (var result in results)
+        {
+            Assert.Same(results[0].ArrayPrototype, result.ArrayPrototype);
+            Assert.Same(results[0].StringPrototype, result.StringPrototype);
+            Assert.Same(results[0].MapPrototype, result.MapPrototype);
+        }
+    }
+
+    [Fact]
+    public void ReentrantResolutionFromAnInitializer_ObservesTheObjectUnderConstruction()
+    {
+        var intrinsics = new RuntimeIntrinsics();
+        JsObject? reentrant = null;
+
+        var value = intrinsics.GetOrCreate(
+            TestSlot,
+            static () => new JsObject(),
+            prototype =>
+            {
+                // The ECMA-262 intrinsic bootstrap cycles depend on this: the thread that
+                // owns the slot resolves it to the object it is still wiring.
+                reentrant = intrinsics.GetOrCreate(TestSlot, static () => new JsObject());
+                prototype["state"] = "ready";
+            });
+
+        Assert.Same(value, reentrant);
+        Assert.Equal("ready", value["state"]);
+        Assert.Same(value, intrinsics.GetOrCreate(TestSlot, static () => new JsObject()));
+    }
+
+    [Fact]
+    public void FailedInitializer_LeavesTheSlotRetryableInsteadOfHalfBuilt()
+    {
+        var intrinsics = new RuntimeIntrinsics();
+        JsObject? abandoned = null;
+
+        Assert.Throws<InvalidOperationException>(() => intrinsics.GetOrCreate(
+            TestSlot,
+            () =>
+            {
+                abandoned = new JsObject();
+                return abandoned;
+            },
+            static _ => throw new InvalidOperationException("initializer failed")));
+
+        var recovered = intrinsics.GetOrCreate(
+            TestSlot,
+            static () => new JsObject(),
+            static prototype => prototype["state"] = "ready");
+
+        Assert.NotNull(abandoned);
+        Assert.NotSame(abandoned, recovered);
+        Assert.Equal("ready", recovered["state"]);
+    }
+
+    [Fact]
+    public async Task FailedInitializer_IsNotObservedByAWaitingThread()
+    {
+        var intrinsics = new RuntimeIntrinsics();
+        using var initializerEntered = new ManualResetEventSlim();
+        using var releaseInitializer = new ManualResetEventSlim();
+
+        var owner = Task.Run(() => intrinsics.GetOrCreate(
+            TestSlot,
+            static () => new JsObject(),
+            _ =>
+            {
+                initializerEntered.Set();
+                Assert.True(releaseInitializer.Wait(SignalTimeout));
+                throw new InvalidOperationException("initializer failed");
+            }));
+
+        Assert.True(initializerEntered.Wait(SignalTimeout));
+
+        var waiter = Task.Run(() => intrinsics.GetOrCreate(
+            TestSlot,
+            static () => new JsObject(),
+            static prototype => prototype["state"] = "ready"));
+
+        await Task.Delay(BlockedProbe);
+        Assert.False(
+            waiter.IsCompleted,
+            "A waiting thread observed the intrinsic while its initializer was still running.");
+
+        releaseInitializer.Set();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => owner.WaitAsync(DeadlockTimeout));
+
+        var recovered = await Guarded(waiter, "The retrying thread never made progress.");
+        Assert.Equal("ready", recovered["state"]);
+    }
+
+    [Fact]
+    public async Task IntrinsicInitializationAndAdapterInitialization_DoNotInvertLocks()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        var context = RuntimeExecutionContext.GetOrCreate(services);
+        using var scope = context.EnterAsRoot();
+
+        var intrinsics = services.OwningRealm!.Intrinsics;
+        var target = LockInversionTarget;
+        var adapter = BuiltinDelegateFunctionAdapter.FromDelegate(target);
+
+        using var adapterLockHeld = new ManualResetEventSlim();
+        using var initializerEntered = new ManualResetEventSlim();
+
+        // Adapter lock first, then intrinsics. %Function.prototype% already exists (the
+        // adapter's own construction materialized it), so a prototype that this realm has
+        // never touched is resolved as well.
+        var adapterFirst = Task.Run(() =>
+        {
+            lock (adapter.InitializationLock)
+            {
+                adapterLockHeld.Set();
+                Assert.True(initializerEntered.Wait(SignalTimeout));
+                _ = JavaScriptRuntime.Map.Prototype;
+                return (object)JavaScriptRuntime.Function.Prototype;
+            }
+        });
+
+        // Intrinsic initialization first, then the same adapter lock. Before the fix the
+        // initializer ran under a realm-wide intrinsic lock, so the task above could never
+        // obtain %Function.prototype% and both threads hung.
+        var intrinsicFirst = Task.Run(() =>
+        {
+            Assert.True(adapterLockHeld.Wait(SignalTimeout));
+            return (object)intrinsics.GetOrCreate(
+                TestSlot,
+                static () => new JsObject(),
+                prototype =>
+                {
+                    initializerEntered.Set();
+                    JavaScriptRuntime.Function.InitializeFunctionInstance(target, 1d, "lockInversionTarget");
+                    prototype["state"] = "ready";
+                });
+        });
+
+        var results = await GuardedAll(
+            [adapterFirst, intrinsicFirst],
+            "The intrinsic graph and a builtin adapter deadlocked on inverted lock order.");
+
+        Assert.Same(JavaScriptRuntime.Function.Prototype, results[0]);
+        Assert.Same(
+            JavaScriptRuntime.Function.Prototype,
+            PrototypeChain.GetPrototypeOrNull(adapter));
+    }
+
+    [Fact]
+    public async Task ConcurrentBootstrapAndAdapterInitialization_ProducesOneFullyWiredRealm()
+    {
+        const int threadCount = 8;
+        var services = RuntimeServices.BuildServiceProvider();
+        var context = RuntimeExecutionContext.GetOrCreate(services);
+        using var scope = context.EnterAsRoot();
+        using var ready = new Barrier(threadCount);
+
+        var tasks = new Task<Dictionary<string, object?>>[threadCount];
+        for (var index = 0; index < threadCount; index++)
+        {
+            tasks[index] = Task.Run(() =>
+            {
+                ready.SignalAndWait();
+
+                var global = GlobalThis.globalThis;
+                var booleanAdapter = (object)BuiltinDelegateFunctionAdapter.FromDelegate(GlobalThis.Boolean);
+                var parseInt = GlobalThis.GetFunctionValue("parseInt");
+                var numberPrototype = GlobalThis.NumberPrototypeValue;
+                var typeErrorPrototype = GlobalThis.TypeErrorPrototypeValue;
+                var objectPrototype = GlobalThis.ObjectPrototypeValue;
+
+                // The realm bootstrap wires all of these, so observing any of them means
+                // the bootstrap completed before this thread was allowed to continue.
+                Assert.Same(objectPrototype, PrototypeChain.GetPrototypeOrNull(numberPrototype));
+                Assert.Same(
+                    GlobalThis.ErrorPrototypeValue,
+                    PrototypeChain.GetPrototypeOrNull(typeErrorPrototype));
+                Assert.Same(
+                    JavaScriptRuntime.Function.Prototype,
+                    PrototypeChain.GetPrototypeOrNull(booleanAdapter));
+                Assert.True(PropertyDescriptorStore.TryGetOwn(booleanAdapter, "name", out _));
+                Assert.NotNull(ObjectRuntime.GetItem(global, "Object"));
+                Assert.NotNull(ObjectRuntime.GetItem(global, "JSON"));
+                AssertFullyWired(objectPrototype, "hasOwnProperty", "toString", "valueOf");
+
+                return new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["globalThis"] = global,
+                    ["Boolean"] = booleanAdapter,
+                    ["parseInt"] = parseInt,
+                    ["Number.prototype"] = numberPrototype,
+                    ["TypeError.prototype"] = typeErrorPrototype,
+                    ["Object.prototype"] = objectPrototype,
+                    ["Array.prototype"] = JavaScriptRuntime.Array.Prototype,
+                };
+            });
+        }
+
+        var results = await GuardedAll(tasks, "Concurrent realm bootstrap deadlocked.");
+
+        foreach (var result in results)
+        {
+            foreach (var (name, value) in results[0])
+            {
+                Assert.NotNull(value);
+                Assert.Same(value, result[name]);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task AmbientRealm_StaysStable_WhileAnotherRealmIsCreated()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        var context = RuntimeExecutionContext.GetOrCreate(services);
+        using var scope = context.EnterAsRoot();
+
+        var ambient = services.OwningRealm!.Intrinsics;
+        var global = GlobalThis.globalThis;
+        var arrayPrototype = JavaScriptRuntime.Array.Prototype;
+        var numberPrototype = GlobalThis.NumberPrototypeValue;
+
+        using var otherRealmReady = new ManualResetEventSlim();
+        using var releaseOtherRealm = new ManualResetEventSlim();
+
+        var otherRealm = Task.Run(() =>
+        {
+            var otherServices = RuntimeServices.BuildServiceProvider();
+            var otherContext = RuntimeExecutionContext.GetOrCreate(otherServices);
+            using var otherScope = otherContext.EnterAsRoot();
+
+            _ = GlobalThis.globalThis;
+            var otherIntrinsics = otherServices.OwningRealm!.Intrinsics;
+            Assert.Same(otherIntrinsics, RuntimeIntrinsics.Current);
+
+            otherRealmReady.Set();
+            Assert.True(releaseOtherRealm.Wait(SignalTimeout));
+            return (object)otherIntrinsics;
+        });
+
+        Assert.True(otherRealmReady.Wait(SignalTimeout));
+
+        // A second live realm must not change any answer this operation already received.
+        for (var attempt = 0; attempt < 200; attempt++)
+        {
+            Assert.Same(ambient, RuntimeIntrinsics.Current);
+            Assert.Same(global, GlobalThis.globalThis);
+            Assert.Same(arrayPrototype, JavaScriptRuntime.Array.Prototype);
+            Assert.Same(numberPrototype, GlobalThis.NumberPrototypeValue);
+        }
+
+        releaseOtherRealm.Set();
+
+        var otherIntrinsics = await Guarded(otherRealm, "The second realm never completed.");
+        Assert.NotSame(ambient, otherIntrinsics);
+    }
+
+    [Fact]
+    public void ContextLessResolution_UsesADeterministicProcessDefaultGraph()
+    {
+        var realm = RuntimeOwnershipFactory.CreateIsolatedRealm();
+        try
+        {
+            var processDefault = RuntimeIntrinsics.Current;
+
+            // A live realm's graph is never handed to a context-less caller, and creating
+            // another realm does not change the context-less answer.
+            Assert.NotSame(realm.Intrinsics, processDefault);
+            var second = realm.Agent.CreateRealm();
+            Assert.NotSame(second.Intrinsics, RuntimeIntrinsics.Current);
+            Assert.Same(processDefault, RuntimeIntrinsics.Current);
+            Assert.Same(processDefault.ObjectPrototype, RuntimeIntrinsics.Current.ObjectPrototype);
+        }
+        finally
+        {
+            realm.Agent.Cluster.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AmbientRealm_WinsOverTheProcessDefaultGraph()
+    {
+        var contextLess = RuntimeIntrinsics.Current;
+        var services = RuntimeServices.BuildServiceProvider();
+        var context = RuntimeExecutionContext.GetOrCreate(services);
+        var realmIntrinsics = services.OwningRealm!.Intrinsics;
+
+        using (context.EnterAsRoot())
+        {
+            Assert.Same(realmIntrinsics, RuntimeIntrinsics.Current);
+            Assert.Same(realmIntrinsics.ObjectPrototype, GlobalThis.ObjectPrototypeValue);
+        }
+
+        Assert.Same(contextLess, RuntimeIntrinsics.Current);
+        Assert.NotSame(realmIntrinsics, RuntimeIntrinsics.Current);
+    }
+
+    [Fact]
+    public async Task PrimitivePrototypeAccessors_NeverExposeAnUnbootstrappedRealm()
+    {
+        const int threadCount = 8;
+        var services = RuntimeServices.BuildServiceProvider();
+        var context = RuntimeExecutionContext.GetOrCreate(services);
+        using var scope = context.EnterAsRoot();
+        using var ready = new Barrier(threadCount);
+
+        var tasks = new Task<bool>[threadCount];
+        for (var index = 0; index < threadCount; index++)
+        {
+            var resolvesErrorFirst = index % 2 == 0;
+            tasks[index] = Task.Run(() =>
+            {
+                ready.SignalAndWait();
+
+                if (resolvesErrorFirst)
+                {
+                    // Error prototypes get their surface from the realm bootstrap alone,
+                    // so this accessor must complete the bootstrap before it returns.
+                    var errorPrototype = GlobalThis.ErrorPrototypeValue;
+                    AssertFullyWired(errorPrototype, "toString", "message", "name");
+                    Assert.Same(
+                        GlobalThis.ObjectPrototypeValue,
+                        PrototypeChain.GetPrototypeOrNull(errorPrototype));
+                }
+                else
+                {
+                    var numberPrototype = GlobalThis.NumberPrototypeValue;
+                    AssertFullyWired(numberPrototype, "toFixed", "toString", "valueOf");
+                    Assert.Same(
+                        GlobalThis.ObjectPrototypeValue,
+                        PrototypeChain.GetPrototypeOrNull(numberPrototype));
+                }
+
+                Assert.Same(
+                    GlobalThis.TypeErrorPrototypeValue,
+                    PrototypeChain.GetPrototypeOrNull(new TypeError("boom")));
+                return true;
+            });
+        }
+
+        var results = await GuardedAll(
+            tasks,
+            "Bootstrapping through a primitive prototype accessor deadlocked.");
+        Assert.All(results, Assert.True);
+    }
+
+    private static void AssertFullyWired(object prototype, params string[] expectedProperties)
+    {
+        Assert.NotNull(prototype);
+        foreach (var name in expectedProperties)
+        {
+            Assert.True(
+                PropertyDescriptorStore.TryGetOwn(prototype, name, out _),
+                $"Observed a partially initialized intrinsic: '{name}' is missing.");
+        }
+    }
+
+    private static async Task<T> Guarded<T>(Task<T> task, string deadlockMessage)
+    {
+        try
+        {
+            return await task.WaitAsync(DeadlockTimeout);
+        }
+        catch (TimeoutException)
+        {
+            Assert.Fail(deadlockMessage);
+            throw;
+        }
+    }
+
+    private static async Task<T[]> GuardedAll<T>(Task<T>[] tasks, string deadlockMessage)
+    {
+        try
+        {
+            return await Task.WhenAll(tasks).WaitAsync(DeadlockTimeout);
+        }
+        catch (TimeoutException)
+        {
+            Assert.Fail(deadlockMessage);
+            throw;
+        }
+    }
+}

--- a/tests/Jroc.Tests/RuntimeIntrinsicIsolationTests.cs
+++ b/tests/Jroc.Tests/RuntimeIntrinsicIsolationTests.cs
@@ -1,0 +1,607 @@
+using JavaScriptRuntime;
+using JavaScriptRuntime.DependencyInjection;
+
+namespace Jroc.Tests;
+
+/// <summary>
+/// Covers GitHub issue #1824: globals, intrinsics, descriptors and prototypes are
+/// realm-owned. See <see cref="RuntimeIntrinsics"/> for the object graph and
+/// <see cref="RuntimeRealm"/> for ownership/lifecycle.
+/// </summary>
+public sealed class RuntimeIntrinsicIsolationTests
+{
+    /// <summary>
+    /// Global bindings whose JavaScript-visible identity must differ between realms.
+    /// </summary>
+    private static readonly string[] RealmOwnedGlobalNames =
+    [
+        "globalThis",
+        "Object",
+        "Function",
+        "Array",
+        "String",
+        "Number",
+        "Boolean",
+        "BigInt",
+        "Symbol",
+        "Map",
+        "Set",
+        "WeakMap",
+        "WeakSet",
+        "WeakRef",
+        "FinalizationRegistry",
+        "Promise",
+        "RegExp",
+        "Proxy",
+        "Error",
+        "TypeError",
+        "RangeError",
+        "SyntaxError",
+        "ReferenceError",
+        "EvalError",
+        "URIError",
+        "AggregateError",
+        "ArrayBuffer",
+        "SharedArrayBuffer",
+        "DataView",
+        "Uint8Array",
+        "Int32Array",
+        "Float64Array",
+        "JSON",
+        "Intl",
+        "Atomics",
+        "parseInt",
+        "parseFloat",
+        "isNaN",
+        "isFinite",
+        "decodeURI",
+        "encodeURI",
+        "setTimeout",
+        "clearTimeout",
+        "setInterval",
+    ];
+
+    [Fact]
+    public void TwoRealms_HaveDistinctGlobalBindingIdentities()
+    {
+        var first = CaptureGlobalBindings();
+        var second = CaptureGlobalBindings();
+
+        foreach (var name in RealmOwnedGlobalNames)
+        {
+            Assert.True(first.ContainsKey(name), $"Missing global binding '{name}'.");
+            Assert.True(first[name] is not null, $"Global binding '{name}' resolved to null.");
+            Assert.True(
+                !ReferenceEquals(first[name], second[name]),
+                $"Global binding '{name}' has a process-shared identity across realms.");
+        }
+    }
+
+    [Fact]
+    public void TwoRealms_HaveDistinctIntrinsicPrototypeIdentities()
+    {
+        var first = CaptureIntrinsicPrototypes();
+        var second = CaptureIntrinsicPrototypes();
+
+        foreach (var (name, prototype) in first)
+        {
+            Assert.NotNull(prototype);
+            Assert.NotSame(prototype, second[name]);
+        }
+    }
+
+    [Fact]
+    public void TwoRealms_HaveDistinctPrototypeMethodIdentities()
+    {
+        static Dictionary<string, object?> Capture()
+            => WithRealm(static () =>
+            {
+                var global = GlobalThis.globalThis;
+                return new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    ["Object.prototype.hasOwnProperty"] =
+                        ObjectRuntime.GetItem(GlobalThis.ObjectPrototypeValue, "hasOwnProperty"),
+                    ["Object.prototype.toString"] =
+                        ObjectRuntime.GetItem(GlobalThis.ObjectPrototypeValue, "toString"),
+                    ["Function.prototype.call"] =
+                        ObjectRuntime.GetItem(JavaScriptRuntime.Function.Prototype, "call"),
+                    ["Function.prototype.bind"] =
+                        ObjectRuntime.GetItem(JavaScriptRuntime.Function.Prototype, "bind"),
+                    ["Array.prototype.map"] =
+                        ObjectRuntime.GetItem(JavaScriptRuntime.Array.Prototype, "map"),
+                    ["Array.prototype.push"] =
+                        ObjectRuntime.GetItem(JavaScriptRuntime.Array.Prototype, "push"),
+                    ["Array.from"] = ObjectRuntime.GetItem(ObjectRuntime.GetItem(global, "Array")!, "from"),
+                    ["String.prototype.slice"] =
+                        ObjectRuntime.GetItem(JavaScriptRuntime.String.Prototype, "slice"),
+                    ["Map.prototype.get"] =
+                        ObjectRuntime.GetItem(JavaScriptRuntime.Map.Prototype, "get"),
+                    ["Promise.prototype.then"] =
+                        ObjectRuntime.GetItem(JavaScriptRuntime.Promise.Prototype, "then"),
+                    ["JSON.stringify"] =
+                        ObjectRuntime.GetItem(ObjectRuntime.GetItem(global, "JSON")!, "stringify"),
+                    ["Math.floor"] =
+                        ObjectRuntime.GetItem(ObjectRuntime.GetItem(global, "Math")!, "floor"),
+                };
+            });
+
+        var first = Capture();
+        var second = Capture();
+
+        foreach (var (name, method) in first)
+        {
+            Assert.True(method is JsFunctionObject, $"'{name}' is not a function object.");
+            Assert.NotSame(method, second[name]);
+        }
+    }
+
+    [Fact]
+    public void TwoRealms_LinkEachRealmsPrototypeChainToItsOwnIntrinsics()
+    {
+        static (object ObjectPrototype, object FunctionPrototype, object ArrayPrototype,
+            object ErrorPrototype, object TypeErrorPrototype, object? ArrayParent,
+            object? TypeErrorParent, object? NumberParent, object? MapParent,
+            object? DateConstructorParent) Capture()
+            => WithRealm(static () =>
+            {
+                _ = GlobalThis.globalThis;
+                var objectPrototype = GlobalThis.ObjectPrototypeValue;
+                return (
+                    objectPrototype,
+                    JavaScriptRuntime.Function.Prototype,
+                    JavaScriptRuntime.Array.Prototype,
+                    GlobalThis.ErrorPrototypeValue,
+                    GlobalThis.TypeErrorPrototypeValue,
+                    PrototypeChain.GetPrototypeOrNull(JavaScriptRuntime.Array.Prototype),
+                    PrototypeChain.GetPrototypeOrNull(GlobalThis.TypeErrorPrototypeValue),
+                    PrototypeChain.GetPrototypeOrNull(GlobalThis.NumberPrototypeValue),
+                    PrototypeChain.GetPrototypeOrNull(JavaScriptRuntime.Map.Prototype),
+                    // typeof(Date) is a process-shared CLR handle; its [[Prototype]] link
+                    // lives in the realm's fallback slot table and must still be this
+                    // realm's %Function.prototype%.
+                    PrototypeChain.GetPrototypeOrNull(GlobalThis.Date));
+            });
+
+        var first = Capture();
+        var second = Capture();
+
+        Assert.NotSame(first.ObjectPrototype, second.ObjectPrototype);
+        Assert.NotSame(first.FunctionPrototype, second.FunctionPrototype);
+
+        foreach (var realm in new[] { first, second })
+        {
+            Assert.Same(realm.ObjectPrototype, realm.ArrayParent);
+            Assert.Same(realm.ObjectPrototype, realm.NumberParent);
+            Assert.Same(realm.ObjectPrototype, realm.MapParent);
+            Assert.Same(realm.ErrorPrototype, realm.TypeErrorParent);
+            Assert.Same(realm.FunctionPrototype, realm.DateConstructorParent);
+        }
+    }
+
+    [Fact]
+    public void MutatingAnIntrinsicPrototype_IsInvisibleInAnotherRealm()
+    {
+        var firstServices = RuntimeServices.BuildServiceProvider();
+        var secondServices = RuntimeServices.BuildServiceProvider();
+
+        WithRealm(firstServices, () =>
+        {
+            _ = GlobalThis.globalThis;
+            ObjectRuntime.SetItem(GlobalThis.ObjectPrototypeValue, "realmMarker", "first");
+            ObjectRuntime.SetItem(JavaScriptRuntime.Array.Prototype, "realmMarker", "first");
+            ObjectRuntime.SetItem(JavaScriptRuntime.Function.Prototype, "realmMarker", "first");
+            ObjectRuntime.SetItem(JavaScriptRuntime.Map.Prototype, "realmMarker", "first");
+            ObjectRuntime.SetItem(GlobalThis.NumberPrototypeValue, "realmMarker", "first");
+            return true;
+        });
+
+        WithRealm(secondServices, () =>
+        {
+            _ = GlobalThis.globalThis;
+            Assert.Null(ObjectRuntime.GetItem(GlobalThis.ObjectPrototypeValue, "realmMarker"));
+            Assert.Null(ObjectRuntime.GetItem(JavaScriptRuntime.Array.Prototype, "realmMarker"));
+            Assert.Null(ObjectRuntime.GetItem(JavaScriptRuntime.Function.Prototype, "realmMarker"));
+            Assert.Null(ObjectRuntime.GetItem(JavaScriptRuntime.Map.Prototype, "realmMarker"));
+            Assert.Null(ObjectRuntime.GetItem(GlobalThis.NumberPrototypeValue, "realmMarker"));
+            return true;
+        });
+
+        // Round-trip: the mutation is still visible in the realm that made it.
+        WithRealm(firstServices, () =>
+        {
+            Assert.Equal("first", ObjectRuntime.GetItem(GlobalThis.ObjectPrototypeValue, "realmMarker"));
+            Assert.Equal("first", ObjectRuntime.GetItem(JavaScriptRuntime.Array.Prototype, "realmMarker"));
+            return true;
+        });
+    }
+
+    [Fact]
+    public void RedefiningAnIntrinsicDescriptor_IsInvisibleInAnotherRealm()
+    {
+        var firstServices = RuntimeServices.BuildServiceProvider();
+        var secondServices = RuntimeServices.BuildServiceProvider();
+
+        var replacement = (Func<object[], object?[]?, object?>)((_, _) => "patched");
+
+        WithRealm(firstServices, () =>
+        {
+            _ = GlobalThis.globalThis;
+            PropertyDescriptorStore.DefineOrUpdate(
+                JavaScriptRuntime.Array.Prototype,
+                "join",
+                new JsPropertyDescriptor
+                {
+                    Kind = JsPropertyDescriptorKind.Data,
+                    Enumerable = false,
+                    Configurable = true,
+                    Writable = true,
+                    Value = replacement
+                });
+            Assert.True(PropertyDescriptorStore.TryGetOwn(
+                JavaScriptRuntime.Array.Prototype, "join", out var patched));
+            Assert.Same(
+                BuiltinDelegateFunctionAdapter.FromDelegate(replacement),
+                patched.Value);
+            return true;
+        });
+
+        WithRealm(secondServices, () =>
+        {
+            _ = GlobalThis.globalThis;
+            Assert.True(PropertyDescriptorStore.TryGetOwn(
+                JavaScriptRuntime.Array.Prototype, "join", out var pristine));
+            Assert.NotSame(
+                BuiltinDelegateFunctionAdapter.FromDelegate(replacement),
+                pristine.Value);
+            return true;
+        });
+    }
+
+    [Fact]
+    public void DeletingAnIntrinsicPrototypeProperty_IsInvisibleInAnotherRealm()
+    {
+        var firstServices = RuntimeServices.BuildServiceProvider();
+        var secondServices = RuntimeServices.BuildServiceProvider();
+
+        WithRealm(firstServices, () =>
+        {
+            _ = GlobalThis.globalThis;
+            Assert.True(PropertyDescriptorStore.Delete(JavaScriptRuntime.Array.Prototype, "map"));
+            Assert.False(PropertyDescriptorStore.TryGetOwn(
+                JavaScriptRuntime.Array.Prototype, "map", out _));
+            return true;
+        });
+
+        WithRealm(secondServices, () =>
+        {
+            _ = GlobalThis.globalThis;
+            Assert.True(PropertyDescriptorStore.TryGetOwn(
+                JavaScriptRuntime.Array.Prototype, "map", out _));
+            return true;
+        });
+    }
+
+    [Fact]
+    public void ReassigningAnIntrinsicPrototypeLink_IsInvisibleInAnotherRealm()
+    {
+        var firstServices = RuntimeServices.BuildServiceProvider();
+        var secondServices = RuntimeServices.BuildServiceProvider();
+
+        WithRealm(firstServices, () =>
+        {
+            _ = GlobalThis.globalThis;
+            // typeof(Date) is a process-shared CLR handle, so its [[Prototype]] link is the
+            // strongest test that fallback prototype slots are realm-owned.
+            PrototypeChain.SetPrototype(GlobalThis.Date, null);
+            Assert.Null(PrototypeChain.GetPrototypeOrNull(GlobalThis.Date));
+            return true;
+        });
+
+        WithRealm(secondServices, () =>
+        {
+            _ = GlobalThis.globalThis;
+            Assert.Same(
+                JavaScriptRuntime.Function.Prototype,
+                PrototypeChain.GetPrototypeOrNull(GlobalThis.Date));
+            return true;
+        });
+    }
+
+    [Fact]
+    public void SharedClrConstructorHandles_ExposeRealmOwnedPrototypeDescriptors()
+    {
+        static (object? DatePrototype, object? Uint8ArrayPrototype) Capture()
+            => WithRealm(static () =>
+            {
+                _ = GlobalThis.globalThis;
+                PropertyDescriptorStore.TryGetOwn(GlobalThis.Date, "prototype", out var date);
+                PropertyDescriptorStore.TryGetOwn(typeof(Uint8Array), "prototype", out var uint8);
+                return (date.Value, uint8.Value);
+            });
+
+        var first = Capture();
+        var second = Capture();
+
+        Assert.NotNull(first.DatePrototype);
+        Assert.NotNull(first.Uint8ArrayPrototype);
+        Assert.NotSame(first.DatePrototype, second.DatePrototype);
+        Assert.NotSame(first.Uint8ArrayPrototype, second.Uint8ArrayPrototype);
+    }
+
+    [Fact]
+    public void RepeatedLookupsWithinOneRealm_PreserveIntrinsicIdentity()
+    {
+        WithRealm(static () =>
+        {
+            var global = GlobalThis.globalThis;
+
+            Assert.Same(global, GlobalThis.globalThis);
+            Assert.Same(GlobalThis.ObjectPrototypeValue, GlobalThis.ObjectPrototypeValue);
+            Assert.Same(JavaScriptRuntime.Function.Prototype, JavaScriptRuntime.Function.Prototype);
+            Assert.Same(JavaScriptRuntime.Array.Prototype, JavaScriptRuntime.Array.Prototype);
+            Assert.Same(
+                ObjectRuntime.GetItem(global, "Map"),
+                ObjectRuntime.GetItem(global, "Map"));
+            Assert.Same(
+                BuiltinDelegateFunctionAdapter.FromDelegate(GlobalThis.Boolean),
+                BuiltinDelegateFunctionAdapter.FromDelegate(GlobalThis.Boolean));
+            Assert.Same(
+                GlobalThis.GetFunctionValue("parseInt"),
+                GlobalThis.GetFunctionValue("parseInt"));
+            return true;
+        });
+    }
+
+    [Fact]
+    public void TwoRealms_HaveDistinctBuiltinDelegateAdapterIdentities()
+    {
+        static (object Boolean, object Number, object ParseInt, object SetTimeout) Capture()
+            => WithRealm(static () => (
+                (object)BuiltinDelegateFunctionAdapter.FromDelegate(GlobalThis.Boolean),
+                BuiltinDelegateFunctionAdapter.FromDelegate(GlobalThis.Number),
+                GlobalThis.GetFunctionValue("parseInt"),
+                GlobalThis.GetFunctionValue("setTimeout")));
+
+        var first = Capture();
+        var second = Capture();
+
+        Assert.NotSame(first.Boolean, second.Boolean);
+        Assert.NotSame(first.Number, second.Number);
+        Assert.NotSame(first.ParseInt, second.ParseInt);
+        Assert.NotSame(first.SetTimeout, second.SetTimeout);
+    }
+
+    [Fact]
+    public void EachRealm_OwnsADistinctIntrinsicsGraphInstance()
+    {
+        var first = RuntimeOwnershipFactory.CreateIsolatedRealm();
+        var second = first.Agent.CreateRealm();
+
+        try
+        {
+            Assert.NotSame(first.Intrinsics, second.Intrinsics);
+            Assert.NotEqual(first.Intrinsics.Id, second.Intrinsics.Id);
+            Assert.NotSame(first.Intrinsics.ObjectPrototype, second.Intrinsics.ObjectPrototype);
+            Assert.NotSame(first.Intrinsics.NumberPrototype, second.Intrinsics.NumberPrototype);
+            Assert.NotSame(first.Intrinsics.ErrorPrototype, second.Intrinsics.ErrorPrototype);
+            Assert.NotSame(first.Intrinsics.SymbolPrototype, second.Intrinsics.SymbolPrototype);
+            Assert.NotSame(first.Intrinsics.Json, second.Intrinsics.Json);
+            Assert.NotSame(first.Intrinsics.IntrinsicDescriptors, second.Intrinsics.IntrinsicDescriptors);
+            Assert.NotSame(first.Intrinsics.PrototypeSlots, second.Intrinsics.PrototypeSlots);
+            Assert.NotSame(first.Intrinsics.BuiltinAdapters, second.Intrinsics.BuiltinAdapters);
+            Assert.NotSame(first.Intrinsics.GlobalFunctionValues, second.Intrinsics.GlobalFunctionValues);
+        }
+        finally
+        {
+            first.Agent.Cluster.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task ConcurrentRealmCreation_ProducesDeterministicIsolatedIntrinsics()
+    {
+        const int realmCount = 6;
+        using var ready = new Barrier(realmCount);
+
+        var tasks = new Task<Dictionary<string, object?>>[realmCount];
+        for (var index = 0; index < realmCount; index++)
+        {
+            tasks[index] = Task.Run(() =>
+            {
+                var services = RuntimeServices.BuildServiceProvider();
+                var context = RuntimeExecutionContext.GetOrCreate(services);
+                using var scope = context.EnterAsRoot();
+
+                ready.SignalAndWait();
+
+                var global = (GlobalThis)GlobalThis.globalThis;
+                var objectPrototype = GlobalThis.ObjectPrototypeValue;
+
+                // Every realm must observe a fully and identically wired intrinsic graph,
+                // regardless of creation order or interleaving.
+                Assert.Same(global.Intrinsics.ObjectPrototype, objectPrototype);
+                Assert.Same(objectPrototype, PrototypeChain.GetPrototypeOrNull(JavaScriptRuntime.Function.Prototype));
+                Assert.Same(objectPrototype, PrototypeChain.GetPrototypeOrNull(JavaScriptRuntime.Array.Prototype));
+                Assert.Same(objectPrototype, PrototypeChain.GetPrototypeOrNull(GlobalThis.NumberPrototypeValue));
+                Assert.Same(
+                    GlobalThis.ErrorPrototypeValue,
+                    PrototypeChain.GetPrototypeOrNull(GlobalThis.TypeErrorPrototypeValue));
+                Assert.True(PropertyDescriptorStore.TryGetOwn(
+                    JavaScriptRuntime.Array.Prototype, "map", out _));
+
+                return CaptureRealmIdentities();
+            });
+        }
+
+        var results = await Task.WhenAll(tasks);
+
+        for (var i = 0; i < realmCount; i++)
+        {
+            Assert.Equal(results[0].Keys.OrderBy(k => k, StringComparer.Ordinal),
+                results[i].Keys.OrderBy(k => k, StringComparer.Ordinal));
+
+            for (var j = i + 1; j < realmCount; j++)
+            {
+                foreach (var key in results[i].Keys)
+                {
+                    Assert.NotSame(results[i][key], results[j][key]);
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void RealmDisposal_ReleasesIntrinsicObjectGraph()
+    {
+        var references = CreateAndDisposeRealmIntrinsics();
+
+        for (var attempt = 0;
+            attempt < 10 && (references.Realm.IsAlive || references.ObjectPrototype.IsAlive
+                || references.ArrayPrototype.IsAlive || references.BooleanAdapter.IsAlive
+                || references.GlobalFunction.IsAlive);
+            attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        Assert.False(references.Realm.IsAlive);
+        Assert.False(references.ObjectPrototype.IsAlive);
+        Assert.False(references.ArrayPrototype.IsAlive);
+        Assert.False(references.BooleanAdapter.IsAlive);
+        Assert.False(references.GlobalFunction.IsAlive);
+    }
+
+    [Fact]
+    public void DisposedRealm_DropsItsIntrinsicSlots()
+    {
+        var realm = RuntimeOwnershipFactory.CreateIsolatedRealm();
+        var intrinsics = realm.Intrinsics;
+        var objectPrototype = intrinsics.ObjectPrototype;
+
+        realm.Agent.Cluster.Dispose();
+
+        Assert.NotSame(objectPrototype, intrinsics.ObjectPrototype);
+        Assert.Empty(intrinsics.GlobalFunctionValues);
+    }
+
+    [Fact]
+    public void PrototypeChain_NoLongerExposesAProcessWideBehaviorSwitch()
+    {
+        // Enabled is now a fixed compatibility shim (always true) rather than a
+        // mutable process-wide switch, and Enable() is a no-op retained only for
+        // existing call sites and compiler-emitted prologue calls.
+        Assert.True(PrototypeChain.Enabled);
+        PrototypeChain.Enable();
+        Assert.True(PrototypeChain.Enabled);
+    }
+
+    private static Dictionary<string, object?> CaptureGlobalBindings()
+        => WithRealm(static () =>
+        {
+            var global = GlobalThis.globalThis;
+            var bindings = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var name in RealmOwnedGlobalNames)
+            {
+                bindings[name] = ObjectRuntime.GetItem(global, name);
+            }
+
+            return bindings;
+        });
+
+    private static Dictionary<string, object?> CaptureIntrinsicPrototypes()
+        => WithRealm(static () =>
+        {
+            _ = GlobalThis.globalThis;
+            return new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["Object.prototype"] = GlobalThis.ObjectPrototypeValue,
+                ["Function.prototype"] = JavaScriptRuntime.Function.Prototype,
+                ["Array.prototype"] = JavaScriptRuntime.Array.Prototype,
+                ["%ArrayPrototypeTemplate%"] = JavaScriptRuntime.Array.ImmutablePrototype,
+                ["String.prototype"] = JavaScriptRuntime.String.Prototype,
+                ["%StringIteratorPrototype%"] = JavaScriptRuntime.String.StringIteratorPrototype,
+                ["Number.prototype"] = GlobalThis.NumberPrototypeValue,
+                ["Boolean.prototype"] = GlobalThis.BooleanPrototypeValue,
+                ["Symbol.prototype"] = GlobalThis.SymbolPrototypeValue,
+                ["Error.prototype"] = GlobalThis.ErrorPrototypeValue,
+                ["TypeError.prototype"] = GlobalThis.TypeErrorPrototypeValue,
+                ["Map.prototype"] = JavaScriptRuntime.Map.Prototype,
+                ["Set.prototype"] = JavaScriptRuntime.Set.Prototype,
+                ["WeakMap.prototype"] = JavaScriptRuntime.WeakMap.Prototype,
+                ["WeakSet.prototype"] = JavaScriptRuntime.WeakSet.Prototype,
+                ["WeakRef.prototype"] = JavaScriptRuntime.WeakRef.Prototype,
+                ["FinalizationRegistry.prototype"] = JavaScriptRuntime.FinalizationRegistry.Prototype,
+                ["Promise.prototype"] = JavaScriptRuntime.Promise.Prototype,
+                ["RegExp.prototype"] = JavaScriptRuntime.RegExp.Prototype,
+                ["Date.prototype"] = GlobalThis.DatePrototypeValue,
+                ["DataView.prototype"] = JavaScriptRuntime.DataView.Prototype,
+                ["Uint8Array.prototype"] = JavaScriptRuntime.Uint8Array.Prototype,
+                ["%IteratorPrototype%"] = JavaScriptRuntime.Iterator.Prototype,
+                ["%AsyncIteratorPrototype%"] = JavaScriptRuntime.AsyncIterator.Prototype,
+                ["%AsyncFunction.prototype%"] = JavaScriptRuntime.AsyncFunction.Prototype,
+                ["%AsyncGeneratorPrototype%"] = JavaScriptRuntime.AsyncGeneratorObject.PrototypeObject,
+            };
+        });
+
+    private static Dictionary<string, object?> CaptureRealmIdentities()
+    {
+        var global = GlobalThis.globalThis;
+        var identities = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["Object.prototype"] = GlobalThis.ObjectPrototypeValue,
+            ["Function.prototype"] = JavaScriptRuntime.Function.Prototype,
+            ["Array.prototype"] = JavaScriptRuntime.Array.Prototype,
+            ["Error.prototype"] = GlobalThis.ErrorPrototypeValue,
+            ["Map.prototype"] = JavaScriptRuntime.Map.Prototype,
+            ["Boolean"] = BuiltinDelegateFunctionAdapter.FromDelegate(GlobalThis.Boolean),
+            ["parseInt"] = GlobalThis.GetFunctionValue("parseInt"),
+        };
+
+        foreach (var name in new[] { "globalThis", "Object", "Array", "Map", "JSON" })
+        {
+            identities[$"global:{name}"] = ObjectRuntime.GetItem(global, name);
+        }
+
+        return identities;
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static (WeakReference Realm, WeakReference ObjectPrototype, WeakReference ArrayPrototype,
+        WeakReference BooleanAdapter, WeakReference GlobalFunction) CreateAndDisposeRealmIntrinsics()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        var realm = services.OwningRealm!;
+        var context = RuntimeExecutionContext.GetOrCreate(services);
+
+        WeakReference objectPrototype;
+        WeakReference arrayPrototype;
+        WeakReference booleanAdapter;
+        WeakReference globalFunction;
+        using (context.EnterAsRoot())
+        {
+            _ = GlobalThis.globalThis;
+            objectPrototype = new WeakReference(GlobalThis.ObjectPrototypeValue);
+            arrayPrototype = new WeakReference(JavaScriptRuntime.Array.Prototype);
+            booleanAdapter = new WeakReference(
+                BuiltinDelegateFunctionAdapter.FromDelegate(GlobalThis.Boolean));
+            globalFunction = new WeakReference(GlobalThis.GetFunctionValue("parseInt"));
+        }
+
+        var realmReference = new WeakReference(realm);
+        realm.Agent.Cluster.Dispose();
+
+        return (realmReference, objectPrototype, arrayPrototype, booleanAdapter, globalFunction);
+    }
+
+    private static T WithRealm<T>(Func<T> body)
+        => WithRealm(RuntimeServices.BuildServiceProvider(), body);
+
+    private static T WithRealm<T>(ServiceContainer services, Func<T> body)
+    {
+        var context = RuntimeExecutionContext.GetOrCreate(services);
+        using var scope = context.EnterAsRoot();
+        return body();
+    }
+}


### PR DESCRIPTION
## Summary

- add a realm-owned `RuntimeIntrinsics` graph for global objects, built-in prototypes, function adapters, intrinsic descriptors, and fallback prototype slots
- make intrinsic bootstrap and lazy slot initialization deterministic and safe under concurrent access
- remove the process-wide prototype-chain behavior switch and isolate descriptor/prototype mutation between realms
- clear realm-owned intrinsic state during realm disposal
- preserve the newly added ArrayBuffer and SharedArrayBuffer intrinsic surfaces with realm-owned prototype identities

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --filter "FullyQualifiedName~RuntimeIntrinsicConcurrencyTests|FullyQualifiedName~RuntimeIntrinsicIsolationTests|FullyQualifiedName~RuntimePrototypeIsolationTests|FullyQualifiedName~RuntimeOwnershipTests|FullyQualifiedName~PropertyDescriptor|FullyQualifiedName~Prototype"` — 142 passed
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --no-restore --filter "FullyQualifiedName~ArrayBuffer|FullyQualifiedName~SharedArrayBuffer"` — 53 passed
- full `tests/Jroc.Tests` validation before the final rebase — 3,281 passed, 1 skipped
- full `tests/Jroc.Test262.Tests` validation before the final rebase — 6,272 passed, 58 skipped
- `dotnet build jroc.sln --no-restore` — succeeded with 0 warnings and 0 errors

Closes #1824
