### PR TITLE
runtime: migrate Map wrappers to JsObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - runtime: continue #1580's incremental built-in representation migration by
   moving RegExp wrappers to `JsObject` inline property/prototype storage.
 
+- runtime: continue #1580's incremental built-in representation migration by
+  moving Map and MapIterator wrappers to `JsObject` inline property/prototype storage.
+
 - runtime/test262: expose SharedArrayBuffer as a first-class global constructor
   with standard constructor/prototype metadata and receiver-checked
   `byteLength`, `maxByteLength`, and `growable` accessors. Activates twenty

--- a/src/JavaScriptRuntime/Map.cs
+++ b/src/JavaScriptRuntime/Map.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace JavaScriptRuntime
 {
     [IntrinsicObject("Map")]
-    public sealed class Map : IEnumerable<object[]>
+    public sealed class Map : JsObject, IEnumerable<object[]>
     {
         private static readonly Func<object[], object?[]?, object?> _prototypeEntriesValue = PrototypeEntries;
         /// <summary>Realm-owned <c>Map Iterator prototype</c> intrinsic (issue #1824).</summary>
@@ -195,7 +195,7 @@ namespace JavaScriptRuntime
 
         private void InitializeIntrinsicSurface()
         {
-            PrototypeChain.SetPrototype(this, Prototype);
+            PrototypeChain.InitializePrototype(this, Prototype);
         }
 
         public Map()
@@ -463,7 +463,7 @@ namespace JavaScriptRuntime
         }
 
         // Iterator support - returns entries as [key, value] arrays
-        public IEnumerator<object[]> GetEnumerator() => _entries.GetEnumerator();
+        public new IEnumerator<object[]> GetEnumerator() => _entries.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => _entries.GetEnumerator();
 
         // JavaScript Map.prototype.keys()
@@ -507,7 +507,7 @@ namespace JavaScriptRuntime
             Entries
         }
 
-        private sealed class MapIterator : IJavaScriptIterator
+        private sealed class MapIterator : JsObject, IJavaScriptIterator
         {
             private readonly Map _map;
             private readonly MapIteratorKind _kind;
@@ -518,7 +518,7 @@ namespace JavaScriptRuntime
             {
                 _map = map;
                 _kind = kind;
-                PrototypeChain.SetPrototype(this, IteratorPrototype);
+                PrototypeChain.InitializePrototype(this, IteratorPrototype);
             }
 
             public bool HasReturn => true;

--- a/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
+++ b/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
@@ -60,8 +60,6 @@ public sealed class JsObjectRepresentationInventoryTests
             ["JavaScriptRuntime.Iterator+TakeIteratorHelper"] = IteratorReason,
             ["JavaScriptRuntime.IteratorResultObject"] = "Requires the dedicated iterator result and helper migration.",
             ["JavaScriptRuntime.IteratorResultObject`1"] = "Requires the dedicated iterator result and helper migration.",
-            ["JavaScriptRuntime.Map"] = "Requires the Map and MapIterator migration.",
-            ["JavaScriptRuntime.Map+MapIterator"] = "Must migrate with Map to preserve collection mutation behavior.",
             ["JavaScriptRuntime.Node.Buffer"] = BufferViewReason,
             ["JavaScriptRuntime.Node.Events+EventEmitterAsyncOnIterator"] = HostIteratorReason,
             ["JavaScriptRuntime.Node.TimersPromises+TimersPromisesIntervalIterator"] = HostIteratorReason,

--- a/tests/Jroc.Tests/MapObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/MapObjectRepresentationTests.cs
@@ -1,0 +1,80 @@
+using JavaScriptRuntime;
+using JsObjectConstructor = JavaScriptRuntime.Object;
+
+namespace Jroc.Tests;
+
+public sealed class MapObjectRepresentationTests
+{
+    [Fact]
+    public void MapAndIterators_UseInlineJsObjectStorage()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        using var scope = RuntimeExecutionContext.GetOrCreate(services).Enter();
+        var map = new JavaScriptRuntime.Map();
+        var iterator = map.entries();
+        var customPrototype = new JsObject();
+
+        Assert.IsAssignableFrom<JsObject>(map);
+        Assert.IsAssignableFrom<JsObject>(iterator);
+        Assert.Same(JavaScriptRuntime.Map.Prototype, JsObjectConstructor.getPrototypeOf(map));
+        Assert.Same(JavaScriptRuntime.Map.IteratorPrototype, JsObjectConstructor.getPrototypeOf(iterator));
+
+        ObjectRuntime.SetProperty(map, "custom", 42d);
+        Assert.Equal(42d, ObjectRuntime.GetProperty(map, "custom"));
+        Assert.True(JsObjectConstructor.hasOwn(map, "custom"));
+
+        ObjectRuntime.SetProperty(iterator, "custom", "iterator");
+        Assert.Equal("iterator", ObjectRuntime.GetProperty(iterator, "custom"));
+        Assert.True(JsObjectConstructor.hasOwn(iterator, "custom"));
+
+        JsObjectConstructor.setPrototypeOf(map, customPrototype);
+        Assert.Same(customPrototype, JsObjectConstructor.getPrototypeOf(map));
+
+        JsObjectConstructor.freeze(map);
+        Assert.True(JsObjectConstructor.isFrozen(map));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(map, "custom", 0d));
+        Assert.Same(map, map.set("key", "value"));
+        Assert.Equal("value", map.get("key"));
+
+        JsObjectConstructor.freeze(iterator);
+        Assert.True(JsObjectConstructor.isFrozen(iterator));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(iterator, "custom", "changed"));
+    }
+
+    [Fact]
+    public void MapPrototypeDescriptorMutations_AreIsolatedAcrossRuntimes()
+    {
+        var mutationResult = InMemoryTestCompiler.CompileAndExecute(
+            "mutate-map-prototype-descriptors",
+            "Map.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+        var readResult = InMemoryTestCompiler.CompileAndExecute(
+            "read-map-prototype-descriptors",
+            "Map.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+
+        Assert.Equal($"runtime-one{Environment.NewLine}", mutationResult.Output);
+        Assert.Equal($"true{Environment.NewLine}", readResult.Output);
+    }
+
+    private static (string Script, string? SourcePath) GetDescriptorIsolationScript(string testName)
+        => testName switch
+        {
+            "mutate-map-prototype-descriptors" => ("""
+                Object.defineProperty(Map.prototype, "descriptorLeakCheck", {
+                  value: "runtime-one",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+                console.log(new Map().descriptorLeakCheck);
+                """, null),
+            "read-map-prototype-descriptors" => ("""
+                console.log(Object.getOwnPropertyDescriptor(
+                  Map.prototype,
+                  "descriptorLeakCheck"
+                ) === undefined);
+                """, null),
+            _ => throw new ArgumentOutOfRangeException(nameof(testName), testName, "Unknown descriptor isolation script.")
+        };
+}

--- a/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
+++ b/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
@@ -32,6 +32,10 @@ public class PrototypeStorageBenchmarks
     public JavaScriptRuntime.RegExp ConstructRegExpWrapper()
         => new("a", "g");
 
+    [Benchmark(Description = "Map with initialized prototype")]
+    public JavaScriptRuntime.Map ConstructMap()
+        => new();
+
     [Benchmark(Description = "Ordinary object with initialized prototype")]
     public JavaScriptRuntime.JsObject ConstructOrdinaryObject()
     {


### PR DESCRIPTION
## Summary

- migrate `Map` and MapIterator instances to `JsObject` inline property/prototype storage
- preserve collection internal slots and Map mutation behavior after integrity operations
- add Map/iterator representation, integrity, realm-isolation, inventory, and construction-benchmark coverage

Closes #1850

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --filter 'FullyQualifiedName~Jroc.Tests.Map|FullyQualifiedName~MapObjectRepresentationTests|FullyQualifiedName~JsObjectRepresentationInventoryTests'`
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --no-restore --filter 'FullyQualifiedName~Jroc.Test262.Tests.built_ins.Map'`
- `dotnet build -c Release src/Cli/Jroc.csproj --no-restore`
- `dotnet build tests/performance/Benchmarks/Benchmarks.csproj --no-restore`
