### PR TITLE
test(runtime): inventory JsObject representations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 - runtime: begin #1580's incremental built-in representation migration by
   moving Boolean wrappers to `JsObject` inline property/prototype storage.
-  Add an intrinsic representation inventory guard, Boolean allocation coverage,
-  and a prototype-storage benchmark.
+  Add a JavaScript-visible representation inventory guard, Boolean allocation
+  coverage, and a prototype-storage benchmark.
 
 - runtime/test262: expose SharedArrayBuffer as a first-class global constructor
   with standard constructor/prototype metadata and receiver-checked

--- a/tests/Jroc.Tests/BooleanObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/BooleanObjectRepresentationTests.cs
@@ -5,45 +5,6 @@ namespace Jroc.Tests;
 
 public sealed class BooleanObjectRepresentationTests
 {
-    private static readonly IReadOnlyDictionary<string, string> DocumentedNonJsObjectIntrinsicExceptions =
-        new Dictionary<string, string>
-        {
-            ["JavaScriptRuntime.AggregateError"] = "Must remain an Exception for CLR throw/catch mechanics.",
-            ["JavaScriptRuntime.ArrayBuffer"] = "Planned shared-base migration with typed-array views.",
-            ["JavaScriptRuntime.DataView"] = "Planned view-object migration with computed buffer metadata.",
-            ["JavaScriptRuntime.Date"] = "Planned low-risk internal-slot wrapper migration.",
-            ["JavaScriptRuntime.Error"] = "Must remain an Exception for CLR throw/catch mechanics.",
-            ["JavaScriptRuntime.EvalError"] = "Must remain an Exception for CLR throw/catch mechanics.",
-            ["JavaScriptRuntime.FinalizationRegistry"] = "Planned internal-slot wrapper migration.",
-            ["JavaScriptRuntime.Float32Array"] = "Planned TypedArrayBase exotic-object migration.",
-            ["JavaScriptRuntime.Float64Array"] = "Planned TypedArrayBase exotic-object migration.",
-            ["JavaScriptRuntime.Int16Array"] = "Planned TypedArrayBase exotic-object migration.",
-            ["JavaScriptRuntime.Int32Array"] = "Planned TypedArrayBase exotic-object migration.",
-            ["JavaScriptRuntime.Int8Array"] = "Planned TypedArrayBase exotic-object migration.",
-            ["JavaScriptRuntime.Map"] = "Planned collection and iterator family migration.",
-            ["JavaScriptRuntime.Node.Buffer"] = "Planned indexed/view-object migration.",
-            ["JavaScriptRuntime.Object"] = "Static intrinsic holder; constructed objects use JsObject.",
-            ["JavaScriptRuntime.Promise"] = "Planned internal-slot wrapper migration.",
-            ["JavaScriptRuntime.Proxy"] = "Requires a dedicated migration to preserve trap invariants.",
-            ["JavaScriptRuntime.RangeError"] = "Must remain an Exception for CLR throw/catch mechanics.",
-            ["JavaScriptRuntime.ReferenceError"] = "Must remain an Exception for CLR throw/catch mechanics.",
-            ["JavaScriptRuntime.RegExp"] = "Planned low-risk internal-slot wrapper migration.",
-            ["JavaScriptRuntime.Set"] = "Planned collection and iterator family migration.",
-            ["JavaScriptRuntime.SharedArrayBuffer"] = "Planned shared-base migration with typed-array views.",
-            ["JavaScriptRuntime.SuppressedError"] = "Must remain an Exception for CLR throw/catch mechanics.",
-            ["JavaScriptRuntime.Symbol"] = "Primitive representation with dedicated identity semantics.",
-            ["JavaScriptRuntime.SyntaxError"] = "Must remain an Exception for CLR throw/catch mechanics.",
-            ["JavaScriptRuntime.TypeError"] = "Must remain an Exception for CLR throw/catch mechanics.",
-            ["JavaScriptRuntime.Uint16Array"] = "Planned TypedArrayBase exotic-object migration.",
-            ["JavaScriptRuntime.Uint32Array"] = "Planned TypedArrayBase exotic-object migration.",
-            ["JavaScriptRuntime.Uint8Array"] = "Planned TypedArrayBase exotic-object migration.",
-            ["JavaScriptRuntime.Uint8ClampedArray"] = "Planned TypedArrayBase exotic-object migration.",
-            ["JavaScriptRuntime.URIError"] = "Must remain an Exception for CLR throw/catch mechanics.",
-            ["JavaScriptRuntime.WeakMap"] = "Planned collection migration.",
-            ["JavaScriptRuntime.WeakRef"] = "Planned internal-slot wrapper migration.",
-            ["JavaScriptRuntime.WeakSet"] = "Planned collection migration."
-        };
-
     [Fact]
     public void BooleanWrappers_UseInlineJsObjectStorage()
     {
@@ -103,26 +64,6 @@ public sealed class BooleanObjectRepresentationTests
 
         Assert.Equal($"runtime-one{Environment.NewLine}", mutationResult.Output);
         Assert.Equal($"true{Environment.NewLine}", readResult.Output);
-    }
-
-    [Fact]
-    public void NonStaticIntrinsicRepresentations_AreDocumentedByJsObjectMigrationInventory()
-    {
-        var nonJsObjectIntrinsics = typeof(JsObject).Assembly
-            .GetTypes()
-            .Where(type => type.GetCustomAttributes(typeof(IntrinsicObjectAttribute), inherit: false).Length > 0)
-            .Where(type => !type.IsAbstract || !type.IsSealed)
-            .Where(type => !typeof(JsObject).IsAssignableFrom(type))
-            .Select(type => type.FullName)
-            .OrderBy(name => name)
-            .ToArray();
-
-        Assert.Equal(
-            DocumentedNonJsObjectIntrinsicExceptions.Keys.OrderBy(name => name),
-            nonJsObjectIntrinsics);
-        Assert.All(
-            DocumentedNonJsObjectIntrinsicExceptions.Values,
-            reason => Assert.False(string.IsNullOrWhiteSpace(reason)));
     }
 
     private static long MeasureJsObjectAllocations(int count, object prototype)

--- a/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
+++ b/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
@@ -1,0 +1,139 @@
+using JavaScriptRuntime;
+
+namespace Jroc.Tests;
+
+public sealed class JsObjectRepresentationInventoryTests
+{
+    private const string BufferViewReason = "Requires a dedicated buffer/view migration that preserves indexed and backing-store semantics.";
+    private const string ErrorReason = "Must remain an Exception for CLR throw/catch mechanics pending the dedicated Error design.";
+    private const string HostIteratorReason = "Preserves host iterator adaptation and needs a focused iterator migration.";
+    private const string IteratorReason = "Must migrate with its owning iterator family to preserve exhaustion and mutation behavior.";
+    private const string TypedArrayReason = "Requires the dedicated TypedArrayBase exotic-object migration.";
+
+    private static readonly string[] ExplicitJavaScriptVisibleTypeNames =
+    [
+        "JavaScriptRuntime.ArgumentsObject",
+        "JavaScriptRuntime.IteratorResultObject`1",
+        "JavaScriptRuntime.IteratorResultObject",
+        "JavaScriptRuntime.PromiseWithResolvers",
+        "JavaScriptRuntime.IntlNumberFormat",
+        "JavaScriptRuntime.IntlSegmenter",
+        "JavaScriptRuntime.TypedArrayBase",
+        "JavaScriptRuntime.Node.Buffer",
+        "JavaScriptRuntime.Node.URL",
+        "JavaScriptRuntime.Node.URLSearchParams",
+        "JavaScriptRuntime.AbortController",
+        "JavaScriptRuntime.AbortSignal"
+    ];
+
+    private static readonly IReadOnlyDictionary<string, string> DocumentedNonJsObjectRepresentations =
+        new Dictionary<string, string>
+        {
+            ["JavaScriptRuntime.AbortController"] = "Requires the AbortController and AbortSignal migration.",
+            ["JavaScriptRuntime.AbortSignal"] = "Requires the AbortController and AbortSignal migration.",
+            ["JavaScriptRuntime.AggregateError"] = ErrorReason,
+            ["JavaScriptRuntime.ArgumentsObject"] = "Requires the dedicated ArgumentsObject exotic-object migration.",
+            ["JavaScriptRuntime.ArgumentsObject+ValueIterator"] = "Must migrate with ArgumentsObject to preserve mapped-parameter behavior.",
+            ["JavaScriptRuntime.Array+ArrayIterator"] = IteratorReason,
+            ["JavaScriptRuntime.ArrayBuffer"] = BufferViewReason,
+            ["JavaScriptRuntime.AsyncGeneratorObject"] = "Requires the dedicated AsyncGeneratorObject migration.",
+            ["JavaScriptRuntime.DataView"] = BufferViewReason,
+            ["JavaScriptRuntime.Date"] = "Requires the Date wrapper migration.",
+            ["JavaScriptRuntime.Error"] = ErrorReason,
+            ["JavaScriptRuntime.EvalError"] = ErrorReason,
+            ["JavaScriptRuntime.FinalizationRegistry"] = "Requires a dedicated internal-slot wrapper migration.",
+            ["JavaScriptRuntime.Float32Array"] = TypedArrayReason,
+            ["JavaScriptRuntime.Float64Array"] = TypedArrayReason,
+            ["JavaScriptRuntime.ForInIterator"] = IteratorReason,
+            ["JavaScriptRuntime.GeneratorObject"] = "Requires the dedicated GeneratorObject migration.",
+            ["JavaScriptRuntime.Int16Array"] = TypedArrayReason,
+            ["JavaScriptRuntime.Int32Array"] = TypedArrayReason,
+            ["JavaScriptRuntime.Int8Array"] = TypedArrayReason,
+            ["JavaScriptRuntime.IntlNumberFormat"] = "Needs a dedicated Intl wrapper migration once its constructor surface expands.",
+            ["JavaScriptRuntime.IntlSegmenter"] = "Needs a dedicated Intl wrapper migration once its constructor surface expands.",
+            ["JavaScriptRuntime.Iterator+DropIteratorHelper"] = IteratorReason,
+            ["JavaScriptRuntime.Iterator+FilterIteratorHelper"] = IteratorReason,
+            ["JavaScriptRuntime.Iterator+FlatMapIteratorHelper"] = IteratorReason,
+            ["JavaScriptRuntime.Iterator+GeneratorIteratorAdapter"] = HostIteratorReason,
+            ["JavaScriptRuntime.Iterator+IteratorHelperBase"] = IteratorReason,
+            ["JavaScriptRuntime.Iterator+IteratorLikeWrapper"] = HostIteratorReason,
+            ["JavaScriptRuntime.Iterator+MapIteratorHelper"] = IteratorReason,
+            ["JavaScriptRuntime.Iterator+TakeIteratorHelper"] = IteratorReason,
+            ["JavaScriptRuntime.IteratorResultObject"] = "Requires the dedicated iterator result and helper migration.",
+            ["JavaScriptRuntime.IteratorResultObject`1"] = "Requires the dedicated iterator result and helper migration.",
+            ["JavaScriptRuntime.Map"] = "Requires the Map and MapIterator migration.",
+            ["JavaScriptRuntime.Map+MapIterator"] = "Must migrate with Map to preserve collection mutation behavior.",
+            ["JavaScriptRuntime.Node.Buffer"] = BufferViewReason,
+            ["JavaScriptRuntime.Node.Events+EventEmitterAsyncOnIterator"] = HostIteratorReason,
+            ["JavaScriptRuntime.Node.TimersPromises+TimersPromisesIntervalIterator"] = HostIteratorReason,
+            ["JavaScriptRuntime.Node.URL"] = "Requires the URL and URLSearchParams migration.",
+            ["JavaScriptRuntime.Node.URLSearchParams"] = "Requires the URL and URLSearchParams migration.",
+            ["JavaScriptRuntime.Node.URLSearchParams+SearchParamsIterator"] = "Must migrate with URLSearchParams.",
+            ["JavaScriptRuntime.Object"] = "Static intrinsic holder; constructed ordinary objects use JsObject.",
+            ["JavaScriptRuntime.ObjectRuntime+ArrayIterator"] = HostIteratorReason,
+            ["JavaScriptRuntime.ObjectRuntime+AsyncDynamicIterator"] = HostIteratorReason,
+            ["JavaScriptRuntime.ObjectRuntime+AsyncFromSyncIterator"] = HostIteratorReason,
+            ["JavaScriptRuntime.ObjectRuntime+DynamicIterator"] = HostIteratorReason,
+            ["JavaScriptRuntime.ObjectRuntime+EnumerableIterator"] = HostIteratorReason,
+            ["JavaScriptRuntime.ObjectRuntime+StringIterator"] = HostIteratorReason,
+            ["JavaScriptRuntime.Promise"] = "Requires the Promise migration.",
+            ["JavaScriptRuntime.PromiseWithResolvers"] = "Must migrate with Promise to preserve resolver identity.",
+            ["JavaScriptRuntime.Proxy"] = "Requires the dedicated Proxy design to preserve traps and invariants.",
+            ["JavaScriptRuntime.RangeError"] = ErrorReason,
+            ["JavaScriptRuntime.ReferenceError"] = ErrorReason,
+            ["JavaScriptRuntime.RegExp"] = "Requires the RegExp wrapper migration.",
+            ["JavaScriptRuntime.Set"] = "Requires the Set and SetIterator migration.",
+            ["JavaScriptRuntime.Set+SetIterator"] = "Must migrate with Set to preserve collection mutation behavior.",
+            ["JavaScriptRuntime.SharedArrayBuffer"] = BufferViewReason,
+            ["JavaScriptRuntime.String+PublicStringIterator"] = IteratorReason,
+            ["JavaScriptRuntime.SuppressedError"] = ErrorReason,
+            ["JavaScriptRuntime.Symbol"] = "Primitive representation with dedicated identity semantics.",
+            ["JavaScriptRuntime.SyntaxError"] = ErrorReason,
+            ["JavaScriptRuntime.TypedArrayBase"] = TypedArrayReason,
+            ["JavaScriptRuntime.TypedArrayIterator"] = TypedArrayReason,
+            ["JavaScriptRuntime.TypeError"] = ErrorReason,
+            ["JavaScriptRuntime.Uint16Array"] = TypedArrayReason,
+            ["JavaScriptRuntime.Uint32Array"] = TypedArrayReason,
+            ["JavaScriptRuntime.Uint8Array"] = TypedArrayReason,
+            ["JavaScriptRuntime.Uint8ClampedArray"] = TypedArrayReason,
+            ["JavaScriptRuntime.URIError"] = ErrorReason,
+            ["JavaScriptRuntime.WeakMap"] = "Requires the WeakMap and WeakSet migration.",
+            ["JavaScriptRuntime.WeakRef"] = "Requires a dedicated internal-slot wrapper migration.",
+            ["JavaScriptRuntime.WeakSet"] = "Requires the WeakMap and WeakSet migration."
+        };
+
+    [Fact]
+    public void JavaScriptVisibleRepresentations_AreMigratedOrDocumented()
+    {
+        var runtimeAssembly = typeof(JsObject).Assembly;
+        var explicitTypes = ExplicitJavaScriptVisibleTypeNames
+            .Select(typeName => runtimeAssembly.GetType(typeName)
+                ?? throw new InvalidOperationException($"Missing JavaScript-visible type: {typeName}"))
+            .ToArray();
+
+        var candidates = runtimeAssembly
+            .GetTypes()
+            .Where(IsIntrinsicInstanceType)
+            .Concat(explicitTypes)
+            .Concat(runtimeAssembly.GetTypes().Where(type => type.IsClass && IsIteratorRepresentation(type)))
+            .Distinct()
+            .Where(type => !typeof(JsObject).IsAssignableFrom(type))
+            .Select(type => type.FullName!)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(DocumentedNonJsObjectRepresentations.Keys.OrderBy(name => name), candidates);
+        Assert.All(
+            DocumentedNonJsObjectRepresentations.Values,
+            reason => Assert.False(string.IsNullOrWhiteSpace(reason)));
+    }
+
+    private static bool IsIntrinsicInstanceType(Type type)
+        => type.GetCustomAttributes(typeof(IntrinsicObjectAttribute), inherit: false).Length > 0
+            && (!type.IsAbstract || !type.IsSealed);
+
+    private static bool IsIteratorRepresentation(Type type)
+        => typeof(IJavaScriptIterator).IsAssignableFrom(type)
+            || typeof(IJavaScriptAsyncIterator).IsAssignableFrom(type)
+            || typeof(IIteratorResult).IsAssignableFrom(type);
+}


### PR DESCRIPTION
## Summary

Closes #1847.

- Expand the #1580 inventory from intrinsic wrappers to all current JavaScript-visible instance representations.
- Automatically discover intrinsic, iterator, async-iterator, and iterator-result representations.
- Require each remaining non-`JsObject` representation to have an exact architectural reason, while preserving the focused explicit catalog for wrappers without a shared marker.

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --filter 'FullyQualifiedName~JsObjectRepresentationInventoryTests|FullyQualifiedName~BooleanObjectRepresentationTests|FullyQualifiedName~RuntimeIntrinsicIsolationTests' --no-restore`
- `dotnet build src/Cli/Jroc.csproj -c Release --no-restore`
