### PR TITLE
runtime: migrate exotic view objects to JsObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   moving Promise, generator, and async-generator wrappers to `JsObject` inline
   property/prototype storage.
 
+- runtime: continue #1580's incremental built-in representation migration by
+  moving typed-array views, Arguments objects, and Buffer wrappers to
+  `JsObject` inline property/prototype storage while retaining their exotic
+  indexed and mapped-parameter slots.
+
 - runtime/test262: expose SharedArrayBuffer as a first-class global constructor
   with standard constructor/prototype metadata and receiver-checked
   `byteLength`, `maxByteLength`, and `growable` accessors. Activates twenty

--- a/src/JavaScriptRuntime/ArgumentsObject.cs
+++ b/src/JavaScriptRuntime/ArgumentsObject.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 namespace JavaScriptRuntime;
 
-public sealed class ArgumentsObject : IDictionary<string, object?>
+public sealed class ArgumentsObject : JsObject, IExoticJsObject, IDictionary<string, object?>
 {
     private static readonly ConcurrentDictionary<(Type ScopeType, string Name), FieldInfo?> _fieldCache = new();
     private static readonly Func<object[], object?[], object?> _restrictedCalleeAccessor = static (_, __) =>
@@ -41,7 +41,7 @@ public sealed class ArgumentsObject : IDictionary<string, object?>
         PrototypeChain.InitializePrototype(this, GlobalThis.ObjectPrototypeValue);
     }
 
-    public object? this[string key]
+    public override object? this[string key]
     {
         get
         {
@@ -52,20 +52,20 @@ public sealed class ArgumentsObject : IDictionary<string, object?>
 
             throw new KeyNotFoundException($"Key '{key}' not found.");
         }
-        set => SetValue(key, value);
+        set => SetArgumentValue(key, value);
     }
 
-    public ICollection<string> Keys => EnumerateOwnKeys().ToArray();
+    public new ICollection<string> Keys => EnumerateOwnKeys().ToArray();
 
-    public ICollection<object?> Values => EnumerateOwnKeys().Select(key => this[key]).ToArray();
+    public new ICollection<object?> Values => EnumerateOwnKeys().Select(key => this[key]).ToArray();
 
-    public int Count => EnumerateOwnKeys().Count();
+    public new int Count => EnumerateOwnKeys().Count();
 
-    public bool IsReadOnly => false;
+    public new bool IsReadOnly => false;
 
-    public void Add(string key, object? value) => SetValue(key, value);
+    public override void Add(string key, object? value) => SetArgumentValue(key, value);
 
-    public bool ContainsKey(string key)
+    public override bool ContainsKey(string key)
     {
         if (string.Equals(key, "length", StringComparison.Ordinal))
         {
@@ -90,7 +90,7 @@ public sealed class ArgumentsObject : IDictionary<string, object?>
         return _extraProperties?.ContainsKey(key) ?? false;
     }
 
-    public bool Remove(string key)
+    public override bool Remove(string key)
     {
         if (string.Equals(key, "length", StringComparison.Ordinal))
         {
@@ -143,7 +143,7 @@ public sealed class ArgumentsObject : IDictionary<string, object?>
         return _extraProperties?.Remove(key) ?? false;
     }
 
-    public bool TryGetValue(string key, out object? value)
+    public override bool TryGetValue(string key, out object? value)
     {
         if (string.Equals(key, "length", StringComparison.Ordinal))
         {
@@ -197,9 +197,9 @@ public sealed class ArgumentsObject : IDictionary<string, object?>
         return false;
     }
 
-    public void Add(KeyValuePair<string, object?> item) => SetValue(item.Key, item.Value);
+    public new void Add(KeyValuePair<string, object?> item) => SetArgumentValue(item.Key, item.Value);
 
-    public void Clear()
+    public override void Clear()
     {
         for (var i = 0; i < _indexedPresent.Length; i++)
         {
@@ -216,10 +216,10 @@ public sealed class ArgumentsObject : IDictionary<string, object?>
         PropertyDescriptorStore.Delete(this, "callee");
     }
 
-    public bool Contains(KeyValuePair<string, object?> item)
+    public override bool Contains(KeyValuePair<string, object?> item)
         => TryGetValue(item.Key, out var value) && Equals(value, item.Value);
 
-    public void CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex)
+    public new void CopyTo(KeyValuePair<string, object?>[] array, int arrayIndex)
     {
         foreach (var item in this)
         {
@@ -227,10 +227,10 @@ public sealed class ArgumentsObject : IDictionary<string, object?>
         }
     }
 
-    public bool Remove(KeyValuePair<string, object?> item)
+    public new bool Remove(KeyValuePair<string, object?> item)
         => Contains(item) && Remove(item.Key);
 
-    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
+    public new IEnumerator<KeyValuePair<string, object?>> GetEnumerator()
     {
         foreach (var key in EnumerateOwnKeys())
         {
@@ -373,7 +373,63 @@ descriptorKeys:
         field?.SetValue(_scopeInstance, value);
     }
 
-    private void SetValue(string key, object? value)
+    internal override bool TryGetOwnPropertyValue(string key, out object? value)
+    {
+        return TryGetValue(key, out value);
+    }
+
+    internal override bool HasOwnPropertyValue(string key)
+        => ContainsKey(key);
+
+    internal override bool SetOwnPropertyValue(string key, object? value)
+    {
+        SetArgumentValue(key, value);
+        return true;
+    }
+
+    internal override bool DefineOwnProperty(string key, JsPropertyDescriptor descriptor)
+    {
+        if (descriptor.Kind == JsPropertyDescriptorKind.Data)
+        {
+            SetArgumentValue(key, descriptor.Value);
+        }
+
+        PropertyDescriptorStore.DefineOrUpdate(this, key, descriptor);
+        return true;
+    }
+
+    internal override bool DeleteOwnProperty(string key)
+    {
+        if (!ContainsKey(key))
+        {
+            return true;
+        }
+
+        if (!Remove(key))
+        {
+            return false;
+        }
+
+        PropertyDescriptorStore.Delete(this, key);
+        return true;
+    }
+
+    internal override IEnumerable<string> GetOwnPropertyKeys()
+    {
+        var keys = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var key in base.GetOwnPropertyKeys().Concat(EnumerateOwnKeys()))
+        {
+            if (!PropertyDescriptorStore.IsDeleted(this, key) && seen.Add(key))
+            {
+                keys.Add(key);
+            }
+        }
+
+        return keys;
+    }
+
+    private void SetArgumentValue(string key, object? value)
     {
         if (string.Equals(key, "length", StringComparison.Ordinal))
         {
@@ -455,7 +511,7 @@ descriptorKeys:
         });
     }
 
-    private sealed class ValueIterator : IJavaScriptIterator
+    private sealed class ValueIterator : JsObject, IJavaScriptIterator
     {
         private readonly ArgumentsObject _argumentsObject;
         private int _index;

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -460,6 +460,9 @@ namespace JavaScriptRuntime
         private static readonly Func<object[], object?[]?, object?> _typedArrayToSortedValue = TypedArrayPrototypeToSorted;
         private static readonly Func<object[], object?[]?, object?> _typedArrayWithValue = TypedArrayPrototypeWith;
         private static readonly Func<object[], object?[]?, object?> _typedArrayLengthGetterValue = TypedArrayPrototypeLength;
+        private static readonly Func<object[], object?[]?, object?> _typedArrayBufferGetterValue = TypedArrayPrototypeBuffer;
+        private static readonly Func<object[], object?[]?, object?> _typedArrayByteOffsetGetterValue = TypedArrayPrototypeByteOffset;
+        private static readonly Func<object[], object?[]?, object?> _typedArrayByteLengthGetterValue = TypedArrayPrototypeByteLength;
         private static readonly Func<object[], object?[]?, object?> _typedArrayToStringValue = TypedArrayPrototypeToString;
         private static readonly Func<object[], object?[]?, object?> _typedArrayToLocaleStringValue = TypedArrayPrototypeToLocaleString;
         private static readonly Func<object[], object?[]?, object?> _typedArrayFindLastValue = TypedArrayPrototypeFindLast;
@@ -1003,6 +1006,9 @@ namespace JavaScriptRuntime
                 Configurable = true,
                 Get = _typedArrayLengthGetterValue
             });
+            DefineTypedArrayAccessor("buffer", _typedArrayBufferGetterValue);
+            DefineTypedArrayAccessor("byteOffset", _typedArrayByteOffsetGetterValue);
+            DefineTypedArrayAccessor("byteLength", _typedArrayByteLengthGetterValue);
             DefineBuiltinFunctionProperty(_typedArrayPrototypeValue, "sort", _typedArraySortValue, 1d);
             DefineBuiltinFunctionProperty(_typedArrayPrototypeValue, "toSorted", _typedArrayToSortedValue, 1d);
             DefineBuiltinFunctionProperty(_typedArrayPrototypeValue, "with", _typedArrayWithValue, 2d);
@@ -1091,6 +1097,31 @@ namespace JavaScriptRuntime
                 Writable = true,
                 Value = constructorValue
             });
+            if (PropertyDescriptorStore.TryGetOwn(constructorValue, "BYTES_PER_ELEMENT", out var bytesPerElement))
+            {
+                PropertyDescriptorStore.DefineOrUpdate(prototypeValue, "BYTES_PER_ELEMENT", new JsPropertyDescriptor
+                {
+                    Kind = JsPropertyDescriptorKind.Data,
+                    Enumerable = false,
+                    Configurable = false,
+                    Writable = false,
+                    Value = bytesPerElement.Value
+                });
+            }
+        }
+
+        private void DefineTypedArrayAccessor(
+            string name,
+            Func<object[], object?[]?, object?> getter)
+        {
+            JavaScriptRuntime.Function.InitializeFunctionInstance(getter, 0d, $"get {name}");
+            PropertyDescriptorStore.DefineOrUpdate(_typedArrayPrototypeValue, name, new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Accessor,
+                Enumerable = false,
+                Configurable = true,
+                Get = getter
+            });
         }
 
         private static object? TypedArrayPrototypeFindLast(object[] _, object?[]? args)
@@ -1141,6 +1172,25 @@ namespace JavaScriptRuntime
             }
 
             return typedArray.length;
+        }
+
+        private static object? TypedArrayPrototypeBuffer(object[] _, object?[]? __)
+            => GetTypedArrayReceiver("buffer").buffer;
+
+        private static object? TypedArrayPrototypeByteOffset(object[] _, object?[]? __)
+            => GetTypedArrayReceiver("byteOffset").byteOffset;
+
+        private static object? TypedArrayPrototypeByteLength(object[] _, object?[]? __)
+            => GetTypedArrayReceiver("byteLength").byteLength;
+
+        private static TypedArrayBase GetTypedArrayReceiver(string propertyName)
+        {
+            if (RuntimeServices.GetCurrentThis() is not TypedArrayBase typedArray)
+            {
+                throw new TypeError($"TypedArray.prototype.{propertyName} called on incompatible receiver");
+            }
+
+            return typedArray;
         }
 
         private static object? TypedArrayPrototypeToString(object[] _, object?[]? args)

--- a/src/JavaScriptRuntime/Iterator.cs
+++ b/src/JavaScriptRuntime/Iterator.cs
@@ -53,7 +53,14 @@ public static class Iterator
     {
         if (PrototypeChain.GetPrototypeOrNull(iterator) == null)
         {
-            PrototypeChain.SetPrototype(iterator, Prototype);
+            if (iterator is JsObject jsObject)
+            {
+                PrototypeChain.InitializePrototype(jsObject, Prototype);
+            }
+            else
+            {
+                PrototypeChain.SetPrototype(iterator, Prototype);
+            }
         }
     }
 

--- a/src/JavaScriptRuntime/Node/Buffer.cs
+++ b/src/JavaScriptRuntime/Node/Buffer.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace JavaScriptRuntime.Node
 {
     [IntrinsicObject("Buffer")]
-    public sealed class Buffer
+    public sealed class Buffer : JsObject
     {
         private readonly byte[] _bytes;
         private readonly int _offset;

--- a/src/JavaScriptRuntime/ObjectRuntime.Operations.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.Operations.cs
@@ -3920,6 +3920,7 @@ namespace JavaScriptRuntime
             }
 
             if (target is JsObject jsObject
+                && target is not JavaScriptRuntime.Node.Buffer
                 && target is not JsClassConstructorObject)
             {
                 return jsObject.GetOwnPropertyDescriptor(propName, out descriptor)
@@ -4361,6 +4362,7 @@ namespace JavaScriptRuntime
             }
 
             if (target is JsObject jsObject
+                && target is not JavaScriptRuntime.Node.Buffer
                 && target is not JsClassConstructorObject)
             {
                 return jsObject.TryGetBoxedValue(propName, receiverForAccessors, out value);
@@ -5727,6 +5729,23 @@ namespace JavaScriptRuntime
                 throw new TypeError($"Cannot access restricted function property '{name}'");
             }
 
+            if (obj is JavaScriptRuntime.Node.Buffer nodeBuffer
+                && TryGetOwnPropertyValue(nodeBuffer, name, out var bufferValue))
+            {
+                return bufferValue;
+            }
+
+            if (obj is JavaScriptRuntime.Node.Buffer
+                && TryGetClrMemberValue(
+                    obj.GetType(),
+                    obj,
+                    name,
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase,
+                    out bufferValue))
+            {
+                return bufferValue;
+            }
+
             if (obj is JsObject jsObject
                 && jsObject.TryGetBoxedValue(name, obj, out var jsObjectValue))
             {
@@ -6163,6 +6182,14 @@ namespace JavaScriptRuntime
             }
 
             InvalidateRegExpWellKnownSymbolFastPath(obj, name);
+
+            if (obj is TypedArrayBase typedArray
+                && TryParseCanonicalIndexString(name, out var typedArrayIndex))
+            {
+                typedArray.SetFromDouble(typedArrayIndex, TypeUtilities.ToNumber(value));
+                return value;
+            }
+
             var hasOwn = HasOwnProperty(obj, name);
             // Proxy set trap
             if (obj is JavaScriptRuntime.Proxy proxy)
@@ -6225,6 +6252,15 @@ namespace JavaScriptRuntime
                 }
 
                 throw new TypeError($"Cannot assign to property '{name}' of object");
+            }
+
+            if (hasOwn
+                && obj is JsObject exoticObject
+                && exoticObject is IExoticJsObject
+                && !PropertyDescriptorStore.TryGetOwn(obj, name, out _)
+                && exoticObject.SetOwnPropertyValue(name, value))
+            {
+                return value;
             }
 
             // Descriptor-defined own property handling (accessors + writable enforcement)

--- a/src/JavaScriptRuntime/ObjectRuntime.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.cs
@@ -733,8 +733,13 @@ namespace JavaScriptRuntime
                 }
                 return array[intIndex]!;
             }
+            else if (obj is ArgumentsObject argumentsObject
+                && argumentsObject.TryGetValue(propName, out var argumentsValue))
+            {
+                return argumentsValue!;
+            }
             // Ordinary object: numeric index coerces to a property-name string per JS ToPropertyKey.
-            else if (obj is JsObject)
+            else if (obj is JsObject && obj is not JavaScriptRuntime.Node.Buffer)
             {
                 return GetProperty(obj, propName)!;
             }
@@ -833,8 +838,18 @@ namespace JavaScriptRuntime
                 }
                 return array[intIndex]!;
             }
+            else if (obj is ArgumentsObject argumentsObject)
+            {
+                var propName = ToPropertyKeyString(index);
+                if (argumentsObject.TryGetValue(propName, out var argumentsValue))
+                {
+                    return argumentsValue!;
+                }
+
+                return GetProperty(obj, propName)!;
+            }
             // Ordinary object: numeric index coerces to a property-name string per JS ToPropertyKey.
-            else if (obj is JsObject)
+            else if (obj is JsObject && obj is not JavaScriptRuntime.Node.Buffer)
             {
                 var propName = ToPropertyKeyString(index);
                 return GetProperty(obj, propName)!;
@@ -925,8 +940,13 @@ namespace JavaScriptRuntime
                 }
                 return array[intIndex]!;
             }
+            else if (obj is ArgumentsObject argumentsObject
+                && argumentsObject.TryGetValue(key, out var argumentsValue))
+            {
+                return argumentsValue!;
+            }
             // Ordinary object: key is already a string property.
-            else if (obj is JsObject)
+            else if (obj is JsObject && obj is not JavaScriptRuntime.Node.Buffer)
             {
                 return GetProperty(obj, key)!;
             }
@@ -1052,7 +1072,7 @@ namespace JavaScriptRuntime
                 return value;
             }
 
-            if (obj is JsObject)
+            if (obj is JsObject && obj is not JavaScriptRuntime.Node.Buffer)
             {
                 return SetProperty(obj, propName, value, throwOnError);
             }
@@ -1135,7 +1155,7 @@ namespace JavaScriptRuntime
                 return value;
             }
 
-            if (obj is JsObject)
+            if (obj is JsObject && obj is not JavaScriptRuntime.Node.Buffer)
             {
                 return SetProperty(
                     obj,
@@ -1228,7 +1248,7 @@ namespace JavaScriptRuntime
                 return value;
             }
 
-            if (obj is JsObject)
+            if (obj is JsObject && obj is not JavaScriptRuntime.Node.Buffer)
             {
                 return SetProperty(obj, key, value, throwOnError);
             }
@@ -1307,7 +1327,7 @@ namespace JavaScriptRuntime
                 return value;
             }
 
-            if (obj is JsObject)
+            if (obj is JsObject && obj is not JavaScriptRuntime.Node.Buffer)
             {
                 return SetProperty(obj, key, value, throwOnError);
             }

--- a/src/JavaScriptRuntime/TypedArrayBase.cs
+++ b/src/JavaScriptRuntime/TypedArrayBase.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 
 namespace JavaScriptRuntime
 {
-    public abstract class TypedArrayBase
+    public abstract class TypedArrayBase : JsObject, IExoticJsObject
     {
         private ArrayBuffer _buffer = new ArrayBuffer();
         private int _byteOffset;
@@ -947,7 +947,7 @@ namespace JavaScriptRuntime
 
         private void InitializeIntrinsicSurface()
         {
-            PrototypeChain.SetPrototype(this, GlobalThis.GetTypedArrayInstancePrototype(this));
+            PrototypeChain.InitializePrototype(this, GlobalThis.GetTypedArrayInstancePrototype(this));
             PropertyDescriptorStore.DefineOrUpdate(this, Symbol.iterator.DebugId, new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Data,
@@ -964,6 +964,106 @@ namespace JavaScriptRuntime
                 Writable = false,
                 Value = TypedArrayName
             });
+        }
+
+        internal override bool TryGetInvariantOwnPropertyValue(string key, out object? value)
+        {
+            if (ObjectRuntime.TryParseCanonicalIndexString(key, out var index)
+                && (uint)index < (uint)GetCurrentLengthOrZero())
+            {
+                value = ReadElementValue(index);
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        internal override bool TryGetOwnPropertyValue(string key, out object? value)
+        {
+            if (TryGetInvariantOwnPropertyValue(key, out value))
+            {
+                return true;
+            }
+
+            if (PropertyDescriptorStore.GetOwnLookupCore(this, key, out _) == PropertyDescriptorLookup.None)
+            {
+                if (string.Equals(key, "BYTES_PER_ELEMENT", StringComparison.Ordinal))
+                {
+                    value = BYTES_PER_ELEMENT;
+                    return true;
+                }
+
+                if (string.Equals(key, Symbol.toStringTag.DebugId, StringComparison.Ordinal))
+                {
+                    value = TypedArrayName;
+                    return true;
+                }
+            }
+
+            return base.TryGetOwnPropertyValue(key, out value);
+        }
+
+        internal override bool HasOwnPropertyValue(string key)
+            => (ObjectRuntime.TryParseCanonicalIndexString(key, out var index)
+                && (uint)index < (uint)GetCurrentLengthOrZero())
+                || base.HasOwnPropertyValue(key);
+
+        internal override bool SetOwnPropertyValue(string key, object? value)
+        {
+            if (ObjectRuntime.TryParseCanonicalIndexString(key, out var index))
+            {
+                return TrySetElementValue(index, value);
+            }
+
+            return base.SetOwnPropertyValue(key, value);
+        }
+
+        internal override bool DefineOwnProperty(string key, JsPropertyDescriptor descriptor)
+        {
+            if (!ObjectRuntime.TryParseCanonicalIndexString(key, out var index)
+                || (uint)index >= (uint)GetCurrentLengthOrZero())
+            {
+                return base.DefineOwnProperty(key, descriptor);
+            }
+
+            if (descriptor.Kind != JsPropertyDescriptorKind.Data
+                || descriptor.Configurable
+                || !descriptor.Enumerable
+                || !descriptor.Writable)
+            {
+                return false;
+            }
+
+            WriteElementValue(index, TypeUtilities.ToNumber(descriptor.Value));
+            return true;
+        }
+
+        internal override bool DeleteOwnProperty(string key)
+        {
+            if (ObjectRuntime.TryParseCanonicalIndexString(key, out var index)
+                && (uint)index < (uint)GetCurrentLengthOrZero())
+            {
+                return false;
+            }
+
+            return base.DeleteOwnProperty(key);
+        }
+
+        internal override IEnumerable<string> GetOwnPropertyKeys()
+        {
+            var keys = new List<string>();
+            for (var index = 0; index < GetCurrentLengthOrZero(); index++)
+            {
+                var key = index.ToString(System.Globalization.CultureInfo.InvariantCulture);
+                if (!PropertyDescriptorStore.IsDeleted(this, key))
+                {
+                    keys.Add(key);
+                }
+            }
+
+            keys.AddRange(base.GetOwnPropertyKeys().Where(key => !keys.Contains(key, StringComparer.Ordinal)));
+            return keys;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1381,7 +1481,7 @@ namespace JavaScriptRuntime
         Entries
     }
 
-    internal sealed class TypedArrayIterator : IJavaScriptIterator
+    internal sealed class TypedArrayIterator : JsObject, IJavaScriptIterator
     {
         private readonly TypedArrayBase _typedArray;
         private readonly TypedArrayIteratorKind _kind;

--- a/src/JavaScriptRuntime/Uint8Array.cs
+++ b/src/JavaScriptRuntime/Uint8Array.cs
@@ -404,7 +404,7 @@ namespace JavaScriptRuntime
             => args != null && args.Length > index ? args[index] : null;
 
         private void InitializeIntrinsicSurface()
-            => PrototypeChain.SetPrototype(this, Prototype);
+            => PrototypeChain.InitializePrototype(this, Prototype);
 
         private static int GetHexDigitValue(char value)
             => value switch

--- a/src/JavaScriptRuntime/Uint8ClampedArray.cs
+++ b/src/JavaScriptRuntime/Uint8ClampedArray.cs
@@ -127,6 +127,6 @@ namespace JavaScriptRuntime
             => new Uint8ClampedArray(buffer, byteOffset, length);
 
         private void InitializeIntrinsicSurface()
-            => PrototypeChain.SetPrototype(this, Prototype);
+            => PrototypeChain.InitializePrototype(this, Prototype);
     }
 }

--- a/tests/Jroc.Tests/ExoticViewObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/ExoticViewObjectRepresentationTests.cs
@@ -1,0 +1,101 @@
+using JavaScriptRuntime;
+using JsObjectConstructor = JavaScriptRuntime.Object;
+
+namespace Jroc.Tests;
+
+public sealed class ExoticViewObjectRepresentationTests
+{
+    [Fact]
+    public void ExoticViews_UseInlineJsObjectStorageWithoutMovingInternalSlots()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        using var scope = RuntimeExecutionContext.GetOrCreate(services).Enter();
+        var typedArray = new Uint8Array(new object?[] { 1d, 2d });
+        var emptyTypedArray = new Uint8Array();
+        var arguments = new ArgumentsObject(new object?[] { "argument" }, null, null, null);
+        var buffer = new JavaScriptRuntime.Node.Buffer(new byte[] { 1, 2 });
+        var customPrototype = new JsObject();
+
+        Assert.IsAssignableFrom<JsObject>(typedArray);
+        Assert.IsAssignableFrom<JsObject>(arguments);
+        Assert.IsAssignableFrom<JsObject>(buffer);
+        Assert.Same(Uint8Array.Prototype, JsObjectConstructor.getPrototypeOf(typedArray));
+        Assert.Same(GlobalThis.ObjectPrototypeValue, JsObjectConstructor.getPrototypeOf(arguments));
+
+        ObjectRuntime.SetProperty(emptyTypedArray, "custom", "typed-array");
+        ObjectRuntime.SetProperty(arguments, "custom", "arguments");
+        ObjectRuntime.SetProperty(buffer, "custom", "buffer");
+        Assert.Equal("typed-array", ObjectRuntime.GetProperty(emptyTypedArray, "custom"));
+        Assert.Equal("arguments", ObjectRuntime.GetProperty(arguments, "custom"));
+        Assert.Equal("buffer", ObjectRuntime.GetProperty(buffer, "custom"));
+
+        JsObjectConstructor.setPrototypeOf(buffer, customPrototype);
+        Assert.Same(customPrototype, JsObjectConstructor.getPrototypeOf(buffer));
+
+        Assert.Throws<TypeError>(() => JsObjectConstructor.freeze(typedArray));
+        JsObjectConstructor.freeze(emptyTypedArray);
+        JsObjectConstructor.freeze(arguments);
+        JsObjectConstructor.freeze(buffer);
+        Assert.True(JsObjectConstructor.isFrozen(emptyTypedArray));
+        Assert.True(JsObjectConstructor.isFrozen(arguments));
+        Assert.True(JsObjectConstructor.isFrozen(buffer));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(emptyTypedArray, "custom", "changed"));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(arguments, "custom", "changed"));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(buffer, "custom", "changed"));
+
+        Assert.Equal(1d, typedArray[0d]);
+        Assert.Equal("argument", ObjectRuntime.GetItem(arguments, 0d));
+        buffer.writeUInt8(255d, 0d);
+        Assert.Equal(255d, buffer[0d]);
+    }
+
+    [Fact]
+    public void TypedArrayAndArgumentsPrototypeDescriptorMutations_AreIsolatedAcrossRuntimes()
+    {
+        var mutationResult = InMemoryTestCompiler.CompileAndExecute(
+            "mutate-exotic-view-prototype-descriptors",
+            "ExoticView.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+        var readResult = InMemoryTestCompiler.CompileAndExecute(
+            "read-exotic-view-prototype-descriptors",
+            "ExoticView.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+
+        Assert.Equal($"typed-array{Environment.NewLine}arguments{Environment.NewLine}", mutationResult.Output);
+        Assert.Equal($"true{Environment.NewLine}true{Environment.NewLine}", readResult.Output);
+    }
+
+    private static (string Script, string? SourcePath) GetDescriptorIsolationScript(string testName)
+        => testName switch
+        {
+            "mutate-exotic-view-prototype-descriptors" => ("""
+                Object.defineProperty(Uint8Array.prototype, "descriptorLeakCheck", {
+                  value: "typed-array",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+                Object.defineProperty(Object.prototype, "argumentsDescriptorLeakCheck", {
+                  value: "arguments",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+                console.log(new Uint8Array().descriptorLeakCheck);
+                console.log((function () {
+                  return arguments.argumentsDescriptorLeakCheck;
+                })());
+                """, null),
+            "read-exotic-view-prototype-descriptors" => ("""
+                console.log(Object.getOwnPropertyDescriptor(
+                  Uint8Array.prototype,
+                  "descriptorLeakCheck"
+                ) === undefined);
+                console.log(Object.getOwnPropertyDescriptor(
+                  Object.prototype,
+                  "argumentsDescriptorLeakCheck"
+                ) === undefined);
+                """, null),
+            _ => throw new ArgumentOutOfRangeException(nameof(testName), testName, "Unknown descriptor isolation script.")
+        };
+}

--- a/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
+++ b/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
@@ -8,8 +8,6 @@ public sealed class JsObjectRepresentationInventoryTests
     private const string ErrorReason = "Must remain an Exception for CLR throw/catch mechanics pending the dedicated Error design.";
     private const string HostIteratorReason = "Preserves host iterator adaptation and needs a focused iterator migration.";
     private const string IteratorReason = "Must migrate with its owning iterator family to preserve exhaustion and mutation behavior.";
-    private const string TypedArrayReason = "Requires the dedicated TypedArrayBase exotic-object migration.";
-
     private static readonly string[] ExplicitJavaScriptVisibleTypeNames =
     [
         "JavaScriptRuntime.ArgumentsObject",
@@ -32,20 +30,13 @@ public sealed class JsObjectRepresentationInventoryTests
             ["JavaScriptRuntime.AbortController"] = "Requires the AbortController and AbortSignal migration.",
             ["JavaScriptRuntime.AbortSignal"] = "Requires the AbortController and AbortSignal migration.",
             ["JavaScriptRuntime.AggregateError"] = ErrorReason,
-            ["JavaScriptRuntime.ArgumentsObject"] = "Requires the dedicated ArgumentsObject exotic-object migration.",
-            ["JavaScriptRuntime.ArgumentsObject+ValueIterator"] = "Must migrate with ArgumentsObject to preserve mapped-parameter behavior.",
             ["JavaScriptRuntime.Array+ArrayIterator"] = IteratorReason,
             ["JavaScriptRuntime.ArrayBuffer"] = BufferViewReason,
             ["JavaScriptRuntime.DataView"] = BufferViewReason,
             ["JavaScriptRuntime.Error"] = ErrorReason,
             ["JavaScriptRuntime.EvalError"] = ErrorReason,
             ["JavaScriptRuntime.FinalizationRegistry"] = "Requires a dedicated internal-slot wrapper migration.",
-            ["JavaScriptRuntime.Float32Array"] = TypedArrayReason,
-            ["JavaScriptRuntime.Float64Array"] = TypedArrayReason,
             ["JavaScriptRuntime.ForInIterator"] = IteratorReason,
-            ["JavaScriptRuntime.Int16Array"] = TypedArrayReason,
-            ["JavaScriptRuntime.Int32Array"] = TypedArrayReason,
-            ["JavaScriptRuntime.Int8Array"] = TypedArrayReason,
             ["JavaScriptRuntime.IntlNumberFormat"] = "Needs a dedicated Intl wrapper migration once its constructor surface expands.",
             ["JavaScriptRuntime.IntlSegmenter"] = "Needs a dedicated Intl wrapper migration once its constructor surface expands.",
             ["JavaScriptRuntime.Iterator+DropIteratorHelper"] = IteratorReason,
@@ -58,7 +49,6 @@ public sealed class JsObjectRepresentationInventoryTests
             ["JavaScriptRuntime.Iterator+TakeIteratorHelper"] = IteratorReason,
             ["JavaScriptRuntime.IteratorResultObject"] = "Requires the dedicated iterator result and helper migration.",
             ["JavaScriptRuntime.IteratorResultObject`1"] = "Requires the dedicated iterator result and helper migration.",
-            ["JavaScriptRuntime.Node.Buffer"] = BufferViewReason,
             ["JavaScriptRuntime.Node.Events+EventEmitterAsyncOnIterator"] = HostIteratorReason,
             ["JavaScriptRuntime.Node.TimersPromises+TimersPromisesIntervalIterator"] = HostIteratorReason,
             ["JavaScriptRuntime.Node.URL"] = "Requires the URL and URLSearchParams migration.",
@@ -79,13 +69,7 @@ public sealed class JsObjectRepresentationInventoryTests
             ["JavaScriptRuntime.SuppressedError"] = ErrorReason,
             ["JavaScriptRuntime.Symbol"] = "Primitive representation with dedicated identity semantics.",
             ["JavaScriptRuntime.SyntaxError"] = ErrorReason,
-            ["JavaScriptRuntime.TypedArrayBase"] = TypedArrayReason,
-            ["JavaScriptRuntime.TypedArrayIterator"] = TypedArrayReason,
             ["JavaScriptRuntime.TypeError"] = ErrorReason,
-            ["JavaScriptRuntime.Uint16Array"] = TypedArrayReason,
-            ["JavaScriptRuntime.Uint32Array"] = TypedArrayReason,
-            ["JavaScriptRuntime.Uint8Array"] = TypedArrayReason,
-            ["JavaScriptRuntime.Uint8ClampedArray"] = TypedArrayReason,
             ["JavaScriptRuntime.URIError"] = ErrorReason,
             ["JavaScriptRuntime.WeakRef"] = "Requires a dedicated internal-slot wrapper migration.",
         };

--- a/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
+++ b/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
@@ -52,6 +52,18 @@ public class PrototypeStorageBenchmarks
     public JavaScriptRuntime.Promise ConstructPromise()
         => (JavaScriptRuntime.Promise)JavaScriptRuntime.Promise.resolve(null)!;
 
+    [Benchmark(Description = "Typed array with initialized prototype")]
+    public JavaScriptRuntime.Uint8Array ConstructTypedArray()
+        => new(0d);
+
+    [Benchmark(Description = "Arguments object with initialized prototype")]
+    public JavaScriptRuntime.ArgumentsObject ConstructArgumentsObject()
+        => new(null, null, null, null);
+
+    [Benchmark(Description = "Buffer with inline ordinary properties")]
+    public JavaScriptRuntime.Node.Buffer ConstructBuffer()
+        => new(System.Array.Empty<byte>());
+
     [Benchmark(Description = "Ordinary object with initialized prototype")]
     public JavaScriptRuntime.JsObject ConstructOrdinaryObject()
     {


### PR DESCRIPTION
## Summary

- migrate typed arrays, arguments objects, and Buffer to `JsObject` while preserving their exotic indexed storage
- add typed-array intrinsic accessors and preserve Buffer's CLR-backed Node API bridge
- add representation, integrity, prototype-isolation, and construction benchmark coverage

Closes #1856
Closes #1857
Closes #1858

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --filter 'FullyQualifiedName~TypedArray|FullyQualifiedName~Buffer|FullyQualifiedName~Arguments|FullyQualifiedName~ExoticViewObjectRepresentationTests|FullyQualifiedName~JsObjectRepresentationInventoryTests'`
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --no-restore --filter 'FullyQualifiedName~built_ins.TypedArray|FullyQualifiedName~language.arguments_object'`
- `dotnet build src/Cli/Jroc.csproj --no-restore`
