### PR TITLE
runtime: move realm-created value caches into realm ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime: move tagged-template objects, materialized class constructor values,
+  and lazy class-method metadata containing captured scopes into a disposable
+  `RuntimeRealmValueCacheState` (issue #1825). Repeated execution preserves
+  required identity within one realm, while identical call sites and generated
+  types in another realm receive distinct JavaScript values. Realm disposal
+  clears the caches so captured scopes and collectible generated assemblies are
+  not retained.
+
 - runtime: begin #1580's incremental built-in representation migration by
   moving Boolean wrappers to `JsObject` inline property/prototype storage.
   Add a JavaScript-visible representation inventory guard, Boolean allocation

--- a/docs/runtime/RuntimeOwnership.md
+++ b/docs/runtime/RuntimeOwnership.md
@@ -8,6 +8,7 @@ RuntimeAgentCluster
       -> RuntimeRealm
           -> RuntimeIntrinsics
           -> RuntimeModuleState
+          -> RuntimeRealmValueCacheState
           -> ServiceContainer
           -> RuntimeExecutionContext (while entered)
 ```
@@ -33,6 +34,9 @@ RuntimeAgentCluster
 - `RuntimeModuleState` owns the realm's CommonJS and ESM graph, including
   module instances, live binding cells, namespace identities, `import.meta`,
   module-scoped require delegates, and the compiled module assembly.
+- `RuntimeRealmValueCacheState` owns tagged-template objects, materialized class
+  constructor objects, and lazy class-method metadata that captures scopes.
+  See [Realm-created value caches](RuntimeRealmValueCaches.md).
 
 The child keeps a reference to its parent so services can receive the correct
 owner through constructor injection. Parents keep their children only while
@@ -46,10 +50,8 @@ retain the same realm owner. After realm disposal, its service container and
 any child scopes reject further use.
 
 The factory currently creates an isolated cluster, agent, realm, and service
-container for each `RuntimeServices.BuildServiceProvider()` call. Template
-objects, materialized class constructors, and captured-scope constructor caches
-still use their prior implementations; subsequent migration issues (tracked by
-#1805, in particular #1825) move that state under these owners.
+container for each `RuntimeServices.BuildServiceProvider()` call. Each realm
+owns its intrinsic graph, module state, and realm-created value caches.
 
 ## Intrinsic ownership
 
@@ -120,6 +122,8 @@ change observable semantics.
 - A realm may reference its agent, intrinsics graph, and service container.
 - A realm owns one module state object; no mutable module graph is
   process-wide.
+- A realm owns its template, materialized class constructor, and captured-scope
+  metadata caches; process-wide caches contain immutable CLR metadata only.
 - An entered execution context is the only ambient pointer to a realm and
   agent; thread identity is not an ownership boundary.
 - Realm services may receive any of the three owners through constructor

--- a/docs/runtime/RuntimeRealmValueCaches.md
+++ b/docs/runtime/RuntimeRealmValueCaches.md
@@ -1,0 +1,24 @@
+# Realm-created value caches
+
+`RuntimeRealmValueCacheState` owns caches whose entries contain JavaScript
+values or captured scope objects:
+
+- tagged-template arrays, keyed by compiled call-site ID;
+- materialized class constructor objects, keyed by generated CLR type, formal
+  parameter count, and captured scope identities;
+- lazy class-method metadata that includes the captured scopes needed when a
+  method function is first materialized.
+
+Generated CLR types, method handles, and other immutable reflection metadata
+may remain process-wide. A JavaScript object, callback wrapper, mutable
+descriptor, realm prototype, or captured scope must not be stored in a
+process-wide cache.
+
+Repeated evaluation in one realm preserves the identities required by
+ECMA-262. Another realm executing the same generated code gets independent
+template and constructor identities, even when it uses the same call-site ID,
+generated type, and scope objects.
+
+The cache state is created and disposed with `RuntimeRealm`. Disposal clears
+all three caches so cached JavaScript values, captured scopes, and collectible
+generated assemblies can be reclaimed.

--- a/src/JavaScriptRuntime/DependencyInjection/ServiceContainer.cs
+++ b/src/JavaScriptRuntime/DependencyInjection/ServiceContainer.cs
@@ -41,6 +41,7 @@ public class ServiceContainer
             _singletons[typeof(RuntimeAgent)] = realm.Agent;
             _singletons[typeof(RuntimeRealm)] = realm;
             _singletons[typeof(Modules.RuntimeModuleState)] = realm.ModuleState;
+            _singletons[typeof(RuntimeRealmValueCacheState)] = realm.ValueCaches;
         }
     }
 
@@ -303,6 +304,7 @@ public class ServiceContainer
         _singletons[typeof(RuntimeAgent)] = _owningRealm.Agent;
         _singletons[typeof(RuntimeRealm)] = _owningRealm;
         _singletons[typeof(Modules.RuntimeModuleState)] = _owningRealm.ModuleState;
+        _singletons[typeof(RuntimeRealmValueCacheState)] = _owningRealm.ValueCaches;
     }
 
     private void ThrowIfOwningRealmDisposed()
@@ -319,7 +321,8 @@ public class ServiceContainer
             && (serviceType == typeof(RuntimeAgentCluster)
                 || serviceType == typeof(RuntimeAgent)
                 || serviceType == typeof(RuntimeRealm)
-                || serviceType == typeof(Modules.RuntimeModuleState)))
+                || serviceType == typeof(Modules.RuntimeModuleState)
+                || serviceType == typeof(RuntimeRealmValueCacheState)))
         {
             throw new InvalidOperationException(
                 $"Runtime ownership service '{serviceType.Name}' cannot be replaced or removed.");

--- a/src/JavaScriptRuntime/RuntimeOwnership.cs
+++ b/src/JavaScriptRuntime/RuntimeOwnership.cs
@@ -195,6 +195,7 @@ internal sealed class RuntimeRealm : IDisposable
     {
         Agent = agent;
         ModuleState = new Modules.RuntimeModuleState();
+        ValueCaches = new RuntimeRealmValueCacheState();
         Intrinsics = new RuntimeIntrinsics();
         Services = new ServiceContainer();
         Services.AttachOwningRealm(this);
@@ -203,6 +204,8 @@ internal sealed class RuntimeRealm : IDisposable
     internal RuntimeAgent Agent { get; }
 
     internal Modules.RuntimeModuleState ModuleState { get; }
+
+    internal RuntimeRealmValueCacheState ValueCaches { get; }
 
     /// <summary>
     /// The realm's well-known intrinsic object graph (ECMA-262 Realm Record
@@ -236,6 +239,7 @@ internal sealed class RuntimeRealm : IDisposable
 
             _state = RuntimeOwnershipState.Disposing;
             ModuleState.Dispose();
+            ValueCaches.Dispose();
             Intrinsics.Dispose();
             DisposalOrder = Agent.Cluster.NextDisposalOrder();
             _state = RuntimeOwnershipState.Disposed;

--- a/src/JavaScriptRuntime/RuntimeRealmValueCacheState.cs
+++ b/src/JavaScriptRuntime/RuntimeRealmValueCacheState.cs
@@ -1,0 +1,27 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+
+namespace JavaScriptRuntime;
+
+/// <summary>
+/// Realm-owned caches whose entries contain JavaScript values or captured scopes.
+/// </summary>
+internal sealed class RuntimeRealmValueCacheState : IDisposable
+{
+    internal ConcurrentDictionary<string, Array> TemplateObjects { get; } =
+        new(StringComparer.Ordinal);
+
+    internal ConcurrentDictionary<
+        RuntimeServices.ClassConstructorCacheKey,
+        JsClassConstructorObject> MaterializedClassConstructors { get; } = new();
+
+    internal ConditionalWeakTable<Type, RuntimeServices.LazyClassMetadataSlot>
+        LazyClassMetadata { get; } = new();
+
+    public void Dispose()
+    {
+        TemplateObjects.Clear();
+        MaterializedClassConstructors.Clear();
+        LazyClassMetadata.Clear();
+    }
+}

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -22,8 +22,10 @@ public class RuntimeServices
     [ThreadStatic] private static Stack<GeneratedFunctionDirectCallState>? _generatedFunctionDirectCallStack;
     [ThreadStatic] private static Stack<object?>? _constructorNewTargetStack;
     [ThreadStatic] private static Stack<object?>? _derivedConstructorThisStack;
-    private static readonly ConditionalWeakTable<Type, LazyClassMetadataSlot> _lazyClassMetadata = new();
-    private static readonly ConcurrentDictionary<ClassConstructorCacheKey, JsClassConstructorObject> _classConstructorValues = new();
+    private static ConditionalWeakTable<Type, LazyClassMetadataSlot> _lazyClassMetadata
+        => GetCurrentRealmValueCaches().LazyClassMetadata;
+    private static ConcurrentDictionary<ClassConstructorCacheKey, JsClassConstructorObject> _classConstructorValues
+        => GetCurrentRealmValueCaches().MaterializedClassConstructors;
 
     // ABI compatibility: when a callee doesn't need scopes, we still pass a 1-element scopes array.
     // NOTE: Consumers must treat scopes arrays as immutable.
@@ -50,12 +52,12 @@ public class RuntimeServices
         public object? Value = TemporalDeadZoneSentinel;
     }
 
-    private sealed class LazyClassMetadataSlot
+    internal sealed class LazyClassMetadataSlot
     {
         public readonly List<LazyClassMethodDataProperty> Methods = new();
     }
 
-    private sealed class ClassConstructorCacheKey : IEquatable<ClassConstructorCacheKey>
+    internal sealed class ClassConstructorCacheKey : IEquatable<ClassConstructorCacheKey>
     {
         private readonly Type _type;
         private readonly int _formalParameterCount;
@@ -106,7 +108,7 @@ public class RuntimeServices
         public override int GetHashCode() => _hashCode;
     }
 
-    private sealed record LazyClassMethodDataProperty(
+    internal sealed record LazyClassMethodDataProperty(
         string PropertyKey,
         string ClrMethodName,
         double Length,
@@ -784,7 +786,8 @@ public class RuntimeServices
         if ((target is JsObject jsObject && jsObject.IsInlineLazyClassMethodDeleted(propName))
             || PropertyDescriptorStore.IsDeleted(target, propName)
             || !TryResolveLazyClassMethodTarget(target, out var ownerType, out var ownerValue, out var isStatic)
-            || !_lazyClassMetadata.TryGetValue(ownerType, out var slot))
+            || !TryGetCurrentRealmValueCaches(out var valueCaches)
+            || !valueCaches.LazyClassMetadata.TryGetValue(ownerType, out var slot))
         {
             return false;
         }
@@ -821,7 +824,8 @@ public class RuntimeServices
     internal static IEnumerable<string> GetLazyClassMethodOwnKeys(object target)
     {
         if (!TryResolveLazyClassMethodTarget(target, out var ownerType, out _, out var isStatic)
-            || !_lazyClassMetadata.TryGetValue(ownerType, out var slot))
+            || !TryGetCurrentRealmValueCaches(out var valueCaches)
+            || !valueCaches.LazyClassMetadata.TryGetValue(ownerType, out var slot))
         {
             return System.Array.Empty<string>();
         }
@@ -842,7 +846,8 @@ public class RuntimeServices
     internal static void MarkLazyClassMethodPropertyDeleted(object target, string propName)
     {
         if (!TryResolveLazyClassMethodTarget(target, out var ownerType, out _, out var isStatic)
-            || !_lazyClassMetadata.TryGetValue(ownerType, out var slot))
+            || !TryGetCurrentRealmValueCaches(out var valueCaches)
+            || !valueCaches.LazyClassMetadata.TryGetValue(ownerType, out var slot))
         {
             return;
         }
@@ -1269,7 +1274,8 @@ public class RuntimeServices
         }
 
         if (!TryResolveLazyClassMethodTarget(target, out var ownerType, out _, out var isStatic)
-            || !_lazyClassMetadata.TryGetValue(ownerType, out var slot))
+            || !TryGetCurrentRealmValueCaches(out var valueCaches)
+            || !valueCaches.LazyClassMetadata.TryGetValue(ownerType, out var slot))
         {
             return false;
         }
@@ -1730,8 +1736,21 @@ public class RuntimeServices
     /// Cache for template objects indexed by call site ID.
     /// Per ECMA-262 spec, each unique call site should return the same template object identity.
     /// </summary>
-    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, Array> _templateObjectCache = new();
+    private static ConcurrentDictionary<string, Array> _templateObjectCache
+        => GetCurrentRealmValueCaches().TemplateObjects;
     private const int MaxTemplateObjectCacheEntries = 4096;
+
+    private static RuntimeRealmValueCacheState GetCurrentRealmValueCaches()
+        => RuntimeExecutionContext.CurrentOrOverride?.Realm.ValueCaches
+            ?? throw new InvalidOperationException(
+                "Realm-created value caches require an active JavaScript runtime.");
+
+    private static bool TryGetCurrentRealmValueCaches(
+        out RuntimeRealmValueCacheState valueCaches)
+    {
+        valueCaches = RuntimeExecutionContext.CurrentOrOverride?.Realm.ValueCaches!;
+        return valueCaches != null;
+    }
 
     /// <summary>
     /// Creates a template object for tagged template expressions.

--- a/tests/Jroc.Tests/RuntimeOwnershipTests.cs
+++ b/tests/Jroc.Tests/RuntimeOwnershipTests.cs
@@ -18,6 +18,9 @@ public sealed class RuntimeOwnershipTests
         Assert.Same(agent, realm.Services.Resolve<RuntimeAgent>());
         Assert.Same(cluster, realm.Services.Resolve<RuntimeAgentCluster>());
         Assert.Same(realm.ModuleState, realm.Services.Resolve<RuntimeModuleState>());
+        Assert.Same(
+            realm.ValueCaches,
+            realm.Services.Resolve<RuntimeRealmValueCacheState>());
         Assert.Equal(1, agent.RealmCount);
         Assert.Equal(1, cluster.AgentCount);
 
@@ -154,6 +157,8 @@ public sealed class RuntimeOwnershipTests
             () => services.Remove<RuntimeRealm>());
         Assert.Throws<InvalidOperationException>(
             () => services.Replace(new RuntimeModuleState()));
+        Assert.Throws<InvalidOperationException>(
+            () => services.Replace(new RuntimeRealmValueCacheState()));
 
         services.Clear();
 
@@ -161,6 +166,9 @@ public sealed class RuntimeOwnershipTests
         Assert.Same(realm.Agent, services.Resolve<RuntimeAgent>());
         Assert.Same(realm.Agent.Cluster, services.Resolve<RuntimeAgentCluster>());
         Assert.Same(realm.ModuleState, services.Resolve<RuntimeModuleState>());
+        Assert.Same(
+            realm.ValueCaches,
+            services.Resolve<RuntimeRealmValueCacheState>());
 
         realm.Agent.Cluster.Dispose();
     }

--- a/tests/Jroc.Tests/RuntimeRealmValueCacheTests.cs
+++ b/tests/Jroc.Tests/RuntimeRealmValueCacheTests.cs
@@ -1,0 +1,247 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using JavaScriptRuntime;
+using AssemblyName = System.Reflection.AssemblyName;
+
+namespace Jroc.Tests;
+
+public sealed class RuntimeRealmValueCacheTests
+{
+    [Fact]
+    public void TemplateObjectsPreserveIdentityWithinARealmButNotAcrossRealms()
+    {
+        var first = CreateContext();
+        var second = CreateContext();
+        object firstTemplate;
+        object secondTemplate;
+
+        using (first.EnterAsRoot())
+        {
+            firstTemplate = RuntimeServices.CreateTemplateObject(
+                "module.js:1:1",
+                ["cooked"],
+                ["raw"]);
+            Assert.Same(
+                firstTemplate,
+                RuntimeServices.CreateTemplateObject(
+                    "module.js:1:1",
+                    ["ignored"],
+                    ["ignored"]));
+        }
+
+        using (second.EnterAsRoot())
+        {
+            secondTemplate = RuntimeServices.CreateTemplateObject(
+                "module.js:1:1",
+                ["cooked"],
+                ["raw"]);
+        }
+
+        Assert.NotSame(firstTemplate, secondTemplate);
+        first.Realm.Agent.Cluster.Dispose();
+        second.Realm.Agent.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void ClassConstructorsPreserveIdentityWithinARealmButNotAcrossRealms()
+    {
+        var first = CreateContext();
+        var second = CreateContext();
+        var sharedScopes = new object[] { new JsObject() };
+        JsClassConstructorObject firstConstructor;
+        JsClassConstructorObject secondConstructor;
+
+        using (first.EnterAsRoot())
+        {
+            firstConstructor = MaterializeConstructor(sharedScopes);
+            Assert.Same(firstConstructor, MaterializeConstructor(sharedScopes));
+        }
+
+        using (second.EnterAsRoot())
+        {
+            secondConstructor = MaterializeConstructor(sharedScopes);
+        }
+
+        Assert.NotSame(firstConstructor, secondConstructor);
+        first.Realm.Agent.Cluster.Dispose();
+        second.Realm.Agent.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void LazyClassMetadataKeepsCapturedScopesIsolatedAcrossRealms()
+    {
+        var first = CreateContext();
+        var second = CreateContext();
+        var firstScope = new JsObject();
+        var secondScope = new JsObject();
+
+        using (first.EnterAsRoot())
+        {
+            RegisterLazyMethod(typeof(TestClassOwner), firstScope);
+        }
+
+        using (second.EnterAsRoot())
+        {
+            RegisterLazyMethod(typeof(TestClassOwner), secondScope);
+        }
+
+        Assert.True(
+            first.Realm.ValueCaches.LazyClassMetadata.TryGetValue(
+                typeof(TestClassOwner),
+                out var firstSlot));
+        Assert.True(
+            second.Realm.ValueCaches.LazyClassMetadata.TryGetValue(
+                typeof(TestClassOwner),
+                out var secondSlot));
+        Assert.NotSame(firstSlot, secondSlot);
+        Assert.Same(firstScope, Assert.Single(firstSlot.Methods).Scopes[0]);
+        Assert.Same(secondScope, Assert.Single(secondSlot.Methods).Scopes[0]);
+
+        first.Realm.Agent.Cluster.Dispose();
+        second.Realm.Agent.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void RealmDisposalClearsTemplatesConstructorsAndCapturedScopes()
+    {
+        var context = CreateContext();
+        var capturedScope = new JsObject();
+
+        using (context.EnterAsRoot())
+        {
+            _ = RuntimeServices.CreateTemplateObject("site", ["value"], ["value"]);
+            _ = MaterializeConstructor([capturedScope]);
+            _ = RuntimeServices.RegisterLazyClassMethodDataProperty(
+                typeof(TestClassOwner),
+                "method",
+                nameof(TestClassOwner.Method),
+                0d,
+                "method",
+                false,
+                false,
+                false,
+                false,
+                new object[] { capturedScope });
+        }
+
+        Assert.Single(context.Realm.ValueCaches.TemplateObjects);
+        Assert.Single(context.Realm.ValueCaches.MaterializedClassConstructors);
+        Assert.True(
+            context.Realm.ValueCaches.LazyClassMetadata.TryGetValue(
+                typeof(TestClassOwner),
+                out _));
+
+        context.Realm.Dispose();
+
+        Assert.Empty(context.Realm.ValueCaches.TemplateObjects);
+        Assert.Empty(context.Realm.ValueCaches.MaterializedClassConstructors);
+        Assert.False(
+            context.Realm.ValueCaches.LazyClassMetadata.TryGetValue(
+                typeof(TestClassOwner),
+                out _));
+    }
+
+    [Fact]
+    public void RealmDisposalReleasesCachedValuesAndCollectibleTypes()
+    {
+        var references = CreateDisposedRealmWithCachedValues();
+
+        for (var attempt = 0;
+            attempt < 10 && references.Any(reference => reference.IsAlive);
+            attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+        Assert.All(references, reference => Assert.False(reference.IsAlive));
+    }
+
+    private static RuntimeExecutionContext CreateContext()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        return RuntimeExecutionContext.GetOrCreate(services);
+    }
+
+    private static JsClassConstructorObject MaterializeConstructor(object[] scopes)
+        => RuntimeServices.InitializeClassConstructorObject(
+            new TestClassConstructor(),
+            typeof(TestClassOwner),
+            scopes,
+            formalParameterCount: 0,
+            freshIdentity: false);
+
+    private static void RegisterLazyMethod(Type ownerType, object capturedScope)
+        => _ = RuntimeServices.RegisterLazyClassMethodDataProperty(
+            ownerType,
+            "method",
+            nameof(TestClassOwner.Method),
+            0d,
+            "method",
+            false,
+            false,
+            false,
+            false,
+            new object[] { capturedScope });
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference[] CreateDisposedRealmWithCachedValues()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName($"CollectibleRealmValues_{Guid.NewGuid():N}"),
+            AssemblyBuilderAccess.RunAndCollect);
+        var module = assembly.DefineDynamicModule("main");
+        var collectibleType = module.DefineType("Generated.Class").CreateType()!;
+        var context = CreateContext();
+        object template;
+        JsClassConstructorObject constructor;
+        var capturedScope = new JsObject();
+
+        using (context.EnterAsRoot())
+        {
+            template = RuntimeServices.CreateTemplateObject(
+                "collectible",
+                ["value"],
+                ["value"]);
+            constructor = RuntimeServices.InitializeClassConstructorObject(
+                new TestClassConstructor(),
+                collectibleType,
+                [capturedScope],
+                formalParameterCount: 0,
+                freshIdentity: false);
+            _ = RuntimeServices.RegisterLazyClassMethodDataProperty(
+                collectibleType,
+                "method",
+                "Method",
+                0d,
+                "method",
+                false,
+                false,
+                false,
+                false,
+                new object[] { capturedScope });
+        }
+
+        var references = new[]
+        {
+            new WeakReference(template),
+            new WeakReference(constructor),
+            new WeakReference(capturedScope),
+            new WeakReference(collectibleType),
+            new WeakReference(assembly)
+        };
+        context.Realm.Dispose();
+        return references;
+    }
+
+    private sealed class TestClassConstructor : JsClassConstructorObject
+    {
+    }
+
+    private sealed class TestClassOwner
+    {
+        public object? Method() => null;
+    }
+}


### PR DESCRIPTION
## Summary

- add disposable `RuntimeRealmValueCacheState` ownership for tagged-template objects, materialized class constructors, and lazy class metadata containing captured scopes
- preserve required identity within one realm while isolating identical compiled call sites and generated types across realms
- protect the cache state as a realm ownership service and clear all retained JavaScript values, scopes, and collectible generated types during realm disposal
- document the cache ownership boundary and add isolation, identity, disposal, and collectible-unload coverage

The adapter portion of the issue was already completed by #1845, which moved global built-in function values and delegate adapters into `RuntimeIntrinsics`; this change completes the remaining value-cache migration without duplicating that ownership.

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --filter "FullyQualifiedName!~Jroc.Tests.ReadmeSampleTests&FullyQualifiedName!~Jroc.Tests.JrocSdkPackageTests"` (3,300 passed, 1 skipped)
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --no-restore` (6,312 passed, 58 skipped)
- `dotnet build jroc.sln --no-restore` (0 warnings, 0 errors)

Closes #1825
