### PR TITLE
runtime: migrate weak collections to JsObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 - runtime: continue #1580's incremental built-in representation migration by
   moving Set and SetIterator wrappers to `JsObject` inline property/prototype storage.
 
+- runtime: continue #1580's incremental built-in representation migration by
+  moving WeakMap and WeakSet wrappers to `JsObject` inline property/prototype storage.
+
 - runtime/test262: expose SharedArrayBuffer as a first-class global constructor
   with standard constructor/prototype metadata and receiver-checked
   `byteLength`, `maxByteLength`, and `growable` accessors. Activates twenty

--- a/src/JavaScriptRuntime/WeakMap.cs
+++ b/src/JavaScriptRuntime/WeakMap.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 namespace JavaScriptRuntime
 {
     [IntrinsicObject("WeakMap")]
-    public sealed class WeakMap
+    public sealed class WeakMap : JsObject
     {
         /// <summary>Realm-owned <c>WeakMap.prototype</c> intrinsic (issue #1824).</summary>
         internal static object Prototype
@@ -17,7 +17,7 @@ namespace JavaScriptRuntime
 
         public WeakMap()
         {
-            PrototypeChain.SetPrototype(this, Prototype);
+            PrototypeChain.InitializePrototype(this, Prototype);
         }
 
         public WeakMap(object? iterable)

--- a/src/JavaScriptRuntime/WeakSet.cs
+++ b/src/JavaScriptRuntime/WeakSet.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 namespace JavaScriptRuntime
 {
     [IntrinsicObject("WeakSet")]
-    public sealed class WeakSet
+    public sealed class WeakSet : JsObject
     {
         /// <summary>Realm-owned <c>WeakSet.prototype</c> intrinsic (issue #1824).</summary>
         internal static object Prototype
@@ -19,7 +19,7 @@ namespace JavaScriptRuntime
 
         public WeakSet()
         {
-            PrototypeChain.SetPrototype(this, Prototype);
+            PrototypeChain.InitializePrototype(this, Prototype);
         }
 
         public WeakSet(object? iterable)

--- a/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
+++ b/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
@@ -91,9 +91,7 @@ public sealed class JsObjectRepresentationInventoryTests
             ["JavaScriptRuntime.Uint8Array"] = TypedArrayReason,
             ["JavaScriptRuntime.Uint8ClampedArray"] = TypedArrayReason,
             ["JavaScriptRuntime.URIError"] = ErrorReason,
-            ["JavaScriptRuntime.WeakMap"] = "Requires the WeakMap and WeakSet migration.",
             ["JavaScriptRuntime.WeakRef"] = "Requires a dedicated internal-slot wrapper migration.",
-            ["JavaScriptRuntime.WeakSet"] = "Requires the WeakMap and WeakSet migration."
         };
 
     [Fact]

--- a/tests/Jroc.Tests/WeakCollectionObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/WeakCollectionObjectRepresentationTests.cs
@@ -1,0 +1,91 @@
+using JavaScriptRuntime;
+using JsObjectConstructor = JavaScriptRuntime.Object;
+
+namespace Jroc.Tests;
+
+public sealed class WeakCollectionObjectRepresentationTests
+{
+    [Fact]
+    public void WeakCollectionWrappers_UseInlineJsObjectStorage()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        using var scope = RuntimeExecutionContext.GetOrCreate(services).Enter();
+        var weakMap = new JavaScriptRuntime.WeakMap();
+        var weakSet = new JavaScriptRuntime.WeakSet();
+        var key = new JsObject();
+        var customPrototype = new JsObject();
+
+        Assert.IsAssignableFrom<JsObject>(weakMap);
+        Assert.IsAssignableFrom<JsObject>(weakSet);
+        Assert.Same(JavaScriptRuntime.WeakMap.Prototype, JsObjectConstructor.getPrototypeOf(weakMap));
+        Assert.Same(JavaScriptRuntime.WeakSet.Prototype, JsObjectConstructor.getPrototypeOf(weakSet));
+
+        ObjectRuntime.SetProperty(weakMap, "custom", 42d);
+        ObjectRuntime.SetProperty(weakSet, "custom", "weak-set");
+        Assert.Equal(42d, ObjectRuntime.GetProperty(weakMap, "custom"));
+        Assert.Equal("weak-set", ObjectRuntime.GetProperty(weakSet, "custom"));
+
+        JsObjectConstructor.setPrototypeOf(weakMap, customPrototype);
+        Assert.Same(customPrototype, JsObjectConstructor.getPrototypeOf(weakMap));
+
+        JsObjectConstructor.freeze(weakMap);
+        JsObjectConstructor.freeze(weakSet);
+        Assert.True(JsObjectConstructor.isFrozen(weakMap));
+        Assert.True(JsObjectConstructor.isFrozen(weakSet));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(weakMap, "custom", 0d));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(weakSet, "custom", "changed"));
+
+        Assert.Same(weakMap, weakMap.set(key, "value"));
+        Assert.Equal("value", weakMap.get(key));
+        Assert.Same(weakSet, weakSet.add(key));
+        Assert.True(weakSet.has(key));
+    }
+
+    [Fact]
+    public void WeakCollectionPrototypeDescriptorMutations_AreIsolatedAcrossRuntimes()
+    {
+        var mutationResult = InMemoryTestCompiler.CompileAndExecute(
+            "mutate-weak-collection-prototype-descriptors",
+            "WeakCollection.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+        var readResult = InMemoryTestCompiler.CompileAndExecute(
+            "read-weak-collection-prototype-descriptors",
+            "WeakCollection.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+
+        Assert.Equal($"weak-map{Environment.NewLine}weak-set{Environment.NewLine}", mutationResult.Output);
+        Assert.Equal($"true{Environment.NewLine}true{Environment.NewLine}", readResult.Output);
+    }
+
+    private static (string Script, string? SourcePath) GetDescriptorIsolationScript(string testName)
+        => testName switch
+        {
+            "mutate-weak-collection-prototype-descriptors" => ("""
+                Object.defineProperty(WeakMap.prototype, "descriptorLeakCheck", {
+                  value: "weak-map",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+                Object.defineProperty(WeakSet.prototype, "descriptorLeakCheck", {
+                  value: "weak-set",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+                console.log(new WeakMap().descriptorLeakCheck);
+                console.log(new WeakSet().descriptorLeakCheck);
+                """, null),
+            "read-weak-collection-prototype-descriptors" => ("""
+                console.log(Object.getOwnPropertyDescriptor(
+                  WeakMap.prototype,
+                  "descriptorLeakCheck"
+                ) === undefined);
+                console.log(Object.getOwnPropertyDescriptor(
+                  WeakSet.prototype,
+                  "descriptorLeakCheck"
+                ) === undefined);
+                """, null),
+            _ => throw new ArgumentOutOfRangeException(nameof(testName), testName, "Unknown descriptor isolation script.")
+        };
+}

--- a/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
+++ b/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
@@ -40,6 +40,14 @@ public class PrototypeStorageBenchmarks
     public JavaScriptRuntime.Set ConstructSet()
         => new();
 
+    [Benchmark(Description = "WeakMap with initialized prototype")]
+    public JavaScriptRuntime.WeakMap ConstructWeakMap()
+        => new();
+
+    [Benchmark(Description = "WeakSet with initialized prototype")]
+    public JavaScriptRuntime.WeakSet ConstructWeakSet()
+        => new();
+
     [Benchmark(Description = "Ordinary object with initialized prototype")]
     public JavaScriptRuntime.JsObject ConstructOrdinaryObject()
     {


### PR DESCRIPTION
## Summary

- migrate `WeakMap` and `WeakSet` instances to `JsObject` inline property/prototype storage
- preserve weak-table internal slots and collection mutation behavior after integrity operations
- add representation, integrity, realm-isolation, inventory, and construction-benchmark coverage

Closes #1852

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --filter 'FullyQualifiedName~Jroc.Tests.WeakMap|FullyQualifiedName~Jroc.Tests.WeakSet|FullyQualifiedName~WeakCollectionObjectRepresentationTests|FullyQualifiedName~JsObjectRepresentationInventoryTests'`
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --no-restore --filter 'FullyQualifiedName~Jroc.Test262.Tests.built_ins.WeakMap|FullyQualifiedName~Jroc.Test262.Tests.built_ins.WeakSet'`
- `dotnet build -c Release src/Cli/Jroc.csproj --no-restore`
- `dotnet build tests/performance/Benchmarks/Benchmarks.csproj --no-restore`
