### PR TITLE
runtime: migrate web platform objects to JsObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,21 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   `JsObject` inline property/prototype storage while retaining their exotic
   indexed and mapped-parameter slots.
 
+- runtime: continue #1580's incremental built-in representation migration by
+  moving URL, URLSearchParams, and URLSearchParams iterators to `JsObject`
+  inline property/prototype storage while retaining their CLR state and live
+  search parameter behavior (issue #1859).
+
+- runtime: continue #1580's incremental built-in representation migration by
+  moving AbortController and AbortSignal to `JsObject` inline
+  property/prototype storage while retaining private CLR abort state and
+  listeners (issue #1860).
+
+- runtime: continue #1580's incremental built-in representation migration by
+  moving iterator helpers and iterator result objects to `JsObject` inline
+  property/prototype storage while retaining iterator cleanup, exhaustion, and
+  result `value`/`done` behavior (issue #1861).
+
 - runtime/test262: expose SharedArrayBuffer as a first-class global constructor
   with standard constructor/prototype metadata and receiver-checked
   `byteLength`, `maxByteLength`, and `growable` accessors. Activates twenty

--- a/docs/ECMA262/7/Section7_4.json
+++ b/docs/ECMA262/7/Section7_4.json
@@ -311,9 +311,10 @@
         "specUrl": "https://tc39.es/ecma262/#sec-createiterresultobject",
         "testScripts": [
           "tests/Jroc.Tests/Generator/JavaScript/Generator_BasicNext.js",
-          "tests/Jroc.Tests/AsyncGenerator/JavaScript/AsyncGenerator_BasicNext.js"
+          "tests/Jroc.Tests/AsyncGenerator/JavaScript/AsyncGenerator_BasicNext.js",
+          "tests/Jroc.Tests/IteratorObjectRepresentationTests.cs"
         ],
-        "notes": "Iterator result objects are produced via IteratorResult helpers for sync and async iterator implementations."
+        "notes": "Iterator result objects are produced via IteratorResult helpers for sync and async iterator implementations. They are ordinary JsObject-backed values with own observable value and done data properties while retaining the runtime's typed iterator-result API."
       },
       {
         "clause": "7.4.17",

--- a/docs/ECMA262/7/Section7_4.md
+++ b/docs/ECMA262/7/Section7_4.md
@@ -4,7 +4,7 @@
 
 [Back to Section7](Section7.md) | [Back to Index](../Index.md)
 
-> Last generated (UTC): 2026-07-07T20:40:52Z
+> Last generated (UTC): 2026-08-16T07:26:37Z
 
 | Clause | Title | Status | Link |
 |---:|---|---|---|
@@ -137,7 +137,7 @@ Feature-level support tracking with repo test references and optional test262 ev
 
 | Feature name | Status | Test scripts | test262 evidence | Notes |
 |---|---|---|---|---|
-| CreateIteratorResultObject | Supported with Limitations | [`Generator_BasicNext.js`](../../../tests/Jroc.Tests/Generator/JavaScript/Generator_BasicNext.js)<br>[`AsyncGenerator_BasicNext.js`](../../../tests/Jroc.Tests/AsyncGenerator/JavaScript/AsyncGenerator_BasicNext.js) |  | Iterator result objects are produced via IteratorResult helpers for sync and async iterator implementations. |
+| CreateIteratorResultObject | Supported with Limitations | [`Generator_BasicNext.js`](../../../tests/Jroc.Tests/Generator/JavaScript/Generator_BasicNext.js)<br>[`AsyncGenerator_BasicNext.js`](../../../tests/Jroc.Tests/AsyncGenerator/JavaScript/AsyncGenerator_BasicNext.js)<br>`tests/Jroc.Tests/IteratorObjectRepresentationTests.cs` |  | Iterator result objects are produced via IteratorResult helpers for sync and async iterator implementations. They are ordinary JsObject-backed values with own observable value and done data properties while retaining the runtime's typed iterator-result API. |
 
 ### 7.4.17 ([tc39.es](https://tc39.es/ecma262/#sec-createlistiteratorRecord))
 

--- a/src/JavaScriptRuntime/Abort.cs
+++ b/src/JavaScriptRuntime/Abort.cs
@@ -3,10 +3,23 @@ using System.Collections.Generic;
 
 namespace JavaScriptRuntime
 {
-    public sealed class AbortController
+    public sealed class AbortController : JsObject
     {
+        private static readonly Func<object[], object?[]?, object?> PrototypeAbortValue =
+            PrototypeAbort;
+        private static readonly Func<object[], object?[]?, object?> PrototypeSignalGetterValue =
+            PrototypeSignalGetter;
+
+        /// <summary>Realm-owned <c>AbortController.prototype</c> intrinsic.</summary>
+        internal static JsObject Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.AbortControllerPrototype,
+                static () => new JsObject(),
+                static prototype => InitializePrototype(prototype));
+
         public AbortController()
         {
+            PrototypeChain.InitializePrototype(this, Prototype);
             signal = new AbortSignal();
         }
 
@@ -17,13 +30,86 @@ namespace JavaScriptRuntime
             signal.Abort(reason);
             return null;
         }
+
+        internal static void InitializeIntrinsicSurface(object objectPrototype)
+        {
+            GlobalThis.ConfigureBuiltinFunctionObject(typeof(AbortController));
+            PrototypeChain.SetPrototype(Prototype, objectPrototype);
+
+            AbortIntrinsicSurface.DefineConstructorPrototypeSurface(
+                typeof(AbortController),
+                Prototype);
+        }
+
+        private static void InitializePrototype(JsObject prototype)
+        {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
+            Function.InitializeFunctionInstance(PrototypeAbortValue, 1d, "abort");
+            Function.MarkUndefinedPrototype(PrototypeAbortValue);
+            Function.InitializeFunctionInstance(
+                PrototypeSignalGetterValue,
+                0d,
+                "get signal");
+            Function.MarkUndefinedPrototype(PrototypeSignalGetterValue);
+            AbortIntrinsicSurface.DefinePrototypeMethod(
+                prototype,
+                "abort",
+                PrototypeAbortValue);
+            AbortIntrinsicSurface.DefinePrototypeAccessor(
+                prototype,
+                "signal",
+                PrototypeSignalGetterValue);
+        }
+
+        private static object? PrototypeAbort(object[] scopes, object?[]? args)
+        {
+            GetAbortControllerReceiver("abort").abort(
+                args is { Length: > 0 } ? args[0] : null);
+            return null;
+        }
+
+        private static object? PrototypeSignalGetter(object[] scopes, object?[]? args)
+            => GetAbortControllerReceiver("signal").signal;
+
+        private static AbortController GetAbortControllerReceiver(string memberName)
+        {
+            if (RuntimeServices.GetCurrentThis() is not AbortController controller)
+            {
+                throw new TypeError(
+                    $"AbortController.prototype.{memberName} called on incompatible receiver");
+            }
+
+            return controller;
+        }
     }
 
-    public sealed class AbortSignal
+    public sealed class AbortSignal : JsObject
     {
+        private static readonly Func<object[], object?[]?, object?> PrototypeAddEventListenerValue =
+            PrototypeAddEventListener;
+        private static readonly Func<object[], object?[]?, object?> PrototypeRemoveEventListenerValue =
+            PrototypeRemoveEventListener;
+        private static readonly Func<object[], object?[]?, object?> PrototypeAbortedGetterValue =
+            PrototypeAbortedGetter;
+        private static readonly Func<object[], object?[]?, object?> PrototypeReasonGetterValue =
+            PrototypeReasonGetter;
+
+        /// <summary>Realm-owned <c>AbortSignal.prototype</c> intrinsic.</summary>
+        internal static JsObject Prototype
+            => RuntimeIntrinsics.Current.GetOrCreate(
+                RuntimeIntrinsicSlot.AbortSignalPrototype,
+                static () => new JsObject(),
+                static prototype => InitializePrototype(prototype));
+
         private readonly object _syncRoot = new();
         private readonly List<object> _eventListeners = new();
         private readonly List<Action<object?>> _internalListeners = new();
+
+        public AbortSignal()
+        {
+            PrototypeChain.InitializePrototype(this, Prototype);
+        }
 
         public bool aborted { get; private set; }
 
@@ -126,6 +212,150 @@ namespace JavaScriptRuntime
         private static bool IsAbortEventName(object? eventName)
         {
             return string.Equals(DotNet2JSConversions.ToString(eventName), "abort", StringComparison.Ordinal);
+        }
+
+        internal static void InitializeIntrinsicSurface(object objectPrototype)
+        {
+            GlobalThis.ConfigureBuiltinFunctionObject(typeof(AbortSignal));
+            PrototypeChain.SetPrototype(Prototype, objectPrototype);
+
+            AbortIntrinsicSurface.DefineConstructorPrototypeSurface(
+                typeof(AbortSignal),
+                Prototype);
+        }
+
+        private static void InitializePrototype(JsObject prototype)
+        {
+            using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
+
+            Function.InitializeFunctionInstance(
+                PrototypeAddEventListenerValue,
+                2d,
+                "addEventListener");
+            Function.MarkUndefinedPrototype(PrototypeAddEventListenerValue);
+            Function.InitializeFunctionInstance(
+                PrototypeRemoveEventListenerValue,
+                2d,
+                "removeEventListener");
+            Function.MarkUndefinedPrototype(PrototypeRemoveEventListenerValue);
+            Function.InitializeFunctionInstance(
+                PrototypeAbortedGetterValue,
+                0d,
+                "get aborted");
+            Function.MarkUndefinedPrototype(PrototypeAbortedGetterValue);
+            Function.InitializeFunctionInstance(
+                PrototypeReasonGetterValue,
+                0d,
+                "get reason");
+            Function.MarkUndefinedPrototype(PrototypeReasonGetterValue);
+
+            AbortIntrinsicSurface.DefinePrototypeAccessor(
+                prototype,
+                "aborted",
+                PrototypeAbortedGetterValue);
+            AbortIntrinsicSurface.DefinePrototypeAccessor(
+                prototype,
+                "reason",
+                PrototypeReasonGetterValue);
+            AbortIntrinsicSurface.DefinePrototypeMethod(
+                prototype,
+                "addEventListener",
+                PrototypeAddEventListenerValue);
+            AbortIntrinsicSurface.DefinePrototypeMethod(
+                prototype,
+                "removeEventListener",
+                PrototypeRemoveEventListenerValue);
+        }
+
+        private static object? PrototypeAbortedGetter(object[] scopes, object?[]? args)
+            => GetAbortSignalReceiver("aborted").aborted;
+
+        private static object? PrototypeReasonGetter(object[] scopes, object?[]? args)
+            => GetAbortSignalReceiver("reason").reason;
+
+        private static object? PrototypeAddEventListener(
+            object[] scopes,
+            object?[]? args)
+        {
+            return GetAbortSignalReceiver("addEventListener").addEventListener(
+                args is { Length: > 0 } ? args[0] : null,
+                args is { Length: > 1 } ? args[1] : null,
+                args is { Length: > 2 } ? args[2] : null);
+        }
+
+        private static object? PrototypeRemoveEventListener(
+            object[] scopes,
+            object?[]? args)
+        {
+            return GetAbortSignalReceiver("removeEventListener").removeEventListener(
+                args is { Length: > 0 } ? args[0] : null,
+                args is { Length: > 1 } ? args[1] : null,
+                args is { Length: > 2 } ? args[2] : null);
+        }
+
+        private static AbortSignal GetAbortSignalReceiver(string memberName)
+        {
+            if (RuntimeServices.GetCurrentThis() is not AbortSignal signal)
+            {
+                throw new TypeError(
+                    $"AbortSignal.prototype.{memberName} called on incompatible receiver");
+            }
+
+            return signal;
+        }
+    }
+
+    internal static class AbortIntrinsicSurface
+    {
+        internal static void DefineConstructorPrototypeSurface(
+            Type constructor,
+            JsObject prototype)
+        {
+            PropertyDescriptorStore.DefineOrUpdate(constructor, "prototype", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = false,
+                Writable = false,
+                Value = prototype
+            });
+            PropertyDescriptorStore.DefineOrUpdate(prototype, "constructor", new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = true,
+                Value = constructor
+            });
+        }
+
+        internal static void DefinePrototypeMethod(
+            JsObject prototype,
+            string name,
+            object method)
+        {
+            PropertyDescriptorStore.DefineOrUpdate(prototype, name, new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = true,
+                Value = method
+            });
+        }
+
+        internal static void DefinePrototypeAccessor(
+            JsObject prototype,
+            string name,
+            object getter)
+        {
+            PropertyDescriptorStore.DefineOrUpdate(prototype, name, new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Accessor,
+                Enumerable = false,
+                Configurable = true,
+                Get = getter
+            });
         }
     }
 

--- a/src/JavaScriptRuntime/GlobalThis.cs
+++ b/src/JavaScriptRuntime/GlobalThis.cs
@@ -808,6 +808,8 @@ namespace JavaScriptRuntime
             DefineBuiltinFunctionProperty(_bigIntPrototypeValue, "valueOf", _bigIntPrototypeValueOfValue, 0d);
             DefineIntrinsicToStringTagProperty(_bigIntPrototypeValue, "BigInt");
             JavaScriptRuntime.Date.InitializeIntrinsicSurface(_objectPrototypeValue);
+            JavaScriptRuntime.AbortController.InitializeIntrinsicSurface(_objectPrototypeValue);
+            JavaScriptRuntime.AbortSignal.InitializeIntrinsicSurface(_objectPrototypeValue);
             ConfigureBuiltinFunctionObject(_stringFunctionValue);
             ConfigureBuiltinFunctionObject(_booleanFunctionValue);
             ConfigureBuiltinFunctionObject(_parseIntValue);

--- a/src/JavaScriptRuntime/Iterator.cs
+++ b/src/JavaScriptRuntime/Iterator.cs
@@ -66,7 +66,14 @@ public static class Iterator
 
     internal static void InitializeHelperSurface(object iterator)
     {
-        PrototypeChain.SetPrototype(iterator, HelperPrototype);
+        if (iterator is JsObject jsObject)
+        {
+            PrototypeChain.InitializePrototype(jsObject, HelperPrototype);
+        }
+        else
+        {
+            PrototypeChain.SetPrototype(iterator, HelperPrototype);
+        }
     }
 
     public static IJavaScriptIterator From(object? value)
@@ -426,7 +433,7 @@ public static class Iterator
         }
     }
 
-    private abstract class IteratorHelperBase : IJavaScriptIterator
+    private abstract class IteratorHelperBase : JsObject, IJavaScriptIterator
     {
         private bool _closed;
 

--- a/src/JavaScriptRuntime/IteratorResult.cs
+++ b/src/JavaScriptRuntime/IteratorResult.cs
@@ -9,10 +9,10 @@ public interface IIteratorResult
 /// <summary>
 /// Strongly-typed iterator result object of the form: { value: any, done: boolean }.
 ///
-/// NOTE: Field names are intentionally lower-case to match JS property lookups
-/// in this runtime's reflection-based `ObjectRuntime.GetProperty`.
+/// The lower-case field names retain the typed iterator-result API, while the
+/// constructor creates matching observable JavaScript own properties.
 /// </summary>
-public class IteratorResultObject<T> : IIteratorResult
+public class IteratorResultObject<T> : JsObject, IIteratorResult
 {
     public T? value;
     public bool done;
@@ -21,6 +21,9 @@ public class IteratorResultObject<T> : IIteratorResult
     {
         this.value = value;
         this.done = done;
+        SetObject(nameof(value), value);
+        SetBoolean(nameof(done), done);
+        PrototypeChain.InitializePrototype(this, GlobalThis.ObjectPrototypeValue);
     }
 
     object? IIteratorResult.value => value;

--- a/src/JavaScriptRuntime/Node/Url.cs
+++ b/src/JavaScriptRuntime/Node/Url.cs
@@ -141,7 +141,7 @@ namespace JavaScriptRuntime.Node
         }
     }
 
-    public sealed class URL
+    public sealed class URL : JsObject
     {
         /// <summary>Realm-owned <c>URL.prototype</c> (issue #1824).</summary>
         internal static object Prototype
@@ -171,7 +171,7 @@ namespace JavaScriptRuntime.Node
 
         public URL(object input, object? baseValue)
         {
-            PrototypeChain.SetPrototype(this, Prototype);
+            PrototypeChain.InitializePrototype(this, Prototype);
             var uri = ResolveUri(input, baseValue);
 
             _protocol = uri.Scheme + ":";
@@ -334,6 +334,18 @@ namespace JavaScriptRuntime.Node
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
+            DefinePrototypeAccessor(prototype, "hash", PrototypeHashGetter, PrototypeHashSetter);
+            DefinePrototypeAccessor(prototype, "host", PrototypeHostGetter);
+            DefinePrototypeAccessor(prototype, "hostname", PrototypeHostnameGetter);
+            DefinePrototypeAccessor(prototype, "href", PrototypeHrefGetter);
+            DefinePrototypeAccessor(prototype, "origin", PrototypeOriginGetter);
+            DefinePrototypeAccessor(prototype, "password", PrototypePasswordGetter);
+            DefinePrototypeAccessor(prototype, "pathname", PrototypePathnameGetter);
+            DefinePrototypeAccessor(prototype, "port", PrototypePortGetter);
+            DefinePrototypeAccessor(prototype, "protocol", PrototypeProtocolGetter);
+            DefinePrototypeAccessor(prototype, "search", PrototypeSearchGetter, PrototypeSearchSetter);
+            DefinePrototypeAccessor(prototype, "searchParams", PrototypeSearchParamsGetter);
+            DefinePrototypeAccessor(prototype, "username", PrototypeUsernameGetter);
             DefinePrototypeMethod(prototype, "toJSON", PrototypeToJson);
             DefinePrototypeMethod(prototype, "toString", PrototypeToString);
             PropertyDescriptorStore.DefineOrUpdate(prototype, global::JavaScriptRuntime.Symbol.toStringTag.DebugId, new JsPropertyDescriptor
@@ -358,6 +370,22 @@ namespace JavaScriptRuntime.Node
             });
         }
 
+        private static void DefinePrototypeAccessor(
+            object prototype,
+            string name,
+            Func<object[], object?[]?, object?> getter,
+            Func<object[], object?[]?, object?>? setter = null)
+        {
+            PropertyDescriptorStore.DefineOrUpdate(prototype, name, new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Accessor,
+                Enumerable = false,
+                Configurable = true,
+                Get = getter,
+                Set = setter
+            });
+        }
+
         private static URL GetUrlReceiver(string memberName)
         {
             var thisValue = RuntimeServices.GetCurrentThis();
@@ -369,14 +397,64 @@ namespace JavaScriptRuntime.Node
             return url;
         }
 
+        private static object? PrototypeHashGetter(object[] scopes, object?[]? args)
+            => GetUrlReceiver("hash").hash;
+
+        private static object? PrototypeHashSetter(object[] scopes, object?[]? args)
+        {
+            GetUrlReceiver("hash").hash = UrlQueryHelpers.CoerceString(
+                args != null && args.Length > 0 ? args[0] : null);
+            return null;
+        }
+
+        private static object? PrototypeHostGetter(object[] scopes, object?[]? args)
+            => GetUrlReceiver("host").host;
+
+        private static object? PrototypeHostnameGetter(object[] scopes, object?[]? args)
+            => GetUrlReceiver("hostname").hostname;
+
+        private static object? PrototypeHrefGetter(object[] scopes, object?[]? args)
+            => GetUrlReceiver("href").href;
+
+        private static object? PrototypeOriginGetter(object[] scopes, object?[]? args)
+            => GetUrlReceiver("origin").origin;
+
+        private static object? PrototypePasswordGetter(object[] scopes, object?[]? args)
+            => GetUrlReceiver("password").password;
+
+        private static object? PrototypePathnameGetter(object[] scopes, object?[]? args)
+            => GetUrlReceiver("pathname").pathname;
+
+        private static object? PrototypePortGetter(object[] scopes, object?[]? args)
+            => GetUrlReceiver("port").port;
+
+        private static object? PrototypeProtocolGetter(object[] scopes, object?[]? args)
+            => GetUrlReceiver("protocol").protocol;
+
+        private static object? PrototypeSearchGetter(object[] scopes, object?[]? args)
+            => GetUrlReceiver("search").search;
+
+        private static object? PrototypeSearchSetter(object[] scopes, object?[]? args)
+        {
+            GetUrlReceiver("search").search = UrlQueryHelpers.CoerceString(
+                args != null && args.Length > 0 ? args[0] : null);
+            return null;
+        }
+
+        private static object? PrototypeSearchParamsGetter(object[] scopes, object?[]? args)
+            => GetUrlReceiver("searchParams").searchParams;
+
         private static object? PrototypeToJson(object[] scopes, object?[]? args)
             => GetUrlReceiver("toJSON").toJSON();
 
         private static object? PrototypeToString(object[] scopes, object?[]? args)
             => GetUrlReceiver("toString").toString();
+
+        private static object? PrototypeUsernameGetter(object[] scopes, object?[]? args)
+            => GetUrlReceiver("username").username;
     }
 
-    public sealed class URLSearchParams
+    public sealed class URLSearchParams : JsObject
     {
         private static readonly Func<object[], object?[]?, object?> PrototypeEntriesValue = PrototypeEntries;
 
@@ -395,13 +473,13 @@ namespace JavaScriptRuntime.Node
 
         public URLSearchParams()
         {
-            PrototypeChain.SetPrototype(this, Prototype);
+            PrototypeChain.InitializePrototype(this, Prototype);
             _entries = new List<KeyValuePair<string, string>>();
         }
 
         public URLSearchParams(object? init)
         {
-            PrototypeChain.SetPrototype(this, Prototype);
+            PrototypeChain.InitializePrototype(this, Prototype);
             _entries = InitializeEntries(init);
         }
 
@@ -645,7 +723,7 @@ namespace JavaScriptRuntime.Node
             Entries,
         }
 
-        private sealed class SearchParamsIterator : IJavaScriptIterator
+        private sealed class SearchParamsIterator : JsObject, IJavaScriptIterator
         {
             private readonly IReadOnlyList<KeyValuePair<string, string>> _entries;
             private readonly SearchParamsIteratorKind _kind;
@@ -656,7 +734,7 @@ namespace JavaScriptRuntime.Node
             {
                 _entries = entries;
                 _kind = kind;
-                JavaScriptRuntime.Iterator.InitializeIteratorSurface(this);
+                PrototypeChain.InitializePrototype(this, JavaScriptRuntime.Iterator.Prototype);
             }
 
             public bool HasReturn => true;

--- a/src/JavaScriptRuntime/ObjectRuntime.Operations.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.Operations.cs
@@ -4965,6 +4965,12 @@ namespace JavaScriptRuntime
 
         public static bool IteratorResultDone(object iteratorResult)
         {
+            if (iteratorResult is JsObject && iteratorResult is IIteratorResult)
+            {
+                return JavaScriptRuntime.TypeUtilities.ToBoolean(
+                    ObjectRuntime.GetItem(iteratorResult, "done"));
+            }
+
             if (iteratorResult is IIteratorResult res)
             {
                 return res.done;
@@ -4977,6 +4983,11 @@ namespace JavaScriptRuntime
 
         public static object? IteratorResultValue(object iteratorResult)
         {
+            if (iteratorResult is JsObject && iteratorResult is IIteratorResult)
+            {
+                return ObjectRuntime.GetItem(iteratorResult, "value");
+            }
+
             if (iteratorResult is IIteratorResult res)
             {
                 return res.value;

--- a/src/JavaScriptRuntime/RuntimeIntrinsics.cs
+++ b/src/JavaScriptRuntime/RuntimeIntrinsics.cs
@@ -76,6 +76,8 @@ internal enum RuntimeIntrinsicSlot
     AsyncFunctionPrototype,
     UrlPrototype,
     UrlSearchParamsPrototype,
+    AbortControllerPrototype,
+    AbortSignalPrototype,
 
     Count
 }

--- a/tests/Jroc.Tests/AbortObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/AbortObjectRepresentationTests.cs
@@ -1,0 +1,165 @@
+using JavaScriptRuntime;
+using JsObjectConstructor = JavaScriptRuntime.Object;
+
+namespace Jroc.Tests;
+
+public sealed class AbortObjectRepresentationTests
+{
+    [Fact]
+    public void AbortWrappers_UseInlineJsObjectStorage()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        using var scope = RuntimeExecutionContext.GetOrCreate(services).Enter();
+        _ = GlobalThis.globalThis;
+
+        var controller = Assert.IsType<AbortController>(
+            ObjectRuntime.ConstructValue(
+                GlobalThis.AbortController,
+                System.Array.Empty<object>()));
+        var signal = controller.signal;
+        var customControllerPrototype = new JsObject();
+        var customSignalPrototype = new JsObject();
+
+        Assert.IsAssignableFrom<JsObject>(controller);
+        Assert.IsAssignableFrom<JsObject>(signal);
+        Assert.Same(AbortController.Prototype, JsObjectConstructor.getPrototypeOf(controller));
+        Assert.Same(AbortSignal.Prototype, JsObjectConstructor.getPrototypeOf(signal));
+        Assert.Same(
+            AbortController.Prototype,
+            ObjectRuntime.GetProperty(GlobalThis.AbortController, "prototype"));
+        Assert.Same(
+            AbortSignal.Prototype,
+            ObjectRuntime.GetProperty(GlobalThis.AbortSignal, "prototype"));
+        Assert.Same(
+            GlobalThis.AbortController,
+            ObjectRuntime.GetProperty(AbortController.Prototype, "constructor"));
+        Assert.Same(
+            GlobalThis.AbortSignal,
+            ObjectRuntime.GetProperty(AbortSignal.Prototype, "constructor"));
+
+        var abort = ObjectRuntime.GetProperty(controller, "abort");
+        var addEventListener = ObjectRuntime.GetProperty(signal, "addEventListener");
+        Assert.Same(
+            ObjectRuntime.GetProperty(AbortController.Prototype, "abort"),
+            abort);
+        Assert.Same(
+            ObjectRuntime.GetProperty(AbortSignal.Prototype, "addEventListener"),
+            addEventListener);
+        Assert.Same(signal, ObjectRuntime.GetProperty(controller, "signal"));
+        Assert.False(JsObjectConstructor.hasOwn(controller, "signal"));
+        Assert.False(JsObjectConstructor.hasOwn(signal, "aborted"));
+        Assert.False(JsObjectConstructor.hasOwn(signal, "reason"));
+
+        var signalDescriptor = Assert.IsAssignableFrom<JsObject>(
+            JsObjectConstructor.getOwnPropertyDescriptor(
+                AbortController.Prototype,
+                "signal"));
+        var signalGetter = ObjectRuntime.GetProperty(signalDescriptor, "get");
+        Assert.Throws<TypeError>(
+            () => CallableOperations.Call0(signalGetter, new JsObject()));
+        Assert.Throws<TypeError>(
+            () => CallableOperations.Call0(addEventListener, new JsObject()));
+
+        ObjectRuntime.SetProperty(controller, "custom", 42d);
+        ObjectRuntime.SetProperty(signal, "custom", "signal");
+        var controllerCustomDescriptor = Assert.IsAssignableFrom<JsObject>(
+            JsObjectConstructor.getOwnPropertyDescriptor(controller, "custom"));
+        var signalCustomDescriptor = Assert.IsAssignableFrom<JsObject>(
+            JsObjectConstructor.getOwnPropertyDescriptor(signal, "custom"));
+        Assert.Equal(42d, ObjectRuntime.GetProperty(controllerCustomDescriptor, "value"));
+        Assert.Equal("signal", ObjectRuntime.GetProperty(signalCustomDescriptor, "value"));
+        Assert.True(JsObjectConstructor.hasOwn(controller, "custom"));
+        Assert.True(JsObjectConstructor.hasOwn(signal, "custom"));
+
+        JsObjectConstructor.setPrototypeOf(controller, customControllerPrototype);
+        JsObjectConstructor.setPrototypeOf(signal, customSignalPrototype);
+        Assert.Same(customControllerPrototype, JsObjectConstructor.getPrototypeOf(controller));
+        Assert.Same(customSignalPrototype, JsObjectConstructor.getPrototypeOf(signal));
+        JsObjectConstructor.setPrototypeOf(controller, AbortController.Prototype);
+        JsObjectConstructor.setPrototypeOf(signal, AbortSignal.Prototype);
+
+        JsObjectConstructor.freeze(controller);
+        JsObjectConstructor.freeze(signal);
+        Assert.True(JsObjectConstructor.isFrozen(controller));
+        Assert.True(JsObjectConstructor.isFrozen(signal));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(controller, "custom", 0d));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(signal, "custom", "changed"));
+
+        var calls = 0;
+        Func<object[], object?[]?, object?> listener = (_, _) =>
+        {
+            calls++;
+            return null;
+        };
+        var abortReason = new JsObject();
+        CallableOperations.Call2(
+            addEventListener,
+            signal,
+            "abort",
+            BuiltinDelegateFunctionAdapter.FromDelegate(listener));
+        CallableOperations.Call1(abort, controller, abortReason);
+
+        Assert.Equal(1, calls);
+        Assert.True(signal.aborted);
+        Assert.True(Assert.IsType<bool>(ObjectRuntime.GetProperty(signal, "aborted")));
+        Assert.Same(abortReason, signal.reason);
+        Assert.Same(abortReason, ObjectRuntime.GetProperty(signal, "reason"));
+    }
+
+    [Fact]
+    public void AbortPrototypeDescriptorMutations_AreIsolatedAcrossRuntimes()
+    {
+        var mutationResult = InMemoryTestCompiler.CompileAndExecute(
+            "mutate-abort-prototype-descriptors",
+            "Abort.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+        var readResult = InMemoryTestCompiler.CompileAndExecute(
+            "read-abort-prototype-descriptors",
+            "Abort.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+
+        Assert.Equal(
+            $"controller{Environment.NewLine}signal{Environment.NewLine}",
+            mutationResult.Output);
+        Assert.Equal(
+            $"true{Environment.NewLine}true{Environment.NewLine}",
+            readResult.Output);
+    }
+
+    private static (string Script, string? SourcePath) GetDescriptorIsolationScript(string testName)
+        => testName switch
+        {
+            "mutate-abort-prototype-descriptors" => ("""
+                const controller = new AbortController();
+                const signal = new AbortSignal();
+                Object.defineProperty(AbortController.prototype, "descriptorLeakCheck", {
+                  value: "controller",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+                Object.defineProperty(AbortSignal.prototype, "descriptorLeakCheck", {
+                  value: "signal",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+                console.log(controller.descriptorLeakCheck);
+                console.log(signal.descriptorLeakCheck);
+                """, null),
+            "read-abort-prototype-descriptors" => ("""
+                console.log(Object.getOwnPropertyDescriptor(
+                  AbortController.prototype,
+                  "descriptorLeakCheck"
+                ) === undefined);
+                console.log(Object.getOwnPropertyDescriptor(
+                  AbortSignal.prototype,
+                  "descriptorLeakCheck"
+                ) === undefined);
+                """, null),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(testName),
+                testName,
+                "Unknown descriptor isolation script.")
+        };
+}

--- a/tests/Jroc.Tests/IteratorObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/IteratorObjectRepresentationTests.cs
@@ -1,0 +1,122 @@
+using JavaScriptRuntime;
+using JsObjectConstructor = JavaScriptRuntime.Object;
+using JsIterator = JavaScriptRuntime.Iterator;
+
+namespace Jroc.Tests;
+
+public sealed class IteratorObjectRepresentationTests
+{
+    [Fact]
+    public void IteratorHelpers_UseInlineJsObjectStorage_AndContinueAfterFreeze()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        using var scope = RuntimeExecutionContext.GetOrCreate(services).Enter();
+        var helper = CreateMappedHelper();
+        var customPrototype = new JsObject();
+
+        Assert.IsAssignableFrom<JsObject>(helper);
+        Assert.Same(JsIterator.HelperPrototype, JsObjectConstructor.getPrototypeOf(helper));
+        Assert.False(JsObjectConstructor.hasOwn(helper, "next"));
+        Assert.False(JsObjectConstructor.hasOwn(helper, "return"));
+        Assert.Same(
+            ObjectRuntime.GetProperty(JsIterator.HelperPrototype, "next"),
+            ObjectRuntime.GetProperty(helper, "next"));
+        Assert.Same(
+            ObjectRuntime.GetProperty(JsIterator.HelperPrototype, "return"),
+            ObjectRuntime.GetProperty(helper, "return"));
+
+        ObjectRuntime.SetProperty(helper, "custom", "helper");
+        Assert.Equal("helper", ObjectRuntime.GetProperty(helper, "custom"));
+        Assert.True(JsObjectConstructor.hasOwn(helper, "custom"));
+
+        JsObjectConstructor.setPrototypeOf(helper, customPrototype);
+        Assert.Same(customPrototype, JsObjectConstructor.getPrototypeOf(helper));
+        JsObjectConstructor.setPrototypeOf(helper, JsIterator.HelperPrototype);
+
+        JsObjectConstructor.freeze(helper);
+        Assert.True(JsObjectConstructor.isFrozen(helper));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(helper, "custom", "changed"));
+
+        var first = helper.Next();
+        var second = helper.Next();
+        var exhausted = helper.Next();
+        Assert.Equal(1d, first.value);
+        Assert.Equal(2d, second.value);
+        Assert.True(exhausted.done);
+        Assert.True(helper.Next().done);
+    }
+
+    [Fact]
+    public void IteratorResults_UseOwnJsObjectValueAndDoneProperties()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        using var scope = RuntimeExecutionContext.GetOrCreate(services).Enter();
+        var result = IteratorResult.Create("value", done: false);
+
+        Assert.IsAssignableFrom<JsObject>(result);
+        Assert.Same(GlobalThis.ObjectPrototypeValue, JsObjectConstructor.getPrototypeOf(result));
+        Assert.True(JsObjectConstructor.hasOwn(result, "value"));
+        Assert.True(JsObjectConstructor.hasOwn(result, "done"));
+        Assert.Equal("value", ObjectRuntime.GetProperty(result, "value"));
+        Assert.False(Assert.IsType<bool>(ObjectRuntime.GetProperty(result, "done")));
+
+        var valueDescriptor = Assert.IsAssignableFrom<JsObject>(
+            JsObjectConstructor.getOwnPropertyDescriptor(result, "value"));
+        var doneDescriptor = Assert.IsAssignableFrom<JsObject>(
+            JsObjectConstructor.getOwnPropertyDescriptor(result, "done"));
+        Assert.True(Assert.IsType<bool>(ObjectRuntime.GetProperty(valueDescriptor, "enumerable")));
+        Assert.True(Assert.IsType<bool>(ObjectRuntime.GetProperty(valueDescriptor, "writable")));
+        Assert.True(Assert.IsType<bool>(ObjectRuntime.GetProperty(valueDescriptor, "configurable")));
+        Assert.True(Assert.IsType<bool>(ObjectRuntime.GetProperty(doneDescriptor, "enumerable")));
+        Assert.True(Assert.IsType<bool>(ObjectRuntime.GetProperty(doneDescriptor, "writable")));
+        Assert.True(Assert.IsType<bool>(ObjectRuntime.GetProperty(doneDescriptor, "configurable")));
+
+        ObjectRuntime.SetProperty(result, "value", "updated");
+        ObjectRuntime.SetProperty(result, "done", true);
+        Assert.Equal("updated", ObjectRuntime.IteratorResultValue(result));
+        Assert.True(ObjectRuntime.IteratorResultDone(result));
+        Assert.Equal("value", ((IIteratorResult)result).value);
+        Assert.False(((IIteratorResult)result).done);
+    }
+
+    [Fact]
+    public void IteratorHelperPrototypeStorage_IsIsolatedAcrossRuntimes()
+    {
+        object firstPrototype;
+        var firstServices = RuntimeServices.BuildServiceProvider();
+        using (RuntimeExecutionContext.GetOrCreate(firstServices).Enter())
+        {
+            var helper = CreateMappedHelper();
+            firstPrototype = JsIterator.HelperPrototype;
+            ObjectRuntime.SetProperty(firstPrototype, "isolationMarker", "first");
+
+            Assert.Same(firstPrototype, JsObjectConstructor.getPrototypeOf(helper));
+            Assert.Equal("first", ObjectRuntime.GetProperty(helper, "isolationMarker"));
+        }
+
+        var secondServices = RuntimeServices.BuildServiceProvider();
+        using (RuntimeExecutionContext.GetOrCreate(secondServices).Enter())
+        {
+            var helper = CreateMappedHelper();
+            var secondPrototype = JsIterator.HelperPrototype;
+
+            Assert.NotSame(firstPrototype, secondPrototype);
+            Assert.Same(secondPrototype, JsObjectConstructor.getPrototypeOf(helper));
+            Assert.Null(ObjectRuntime.GetProperty(secondPrototype, "isolationMarker"));
+            Assert.Null(ObjectRuntime.GetProperty(helper, "isolationMarker"));
+        }
+    }
+
+    private static IJavaScriptIterator CreateMappedHelper()
+    {
+        _ = GlobalThis.globalThis;
+        var source = JsIterator.From(new JavaScriptRuntime.Array(new object?[] { 1d, 2d }));
+        var map = ObjectRuntime.GetProperty(source, "map");
+        return Assert.IsAssignableFrom<IJavaScriptIterator>(
+            CallableOperations.Call1(
+                map,
+                source,
+                BuiltinDelegateFunctionAdapter.FromDelegate(
+                    (Func<object[], object?[]?, object?>)(static (_, args) => args![0]))));
+    }
+}

--- a/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
+++ b/tests/Jroc.Tests/JsObjectRepresentationInventoryTests.cs
@@ -11,24 +11,16 @@ public sealed class JsObjectRepresentationInventoryTests
     private static readonly string[] ExplicitJavaScriptVisibleTypeNames =
     [
         "JavaScriptRuntime.ArgumentsObject",
-        "JavaScriptRuntime.IteratorResultObject`1",
-        "JavaScriptRuntime.IteratorResultObject",
         "JavaScriptRuntime.PromiseWithResolvers",
         "JavaScriptRuntime.IntlNumberFormat",
         "JavaScriptRuntime.IntlSegmenter",
         "JavaScriptRuntime.TypedArrayBase",
-        "JavaScriptRuntime.Node.Buffer",
-        "JavaScriptRuntime.Node.URL",
-        "JavaScriptRuntime.Node.URLSearchParams",
-        "JavaScriptRuntime.AbortController",
-        "JavaScriptRuntime.AbortSignal"
+        "JavaScriptRuntime.Node.Buffer"
     ];
 
     private static readonly IReadOnlyDictionary<string, string> DocumentedNonJsObjectRepresentations =
         new Dictionary<string, string>
         {
-            ["JavaScriptRuntime.AbortController"] = "Requires the AbortController and AbortSignal migration.",
-            ["JavaScriptRuntime.AbortSignal"] = "Requires the AbortController and AbortSignal migration.",
             ["JavaScriptRuntime.AggregateError"] = ErrorReason,
             ["JavaScriptRuntime.Array+ArrayIterator"] = IteratorReason,
             ["JavaScriptRuntime.ArrayBuffer"] = BufferViewReason,
@@ -39,21 +31,10 @@ public sealed class JsObjectRepresentationInventoryTests
             ["JavaScriptRuntime.ForInIterator"] = IteratorReason,
             ["JavaScriptRuntime.IntlNumberFormat"] = "Needs a dedicated Intl wrapper migration once its constructor surface expands.",
             ["JavaScriptRuntime.IntlSegmenter"] = "Needs a dedicated Intl wrapper migration once its constructor surface expands.",
-            ["JavaScriptRuntime.Iterator+DropIteratorHelper"] = IteratorReason,
-            ["JavaScriptRuntime.Iterator+FilterIteratorHelper"] = IteratorReason,
-            ["JavaScriptRuntime.Iterator+FlatMapIteratorHelper"] = IteratorReason,
             ["JavaScriptRuntime.Iterator+GeneratorIteratorAdapter"] = HostIteratorReason,
-            ["JavaScriptRuntime.Iterator+IteratorHelperBase"] = IteratorReason,
             ["JavaScriptRuntime.Iterator+IteratorLikeWrapper"] = HostIteratorReason,
-            ["JavaScriptRuntime.Iterator+MapIteratorHelper"] = IteratorReason,
-            ["JavaScriptRuntime.Iterator+TakeIteratorHelper"] = IteratorReason,
-            ["JavaScriptRuntime.IteratorResultObject"] = "Requires the dedicated iterator result and helper migration.",
-            ["JavaScriptRuntime.IteratorResultObject`1"] = "Requires the dedicated iterator result and helper migration.",
             ["JavaScriptRuntime.Node.Events+EventEmitterAsyncOnIterator"] = HostIteratorReason,
             ["JavaScriptRuntime.Node.TimersPromises+TimersPromisesIntervalIterator"] = HostIteratorReason,
-            ["JavaScriptRuntime.Node.URL"] = "Requires the URL and URLSearchParams migration.",
-            ["JavaScriptRuntime.Node.URLSearchParams"] = "Requires the URL and URLSearchParams migration.",
-            ["JavaScriptRuntime.Node.URLSearchParams+SearchParamsIterator"] = "Must migrate with URLSearchParams.",
             ["JavaScriptRuntime.Object"] = "Static intrinsic holder; constructed ordinary objects use JsObject.",
             ["JavaScriptRuntime.ObjectRuntime+ArrayIterator"] = HostIteratorReason,
             ["JavaScriptRuntime.ObjectRuntime+AsyncDynamicIterator"] = HostIteratorReason,

--- a/tests/Jroc.Tests/UrlObjectRepresentationTests.cs
+++ b/tests/Jroc.Tests/UrlObjectRepresentationTests.cs
@@ -1,0 +1,147 @@
+using JavaScriptRuntime;
+using JsObjectConstructor = JavaScriptRuntime.Object;
+
+namespace Jroc.Tests;
+
+public sealed class UrlObjectRepresentationTests
+{
+    [Fact]
+    public void UrlWrappersAndIterators_UseInlineJsObjectStorage()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        using var scope = RuntimeExecutionContext.GetOrCreate(services).Enter();
+        var url = new JavaScriptRuntime.Node.URL(
+            "https://user:password@example.test:8443/path?one=1#initial");
+        var searchParams = url.searchParams;
+        var iterator = searchParams.entries();
+        var customPrototype = new JsObject();
+
+        Assert.IsAssignableFrom<JsObject>(url);
+        Assert.IsAssignableFrom<JsObject>(searchParams);
+        Assert.IsAssignableFrom<JsObject>(iterator);
+        Assert.Same(JavaScriptRuntime.Node.URL.Prototype, JsObjectConstructor.getPrototypeOf(url));
+        Assert.Same(JavaScriptRuntime.Node.URLSearchParams.Prototype, JsObjectConstructor.getPrototypeOf(searchParams));
+        Assert.Same(JavaScriptRuntime.Iterator.Prototype, JsObjectConstructor.getPrototypeOf(iterator));
+
+        Assert.Equal(url.href, ObjectRuntime.GetProperty(url, "href"));
+        Assert.Equal(url.origin, ObjectRuntime.GetProperty(url, "origin"));
+        Assert.Equal(url.protocol, ObjectRuntime.GetProperty(url, "protocol"));
+        Assert.Equal(url.username, ObjectRuntime.GetProperty(url, "username"));
+        Assert.Equal(url.password, ObjectRuntime.GetProperty(url, "password"));
+        Assert.Equal(url.host, ObjectRuntime.GetProperty(url, "host"));
+        Assert.Equal(url.hostname, ObjectRuntime.GetProperty(url, "hostname"));
+        Assert.Equal(url.port, ObjectRuntime.GetProperty(url, "port"));
+        Assert.Equal(url.pathname, ObjectRuntime.GetProperty(url, "pathname"));
+        Assert.Equal(url.search, ObjectRuntime.GetProperty(url, "search"));
+        Assert.Equal(url.hash, ObjectRuntime.GetProperty(url, "hash"));
+        Assert.Same(searchParams, ObjectRuntime.GetProperty(url, "searchParams"));
+        Assert.Equal(searchParams.size, ObjectRuntime.GetProperty(searchParams, "size"));
+
+        var hrefDescriptor = Assert.IsAssignableFrom<JsObject>(
+            JsObjectConstructor.getOwnPropertyDescriptor(JavaScriptRuntime.Node.URL.Prototype, "href"));
+        var hrefGetter = ObjectRuntime.GetProperty(hrefDescriptor, "get");
+        Assert.Throws<TypeError>(() => CallableOperations.Call0(hrefGetter, new JsObject()));
+
+        ObjectRuntime.SetProperty(url, "search", "?two=2");
+        ObjectRuntime.SetProperty(url, "hash", "changed");
+        searchParams.append("live", "value");
+        Assert.Same(searchParams, url.searchParams);
+        Assert.Equal("?two=2&live=value", url.search);
+        Assert.Equal("#changed", url.hash);
+
+        ObjectRuntime.SetProperty(url, "custom", 42d);
+        ObjectRuntime.SetProperty(searchParams, "custom", "searchParams");
+        ObjectRuntime.SetProperty(iterator, "custom", "iterator");
+        Assert.Equal(42d, ObjectRuntime.GetProperty(url, "custom"));
+        Assert.Equal("searchParams", ObjectRuntime.GetProperty(searchParams, "custom"));
+        Assert.Equal("iterator", ObjectRuntime.GetProperty(iterator, "custom"));
+        Assert.True(JsObjectConstructor.hasOwn(url, "custom"));
+        Assert.True(JsObjectConstructor.hasOwn(searchParams, "custom"));
+        Assert.True(JsObjectConstructor.hasOwn(iterator, "custom"));
+
+        JsObjectConstructor.setPrototypeOf(url, customPrototype);
+        Assert.Same(customPrototype, JsObjectConstructor.getPrototypeOf(url));
+        JsObjectConstructor.setPrototypeOf(url, JavaScriptRuntime.Node.URL.Prototype);
+
+        JsObjectConstructor.freeze(url);
+        JsObjectConstructor.freeze(searchParams);
+        JsObjectConstructor.freeze(iterator);
+        Assert.True(JsObjectConstructor.isFrozen(url));
+        Assert.True(JsObjectConstructor.isFrozen(searchParams));
+        Assert.True(JsObjectConstructor.isFrozen(iterator));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(url, "custom", 0d));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(searchParams, "custom", "changed"));
+        Assert.Throws<TypeError>(() => ObjectRuntime.SetProperty(iterator, "custom", "changed"));
+
+        ObjectRuntime.SetProperty(url, "hash", "after-freeze");
+        searchParams.append("mutable", "internal-slot");
+        Assert.Equal("#after-freeze", url.hash);
+        Assert.Equal(
+            "?two=2&live=value&mutable=internal-slot",
+            url.search);
+
+        var firstEntry = iterator.Next();
+        Assert.False(firstEntry.done);
+        iterator.Return();
+        Assert.True(iterator.Next().done);
+
+        var exhaustedIterator = searchParams.values();
+        Assert.False(exhaustedIterator.Next().done);
+        Assert.False(exhaustedIterator.Next().done);
+        Assert.False(exhaustedIterator.Next().done);
+        Assert.True(exhaustedIterator.Next().done);
+        Assert.True(exhaustedIterator.Next().done);
+    }
+
+    [Fact]
+    public void UrlPrototypeDescriptorMutations_AreIsolatedAcrossRuntimes()
+    {
+        var mutationResult = InMemoryTestCompiler.CompileAndExecute(
+            "mutate-url-prototype-descriptors",
+            "Url.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+        var readResult = InMemoryTestCompiler.CompileAndExecute(
+            "read-url-prototype-descriptors",
+            "Url.PrototypeIsolation",
+            GetDescriptorIsolationScript);
+
+        Assert.Equal(
+            $"url{Environment.NewLine}search-params{Environment.NewLine}",
+            mutationResult.Output);
+        Assert.Equal(
+            $"true{Environment.NewLine}true{Environment.NewLine}",
+            readResult.Output);
+    }
+
+    private static (string Script, string? SourcePath) GetDescriptorIsolationScript(string testName)
+        => testName switch
+        {
+            "mutate-url-prototype-descriptors" => ("""
+                Object.defineProperty(URL.prototype, "descriptorLeakCheck", {
+                  value: "url",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+                Object.defineProperty(URLSearchParams.prototype, "descriptorLeakCheck", {
+                  value: "search-params",
+                  enumerable: true,
+                  configurable: true,
+                  writable: true
+                });
+                console.log(new URL("https://example.test").descriptorLeakCheck);
+                console.log(new URLSearchParams().descriptorLeakCheck);
+                """, null),
+            "read-url-prototype-descriptors" => ("""
+                console.log(Object.getOwnPropertyDescriptor(
+                  URL.prototype,
+                  "descriptorLeakCheck"
+                ) === undefined);
+                console.log(Object.getOwnPropertyDescriptor(
+                  URLSearchParams.prototype,
+                  "descriptorLeakCheck"
+                ) === undefined);
+                """, null),
+            _ => throw new ArgumentOutOfRangeException(nameof(testName), testName, "Unknown descriptor isolation script.")
+        };
+}

--- a/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
+++ b/tests/performance/Benchmarks/PrototypeStorageBenchmarks.cs
@@ -15,6 +15,8 @@ namespace Benchmarks;
 public class PrototypeStorageBenchmarks
 {
     private readonly JavaScriptRuntime.JsObject _prototype = new();
+    private static readonly Func<object[], object?[]?, object?> _identityMapper =
+        static (_, args) => args![0];
 
     [Benchmark(Description = "Array with initialized prototype")]
     public JavaScriptRuntime.Array ConstructArray()
@@ -63,6 +65,43 @@ public class PrototypeStorageBenchmarks
     [Benchmark(Description = "Buffer with inline ordinary properties")]
     public JavaScriptRuntime.Node.Buffer ConstructBuffer()
         => new(System.Array.Empty<byte>());
+
+    [Benchmark(Description = "AbortController with initialized prototype")]
+    public JavaScriptRuntime.AbortController ConstructAbortController()
+        => new();
+
+    [Benchmark(Description = "AbortSignal with initialized prototype")]
+    public JavaScriptRuntime.AbortSignal ConstructAbortSignal()
+        => new();
+
+    [Benchmark(Description = "URL with initialized prototype")]
+    public JavaScriptRuntime.Node.URL ConstructUrl()
+        => new("https://example.test/path?key=value");
+
+    [Benchmark(Description = "URLSearchParams with initialized prototype")]
+    public JavaScriptRuntime.Node.URLSearchParams ConstructUrlSearchParams()
+        => new("key=value");
+
+    [Benchmark(Description = "URLSearchParams iterator with initialized prototype")]
+    public JavaScriptRuntime.IJavaScriptIterator ConstructUrlSearchParamsIterator()
+        => new JavaScriptRuntime.Node.URLSearchParams("key=value").entries();
+
+    [Benchmark(Description = "Iterator helper with initialized prototype")]
+    public JavaScriptRuntime.IJavaScriptIterator ConstructIteratorHelper()
+    {
+        _ = JavaScriptRuntime.GlobalThis.globalThis;
+        var source = JavaScriptRuntime.Iterator.From(
+            new JavaScriptRuntime.Array(new object?[] { 1d }));
+        var map = JavaScriptRuntime.ObjectRuntime.GetProperty(source, "map");
+        return (JavaScriptRuntime.IJavaScriptIterator)JavaScriptRuntime.CallableOperations.Call1(
+            map,
+            source,
+            JavaScriptRuntime.BuiltinDelegateFunctionAdapter.FromDelegate(_identityMapper))!;
+    }
+
+    [Benchmark(Description = "Iterator result with initialized prototype and own values")]
+    public JavaScriptRuntime.IteratorResultObject ConstructIteratorResult()
+        => JavaScriptRuntime.IteratorResult.Create(null, done: false);
 
     [Benchmark(Description = "Ordinary object with initialized prototype")]
     public JavaScriptRuntime.JsObject ConstructOrdinaryObject()


### PR DESCRIPTION
## Summary

- migrate `URL`, `URLSearchParams`, their iterator, `AbortController`, `AbortSignal`, iterator helpers, and iterator results to `JsObject`
- preserve CLR internal slots, receiver checks, prototype dispatch, iterator cleanup, and `value`/`done` result behavior
- add representation, integrity, isolation, and construction benchmark coverage; update ECMA-262 iterator-result support documentation

Closes #1859
Closes #1860
Closes #1861

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --filter 'FullyQualifiedName~Node.Url|FullyQualifiedName~UrlObjectRepresentationTests|FullyQualifiedName~Abort|FullyQualifiedName~AbortObjectRepresentationTests|FullyQualifiedName~Iterator|FullyQualifiedName~IteratorObjectRepresentationTests|FullyQualifiedName~ObjectRuntimeOrdinaryObjectTests|FullyQualifiedName~TimersPromises'`
- `dotnet build src/Cli/Jroc.csproj --no-restore`
- `dotnet build tests/performance/Benchmarks/Benchmarks.csproj --no-restore`
