### PR TITLE
runtime: migrate RegExp wrappers to JsObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - runtime: continue #1580's incremental built-in representation migration by
   moving Date wrappers to `JsObject` inline property/prototype storage.
 
+- runtime: continue #1580's incremental built-in representation migration by
+  moving RegExp wrappers to `JsObject` inline property/prototype storage.
+
 - runtime/test262: expose SharedArrayBuffer as a first-class global constructor
   with standard constructor/prototype metadata and receiver-checked
   `byteLength`, `maxByteLength`, and `growable` accessors. Activates twenty

--- a/src/JavaScriptRuntime/RegExp.cs
+++ b/src/JavaScriptRuntime/RegExp.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 namespace JavaScriptRuntime
 {
     [IntrinsicObject("RegExp", IntrinsicCallKind.ConstructorLike)]
-    public sealed class RegExp
+    public sealed class RegExp : JsObject, IExoticJsObject
     {
         [Flags]
         private enum WellKnownSymbolFastPathFlags
@@ -388,7 +388,19 @@ namespace JavaScriptRuntime
             DefineSymbolMethod(prototype, ReplaceSymbolPropertyKey, ReplaceSymbolDelegate);
             DefineSymbolMethod(prototype, SearchSymbolPropertyKey, SearchSymbolDelegate);
             DefineSymbolMethod(prototype, SplitSymbolPropertyKey, SplitSymbolDelegate);
+            DefinePrototypeMethod(prototype, "exec", (Func<object[], object?[]?, object?>)PrototypeExec);
+            DefinePrototypeMethod(prototype, "test", (Func<object[], object?[]?, object?>)PrototypeTest);
             DefinePrototypeMethod(prototype, "toString", (Func<object[], object?[]?, object?>)PrototypeToString);
+            DefinePrototypeGetter(prototype, "dotAll", static regExp => regExp.dotAll);
+            DefinePrototypeGetter(prototype, "flags", static regExp => regExp.flags);
+            DefinePrototypeGetter(prototype, "global", static regExp => regExp.global);
+            DefinePrototypeGetter(prototype, "hasIndices", static regExp => regExp.hasIndices);
+            DefinePrototypeGetter(prototype, "ignoreCase", static regExp => regExp.ignoreCase);
+            DefinePrototypeGetter(prototype, "multiline", static regExp => regExp.multiline);
+            DefinePrototypeGetter(prototype, "source", static regExp => regExp.source);
+            DefinePrototypeGetter(prototype, "sticky", static regExp => regExp.sticky);
+            DefinePrototypeGetter(prototype, "unicode", static regExp => regExp.unicode);
+            DefinePrototypeGetter(prototype, "unicodeSets", static regExp => regExp.unicodeSets);
         }
 
         private static void DefinePrototypeMethod(object target, string key, object? value)
@@ -403,15 +415,149 @@ namespace JavaScriptRuntime
             });
         }
 
-        private static object? PrototypeToString(object[] scopes, object?[]? args)
+        private static void DefinePrototypeGetter(
+            JsObject prototype,
+            string key,
+            Func<RegExp, object?> getter)
+        {
+            PropertyDescriptorStore.DefineOrUpdate(prototype, key, new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Accessor,
+                Enumerable = false,
+                Configurable = true,
+                Get = (Func<object[], object?[]?, object?>)((_, _) => getter(GetRegExpReceiver(key)))
+            });
+        }
+
+        private static RegExp GetRegExpReceiver(string propertyName)
         {
             if (RuntimeServices.GetCurrentThis() is not RegExp regExp)
             {
-                throw new TypeError("RegExp.prototype.toString called on incompatible receiver");
+                throw new TypeError($"RegExp.prototype.{propertyName} called on incompatible receiver");
             }
 
-            return regExp.toString();
+            return regExp;
         }
+
+        private static object? PrototypeExec(object[] scopes, object?[]? args)
+            => GetRegExpReceiver("exec").exec(args != null && args.Length > 0 ? args[0] : null);
+
+        private static object? PrototypeTest(object[] scopes, object?[]? args)
+            => GetRegExpReceiver("test").test(args != null && args.Length > 0 ? args[0] : null);
+
+        private static object? PrototypeToString(object[] scopes, object?[]? args)
+        {
+            return GetRegExpReceiver("toString").toString();
+        }
+
+        internal override PropertyDescriptorLookup GetOwnPropertyDescriptor(
+            string key,
+            out JsPropertyDescriptor descriptor)
+        {
+            if (string.Equals(key, nameof(lastIndex), StringComparison.Ordinal))
+            {
+                var lookup = PropertyDescriptorStore.GetOwnLookupCore(this, key, out descriptor);
+                if (lookup == PropertyDescriptorLookup.Deleted)
+                {
+                    return lookup;
+                }
+
+                if (lookup == PropertyDescriptorLookup.Found)
+                {
+                    descriptor = PropertyDescriptorStore.CloneDescriptor(descriptor);
+                    descriptor.Value = lastIndex;
+                    return lookup;
+                }
+
+                descriptor = new JsPropertyDescriptor
+                {
+                    Kind = JsPropertyDescriptorKind.Data,
+                    Value = lastIndex,
+                    Writable = true,
+                    Enumerable = false,
+                    Configurable = false
+                };
+                return PropertyDescriptorLookup.Found;
+            }
+
+            return base.GetOwnPropertyDescriptor(key, out descriptor);
+        }
+
+        internal override bool TryGetOwnPropertyValue(string key, out object? value)
+        {
+            if (string.Equals(key, nameof(lastIndex), StringComparison.Ordinal))
+            {
+                value = lastIndex;
+                return true;
+            }
+
+            return base.TryGetOwnPropertyValue(key, out value);
+        }
+
+        internal override bool TryGetInvariantOwnPropertyValue(string key, out object? value)
+        {
+            if (string.Equals(key, nameof(lastIndex), StringComparison.Ordinal))
+            {
+                value = lastIndex;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        internal override bool HasOwnPropertyValue(string key)
+            => string.Equals(key, nameof(lastIndex), StringComparison.Ordinal)
+                || base.HasOwnPropertyValue(key);
+
+        internal override bool SetOwnPropertyValue(string key, object? value)
+        {
+            if (string.Equals(key, nameof(lastIndex), StringComparison.Ordinal))
+            {
+                if (PropertyDescriptorStore.GetOwnLookupCore(this, key, out var descriptor) == PropertyDescriptorLookup.Found
+                    && !descriptor.Writable)
+                {
+                    return false;
+                }
+
+                lastIndex = TypeUtilities.ToNumber(value);
+                return true;
+            }
+
+            return base.SetOwnPropertyValue(key, value);
+        }
+
+        internal override bool DefineOwnProperty(string key, JsPropertyDescriptor descriptor)
+        {
+            if (string.Equals(key, nameof(lastIndex), StringComparison.Ordinal))
+            {
+                if (descriptor.Kind != JsPropertyDescriptorKind.Data)
+                {
+                    return false;
+                }
+
+                lastIndex = TypeUtilities.ToNumber(descriptor.Value);
+            }
+
+            return base.DefineOwnProperty(key, descriptor);
+        }
+
+        internal override IEnumerable<string> GetOwnPropertyKeys()
+        {
+            yield return nameof(lastIndex);
+
+            foreach (var key in base.GetOwnPropertyKeys())
+            {
+                if (!string.Equals(key, nameof(lastIndex), StringComparison.Ordinal))
+                {
+                    yield return key;
+                }
+            }
+        }
+
+        internal override bool DeleteOwnProperty(string key)
+            => !string.Equals(key, nameof(lastIndex), StringComparison.Ordinal)
+                && base.DeleteOwnProperty(key);
 
         private bool HasIntrinsicWellKnownSymbolFastPath(WellKnownSymbolFastPathFlags flag)
         {
@@ -807,7 +953,7 @@ namespace JavaScriptRuntime
 
         private void InitializeIntrinsicSurface()
         {
-            PrototypeChain.SetPrototype(this, Prototype);
+            PrototypeChain.InitializePrototype(this, Prototype);
         }
 
         private static void DefineSymbolMethod(object target, string symbolPropertyKey, Delegate method)

--- a/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
+++ b/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
@@ -80,7 +80,6 @@ public sealed class JsObjectRepresentationInventoryTests
             ["JavaScriptRuntime.Proxy"] = "Requires the dedicated Proxy design to preserve traps and invariants.",
             ["JavaScriptRuntime.RangeError"] = ErrorReason,
             ["JavaScriptRuntime.ReferenceError"] = ErrorReason,
-            ["JavaScriptRuntime.RegExp"] = "Requires the RegExp wrapper migration.",
             ["JavaScriptRuntime.Set"] = "Requires the Set and SetIterator migration.",
             ["JavaScriptRuntime.Set+SetIterator"] = "Must migrate with Set to preserve collection mutation behavior.",
             ["JavaScriptRuntime.SharedArrayBuffer"] = BufferViewReason,

--- a/tests/Jroc.Tests/RegExpObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/RegExpObjectRepresentationTests.cs
@@ -1,0 +1,79 @@
+using JavaScriptRuntime;
+using JsObjectConstructor = JavaScriptRuntime.Object;
+
+namespace Jroc.Tests;
+
+public sealed class RegExpObjectRepresentationTests
+{
+    [Fact]
+    public void RegExpWrappers_UseInlineJsObjectStorage()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        using var scope = RuntimeExecutionContext.GetOrCreate(services).Enter();
+        var regExp = new RegExp("a", "g");
+        var customPrototype = new JsObject();
+
+        Assert.IsAssignableFrom<JsObject>(regExp);
+        Assert.Same(RegExp.Prototype, JsObjectConstructor.getPrototypeOf(regExp));
+        Assert.Equal("a", ObjectRuntime.GetProperty(regExp, "source"));
+        Assert.Equal("g", ObjectRuntime.GetProperty(regExp, "flags"));
+
+        var lastIndex = Assert.IsAssignableFrom<JsObject>(
+            JsObjectConstructor.getOwnPropertyDescriptor(regExp, "lastIndex"));
+        Assert.False((bool)ObjectRuntime.GetProperty(lastIndex, "enumerable")!);
+        Assert.False((bool)ObjectRuntime.GetProperty(lastIndex, "configurable")!);
+        Assert.True((bool)ObjectRuntime.GetProperty(lastIndex, "writable")!);
+
+        ObjectRuntime.SetProperty(regExp, "custom", 42d);
+        Assert.Equal(42d, ObjectRuntime.GetProperty(regExp, "custom"));
+        Assert.True(JsObjectConstructor.hasOwn(regExp, "custom"));
+
+        ObjectRuntime.SetProperty(regExp, "lastIndex", 2d);
+        Assert.Equal(2d, regExp.lastIndex);
+
+        JsObjectConstructor.setPrototypeOf(regExp, customPrototype);
+        Assert.Same(customPrototype, JsObjectConstructor.getPrototypeOf(regExp));
+
+        JsObjectConstructor.freeze(regExp);
+        Assert.True(JsObjectConstructor.isFrozen(regExp));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(regExp, "custom", 0d));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(regExp, "lastIndex", 0d));
+    }
+
+    [Fact]
+    public void RegExpPrototypeDescriptorMutations_AreIsolatedAcrossRuntimes()
+    {
+        var mutationResult = InMemoryTestCompiler.CompileAndExecute(
+            "mutate-regexp-prototype-descriptors",
+            "RegExp.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+        var readResult = InMemoryTestCompiler.CompileAndExecute(
+            "read-regexp-prototype-descriptors",
+            "RegExp.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+
+        Assert.Equal($"runtime-one{Environment.NewLine}", mutationResult.Output);
+        Assert.Equal($"true{Environment.NewLine}", readResult.Output);
+    }
+
+    private static (string Script, string? SourcePath) GetDescriptorIsolationScript(string testName)
+        => testName switch
+        {
+            "mutate-regexp-prototype-descriptors" => ("""
+                Object.defineProperty(RegExp.prototype, "descriptorLeakCheck", {
+                  value: "runtime-one",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+                console.log(new RegExp("a").descriptorLeakCheck);
+                """, null),
+            "read-regexp-prototype-descriptors" => ("""
+                console.log(Object.getOwnPropertyDescriptor(
+                  RegExp.prototype,
+                  "descriptorLeakCheck"
+                ) === undefined);
+                """, null),
+            _ => throw new ArgumentOutOfRangeException(nameof(testName), testName, "Unknown descriptor isolation script.")
+        };
+}

--- a/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
+++ b/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
@@ -28,6 +28,10 @@ public class PrototypeStorageBenchmarks
     public JavaScriptRuntime.Date ConstructDateWrapper()
         => new(0d);
 
+    [Benchmark(Description = "RegExp wrapper with initialized prototype")]
+    public JavaScriptRuntime.RegExp ConstructRegExpWrapper()
+        => new("a", "g");
+
     [Benchmark(Description = "Ordinary object with initialized prototype")]
     public JavaScriptRuntime.JsObject ConstructOrdinaryObject()
     {


### PR DESCRIPTION
## Summary

- migrate `RegExp` instances to `JsObject` inline property/prototype storage
- preserve native `lastIndex` own-property semantics and move RegExp methods/accessors onto the realm-owned prototype
- add representation, integrity, realm-isolation, inventory, and construction-benchmark coverage

Closes #1849

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --filter 'FullyQualifiedName~RegExpObjectRepresentationTests|FullyQualifiedName~IntrinsicCallables.ExecutionTests|FullyQualifiedName~String.ExecutionTests|FullyQualifiedName~JsObjectRepresentationInventoryTests'`
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --no-restore --filter 'FullyQualifiedName~Jroc.Test262.Tests.built_ins.RegExp'`
- `dotnet build -c Release src/Cli/Jroc.csproj --no-restore`
- `dotnet build tests/performance/Benchmarks/Benchmarks.csproj --no-restore`
