### PR TITLE
runtime: migrate Set wrappers to JsObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - runtime: continue #1580's incremental built-in representation migration by
   moving Map and MapIterator wrappers to `JsObject` inline property/prototype storage.
 
+- runtime: continue #1580's incremental built-in representation migration by
+  moving Set and SetIterator wrappers to `JsObject` inline property/prototype storage.
+
 - runtime/test262: expose SharedArrayBuffer as a first-class global constructor
   with standard constructor/prototype metadata and receiver-checked
   `byteLength`, `maxByteLength`, and `growable` accessors. Activates twenty

--- a/src/JavaScriptRuntime/Set.cs
+++ b/src/JavaScriptRuntime/Set.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace JavaScriptRuntime
 {
     [IntrinsicObject("Set")]
-    public sealed class Set : IEnumerable<object>
+    public sealed class Set : JsObject, IEnumerable<object>
     {
         private static readonly Func<object[], object?[]?, object?> _prototypeValuesValue = PrototypeValues;
         /// <summary>Realm-owned <c>Set Iterator prototype</c> intrinsic (issue #1824).</summary>
@@ -207,7 +207,7 @@ namespace JavaScriptRuntime
 
         private void InitializeIntrinsicSurface()
         {
-            PrototypeChain.SetPrototype(this, Prototype);
+            PrototypeChain.InitializePrototype(this, Prototype);
         }
 
         public Set()
@@ -651,7 +651,7 @@ namespace JavaScriptRuntime
             return result;
         }
 
-        public IEnumerator<object> GetEnumerator() => _items.GetEnumerator();
+        public new IEnumerator<object> GetEnumerator() => _items.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
         private enum SetIteratorKind
         {
@@ -659,7 +659,7 @@ namespace JavaScriptRuntime
             Entries
         }
 
-        private sealed class SetIterator : IJavaScriptIterator
+        private sealed class SetIterator : JsObject, IJavaScriptIterator
         {
             private readonly Set _set;
             private readonly SetIteratorKind _kind;
@@ -670,7 +670,7 @@ namespace JavaScriptRuntime
             {
                 _set = set;
                 _kind = kind;
-                PrototypeChain.SetPrototype(this, IteratorPrototype);
+                PrototypeChain.InitializePrototype(this, IteratorPrototype);
             }
 
             public bool HasReturn => true;

--- a/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
+++ b/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
@@ -78,8 +78,6 @@ public sealed class JsObjectRepresentationInventoryTests
             ["JavaScriptRuntime.Proxy"] = "Requires the dedicated Proxy design to preserve traps and invariants.",
             ["JavaScriptRuntime.RangeError"] = ErrorReason,
             ["JavaScriptRuntime.ReferenceError"] = ErrorReason,
-            ["JavaScriptRuntime.Set"] = "Requires the Set and SetIterator migration.",
-            ["JavaScriptRuntime.Set+SetIterator"] = "Must migrate with Set to preserve collection mutation behavior.",
             ["JavaScriptRuntime.SharedArrayBuffer"] = BufferViewReason,
             ["JavaScriptRuntime.String+PublicStringIterator"] = IteratorReason,
             ["JavaScriptRuntime.SuppressedError"] = ErrorReason,

--- a/tests/Jroc.Tests/SetObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/SetObjectRepresentationTests.cs
@@ -1,0 +1,80 @@
+using JavaScriptRuntime;
+using JsObjectConstructor = JavaScriptRuntime.Object;
+
+namespace Jroc.Tests;
+
+public sealed class SetObjectRepresentationTests
+{
+    [Fact]
+    public void SetAndIterators_UseInlineJsObjectStorage()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        using var scope = RuntimeExecutionContext.GetOrCreate(services).Enter();
+        var set = new JavaScriptRuntime.Set();
+        var iterator = set.values();
+        var customPrototype = new JsObject();
+
+        Assert.IsAssignableFrom<JsObject>(set);
+        Assert.IsAssignableFrom<JsObject>(iterator);
+        Assert.Same(JavaScriptRuntime.Set.Prototype, JsObjectConstructor.getPrototypeOf(set));
+        Assert.Same(JavaScriptRuntime.Set.IteratorPrototype, JsObjectConstructor.getPrototypeOf(iterator));
+
+        ObjectRuntime.SetProperty(set, "custom", 42d);
+        Assert.Equal(42d, ObjectRuntime.GetProperty(set, "custom"));
+        Assert.True(JsObjectConstructor.hasOwn(set, "custom"));
+
+        ObjectRuntime.SetProperty(iterator, "custom", "iterator");
+        Assert.Equal("iterator", ObjectRuntime.GetProperty(iterator, "custom"));
+        Assert.True(JsObjectConstructor.hasOwn(iterator, "custom"));
+
+        JsObjectConstructor.setPrototypeOf(set, customPrototype);
+        Assert.Same(customPrototype, JsObjectConstructor.getPrototypeOf(set));
+
+        JsObjectConstructor.freeze(set);
+        Assert.True(JsObjectConstructor.isFrozen(set));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(set, "custom", 0d));
+        Assert.Same(set, set.add("value"));
+        Assert.True((bool)set.has("value"));
+
+        JsObjectConstructor.freeze(iterator);
+        Assert.True(JsObjectConstructor.isFrozen(iterator));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(iterator, "custom", "changed"));
+    }
+
+    [Fact]
+    public void SetPrototypeDescriptorMutations_AreIsolatedAcrossRuntimes()
+    {
+        var mutationResult = InMemoryTestCompiler.CompileAndExecute(
+            "mutate-set-prototype-descriptors",
+            "Set.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+        var readResult = InMemoryTestCompiler.CompileAndExecute(
+            "read-set-prototype-descriptors",
+            "Set.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+
+        Assert.Equal($"runtime-one{Environment.NewLine}", mutationResult.Output);
+        Assert.Equal($"true{Environment.NewLine}", readResult.Output);
+    }
+
+    private static (string Script, string? SourcePath) GetDescriptorIsolationScript(string testName)
+        => testName switch
+        {
+            "mutate-set-prototype-descriptors" => ("""
+                Object.defineProperty(Set.prototype, "descriptorLeakCheck", {
+                  value: "runtime-one",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+                console.log(new Set().descriptorLeakCheck);
+                """, null),
+            "read-set-prototype-descriptors" => ("""
+                console.log(Object.getOwnPropertyDescriptor(
+                  Set.prototype,
+                  "descriptorLeakCheck"
+                ) === undefined);
+                """, null),
+            _ => throw new ArgumentOutOfRangeException(nameof(testName), testName, "Unknown descriptor isolation script.")
+        };
+}

--- a/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
+++ b/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
@@ -36,6 +36,10 @@ public class PrototypeStorageBenchmarks
     public JavaScriptRuntime.Map ConstructMap()
         => new();
 
+    [Benchmark(Description = "Set with initialized prototype")]
+    public JavaScriptRuntime.Set ConstructSet()
+        => new();
+
     [Benchmark(Description = "Ordinary object with initialized prototype")]
     public JavaScriptRuntime.JsObject ConstructOrdinaryObject()
     {


### PR DESCRIPTION
## Summary

- migrate `Set` and SetIterator instances to `JsObject` inline property/prototype storage
- preserve collection internal slots and Set mutation behavior after integrity operations
- add Set/iterator representation, integrity, realm-isolation, inventory, and construction-benchmark coverage

Closes #1851

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --filter 'FullyQualifiedName~Jroc.Tests.Set|FullyQualifiedName~SetObjectRepresentationTests|FullyQualifiedName~JsObjectRepresentationInventoryTests'`
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --no-restore --filter 'FullyQualifiedName~Jroc.Test262.Tests.built_ins.Set'`
- `dotnet build -c Release src/Cli/Jroc.csproj --no-restore`
- `dotnet build tests/performance/Benchmarks/Benchmarks.csproj --no-restore`
