### PR TITLE
runtime: migrate Date wrappers to JsObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   Add a JavaScript-visible representation inventory guard, Boolean allocation
   coverage, and a prototype-storage benchmark.
 
+- runtime: continue #1580's incremental built-in representation migration by
+  moving Date wrappers to `JsObject` inline property/prototype storage.
+
 - runtime/test262: expose SharedArrayBuffer as a first-class global constructor
   with standard constructor/prototype metadata and receiver-checked
   `byteLength`, `maxByteLength`, and `growable` accessors. Activates twenty

--- a/src/JavaScriptRuntime/Date.cs
+++ b/src/JavaScriptRuntime/Date.cs
@@ -16,7 +16,7 @@ namespace JavaScriptRuntime
     /// Note: This is intentionally small and not spec-complete.
     /// </summary>
     [IntrinsicObject("Date", IntrinsicCallKind.DateToString)]
-    public class Date
+    public class Date : JsObject
     {
         /// <summary>Realm-owned <c>Date.prototype</c> (issue #1824).</summary>
         internal static object Prototype
@@ -92,19 +92,19 @@ namespace JavaScriptRuntime
         public Date()
         {
             _msSinceEpoch = NowMs();
-            PrototypeChain.SetPrototype(this, GlobalThis.DatePrototypeValue);
+            PrototypeChain.InitializePrototype(this, GlobalThis.DatePrototypeValue);
         }
 
         public Date(object? arg)
         {
             _msSinceEpoch = CoerceToMs(arg);
-            PrototypeChain.SetPrototype(this, GlobalThis.DatePrototypeValue);
+            PrototypeChain.InitializePrototype(this, GlobalThis.DatePrototypeValue);
         }
 
         private Date(double msSinceEpoch, bool _)
         {
             _msSinceEpoch = msSinceEpoch;
-            PrototypeChain.SetPrototype(this, GlobalThis.DatePrototypeValue);
+            PrototypeChain.InitializePrototype(this, GlobalThis.DatePrototypeValue);
         }
 
         public static object Construct()

--- a/tests/Jroc.Tests/DateObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/DateObjectRepresentationTests.cs
@@ -1,0 +1,116 @@
+using JavaScriptRuntime;
+using JsObjectConstructor = JavaScriptRuntime.Object;
+
+namespace Jroc.Tests;
+
+public sealed class DateObjectRepresentationTests
+{
+    [Fact]
+    public void DateWrappers_UseInlineJsObjectStorage()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        using var scope = RuntimeExecutionContext.GetOrCreate(services).Enter();
+        var date = new JavaScriptRuntime.Date(0d);
+        var customPrototype = new JsObject();
+
+        Assert.IsAssignableFrom<JsObject>(date);
+        Assert.Same(GlobalThis.DatePrototypeValue, JsObjectConstructor.getPrototypeOf(date));
+        Assert.Equal(0d, date.getTime());
+
+        ObjectRuntime.SetProperty(date, "custom", 42d);
+        Assert.Equal(42d, ObjectRuntime.GetProperty(date, "custom"));
+        Assert.True(JsObjectConstructor.hasOwn(date, "custom"));
+
+        JsObjectConstructor.setPrototypeOf(date, customPrototype);
+        Assert.Same(customPrototype, JsObjectConstructor.getPrototypeOf(date));
+
+        JsObjectConstructor.freeze(date);
+        Assert.True(JsObjectConstructor.isFrozen(date));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(date, "custom", 0d));
+    }
+
+    [Fact]
+    public void DateWrappers_DoNotAllocatePrototypeFallbackStorage()
+    {
+        const int objectCount = 10_000;
+        var prototype = new JsObject();
+
+        _ = MeasureJsObjectAllocations(1, prototype);
+        _ = MeasureDateWrapperAllocations(1);
+
+        var jsObjectAllocations = MeasureJsObjectAllocations(objectCount, prototype);
+        var dateWrapperAllocations = MeasureDateWrapperAllocations(objectCount);
+
+        Assert.InRange(dateWrapperAllocations, 0, jsObjectAllocations + objectCount * 32L);
+    }
+
+    [Fact]
+    public void DatePrototypeDescriptorMutations_AreIsolatedAcrossRuntimes()
+    {
+        var mutationResult = InMemoryTestCompiler.CompileAndExecute(
+            "mutate-date-prototype-descriptors",
+            "Date.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+        var readResult = InMemoryTestCompiler.CompileAndExecute(
+            "read-date-prototype-descriptors",
+            "Date.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+
+        Assert.Equal($"runtime-one{Environment.NewLine}", mutationResult.Output);
+        Assert.Equal($"true{Environment.NewLine}", readResult.Output);
+    }
+
+    private static long MeasureJsObjectAllocations(int count, object prototype)
+    {
+        var objects = new JsObject[count];
+        var before = GC.GetAllocatedBytesForCurrentThread();
+
+        for (var index = 0; index < objects.Length; index++)
+        {
+            var value = new JsObject();
+            PrototypeChain.InitializePrototype(value, prototype);
+            objects[index] = value;
+        }
+
+        GC.KeepAlive(objects);
+        return GC.GetAllocatedBytesForCurrentThread() - before;
+    }
+
+    private static long MeasureDateWrapperAllocations(int count)
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        using var scope = RuntimeExecutionContext.GetOrCreate(services).Enter();
+        _ = new JavaScriptRuntime.Date(0d);
+        var wrappers = new JavaScriptRuntime.Date[count];
+        var before = GC.GetAllocatedBytesForCurrentThread();
+
+        for (var index = 0; index < wrappers.Length; index++)
+        {
+            wrappers[index] = new JavaScriptRuntime.Date(0d);
+        }
+
+        GC.KeepAlive(wrappers);
+        return GC.GetAllocatedBytesForCurrentThread() - before;
+    }
+
+    private static (string Script, string? SourcePath) GetDescriptorIsolationScript(string testName)
+        => testName switch
+        {
+            "mutate-date-prototype-descriptors" => ("""
+                Object.defineProperty(Date.prototype, "descriptorLeakCheck", {
+                  value: "runtime-one",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+                console.log(new Date(0).descriptorLeakCheck);
+                """, null),
+            "read-date-prototype-descriptors" => ("""
+                console.log(Object.getOwnPropertyDescriptor(
+                  Date.prototype,
+                  "descriptorLeakCheck"
+                ) === undefined);
+                """, null),
+            _ => throw new ArgumentOutOfRangeException(nameof(testName), testName, "Unknown descriptor isolation script.")
+        };
+}

--- a/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
+++ b/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
@@ -38,7 +38,6 @@ public sealed class JsObjectRepresentationInventoryTests
             ["JavaScriptRuntime.ArrayBuffer"] = BufferViewReason,
             ["JavaScriptRuntime.AsyncGeneratorObject"] = "Requires the dedicated AsyncGeneratorObject migration.",
             ["JavaScriptRuntime.DataView"] = BufferViewReason,
-            ["JavaScriptRuntime.Date"] = "Requires the Date wrapper migration.",
             ["JavaScriptRuntime.Error"] = ErrorReason,
             ["JavaScriptRuntime.EvalError"] = ErrorReason,
             ["JavaScriptRuntime.FinalizationRegistry"] = "Requires a dedicated internal-slot wrapper migration.",

--- a/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
+++ b/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
@@ -24,6 +24,10 @@ public class PrototypeStorageBenchmarks
     public JavaScriptRuntime.Boolean ConstructBooleanWrapper()
         => new(true);
 
+    [Benchmark(Description = "Date wrapper with initialized prototype")]
+    public JavaScriptRuntime.Date ConstructDateWrapper()
+        => new(0d);
+
     [Benchmark(Description = "Ordinary object with initialized prototype")]
     public JavaScriptRuntime.JsObject ConstructOrdinaryObject()
     {


### PR DESCRIPTION
## Summary

Closes #1848.

- Migrate Date wrappers to `JsObject` inline property/prototype storage.
- Preserve Date’s timestamp as a private internal slot and initialize its realm-owned prototype without observable mutation notifications.
- Add direct property/prototype, allocation, and realm-isolation coverage, then remove Date from the #1580 representation inventory.

## Validation

- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --filter 'FullyQualifiedName~built_ins.Date' --no-restore`
- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --filter 'FullyQualifiedName~DateObjectRepresentationTests|FullyQualifiedName~RuntimeIntrinsicIsolationTests|FullyQualifiedName~PrototypeChainTests' --no-restore`
- `dotnet build src/Cli/Jroc.csproj -c Release --no-restore`
- `dotnet build tests/performance/Benchmarks/Benchmarks.csproj --no-restore`
