### PR TITLE
runtime: move scheduling and async context into RuntimeAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime: move timers, queues, pending I/O, event-loop pumping, async-hooks
+  context, finalization jobs, wake-up signaling, and cooperative cancellation
+  into `RuntimeAgentSchedulingState` (issue #1826). Realms in one agent share
+  one scheduling graph, separate agents run independently, external producers
+  only enqueue work for the receiver executor, and agent disposal clears all
+  referenced handles and queued work without affecting another agent.
+
 - runtime: move tagged-template objects, materialized class constructor values,
   and lazy class-method metadata containing captured scopes into a disposable
   `RuntimeRealmValueCacheState` (issue #1825). Repeated execution preserves

--- a/docs/compiler/EventLoopAndScheduling.md
+++ b/docs/compiler/EventLoopAndScheduling.md
@@ -63,6 +63,11 @@ The engine uses two distinct components:
 - `NodeSchedulerState` (thread-safe): owns the queues/timers state and implements `IScheduler` + `IMicrotaskScheduler`.
 - `NodeEventLoopPump` (JS thread only): drains `NodeSchedulerState` and executes callbacks.
 
+Both components, their wake handle, `AsyncContextRuntime`, finalization jobs,
+and cooperative cancellation are owned by one `RuntimeAgentSchedulingState`.
+All realms in an agent resolve that same graph; another agent has an independent
+graph. See [Runtime agent scheduling](../runtime/RuntimeAgentScheduling.md).
+
 ### Why Split Them?
 
 - The scheduler must be safe to call from multiple threads (e.g., hosting thread scheduling timers while the JS thread is running).
@@ -78,6 +83,10 @@ The engine uses two distinct components:
 - `clearInterval` marks the interval id as canceled; the pump will discard pending interval entries.
 
 When any work is scheduled or canceled, the scheduler signals a wake-up handle so the event loop can resume.
+
+Background producers use the agent's external wake path. It queues raw work
+without reading receiver async-context state on the producer thread; only the
+agent executor invokes the callback.
 
 ### Immediates
 

--- a/docs/runtime/RuntimeAgentScheduling.md
+++ b/docs/runtime/RuntimeAgentScheduling.md
@@ -1,0 +1,54 @@
+# Runtime agent scheduling
+
+`RuntimeAgentSchedulingState` is the single owner of asynchronous execution
+state shared by all realms in one `RuntimeAgent`:
+
+- `NodeSchedulerState`, including timers, immediates, next-tick callbacks,
+  Promise microtasks, cleanup jobs, pending I/O, and its wake handle;
+- the thread-affine `NodeEventLoopPump`;
+- `AsyncContextRuntime` and async-hooks propagation;
+- the `FinalizationRegistryHost` and its cleanup-job scheduling;
+- the agent cooperative-shutdown token.
+
+Realm service containers expose these objects through dependency injection, but
+the registrations are reserved ownership services. Resolving a scheduler,
+event-loop, async-context, or finalization service from two realms in one agent
+returns the same instance. Two agents always receive independent instances and
+can drain work concurrently without a global scheduler lock.
+
+The scheduler records the clock and wake handle used when it is first created.
+The event-loop pump is built from those same dependencies even when another
+realm resolves it later. The thread that first resolves the pump is its
+executor; pump methods reject calls from any other thread.
+
+## Cross-thread work
+
+`RuntimeAgent.EnqueueFromExternalThread` is the wake-up boundary for producers
+such as I/O completion threads. It places work on the receiving agent's
+immediate queue without reading or capturing mutable async-hook state on the
+producer thread. The callback runs only when the owning executor drains the
+queue. Network and DNS completion paths use the same raw external queue.
+
+Normal JavaScript scheduling APIs still capture the current agent async context
+before queueing work. This preserves `AsyncLocalStorage` and async-hook behavior
+for timers, Promise jobs, next-tick callbacks, and immediates created while
+JavaScript is running.
+
+## Shutdown
+
+Agent shutdown is cooperative and deterministic:
+
+1. cancel the agent shutdown token and signal its wake handle;
+2. dispose the agent's realms in reverse creation order;
+3. stop the pump from starting another callback;
+4. clear finalization registrations, timers, queues, and pending I/O;
+5. dispose the wake handle.
+
+Disposing one agent does not cancel, reset, drain, or dispose another agent.
+Concurrent disposal waits for the callback already executing on the owner
+thread, then prevents the next queued callback from starting.
+
+`JsRuntimeInstance` observes the agent shutdown token after runtime
+initialization. Its pre-initialization host queue still has a bootstrap
+cancellation source; issue #1828 will unify that startup path with the common
+agent/realm lifecycle factory.

--- a/docs/runtime/RuntimeOwnership.md
+++ b/docs/runtime/RuntimeOwnership.md
@@ -5,6 +5,11 @@ JROC runtime state has three explicit lifetime owners:
 ```text
 RuntimeAgentCluster
   -> RuntimeAgent
+      -> RuntimeAgentSchedulingState
+          -> NodeSchedulerState
+          -> NodeEventLoopPump
+          -> AsyncContextRuntime
+          -> FinalizationRegistryHost
       -> RuntimeRealm
           -> RuntimeIntrinsics
           -> RuntimeModuleState
@@ -17,6 +22,10 @@ RuntimeAgentCluster
   resources intentionally shared across agents.
 - `RuntimeAgent` owns execution and scheduling lifecycle and can own one or
   more realms.
+- `RuntimeAgentSchedulingState` owns timers, queues, pending I/O, the event-loop
+  pump, async-hooks context, finalization jobs, wake-up signaling, and
+  cooperative cancellation. See
+  [Runtime agent scheduling](RuntimeAgentScheduling.md).
 - `RuntimeRealm` owns one JavaScript object graph and exactly one runtime
   `ServiceContainer`.
 - `RuntimeIntrinsics` owns the realm's well-known intrinsic object graph
@@ -44,14 +53,17 @@ the children are active. Disposing a child detaches it from its parent.
 Disposing a parent disposes children in reverse creation order, then marks the
 parent disposed. Disposal is idempotent.
 
-Runtime service containers register their realm, agent, and cluster as reserved
-services. Those registrations cannot be replaced or removed. Child DI scopes
-retain the same realm owner. After realm disposal, its service container and
-any child scopes reject further use.
+Runtime service containers register their realm, agent, cluster, and
+agent-scheduling services as reserved services. Those registrations cannot be
+replaced or removed. Realms in one agent resolve the same scheduler, event
+loop, async context, and finalization host. Child DI scopes retain the same
+owners. After realm disposal, its service container and any child scopes reject
+further use.
 
 The factory currently creates an isolated cluster, agent, realm, and service
 container for each `RuntimeServices.BuildServiceProvider()` call. Each realm
-owns its intrinsic graph, module state, and realm-created value caches.
+owns its intrinsic graph, module state, and realm-created value caches; its
+agent owns one scheduling graph.
 
 ## Intrinsic ownership
 
@@ -119,6 +131,9 @@ change observable semantics.
   agent, or cluster.
 - A cluster may reference its active agents.
 - An agent may reference its cluster and active realms.
+- An agent owns one scheduling graph and cancellation source. Its external
+  wake API queues work for the agent executor and never runs JavaScript on the
+  producer thread.
 - A realm may reference its agent, intrinsics graph, and service container.
 - A realm owns one module state object; no mutable module graph is
   process-wide.

--- a/src/JavaScriptRuntime/DependencyInjection/ServiceContainer.cs
+++ b/src/JavaScriptRuntime/DependencyInjection/ServiceContainer.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using JavaScriptRuntime.EngineCore;
+using JavaScriptRuntime.Node;
 
 namespace JavaScriptRuntime.DependencyInjection;
 
@@ -39,6 +41,8 @@ public class ServiceContainer
             _owningRealm = realm;
             _singletons[typeof(RuntimeAgentCluster)] = realm.Agent.Cluster;
             _singletons[typeof(RuntimeAgent)] = realm.Agent;
+            _singletons[typeof(RuntimeAgentSchedulingState)] = realm.Agent.Scheduling;
+            _singletons[typeof(AsyncContextRuntime)] = realm.Agent.Scheduling.AsyncContext;
             _singletons[typeof(RuntimeRealm)] = realm;
             _singletons[typeof(Modules.RuntimeModuleState)] = realm.ModuleState;
             _singletons[typeof(RuntimeRealmValueCacheState)] = realm.ValueCaches;
@@ -156,6 +160,12 @@ public class ServiceContainer
                 return existing;
             }
 
+            if (TryResolveAgentSchedulingService(serviceType, out var agentService))
+            {
+                _singletons[serviceType] = agentService;
+                return agentService;
+            }
+
             // Determine the actual type to instantiate
             var implementationType = ResolveImplementationType(serviceType);
 
@@ -215,7 +225,9 @@ public class ServiceContainer
         lock (_lock)
         {
             ThrowIfOwningRealmDisposed();
-            return _singletons.ContainsKey(typeof(T)) || _typeRegistrations.ContainsKey(typeof(T));
+            return _singletons.ContainsKey(typeof(T))
+                || _typeRegistrations.ContainsKey(typeof(T))
+                || IsAgentSchedulingServiceType(typeof(T));
         }
     }
 
@@ -302,9 +314,13 @@ public class ServiceContainer
 
         _singletons[typeof(RuntimeAgentCluster)] = _owningRealm.Agent.Cluster;
         _singletons[typeof(RuntimeAgent)] = _owningRealm.Agent;
+        _singletons[typeof(RuntimeAgentSchedulingState)] = _owningRealm.Agent.Scheduling;
+        _singletons[typeof(AsyncContextRuntime)] = _owningRealm.Agent.Scheduling.AsyncContext;
         _singletons[typeof(RuntimeRealm)] = _owningRealm;
         _singletons[typeof(Modules.RuntimeModuleState)] = _owningRealm.ModuleState;
         _singletons[typeof(RuntimeRealmValueCacheState)] = _owningRealm.ValueCaches;
+        _typeRegistrations[typeof(ITickSource)] = typeof(TickSource);
+        _typeRegistrations[typeof(IWaitHandle)] = typeof(EngineCore.WaitHandle);
     }
 
     private void ThrowIfOwningRealmDisposed()
@@ -320,13 +336,74 @@ public class ServiceContainer
         if (_owningRealm != null
             && (serviceType == typeof(RuntimeAgentCluster)
                 || serviceType == typeof(RuntimeAgent)
+                || serviceType == typeof(RuntimeAgentSchedulingState)
                 || serviceType == typeof(RuntimeRealm)
                 || serviceType == typeof(Modules.RuntimeModuleState)
-                || serviceType == typeof(RuntimeRealmValueCacheState)))
+                || serviceType == typeof(RuntimeRealmValueCacheState)
+                || IsAgentSchedulingServiceType(serviceType)))
         {
             throw new InvalidOperationException(
                 $"Runtime ownership service '{serviceType.Name}' cannot be replaced or removed.");
         }
+    }
+
+    private bool IsAgentSchedulingServiceType(Type serviceType)
+        => _owningRealm != null
+            && (serviceType == typeof(AsyncContextRuntime)
+                || serviceType == typeof(NodeSchedulerState)
+                || serviceType == typeof(NodeEventLoopPump)
+                || serviceType == typeof(IFinalizationRegistryHost)
+                || serviceType == typeof(ICleanupJobScheduler)
+                || serviceType == typeof(IMicrotaskScheduler)
+                || serviceType == typeof(IScheduler)
+                || serviceType == typeof(IIOScheduler));
+
+    private bool TryResolveAgentSchedulingService(
+        Type serviceType,
+        out object service)
+    {
+        if (_owningRealm == null)
+        {
+            service = null!;
+            return false;
+        }
+
+        var scheduling = _owningRealm.Agent.Scheduling;
+        if (serviceType == typeof(AsyncContextRuntime))
+        {
+            service = scheduling.AsyncContext;
+            return true;
+        }
+
+        if (serviceType == typeof(NodeSchedulerState)
+            || serviceType == typeof(ICleanupJobScheduler)
+            || serviceType == typeof(IMicrotaskScheduler)
+            || serviceType == typeof(IScheduler)
+            || serviceType == typeof(IIOScheduler))
+        {
+            service = scheduling.GetOrCreateScheduler(
+                Resolve<ITickSource>(),
+                Resolve<IWaitHandle>());
+            return true;
+        }
+
+        if (serviceType == typeof(IFinalizationRegistryHost))
+        {
+            service = scheduling.GetOrCreateFinalizationHost(
+                () => Resolve<NodeSchedulerState>());
+            return true;
+        }
+
+        if (serviceType == typeof(NodeEventLoopPump))
+        {
+            _ = Resolve<IFinalizationRegistryHost>();
+            service = scheduling.GetOrCreateEventLoop(
+                () => Resolve<NodeSchedulerState>());
+            return true;
+        }
+
+        service = null!;
+        return false;
     }
 
     private Type ResolveImplementationType(Type serviceType)

--- a/src/JavaScriptRuntime/Engine/FinalizationRegistryHost.cs
+++ b/src/JavaScriptRuntime/Engine/FinalizationRegistryHost.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace JavaScriptRuntime.EngineCore;
 
-internal sealed class FinalizationRegistryHost : IFinalizationRegistryHost
+internal sealed class FinalizationRegistryHost : IFinalizationRegistryHost, IDisposable
 {
     private readonly object _sync = new();
     private readonly ICleanupJobScheduler _cleanupScheduler;
@@ -92,6 +92,15 @@ internal sealed class FinalizationRegistryHost : IFinalizationRegistryHost
             {
                 HostJobCallbacks.HostCallJobCallback(jobCallback, v: null, argumentsList: System.Array.Empty<object?>());
             });
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_sync)
+        {
+            _registries.Clear();
+            _keptObjects.Clear();
         }
     }
 }

--- a/src/JavaScriptRuntime/Engine/NodeEventLoopPump.cs
+++ b/src/JavaScriptRuntime/Engine/NodeEventLoopPump.cs
@@ -5,7 +5,7 @@ namespace JavaScriptRuntime.EngineCore;
 ///
 /// This is intended to be owned by the single JS/runtime thread.
 /// </summary>
-public sealed class NodeEventLoopPump
+public sealed class NodeEventLoopPump : IDisposable
 {
     private sealed class NoOpFinalizationRegistryHost : IFinalizationRegistryHost
     {
@@ -23,8 +23,11 @@ public sealed class NodeEventLoopPump
     private readonly IFinalizationRegistryHost _finalizationHost;
 
     private readonly Queue<Action> _macro = new();
+    private readonly object _macroLock = new();
+    private readonly object _lifecycleLock = new();
 
     private readonly int _ownerThreadId;
+    private int _disposed;
 
     public NodeEventLoopPump(NodeSchedulerState state, ITickSource tickSource, IWaitHandle waitHandle, IFinalizationRegistryHost? finalizationHost = null)
     {
@@ -37,6 +40,10 @@ public sealed class NodeEventLoopPump
 
     private void ThrowIfNotOwnerThread()
     {
+        ObjectDisposedException.ThrowIf(
+            Volatile.Read(ref _disposed) != 0,
+            this);
+
         if (Environment.CurrentManagedThreadId != _ownerThreadId)
         {
             throw new InvalidOperationException(
@@ -47,31 +54,52 @@ public sealed class NodeEventLoopPump
     public bool HasPendingWork()
     {
         ThrowIfNotOwnerThread();
-        return _macro.Count > 0 || _state.HasPendingWork();
+        lock (_lifecycleLock)
+        {
+            ThrowIfNotOwnerThread();
+            lock (_macroLock)
+            {
+                return _macro.Count > 0 || _state.HasPendingWork();
+            }
+        }
     }
 
     public bool HasPendingWorkNow()
     {
         ThrowIfNotOwnerThread();
-        if (_macro.Count > 0)
+        lock (_lifecycleLock)
         {
-            return true;
-        }
+            ThrowIfNotOwnerThread();
+            lock (_macroLock)
+            {
+                if (_macro.Count > 0)
+                {
+                    return true;
+                }
+            }
 
-        var now = _tickSource.GetTicks();
-        return _state.HasPendingWorkNow(now);
+            var now = _tickSource.GetTicks();
+            return _state.HasPendingWorkNow(now);
+        }
     }
 
     public int GetWaitForWorkOrNextTimerMilliseconds(int maxWaitMs = 50)
     {
         ThrowIfNotOwnerThread();
-        if (_macro.Count > 0)
+        lock (_lifecycleLock)
         {
-            return 0;
-        }
+            ThrowIfNotOwnerThread();
+            lock (_macroLock)
+            {
+                if (_macro.Count > 0)
+                {
+                    return 0;
+                }
+            }
 
-        var now = _tickSource.GetTicks();
-        return _state.GetWaitForWorkOrNextTimerMilliseconds(now, maxWaitMs);
+            var now = _tickSource.GetTicks();
+            return _state.GetWaitForWorkOrNextTimerMilliseconds(now, maxWaitMs);
+        }
     }
 
     /// <summary>
@@ -93,44 +121,64 @@ public sealed class NodeEventLoopPump
     public void RunOneIteration()
     {
         ThrowIfNotOwnerThread();
-
-        _finalizationHost.ClearKeptObjects();
-        _finalizationHost.CollectAndQueueCleanupJobs(forceCollection: false);
-        DrainNextTicks();
-        DrainMicrotasks();
-        _finalizationHost.CollectAndQueueCleanupJobs(forceCollection: false);
-        DrainCleanupJobs();
-        DrainNextTicks();
-        DrainImmediatesOneTick();
-        PromoteOneDueTimerToMacro();
-
-        if (_macro.Count > 0)
+        lock (_lifecycleLock)
         {
-            _macro.Dequeue().Invoke();
+            ThrowIfNotOwnerThread();
+
+            _finalizationHost.ClearKeptObjects();
+            _finalizationHost.CollectAndQueueCleanupJobs(forceCollection: false);
             DrainNextTicks();
             DrainMicrotasks();
             _finalizationHost.CollectAndQueueCleanupJobs(forceCollection: false);
             DrainCleanupJobs();
-        }
+            DrainNextTicks();
+            DrainImmediatesOneTick();
+            PromoteOneDueTimerToMacro();
 
-        DrainNextTicks();
-        DrainMicrotasks();
-        _finalizationHost.CollectAndQueueCleanupJobs(forceCollection: false);
-        DrainCleanupJobs();
-        _finalizationHost.ClearKeptObjects();
+            Action? macro = null;
+            if (Volatile.Read(ref _disposed) == 0)
+            {
+                lock (_macroLock)
+                {
+                    if (_macro.Count > 0)
+                    {
+                        macro = _macro.Dequeue();
+                    }
+                }
+            }
+
+            if (macro != null)
+            {
+                macro.Invoke();
+                DrainNextTicks();
+                DrainMicrotasks();
+                _finalizationHost.CollectAndQueueCleanupJobs(forceCollection: false);
+                DrainCleanupJobs();
+            }
+
+            DrainNextTicks();
+            DrainMicrotasks();
+            _finalizationHost.CollectAndQueueCleanupJobs(forceCollection: false);
+            DrainCleanupJobs();
+            _finalizationHost.ClearKeptObjects();
+        }
     }
 
     public void WaitForWorkOrNextTimer(int maxWaitMs = 50)
     {
         ThrowIfNotOwnerThread();
-
-        int waitMs = GetWaitForWorkOrNextTimerMilliseconds(maxWaitMs);
-        if (waitMs == 0)
+        lock (_lifecycleLock)
         {
-            return;
-        }
+            ThrowIfNotOwnerThread();
 
-        _wakeup.WaitOne(waitMs);
+            int waitMs = GetWaitForWorkOrNextTimerMilliseconds(maxWaitMs);
+            if (waitMs == 0)
+            {
+                return;
+            }
+
+            _wakeup.WaitOne(waitMs);
+        }
     }
 
     private void DrainImmediatesOneTick(int max = 1024)
@@ -138,6 +186,11 @@ public sealed class NodeEventLoopPump
         int count = _state.GetImmediateCountSnapshot(max);
         for (int i = 0; i < count; i++)
         {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                return;
+            }
+
             if (!_state.TryDequeueImmediate(out var callback) || callback == null)
             {
                 return;
@@ -160,6 +213,11 @@ public sealed class NodeEventLoopPump
         int count = _state.GetNextTickCountSnapshot(max);
         for (int i = 0; i < count; i++)
         {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                return;
+            }
+
             if (!_state.TryDequeueNextTick(out var callback) || callback == null)
             {
                 return;
@@ -171,11 +229,19 @@ public sealed class NodeEventLoopPump
 
     private void PromoteOneDueTimerToMacro()
     {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return;
+        }
+
         var now = _tickSource.GetTicks();
 
         if (_state.TryDequeueDueTimer(now, out var entry))
         {
-            _macro.Enqueue(entry.Callback);
+            lock (_macroLock)
+            {
+                _macro.Enqueue(entry.Callback);
+            }
             _state.RescheduleIntervalFromNow(entry, now);
         }
     }
@@ -187,6 +253,11 @@ public sealed class NodeEventLoopPump
         int ticks = 0;
         while (ticks++ < max)
         {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                return;
+            }
+
             // Maintain Node-like priority for process.nextTick, including those queued from microtasks.
             DrainNextTicks();
 
@@ -206,6 +277,11 @@ public sealed class NodeEventLoopPump
         int ticks = 0;
         while (ticks++ < max)
         {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                return;
+            }
+
             if (!_state.TryDequeueCleanupJob(out var action) || action == null)
             {
                 break;
@@ -214,6 +290,22 @@ public sealed class NodeEventLoopPump
             action.Invoke();
             DrainNextTicks();
             DrainMicrotasks();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        lock (_lifecycleLock)
+        {
+            lock (_macroLock)
+            {
+                _macro.Clear();
+            }
         }
     }
 }

--- a/src/JavaScriptRuntime/Engine/NodeSchedulerState.cs
+++ b/src/JavaScriptRuntime/Engine/NodeSchedulerState.cs
@@ -42,7 +42,12 @@ internal struct ImmediateEntry : IEquatable<ImmediateEntry>
 ///
 /// The event loop/message pump is responsible for draining and executing work.
 /// </summary>
-public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, ICleanupJobScheduler, IIOScheduler
+public sealed class NodeSchedulerState :
+    IScheduler,
+    IMicrotaskScheduler,
+    ICleanupJobScheduler,
+    IIOScheduler,
+    IDisposable
 {
     private long _nextTimerId = 0;
     private long _nextImmediateId = 0;
@@ -66,6 +71,7 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
     private readonly ITickSource _tickSource;
     private readonly IWaitHandle _wakeup;
     private readonly global::JavaScriptRuntime.Node.AsyncContextRuntime? _asyncContext;
+    private int _disposed;
 
     public NodeSchedulerState(ITickSource tickSource, IWaitHandle waitHandle)
         : this(tickSource, waitHandle, null)
@@ -84,6 +90,11 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
     internal bool HasPendingWork()
     {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return false;
+        }
+
         lock (_micro)
         {
             if (_micro.Count > 0) return true;
@@ -117,6 +128,11 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
     internal bool HasPendingWorkNow(long nowTicks)
     {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return false;
+        }
+
         lock (_micro)
         {
             if (_micro.Count > 0) return true;
@@ -287,6 +303,11 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
     internal void RescheduleIntervalFromNow(TimerEntry previous, long nowTicks)
     {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return;
+        }
+
         if (!previous.IsRepeating || previous.IntervalTicks <= 0)
         {
             return;
@@ -303,6 +324,11 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
         lock (_timerLock)
         {
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                return;
+            }
+
             _timers.Enqueue(nextEntry, nextEntry.DueTicks);
         }
 
@@ -322,6 +348,7 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
     object IScheduler.Schedule(Action action, TimeSpan delay)
     {
+        ThrowIfDisposed();
         action = CaptureContext(action);
         var now = _tickSource.GetTicks();
         var id = System.Threading.Interlocked.Increment(ref _nextTimerId);
@@ -337,6 +364,7 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
         lock (_timerLock)
         {
+            ThrowIfDisposed();
             _timers.Enqueue(entry, entry.DueTicks);
         }
 
@@ -346,6 +374,7 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
     void IScheduler.Cancel(object handle)
     {
+        ThrowIfDisposed();
         if (handle is TimerEntry entry)
         {
             lock (_timerLock)
@@ -358,6 +387,7 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
     object IScheduler.ScheduleInterval(Action action, TimeSpan interval)
     {
+        ThrowIfDisposed();
         action = CaptureContext(action);
         var now = _tickSource.GetTicks();
         var id = System.Threading.Interlocked.Increment(ref _nextTimerId);
@@ -376,6 +406,7 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
         lock (_timerLock)
         {
+            ThrowIfDisposed();
             _timers.Enqueue(entry, entry.DueTicks);
         }
 
@@ -385,6 +416,7 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
     void IScheduler.CancelInterval(object handle)
     {
+        ThrowIfDisposed();
         if (handle is TimerEntry entry)
         {
             lock (_timerLock)
@@ -397,21 +429,16 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
     object IScheduler.ScheduleImmediate(Action action)
     {
+        ThrowIfDisposed();
         action = CaptureContext(action);
-        var id = System.Threading.Interlocked.Increment(ref _nextImmediateId);
-        var entry = new ImmediateEntry { id = id, Callback = action };
-        lock (_immediateLock)
-        {
-            _immediate.Enqueue(entry);
-            _immediateIds.Add(entry.id);
-        }
-
+        var entry = EnqueueImmediate(action);
         _wakeup.Set();
         return entry;
     }
 
     void IScheduler.CancelImmediate(object handle)
     {
+        ThrowIfDisposed();
         if (handle is ImmediateEntry entry)
         {
             lock (_immediateLock)
@@ -428,9 +455,11 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
     void IMicrotaskScheduler.QueueMicrotask(Action task)
     {
+        ThrowIfDisposed();
         task = CaptureContext(task);
         lock (_micro)
         {
+            ThrowIfDisposed();
             _micro.Enqueue(task);
         }
 
@@ -439,9 +468,11 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
     void ICleanupJobScheduler.QueueCleanupJob(Action task)
     {
+        ThrowIfDisposed();
         task = CaptureContext(task);
         lock (_cleanup)
         {
+            ThrowIfDisposed();
             _cleanup.Enqueue(task);
         }
 
@@ -450,9 +481,11 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
     internal void QueueNextTick(Action task)
     {
+        ThrowIfDisposed();
         task = CaptureContext(task);
         lock (_nextTickLock)
         {
+            ThrowIfDisposed();
             _nextTick.Enqueue(task);
         }
 
@@ -461,7 +494,13 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
 
     public void BeginIo()
     {
-        System.Threading.Interlocked.Increment(ref _pendingIoCount);
+        ThrowIfDisposed();
+        Interlocked.Increment(ref _pendingIoCount);
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            CancelPendingIo();
+            ThrowIfDisposed();
+        }
     }
 
     public void EndIo(global::JavaScriptRuntime.PromiseWithResolvers promiseWithResolvers, object? result, bool isError = false)
@@ -491,24 +530,156 @@ public sealed class NodeSchedulerState : IScheduler, IMicrotaskScheduler, IClean
             }
         }
 
+        if (!TryQueueExternalImmediate(CompleteNow))
+        {
+            CancelPendingIo();
+        }
+    }
+
+    internal bool TryQueueExternalImmediate(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return false;
+        }
+
+        _ = EnqueueImmediate(action);
         try
         {
-            ((IScheduler)this).ScheduleImmediate(CompleteNow);
+            _wakeup.Set();
         }
-        catch
+        catch (ObjectDisposedException) when (Volatile.Read(ref _disposed) != 0)
         {
-            try
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            // The callback is already queued and hosted loops also poll for work.
+        }
+
+        return true;
+    }
+
+    internal bool TryQueueExternalNextTick(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return false;
+        }
+
+        lock (_nextTickLock)
+        {
+            if (Volatile.Read(ref _disposed) != 0)
             {
-                // Fallback path: if enqueueing completion via ScheduleImmediate fails,
-                // queue it as a next-tick task so completion still runs on the event-loop
-                // thread and pending I/O does not remain elevated indefinitely.
-                QueueNextTick(CompleteNow);
+                return false;
             }
-            catch
-            {
-                // Last-resort fallback if queue signaling itself fails.
-                CompleteNow();
-            }
+
+            _nextTick.Enqueue(action);
+        }
+
+        try
+        {
+            _wakeup.Set();
+        }
+        catch (ObjectDisposedException) when (Volatile.Read(ref _disposed) != 0)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            // The owning event loop also polls for work.
+        }
+
+        return true;
+    }
+
+    internal long PendingIoCount => Interlocked.Read(ref _pendingIoCount);
+
+    internal void CancelPendingIo()
+    {
+        var value = Interlocked.Decrement(ref _pendingIoCount);
+        if (value < 0)
+        {
+            Interlocked.Exchange(ref _pendingIoCount, 0);
+        }
+    }
+
+    internal void SignalWakeup()
+    {
+        try
+        {
+            _wakeup.Set();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        SignalWakeup();
+
+        lock (_nextTickLock)
+        {
+            _nextTick.Clear();
+        }
+
+        lock (_immediateLock)
+        {
+            _immediate.Clear();
+            _immediateIds.Clear();
+            _canceledImmediates.Clear();
+        }
+
+        lock (_timerLock)
+        {
+            _timers.Clear();
+            _canceledIntervals.Clear();
+        }
+
+        lock (_micro)
+        {
+            _micro.Clear();
+        }
+
+        lock (_cleanup)
+        {
+            _cleanup.Clear();
+        }
+
+        Interlocked.Exchange(ref _pendingIoCount, 0);
+        if (_wakeup is IDisposable disposableWakeup)
+        {
+            disposableWakeup.Dispose();
+        }
+    }
+
+    private ImmediateEntry EnqueueImmediate(Action action)
+    {
+        var id = Interlocked.Increment(ref _nextImmediateId);
+        var entry = new ImmediateEntry { id = id, Callback = action };
+        lock (_immediateLock)
+        {
+            ThrowIfDisposed();
+            _immediate.Enqueue(entry);
+            _immediateIds.Add(entry.id);
+        }
+
+        return entry;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            throw new ObjectDisposedException(nameof(NodeSchedulerState));
         }
     }
 

--- a/src/JavaScriptRuntime/Engine/WaitHandle.cs
+++ b/src/JavaScriptRuntime/Engine/WaitHandle.cs
@@ -1,6 +1,6 @@
 namespace JavaScriptRuntime.EngineCore;
 
-public class WaitHandle : IWaitHandle
+public class WaitHandle : IWaitHandle, IDisposable
 {
     private readonly AutoResetEvent _event = new(false);
 
@@ -12,5 +12,10 @@ public class WaitHandle : IWaitHandle
     public void WaitOne(int millisecondsTimeout)
     {
         _event.WaitOne(millisecondsTimeout);
+    }
+
+    public void Dispose()
+    {
+        _event.Dispose();
     }
 }

--- a/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
+++ b/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
@@ -43,6 +43,7 @@ internal sealed class JsRuntimeInstance : IDisposable
     // Service provider/sync context are thread-affine and created inside ThreadMain.
     private ServiceContainer? _serviceProvider;
     private NodeEventLoopPump? _eventLoop;
+    private RuntimeAgent? _agent;
 
     // Exports returned by CommonJS module evaluation (require(...) result).
     private object? _exports;
@@ -195,6 +196,8 @@ internal sealed class JsRuntimeInstance : IDisposable
         }
 
         FailPendingOperations();
+
+        _agent?.RequestShutdown();
 
         // Stop accepting work and wake the consuming enumerable.
         try
@@ -445,6 +448,7 @@ internal sealed class JsRuntimeInstance : IDisposable
                 isHostedExecution: true,
                 compiledAssemblyPath: _options?.CompiledAssemblyPath);
             _serviceProvider = serviceProvider;
+            _agent = serviceProvider.Resolve<RuntimeAgent>();
             executionScope = serviceProvider
                 .Resolve<RuntimeExecutionContext>()
                 .EnterAsRoot();
@@ -475,7 +479,8 @@ internal sealed class JsRuntimeInstance : IDisposable
             // Process cross-thread invocations serially, while also pumping the JS event loop
             // (including timers) even when the host is idle. This avoids deadlocks where a
             // Promise resolves via setTimeout/setInterval but no new host invocations arrive.
-            while (!_shutdown.IsCancellationRequested)
+            while (!_shutdown.IsCancellationRequested
+                && !_agent.ShutdownToken.IsCancellationRequested)
             {
                 int waitMs = _eventLoop.GetWaitForWorkOrNextTimerMilliseconds(maxWaitMs: 50);
 
@@ -511,10 +516,13 @@ internal sealed class JsRuntimeInstance : IDisposable
         {
             FailPendingOperations();
 
+            var agent = _agent;
             executionScope?.Dispose();
+            agent?.Dispose();
             _exports = null;
             _eventLoop = null;
             _serviceProvider = null;
+            _agent = null;
 
             // Mark thread termination before disposing shared resources.
             _terminated.TrySetResult();

--- a/src/JavaScriptRuntime/Node/Dns.cs
+++ b/src/JavaScriptRuntime/Node/Dns.cs
@@ -61,7 +61,7 @@ public sealed partial class Dns
         {
             var addresses = await Task.Run(
                 () => ResolveAddresses(hostname, options)).ConfigureAwait(false);
-            ((IScheduler)scheduler).ScheduleImmediate(() =>
+            if (!scheduler.TryQueueExternalImmediate(() =>
             {
                 try
                 {
@@ -88,12 +88,15 @@ public sealed partial class Dns
                 {
                     scheduler.EndIo(lifetime, null);
                 }
-            });
+            }))
+            {
+                scheduler.CancelPendingIo();
+            }
         }
         catch (Exception ex)
         {
             var error = new DnsLookupError(hostname, ex);
-            ((IScheduler)scheduler).ScheduleImmediate(() =>
+            if (!scheduler.TryQueueExternalImmediate(() =>
             {
                 try
                 {
@@ -103,7 +106,10 @@ public sealed partial class Dns
                 {
                     scheduler.EndIo(lifetime, null);
                 }
-            });
+            }))
+            {
+                scheduler.CancelPendingIo();
+            }
         }
     }
 

--- a/src/JavaScriptRuntime/Node/Net.cs
+++ b/src/JavaScriptRuntime/Node/Net.cs
@@ -219,17 +219,13 @@ namespace JavaScriptRuntime.Node
 
         internal static void ScheduleOnEventLoop(NodeSchedulerState? scheduler, Action action)
         {
-            try
+            var targetScheduler =
+                scheduler
+                ?? GlobalThis.ServiceProvider?.Resolve<NodeSchedulerState>();
+            if (targetScheduler != null)
             {
-                var targetScheduler = scheduler ?? GlobalThis.ServiceProvider?.Resolve<NodeSchedulerState>();
-                if (targetScheduler != null)
-                {
-                    targetScheduler.QueueNextTick(action);
-                    return;
-                }
-            }
-            catch
-            {
+                _ = targetScheduler.TryQueueExternalNextTick(action);
+                return;
             }
 
             action();
@@ -237,20 +233,16 @@ namespace JavaScriptRuntime.Node
 
         internal static void ScheduleImmediateOnEventLoop(NodeSchedulerState? scheduler, Action action)
         {
-            try
+            var targetScheduler =
+                scheduler
+                ?? GlobalThis.ServiceProvider?.Resolve<NodeSchedulerState>();
+            if (targetScheduler != null)
             {
-                var targetScheduler = scheduler ?? GlobalThis.ServiceProvider?.Resolve<NodeSchedulerState>();
-                if (targetScheduler != null)
-                {
-                    ((IScheduler)targetScheduler).ScheduleImmediate(action);
-                    return;
-                }
-            }
-            catch
-            {
+                _ = targetScheduler.TryQueueExternalImmediate(action);
+                return;
             }
 
-            ScheduleOnEventLoop(scheduler, action);
+            action();
         }
 
         internal static PromiseWithResolvers CreateIoPromise(Action<object?>? onSuccess = null, Action<object?>? onError = null)

--- a/src/JavaScriptRuntime/RuntimeAgentSchedulingState.cs
+++ b/src/JavaScriptRuntime/RuntimeAgentSchedulingState.cs
@@ -1,0 +1,172 @@
+using JavaScriptRuntime.EngineCore;
+using JavaScriptRuntime.Node;
+
+namespace JavaScriptRuntime;
+
+/// <summary>
+/// Agent-owned scheduling, asynchronous context, and cooperative shutdown state.
+/// </summary>
+internal sealed class RuntimeAgentSchedulingState : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly CancellationTokenSource _shutdown = new();
+    private NodeSchedulerState? _scheduler;
+    private NodeEventLoopPump? _eventLoop;
+    private FinalizationRegistryHost? _finalizationHost;
+    private ITickSource? _tickSource;
+    private IWaitHandle? _wakeup;
+    private RuntimeOwnershipState _state;
+
+    internal AsyncContextRuntime AsyncContext { get; } = new();
+
+    internal CancellationToken ShutdownToken => _shutdown.Token;
+
+    internal NodeSchedulerState GetOrCreateScheduler(
+        ITickSource tickSource,
+        IWaitHandle wakeup)
+    {
+        ArgumentNullException.ThrowIfNull(tickSource);
+        ArgumentNullException.ThrowIfNull(wakeup);
+
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            if (_scheduler != null)
+            {
+                return _scheduler;
+            }
+
+            _tickSource = tickSource;
+            _wakeup = wakeup;
+            _scheduler = new NodeSchedulerState(
+                tickSource,
+                wakeup,
+                AsyncContext);
+            return _scheduler;
+        }
+    }
+
+    internal IFinalizationRegistryHost GetOrCreateFinalizationHost(
+        Func<NodeSchedulerState> schedulerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(schedulerFactory);
+
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            return _finalizationHost ??= new FinalizationRegistryHost(
+                schedulerFactory());
+        }
+    }
+
+    internal NodeEventLoopPump GetOrCreateEventLoop(
+        Func<NodeSchedulerState> schedulerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(schedulerFactory);
+
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            if (_eventLoop != null)
+            {
+                return _eventLoop;
+            }
+
+            var scheduler = schedulerFactory();
+            var tickSource = _tickSource
+                ?? throw new InvalidOperationException(
+                    "The runtime agent tick source has not been initialized.");
+            var wakeup = _wakeup
+                ?? throw new InvalidOperationException(
+                    "The runtime agent wake handle has not been initialized.");
+            var finalizationHost = _finalizationHost
+                ??= new FinalizationRegistryHost(scheduler);
+            _eventLoop = new NodeEventLoopPump(
+                scheduler,
+                tickSource,
+                wakeup,
+                finalizationHost);
+            return _eventLoop;
+        }
+    }
+
+    internal void EnqueueFromExternalThread(Action callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        NodeSchedulerState scheduler;
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            scheduler = _scheduler
+                ?? throw new InvalidOperationException(
+                    "The runtime agent scheduler has not been initialized.");
+        }
+
+        if (!scheduler.TryQueueExternalImmediate(callback))
+        {
+            throw new ObjectDisposedException(nameof(RuntimeAgent));
+        }
+    }
+
+    internal void RequestShutdown()
+    {
+        NodeSchedulerState? scheduler;
+        lock (_gate)
+        {
+            if (_state == RuntimeOwnershipState.Disposed)
+            {
+                return;
+            }
+
+            _state = RuntimeOwnershipState.Disposing;
+            scheduler = _scheduler;
+        }
+
+        if (!_shutdown.IsCancellationRequested)
+        {
+            _shutdown.Cancel();
+        }
+
+        scheduler?.SignalWakeup();
+    }
+
+    public void Dispose()
+    {
+        NodeEventLoopPump? eventLoop;
+        NodeSchedulerState? scheduler;
+        FinalizationRegistryHost? finalizationHost;
+
+        lock (_gate)
+        {
+            if (_state == RuntimeOwnershipState.Disposed)
+            {
+                return;
+            }
+
+            _state = RuntimeOwnershipState.Disposing;
+            eventLoop = _eventLoop;
+            scheduler = _scheduler;
+            finalizationHost = _finalizationHost;
+        }
+
+        RequestShutdown();
+        eventLoop?.Dispose();
+        finalizationHost?.Dispose();
+        scheduler?.Dispose();
+        AsyncContext.Reset();
+
+        lock (_gate)
+        {
+            _state = RuntimeOwnershipState.Disposed;
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_state != RuntimeOwnershipState.Active)
+        {
+            throw new ObjectDisposedException(nameof(RuntimeAgent));
+        }
+    }
+}

--- a/src/JavaScriptRuntime/RuntimeOwnership.cs
+++ b/src/JavaScriptRuntime/RuntimeOwnership.cs
@@ -104,9 +104,14 @@ internal sealed class RuntimeAgent : IDisposable
     internal RuntimeAgent(RuntimeAgentCluster cluster)
     {
         Cluster = cluster;
+        Scheduling = new RuntimeAgentSchedulingState();
     }
 
     internal RuntimeAgentCluster Cluster { get; }
+
+    internal RuntimeAgentSchedulingState Scheduling { get; }
+
+    internal CancellationToken ShutdownToken => Scheduling.ShutdownToken;
 
     internal bool IsDisposed
     {
@@ -144,6 +149,24 @@ internal sealed class RuntimeAgent : IDisposable
         }
     }
 
+    internal void EnqueueFromExternalThread(Action callback)
+        => Scheduling.EnqueueFromExternalThread(callback);
+
+    internal void RequestShutdown()
+    {
+        lock (_gate)
+        {
+            if (_state == RuntimeOwnershipState.Disposed)
+            {
+                return;
+            }
+
+            _state = RuntimeOwnershipState.Disposing;
+        }
+
+        Scheduling.RequestShutdown();
+    }
+
     public void Dispose()
     {
         lock (_gate)
@@ -154,6 +177,7 @@ internal sealed class RuntimeAgent : IDisposable
             }
 
             _state = RuntimeOwnershipState.Disposing;
+            Scheduling.RequestShutdown();
             var realms = _realms.ToArray();
             _realms.Clear();
 
@@ -162,6 +186,7 @@ internal sealed class RuntimeAgent : IDisposable
                 realms[index].Dispose();
             }
 
+            Scheduling.Dispose();
             DisposalOrder = Cluster.NextDisposalOrder();
             _state = RuntimeOwnershipState.Disposed;
         }
@@ -199,6 +224,10 @@ internal sealed class RuntimeRealm : IDisposable
         Intrinsics = new RuntimeIntrinsics();
         Services = new ServiceContainer();
         Services.AttachOwningRealm(this);
+        Services.Register<EngineCore.ITickSource, EngineCore.TickSource>();
+        Services.Register<
+            EngineCore.IWaitHandle,
+            EngineCore.WaitHandle>();
     }
 
     internal RuntimeAgent Agent { get; }

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -1802,21 +1802,10 @@ public class RuntimeServices
         container.RegisterInstance(HostRuntimeIntrinsicDescriptors.Empty);
         container.RegisterInstance(new ConsoleOutputSinks());
 
-        // Register default engine dependencies
-        container.Register<EngineCore.ITickSource, EngineCore.TickSource>();
-        container.Register<EngineCore.IWaitHandle, EngineCore.WaitHandle>();
-        container.Register<EngineCore.NodeSchedulerState>();
-        container.Register<EngineCore.NodeEventLoopPump>();
-        container.Register<EngineCore.ICleanupJobScheduler, EngineCore.NodeSchedulerState>();
-        container.Register<EngineCore.IMicrotaskScheduler, EngineCore.NodeSchedulerState>();
-        container.Register<EngineCore.IScheduler, EngineCore.NodeSchedulerState>();
-        container.Register<EngineCore.IIOScheduler, EngineCore.NodeSchedulerState>();
-        container.Register<EngineCore.IFinalizationRegistryHost, EngineCore.FinalizationRegistryHost>();
         container.Register<Modules.CommonJS.Require>();
         container.RegisterInstance<IPropertyDescriptorStore>(new PropertyDescriptorStore());
         container.Register<IEnvironment, DefaultEnvironment>();
         container.Register<Node.IChildProcessLauncher, Node.DefaultChildProcessLauncher>();
-        container.Register<Node.AsyncContextRuntime>();
         container.Register<Node.DiagnosticsChannelRuntime>();
 
         return container;

--- a/tests/Jroc.Tests/RuntimeAgentSchedulingTests.cs
+++ b/tests/Jroc.Tests/RuntimeAgentSchedulingTests.cs
@@ -1,0 +1,338 @@
+using JavaScriptRuntime;
+using JavaScriptRuntime.DependencyInjection;
+using JavaScriptRuntime.EngineCore;
+using JavaScriptRuntime.Node;
+
+namespace Jroc.Tests;
+
+public sealed class RuntimeAgentSchedulingTests
+{
+    [Fact]
+    public void RealmsInOneAgentShareSchedulingAndAsyncContextServices()
+    {
+        var cluster = new RuntimeAgentCluster();
+        var agent = cluster.CreateAgent();
+        var first = CreateConfiguredRealm(agent);
+        var second = CreateConfiguredRealm(agent);
+
+        var firstScheduler = first.Services.Resolve<NodeSchedulerState>();
+        var firstEventLoop = first.Services.Resolve<NodeEventLoopPump>();
+
+        Assert.Same(firstScheduler, second.Services.Resolve<NodeSchedulerState>());
+        Assert.Same(firstScheduler, second.Services.Resolve<IScheduler>());
+        Assert.Same(firstScheduler, second.Services.Resolve<IMicrotaskScheduler>());
+        Assert.Same(firstEventLoop, second.Services.Resolve<NodeEventLoopPump>());
+        Assert.Same(
+            first.Services.Resolve<AsyncContextRuntime>(),
+            second.Services.Resolve<AsyncContextRuntime>());
+        Assert.Same(
+            first.Services.Resolve<IFinalizationRegistryHost>(),
+            second.Services.Resolve<IFinalizationRegistryHost>());
+        Assert.Same(
+            agent.Scheduling,
+            first.Services.Resolve<RuntimeAgentSchedulingState>());
+
+        cluster.Dispose();
+    }
+
+    [Fact]
+    public void AgentsDrainTimersMicrotasksAndCallbacksIndependently()
+    {
+        var first = CreateAgentRuntime();
+        var second = CreateAgentRuntime();
+        var firstCallbacks = new List<string>();
+        var secondCallbacks = new List<string>();
+
+        QueueAllPhases(first.Services, firstCallbacks);
+        QueueAllPhases(second.Services, secondCallbacks);
+
+        DrainRunnableWork(first.EventLoop);
+
+        Assert.Equal(["nextTick", "microtask", "immediate", "timer"], firstCallbacks);
+        Assert.Empty(secondCallbacks);
+        Assert.True(second.EventLoop.HasPendingWork());
+
+        DrainRunnableWork(second.EventLoop);
+
+        Assert.Equal(["nextTick", "microtask", "immediate", "timer"], secondCallbacks);
+        first.Cluster.Dispose();
+        second.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void AgentsRunSchedulingAndAsyncContextConcurrentlyWithoutCrossDelivery()
+    {
+        using var start = new Barrier(3);
+        var firstCallbacks = new List<string>();
+        var secondCallbacks = new List<string>();
+        Exception? firstFailure = null;
+        Exception? secondFailure = null;
+        var firstThread = new Thread(
+            () => RunConcurrentAgent(
+                "first",
+                start,
+                firstCallbacks,
+                exception => firstFailure = exception));
+        var secondThread = new Thread(
+            () => RunConcurrentAgent(
+                "second",
+                start,
+                secondCallbacks,
+                exception => secondFailure = exception));
+
+        firstThread.Start();
+        secondThread.Start();
+        Assert.True(start.SignalAndWait(TimeSpan.FromSeconds(5)));
+        firstThread.Join();
+        secondThread.Join();
+
+        Assert.Null(firstFailure);
+        Assert.Null(secondFailure);
+        Assert.Equal(
+            ["first-nextTick", "first-microtask", "first-store", "first-immediate", "first-timer"],
+            firstCallbacks);
+        Assert.Equal(
+            ["second-nextTick", "second-microtask", "second-store", "second-immediate", "second-timer"],
+            secondCallbacks);
+    }
+
+    [Fact]
+    public void ExternalWakeRunsOnlyOnTheOwningAgentExecutor()
+    {
+        var runtime = CreateAgentRuntime();
+        var ownerThreadId = Environment.CurrentManagedThreadId;
+        var callbackThreadId = 0;
+        Exception? producerFailure = null;
+
+        var producer = new Thread(() =>
+        {
+            try
+            {
+                runtime.Agent.EnqueueFromExternalThread(
+                    () => callbackThreadId = Environment.CurrentManagedThreadId);
+            }
+            catch (Exception exception)
+            {
+                producerFailure = exception;
+            }
+        });
+        producer.Start();
+        producer.Join();
+
+        Assert.Null(producerFailure);
+        Assert.Equal(0, callbackThreadId);
+        runtime.EventLoop.RunOneIteration();
+        Assert.Equal(ownerThreadId, callbackThreadId);
+
+        Exception? wrongThreadFailure = null;
+        var wrongExecutor = new Thread(() =>
+        {
+            wrongThreadFailure = Record.Exception(
+                runtime.EventLoop.RunOneIteration);
+        });
+        wrongExecutor.Start();
+        wrongExecutor.Join();
+
+        Assert.IsType<InvalidOperationException>(wrongThreadFailure);
+        runtime.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void DisposingOneAgentCancelsAndClearsOnlyItsOwnWork()
+    {
+        var first = CreateAgentRuntime();
+        var second = CreateAgentRuntime();
+        var firstRan = false;
+        var secondRan = false;
+        var firstScheduler = first.Services.Resolve<NodeSchedulerState>();
+
+        first.Agent.EnqueueFromExternalThread(() => firstRan = true);
+        second.Agent.EnqueueFromExternalThread(() => secondRan = true);
+        firstScheduler.BeginIo();
+        _ = first.Services.Resolve<IScheduler>().Schedule(
+            () => firstRan = true,
+            TimeSpan.FromHours(1));
+
+        first.Agent.Dispose();
+
+        Assert.True(first.Agent.ShutdownToken.IsCancellationRequested);
+        Assert.False(firstScheduler.HasPendingWork());
+        Assert.Equal(0, firstScheduler.PendingIoCount);
+        Assert.Throws<ObjectDisposedException>(
+            () => first.Agent.EnqueueFromExternalThread(() => { }));
+        Assert.False(firstRan);
+        Assert.True(second.EventLoop.HasPendingWork());
+
+        second.EventLoop.RunOneIteration();
+        Assert.True(secondRan);
+        Assert.False(second.Agent.ShutdownToken.IsCancellationRequested);
+
+        first.Cluster.Dispose();
+        second.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void ConcurrentAgentDisposalStopsBeforeTheNextQueuedCallback()
+    {
+        var runtime = CreateAgentRuntime();
+        var firstRan = false;
+        var secondRan = false;
+        Thread? disposer = null;
+
+        runtime.Agent.EnqueueFromExternalThread(() =>
+        {
+            firstRan = true;
+            disposer = new Thread(runtime.Agent.Dispose);
+            disposer.Start();
+            Assert.True(
+                SpinWait.SpinUntil(
+                    () => runtime.Agent.ShutdownToken.IsCancellationRequested,
+                    TimeSpan.FromSeconds(5)));
+        });
+        runtime.Agent.EnqueueFromExternalThread(() => secondRan = true);
+
+        runtime.EventLoop.RunOneIteration();
+        disposer!.Join();
+
+        Assert.True(firstRan);
+        Assert.False(secondRan);
+        Assert.True(runtime.Agent.IsDisposed);
+        runtime.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void ShutdownPreventsNewRealmsWithoutAffectingAnotherAgent()
+    {
+        var first = CreateAgentRuntime();
+        var second = CreateAgentRuntime();
+
+        first.Agent.RequestShutdown();
+
+        Assert.True(first.Agent.ShutdownToken.IsCancellationRequested);
+        Assert.Throws<ObjectDisposedException>(first.Agent.CreateRealm);
+        Assert.Throws<ObjectDisposedException>(
+            () => first.Agent.EnqueueFromExternalThread(() => { }));
+        Assert.False(second.Agent.ShutdownToken.IsCancellationRequested);
+
+        var additionalRealm = second.Agent.CreateRealm();
+        Assert.Same(second.Agent, additionalRealm.Agent);
+
+        first.Agent.Dispose();
+        first.Cluster.Dispose();
+        second.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void AgentSchedulingServicesCannotBeReplacedOrRemoved()
+    {
+        var runtime = CreateAgentRuntime();
+
+        Assert.Throws<InvalidOperationException>(
+            () => runtime.Services.Replace(new AsyncContextRuntime()));
+        Assert.Throws<InvalidOperationException>(
+            () => runtime.Services.Remove<NodeSchedulerState>());
+        Assert.Throws<InvalidOperationException>(
+            () => runtime.Services.Remove<NodeEventLoopPump>());
+        Assert.Throws<InvalidOperationException>(
+            () => runtime.Services.Remove<IScheduler>());
+
+        runtime.Services.Clear();
+
+        Assert.Same(
+            runtime.Agent.Scheduling.AsyncContext,
+            runtime.Services.Resolve<AsyncContextRuntime>());
+        Assert.Same(
+            runtime.Agent.Scheduling,
+            runtime.Services.Resolve<RuntimeAgentSchedulingState>());
+
+        runtime.Cluster.Dispose();
+    }
+
+    private static AgentRuntime CreateAgentRuntime()
+    {
+        var cluster = new RuntimeAgentCluster();
+        var agent = cluster.CreateAgent();
+        var realm = CreateConfiguredRealm(agent);
+        return new AgentRuntime(
+            cluster,
+            agent,
+            realm.Services,
+            realm.Services.Resolve<NodeEventLoopPump>());
+    }
+
+    private static RuntimeRealm CreateConfiguredRealm(RuntimeAgent agent)
+        => agent.CreateRealm();
+
+    private static void QueueAllPhases(
+        ServiceContainer services,
+        List<string> callbacks,
+        string prefix = "")
+    {
+        var scheduler = services.Resolve<NodeSchedulerState>();
+        scheduler.QueueNextTick(() => callbacks.Add($"{prefix}nextTick"));
+        services.Resolve<IMicrotaskScheduler>()
+            .QueueMicrotask(() => callbacks.Add($"{prefix}microtask"));
+        _ = services.Resolve<IScheduler>()
+            .ScheduleImmediate(() => callbacks.Add($"{prefix}immediate"));
+        _ = services.Resolve<IScheduler>()
+            .Schedule(() => callbacks.Add($"{prefix}timer"), TimeSpan.Zero);
+    }
+
+    private static void RunConcurrentAgent(
+        string name,
+        Barrier start,
+        List<string> callbacks,
+        Action<Exception> recordFailure)
+    {
+        RuntimeAgentCluster? cluster = null;
+        try
+        {
+            var runtime = CreateAgentRuntime();
+            cluster = runtime.Cluster;
+            var asyncContext = runtime.Services.Resolve<AsyncContextRuntime>();
+            var storage = new AsyncLocalStorageObject(
+                asyncContext,
+                options: null,
+                prototype: new JsObject());
+            storage.enterWith($"{name}-store");
+
+            QueueAllPhases(runtime.Services, callbacks, $"{name}-");
+            runtime.Services.Resolve<IMicrotaskScheduler>()
+                .QueueMicrotask(
+                    () => callbacks.Add(
+                        storage.getStore()?.ToString()
+                            ?? throw new InvalidOperationException(
+                                "The agent async context store was not restored.")));
+
+            if (!start.SignalAndWait(TimeSpan.FromSeconds(5)))
+            {
+                throw new TimeoutException(
+                    "Timed out waiting for the concurrent agent start barrier.");
+            }
+
+            DrainRunnableWork(runtime.EventLoop);
+        }
+        catch (Exception exception)
+        {
+            recordFailure(exception);
+        }
+        finally
+        {
+            cluster?.Dispose();
+        }
+    }
+
+    private static void DrainRunnableWork(NodeEventLoopPump eventLoop)
+    {
+        while (eventLoop.HasPendingWorkNow())
+        {
+            eventLoop.RunOneIteration();
+        }
+    }
+
+    private sealed record AgentRuntime(
+        RuntimeAgentCluster Cluster,
+        RuntimeAgent Agent,
+        ServiceContainer Services,
+        NodeEventLoopPump EventLoop);
+}


### PR DESCRIPTION
## Summary

- add `RuntimeAgentSchedulingState` as the owner of scheduler queues, timers, pending I/O, the event-loop pump, async-hooks context, finalization jobs, wake signaling, and cooperative cancellation
- make all realms in one agent resolve the same protected scheduling services while keeping separate agents fully isolated
- add a raw cross-thread wake API so background I/O only enqueues work and JavaScript callbacks execute on the receiving agent executor
- make agent shutdown reject new work, stop before the next queued callback, clear handles/queues, and leave other agents untouched
- integrate hosted runtime shutdown with the agent cancellation/disposal lifecycle and document the remaining #1828 bootstrap unification boundary

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --filter "FullyQualifiedName!~Jroc.Tests.ReadmeSampleTests&FullyQualifiedName!~Jroc.Tests.JrocSdkPackageTests"` (3,311 passed, 1 skipped)
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --no-restore` (6,312 passed, 58 skipped)
- `dotnet build jroc.sln --no-restore --nologo` (0 warnings, 0 errors)

Closes #1826
