### PR TITLE
runtime: add agent-cluster shared services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime: make agent and agent-cluster shared services explicit (issue #1827).
+  `Symbol.for`/`Symbol.keyFor` identity is now owned by `RuntimeAgent`, while
+  opaque MessagePort transport queues, BroadcastChannel routing, shared buffer
+  backing stores, and the Atomics waiter domain are owned by
+  `RuntimeAgentCluster`. Realm wrappers remain distinct, cross-cluster sharing
+  is rejected, and agent/last-agent disposal unregisters endpoints and waiters
+  and releases cluster resources.
+
 - runtime: move timers, queues, pending I/O, event-loop pumping, async-hooks
   context, finalization jobs, wake-up signaling, and cooperative cancellation
   into `RuntimeAgentSchedulingState` (issue #1826). Realms in one agent share

--- a/docs/runtime/RuntimeOwnership.md
+++ b/docs/runtime/RuntimeOwnership.md
@@ -4,7 +4,13 @@ JROC runtime state has three explicit lifetime owners:
 
 ```text
 RuntimeAgentCluster
+  -> RuntimeAgentClusterSharedServices
+      -> RuntimeMessageTransportService
+      -> RuntimeBroadcastChannelRegistry
+      -> RuntimeSharedMemoryService
+      -> RuntimeAtomicsSynchronizationDomain
   -> RuntimeAgent
+      -> RuntimeAgentSymbolRegistry
       -> RuntimeAgentSchedulingState
           -> NodeSchedulerState
           -> NodeEventLoopPump
@@ -18,10 +24,10 @@ RuntimeAgentCluster
           -> RuntimeExecutionContext (while entered)
 ```
 
-- `RuntimeAgentCluster` owns agents and, in later migration stages, only
-  resources intentionally shared across agents.
-- `RuntimeAgent` owns execution and scheduling lifecycle and can own one or
-  more realms.
+- `RuntimeAgentCluster` owns agents and the deliberately cross-agent transport,
+  broadcast, shared-memory, and Atomics coordination services.
+- `RuntimeAgent` owns execution, scheduling, and global-symbol-registry
+  lifecycle and can own one or more realms.
 - `RuntimeAgentSchedulingState` owns timers, queues, pending I/O, the event-loop
   pump, async-hooks context, finalization jobs, wake-up signaling, and
   cooperative cancellation. See
@@ -47,6 +53,42 @@ RuntimeAgentCluster
   constructor objects, and lazy class-method metadata that captures scopes.
   See [Realm-created value caches](RuntimeRealmValueCaches.md).
 
+## Agent and agent-cluster services
+
+`RuntimeAgentSymbolRegistry` owns the mutable `Symbol.for`/`Symbol.keyFor`
+registry. Realms in one agent therefore share registered-symbol identity, while
+agents in the same process or cluster do not. Agent disposal clears both
+registry directions. Well-known symbol objects and the monotonic symbol debug
+identifier remain static: they are immutable identities/metadata, contain no
+realm object or callback, and cannot be mutated through JavaScript.
+
+`RuntimeAgentClusterSharedServices` is the only cluster-shared service graph:
+
+- `RuntimeMessageTransportService` owns entangled, ordered byte-message queues.
+  Its `RuntimeMessagePortCore` objects are transport endpoints, not
+  JavaScript-visible `MessagePort` wrappers. A producer copies the opaque
+  payload before enqueueing and never invokes JavaScript.
+- `RuntimeBroadcastChannelRegistry` owns named, ordered byte-message queues and
+  excludes the sending endpoint. Its endpoints are transport cores, not
+  JavaScript-visible `BroadcastChannel` wrappers or callbacks.
+- `RuntimeSharedMemoryService` creates cluster-associated
+  `RuntimeSharedArrayBufferBackingStore` instances. Each realm can create a
+  distinct `SharedArrayBuffer` wrapper over one backing store; attempts to wrap
+  a store in another cluster fail.
+- `RuntimeAtomicsSynchronizationDomain` coordinates waiters by backing-store
+  identity and byte offset. Waiters belong to agents and are cancelled when
+  their agent leaves the cluster.
+
+The transport and broadcast services retain an agent only while that agent has
+registered endpoints. Removing an agent closes and unregisters those endpoints
+and cancels its waiters. When the last agent leaves, live shared backing stores
+are released and all remaining wait state is cleared. Explicit cluster disposal
+also clears every service. These core services intentionally contain no global
+objects, module caches, prototypes, realm wrappers, JavaScript objects,
+delegates, or callbacks. Future `worker_threads` wrappers and structured-clone
+logic must remain realm-owned and use these narrow queue/backing-store
+boundaries.
+
 The child keeps a reference to its parent so services can receive the correct
 owner through constructor injection. Parents keep their children only while
 the children are active. Disposing a child detaches it from its parent.
@@ -54,11 +96,12 @@ Disposing a parent disposes children in reverse creation order, then marks the
 parent disposed. Disposal is idempotent.
 
 Runtime service containers register their realm, agent, cluster, and
-agent-scheduling services as reserved services. Those registrations cannot be
-replaced or removed. Realms in one agent resolve the same scheduler, event
-loop, async context, and finalization host. Child DI scopes retain the same
-owners. After realm disposal, its service container and any child scopes reject
-further use.
+agent/cluster services as reserved services. Those registrations cannot be
+replaced or removed. Realms in one agent resolve the same symbol registry,
+scheduler, event loop, async context, and finalization host. Agents in one
+cluster resolve the same transport, broadcast, shared-memory, and Atomics
+services. Child DI scopes retain the same owners. After realm disposal, its
+service container and any child scopes reject further use.
 
 The factory currently creates an isolated cluster, agent, realm, and service
 container for each `RuntimeServices.BuildServiceProvider()` call. Each realm
@@ -130,7 +173,12 @@ change observable semantics.
 - Process-wide code may retain immutable metadata, but not an active realm,
   agent, or cluster.
 - A cluster may reference its active agents.
+- A cluster owns transport and broadcast cores, shared backing-store
+  coordination, and the Atomics waiter domain, but never realm wrappers,
+  JavaScript callbacks, globals, prototypes, or module state.
 - An agent may reference its cluster and active realms.
+- An agent owns its mutable global symbol registry. Registered-symbol identity
+  is shared across that agent's realms and isolated from every other agent.
 - An agent owns one scheduling graph and cancellation source. Its external
   wake API queues work for the agent executor and never runs JavaScript on the
   producer thread.
@@ -145,3 +193,6 @@ change observable semantics.
   injection, but must not discover them through a second service locator.
 - Realm-created JavaScript objects must not be stored on an agent or cluster.
 - Cross-agent resources must not retain realm-created wrappers or callbacks.
+- Removing an agent unregisters every cluster endpoint/waiter that identifies
+  it. Removing the final agent releases the cluster's live shared-memory and
+  synchronization resources.

--- a/src/JavaScriptRuntime/ArrayBuffer.cs
+++ b/src/JavaScriptRuntime/ArrayBuffer.cs
@@ -7,13 +7,13 @@ namespace JavaScriptRuntime
     {
         internal static object Prototype
             => RuntimeIntrinsics.Current.ArrayBufferPrototype;
-        private byte[] _bytes;
+        private readonly RuntimeArrayBufferStorage _storage;
         private readonly int _maxByteLength;
         private readonly bool _isResizable;
 
         public ArrayBuffer()
         {
-            _bytes = System.Array.Empty<byte>();
+            _storage = new RuntimeArrayBufferStorage(System.Array.Empty<byte>());
             _maxByteLength = 0;
             InitializeIntrinsicSurface();
         }
@@ -21,9 +21,10 @@ namespace JavaScriptRuntime
         public ArrayBuffer(object? length)
         {
             var byteLength = CoerceByteLength(length);
-            _bytes = byteLength == 0
-                ? System.Array.Empty<byte>()
-                : new byte[byteLength];
+            _storage = new RuntimeArrayBufferStorage(
+                byteLength == 0
+                    ? System.Array.Empty<byte>()
+                    : new byte[byteLength]);
             _maxByteLength = byteLength;
             InitializeIntrinsicSurface();
         }
@@ -36,9 +37,10 @@ namespace JavaScriptRuntime
         protected ArrayBuffer(object? length, object? options, bool supportsResizing)
         {
             var byteLength = CoerceByteLength(length);
-            _bytes = byteLength == 0
-                ? System.Array.Empty<byte>()
-                : new byte[byteLength];
+            _storage = new RuntimeArrayBufferStorage(
+                byteLength == 0
+                    ? System.Array.Empty<byte>()
+                    : new byte[byteLength]);
 
             if (supportsResizing && TryGetMaxByteLength(options, out var maxByteLength))
             {
@@ -59,12 +61,20 @@ namespace JavaScriptRuntime
 
         internal ArrayBuffer(byte[] bytes, bool cloneBuffer)
         {
-            _bytes = cloneBuffer ? (byte[])bytes.Clone() : bytes;
-            _maxByteLength = _bytes.Length;
+            _storage = new RuntimeArrayBufferStorage(
+                cloneBuffer ? (byte[])bytes.Clone() : bytes);
+            _maxByteLength = _storage.Bytes.Length;
             InitializeIntrinsicSurface();
         }
 
-        public double byteLength => _bytes.Length;
+        internal ArrayBuffer(RuntimeArrayBufferStorage storage)
+        {
+            _storage = storage;
+            _maxByteLength = storage.Bytes.Length;
+            InitializeIntrinsicSurface();
+        }
+
+        public double byteLength => _storage.Bytes.Length;
         public double maxByteLength => _maxByteLength;
         public bool resizable => _isResizable;
 
@@ -73,8 +83,9 @@ namespace JavaScriptRuntime
 
         public ArrayBuffer slice(object? start, object? end)
         {
-            var startIndex = CoerceRelativeIndex(start, 0, _bytes.Length);
-            var endIndex = CoerceRelativeIndex(end, _bytes.Length, _bytes.Length);
+            var bytes = _storage.Bytes;
+            var startIndex = CoerceRelativeIndex(start, 0, bytes.Length);
+            var endIndex = CoerceRelativeIndex(end, bytes.Length, bytes.Length);
             if (endIndex < startIndex)
             {
                 endIndex = startIndex;
@@ -87,7 +98,7 @@ namespace JavaScriptRuntime
             }
 
             var copy = new byte[length];
-            System.Buffer.BlockCopy(_bytes, startIndex, copy, 0, length);
+            System.Buffer.BlockCopy(bytes, startIndex, copy, 0, length);
             return new ArrayBuffer(copy, cloneBuffer: false);
         }
 
@@ -107,7 +118,8 @@ namespace JavaScriptRuntime
                 throw new RangeError("Invalid ArrayBuffer length");
             }
 
-            if (byteLength == _bytes.Length)
+            var bytes = _storage.Bytes;
+            if (byteLength == bytes.Length)
             {
                 return null;
             }
@@ -115,17 +127,17 @@ namespace JavaScriptRuntime
             var resized = byteLength == 0
                 ? System.Array.Empty<byte>()
                 : new byte[byteLength];
-            System.Buffer.BlockCopy(_bytes, 0, resized, 0, System.Math.Min(_bytes.Length, byteLength));
-            _bytes = resized;
+            System.Buffer.BlockCopy(bytes, 0, resized, 0, System.Math.Min(bytes.Length, byteLength));
+            _storage.Bytes = resized;
             return null;
         }
 
         public static bool isView(object? arg)
             => arg is DataView or TypedArrayBase;
 
-        internal int ByteLengthInt => _bytes.Length;
+        internal int ByteLengthInt => _storage.Bytes.Length;
 
-        internal byte[] RawBytes => _bytes;
+        internal byte[] RawBytes => _storage.Bytes;
         internal bool IsResizable => _isResizable;
 
         private void InitializeIntrinsicSurface()
@@ -136,7 +148,7 @@ namespace JavaScriptRuntime
             }
         }
 
-        private static int CoerceByteLength(object? value)
+        internal static int CoerceByteLength(object? value)
         {
             if (value is null || value is JsNull)
             {

--- a/src/JavaScriptRuntime/Atomics.cs
+++ b/src/JavaScriptRuntime/Atomics.cs
@@ -35,13 +35,33 @@ namespace JavaScriptRuntime
 
             var elementIndex = (int)elementIndexInteger;
             var expectedValue = TypeUtilities.ToInt32(value);
+            var timeoutMs = NormalizeTimeout(timeout);
+            var context = RuntimeExecutionContext.CurrentOrOverride;
+            var backingStore = ((SharedArrayBuffer)int32Array.buffer).BackingStore;
+            if (context != null
+                && ReferenceEquals(
+                    backingStore.Owner,
+                    context.Agent.Cluster.SharedServices))
+            {
+                return context.Agent.Cluster.SharedServices.Atomics.Wait(
+                    context.Agent,
+                    backingStore,
+                    checked((int)int32Array.byteOffset + (elementIndex * sizeof(int))),
+                    expectedValue,
+                    timeoutMs) switch
+                {
+                    RuntimeAtomicsWaitResult.NotEqual => "not-equal",
+                    RuntimeAtomicsWaitResult.Notified => "ok",
+                    _ => "timed-out"
+                };
+            }
+
             var actualValue = TypeUtilities.ToInt32(int32Array[(double)elementIndex]);
             if (actualValue != expectedValue)
             {
                 return "not-equal";
             }
 
-            var timeoutMs = NormalizeTimeout(timeout);
             if (timeoutMs > 0)
             {
                 global::System.Threading.Thread.Sleep(timeoutMs);

--- a/src/JavaScriptRuntime/DependencyInjection/ServiceContainer.cs
+++ b/src/JavaScriptRuntime/DependencyInjection/ServiceContainer.cs
@@ -40,8 +40,14 @@ public class ServiceContainer
 
             _owningRealm = realm;
             _singletons[typeof(RuntimeAgentCluster)] = realm.Agent.Cluster;
+            _singletons[typeof(RuntimeAgentClusterSharedServices)] = realm.Agent.Cluster.SharedServices;
+            _singletons[typeof(RuntimeMessageTransportService)] = realm.Agent.Cluster.SharedServices.Transport;
+            _singletons[typeof(RuntimeBroadcastChannelRegistry)] = realm.Agent.Cluster.SharedServices.Broadcasts;
+            _singletons[typeof(RuntimeSharedMemoryService)] = realm.Agent.Cluster.SharedServices.SharedMemory;
+            _singletons[typeof(RuntimeAtomicsSynchronizationDomain)] = realm.Agent.Cluster.SharedServices.Atomics;
             _singletons[typeof(RuntimeAgent)] = realm.Agent;
             _singletons[typeof(RuntimeAgentSchedulingState)] = realm.Agent.Scheduling;
+            _singletons[typeof(RuntimeAgentSymbolRegistry)] = realm.Agent.SymbolRegistry;
             _singletons[typeof(AsyncContextRuntime)] = realm.Agent.Scheduling.AsyncContext;
             _singletons[typeof(RuntimeRealm)] = realm;
             _singletons[typeof(Modules.RuntimeModuleState)] = realm.ModuleState;
@@ -313,8 +319,14 @@ public class ServiceContainer
         }
 
         _singletons[typeof(RuntimeAgentCluster)] = _owningRealm.Agent.Cluster;
+        _singletons[typeof(RuntimeAgentClusterSharedServices)] = _owningRealm.Agent.Cluster.SharedServices;
+        _singletons[typeof(RuntimeMessageTransportService)] = _owningRealm.Agent.Cluster.SharedServices.Transport;
+        _singletons[typeof(RuntimeBroadcastChannelRegistry)] = _owningRealm.Agent.Cluster.SharedServices.Broadcasts;
+        _singletons[typeof(RuntimeSharedMemoryService)] = _owningRealm.Agent.Cluster.SharedServices.SharedMemory;
+        _singletons[typeof(RuntimeAtomicsSynchronizationDomain)] = _owningRealm.Agent.Cluster.SharedServices.Atomics;
         _singletons[typeof(RuntimeAgent)] = _owningRealm.Agent;
         _singletons[typeof(RuntimeAgentSchedulingState)] = _owningRealm.Agent.Scheduling;
+        _singletons[typeof(RuntimeAgentSymbolRegistry)] = _owningRealm.Agent.SymbolRegistry;
         _singletons[typeof(AsyncContextRuntime)] = _owningRealm.Agent.Scheduling.AsyncContext;
         _singletons[typeof(RuntimeRealm)] = _owningRealm;
         _singletons[typeof(Modules.RuntimeModuleState)] = _owningRealm.ModuleState;
@@ -337,6 +349,12 @@ public class ServiceContainer
             && (serviceType == typeof(RuntimeAgentCluster)
                 || serviceType == typeof(RuntimeAgent)
                 || serviceType == typeof(RuntimeAgentSchedulingState)
+                || serviceType == typeof(RuntimeAgentSymbolRegistry)
+                || serviceType == typeof(RuntimeAgentClusterSharedServices)
+                || serviceType == typeof(RuntimeMessageTransportService)
+                || serviceType == typeof(RuntimeBroadcastChannelRegistry)
+                || serviceType == typeof(RuntimeSharedMemoryService)
+                || serviceType == typeof(RuntimeAtomicsSynchronizationDomain)
                 || serviceType == typeof(RuntimeRealm)
                 || serviceType == typeof(Modules.RuntimeModuleState)
                 || serviceType == typeof(RuntimeRealmValueCacheState)

--- a/src/JavaScriptRuntime/Node/Util.cs
+++ b/src/JavaScriptRuntime/Node/Util.cs
@@ -12,8 +12,16 @@ namespace JavaScriptRuntime.Node
         private readonly BuiltinDelegateFunctionAdapter _inspectFunction;
 
         public Util()
+            : this(
+                RuntimeExecutionContext.CurrentOrOverride?.Agent.SymbolRegistry
+                    ?? new RuntimeAgentSymbolRegistry())
         {
-            _inspectCustomSymbol = (Symbol)Symbol.@for("nodejs.util.inspect.custom");
+        }
+
+        public Util(RuntimeAgentSymbolRegistry symbolRegistry)
+        {
+            ArgumentNullException.ThrowIfNull(symbolRegistry);
+            _inspectCustomSymbol = symbolRegistry.GetOrCreate("nodejs.util.inspect.custom");
 
             // Expose util.inspect as a delegate-valued property so util.inspect.custom is observable.
             _inspectFunction =

--- a/src/JavaScriptRuntime/RuntimeAgentClusterSharedServices.cs
+++ b/src/JavaScriptRuntime/RuntimeAgentClusterSharedServices.cs
@@ -1,0 +1,814 @@
+namespace JavaScriptRuntime;
+
+internal sealed class RuntimeAgentClusterSharedServices : IDisposable
+{
+    private int _disposed;
+
+    internal RuntimeAgentClusterSharedServices(RuntimeAgentCluster cluster)
+    {
+        Cluster = cluster;
+        Transport = new RuntimeMessageTransportService(cluster);
+        Broadcasts = new RuntimeBroadcastChannelRegistry(cluster);
+        Atomics = new RuntimeAtomicsSynchronizationDomain(cluster);
+        SharedMemory = new RuntimeSharedMemoryService(this);
+    }
+
+    internal RuntimeAgentCluster Cluster { get; }
+
+    internal RuntimeMessageTransportService Transport { get; }
+
+    internal RuntimeBroadcastChannelRegistry Broadcasts { get; }
+
+    internal RuntimeSharedMemoryService SharedMemory { get; }
+
+    internal RuntimeAtomicsSynchronizationDomain Atomics { get; }
+
+    internal void RemoveAgent(RuntimeAgent agent, bool isLastAgent)
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return;
+        }
+
+        Transport.RemoveAgent(agent);
+        Broadcasts.RemoveAgent(agent);
+        Atomics.RemoveAgent(agent);
+        if (isLastAgent)
+        {
+            SharedMemory.ReleaseAll();
+            Atomics.Reset();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        Transport.Dispose();
+        Broadcasts.Dispose();
+        Atomics.Dispose();
+        SharedMemory.Dispose();
+    }
+}
+
+internal sealed class RuntimeMessageTransportService : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly RuntimeAgentCluster _cluster;
+    private readonly Dictionary<long, RuntimeMessagePortCore> _ports = new();
+    private long _nextId;
+    private bool _disposed;
+
+    internal RuntimeMessageTransportService(RuntimeAgentCluster cluster)
+    {
+        _cluster = cluster;
+    }
+
+    internal (RuntimeMessagePortCore First, RuntimeMessagePortCore Second) CreateEntangledPair(
+        RuntimeAgent firstOwner,
+        RuntimeAgent secondOwner)
+    {
+        ArgumentNullException.ThrowIfNull(firstOwner);
+        ArgumentNullException.ThrowIfNull(secondOwner);
+        return _cluster.WhileAgentsActive(
+            firstOwner,
+            secondOwner,
+            () =>
+            {
+                lock (_gate)
+                {
+                    ThrowIfDisposed();
+                    var firstId = ++_nextId;
+                    var secondId = ++_nextId;
+                    var first = new RuntimeMessagePortCore(
+                        this,
+                        firstId,
+                        firstOwner,
+                        secondId);
+                    var second = new RuntimeMessagePortCore(
+                        this,
+                        secondId,
+                        secondOwner,
+                        firstId);
+                    _ports.Add(firstId, first);
+                    _ports.Add(secondId, second);
+                    return (first, second);
+                }
+            });
+    }
+
+    internal bool Post(long senderId, long receiverId, ReadOnlySpan<byte> payload)
+    {
+        RuntimeMessagePortCore? receiver;
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            if (!_ports.ContainsKey(senderId)
+                || !_ports.TryGetValue(receiverId, out receiver))
+            {
+                return false;
+            }
+        }
+
+        return receiver.Enqueue(payload);
+    }
+
+    internal void Close(long id)
+    {
+        RuntimeMessagePortCore? port;
+        RuntimeMessagePortCore? peer = null;
+        lock (_gate)
+        {
+            if (!_ports.Remove(id, out port))
+            {
+                return;
+            }
+
+            if (_ports.TryGetValue(port.PeerId, out peer))
+            {
+                peer.DetachPeer();
+            }
+        }
+
+        port.CloseFromService();
+    }
+
+    internal void RemoveAgent(RuntimeAgent agent)
+    {
+        RuntimeMessagePortCore[] owned;
+        lock (_gate)
+        {
+            owned = _ports.Values
+                .Where(port => ReferenceEquals(port.Owner, agent))
+                .ToArray();
+        }
+
+        foreach (var port in owned)
+        {
+            Close(port.Id);
+        }
+    }
+
+    public void Dispose()
+    {
+        RuntimeMessagePortCore[] ports;
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            ports = _ports.Values.ToArray();
+            _ports.Clear();
+        }
+
+        foreach (var port in ports)
+        {
+            port.CloseFromService();
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(RuntimeMessageTransportService));
+        }
+    }
+}
+
+internal sealed class RuntimeMessagePortCore : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly RuntimeMessageTransportService _transport;
+    private readonly Queue<byte[]> _messages = new();
+    private long _peerId;
+    private bool _closed;
+
+    internal RuntimeMessagePortCore(
+        RuntimeMessageTransportService transport,
+        long id,
+        RuntimeAgent owner,
+        long peerId)
+    {
+        _transport = transport;
+        Id = id;
+        Owner = owner;
+        _peerId = peerId;
+    }
+
+    internal long Id { get; }
+
+    internal RuntimeAgent Owner { get; }
+
+    internal long PeerId => Volatile.Read(ref _peerId);
+
+    internal bool Post(ReadOnlySpan<byte> payload)
+    {
+        var peerId = PeerId;
+        return peerId != 0 && _transport.Post(Id, peerId, payload);
+    }
+
+    internal bool TryReceive(out byte[]? payload)
+    {
+        lock (_gate)
+        {
+            if (_messages.Count == 0)
+            {
+                payload = null;
+                return false;
+            }
+
+            payload = _messages.Dequeue();
+            return true;
+        }
+    }
+
+    internal bool Enqueue(ReadOnlySpan<byte> payload)
+    {
+        lock (_gate)
+        {
+            if (_closed)
+            {
+                return false;
+            }
+
+            _messages.Enqueue(payload.ToArray());
+            return true;
+        }
+    }
+
+    internal void DetachPeer()
+        => Interlocked.Exchange(ref _peerId, 0);
+
+    internal void CloseFromService()
+    {
+        lock (_gate)
+        {
+            _closed = true;
+            _messages.Clear();
+            DetachPeer();
+        }
+    }
+
+    public void Dispose()
+        => _transport.Close(Id);
+}
+
+internal sealed class RuntimeBroadcastChannelRegistry : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly RuntimeAgentCluster _cluster;
+    private readonly Dictionary<long, RuntimeBroadcastEndpointCore> _endpoints = new();
+    private long _nextId;
+    private bool _disposed;
+
+    internal RuntimeBroadcastChannelRegistry(RuntimeAgentCluster cluster)
+    {
+        _cluster = cluster;
+    }
+
+    internal RuntimeBroadcastEndpointCore Register(RuntimeAgent owner, string name)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(name);
+        return _cluster.WhileAgentsActive(
+            owner,
+            second: null,
+            () =>
+            {
+                lock (_gate)
+                {
+                    ThrowIfDisposed();
+                    var id = ++_nextId;
+                    var endpoint = new RuntimeBroadcastEndpointCore(
+                        this,
+                        id,
+                        owner,
+                        name);
+                    _endpoints.Add(id, endpoint);
+                    return endpoint;
+                }
+            });
+    }
+
+    internal int Post(long senderId, string name, ReadOnlySpan<byte> payload)
+    {
+        RuntimeBroadcastEndpointCore[] recipients;
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            if (!_endpoints.ContainsKey(senderId))
+            {
+                return 0;
+            }
+
+            recipients = _endpoints.Values
+                .Where(endpoint => endpoint.Id != senderId
+                    && string.Equals(endpoint.Name, name, StringComparison.Ordinal))
+                .ToArray();
+        }
+
+        var delivered = 0;
+        foreach (var recipient in recipients)
+        {
+            if (recipient.Enqueue(payload))
+            {
+                delivered++;
+            }
+        }
+
+        return delivered;
+    }
+
+    internal void Close(long id)
+    {
+        RuntimeBroadcastEndpointCore? endpoint;
+        lock (_gate)
+        {
+            if (!_endpoints.Remove(id, out endpoint))
+            {
+                return;
+            }
+        }
+
+        endpoint.CloseFromService();
+    }
+
+    internal void RemoveAgent(RuntimeAgent agent)
+    {
+        RuntimeBroadcastEndpointCore[] owned;
+        lock (_gate)
+        {
+            owned = _endpoints.Values
+                .Where(endpoint => ReferenceEquals(endpoint.Owner, agent))
+                .ToArray();
+        }
+
+        foreach (var endpoint in owned)
+        {
+            Close(endpoint.Id);
+        }
+    }
+
+    public void Dispose()
+    {
+        RuntimeBroadcastEndpointCore[] endpoints;
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            endpoints = _endpoints.Values.ToArray();
+            _endpoints.Clear();
+        }
+
+        foreach (var endpoint in endpoints)
+        {
+            endpoint.CloseFromService();
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(RuntimeBroadcastChannelRegistry));
+        }
+    }
+}
+
+internal sealed class RuntimeBroadcastEndpointCore : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly RuntimeBroadcastChannelRegistry _registry;
+    private readonly Queue<byte[]> _messages = new();
+    private bool _closed;
+
+    internal RuntimeBroadcastEndpointCore(
+        RuntimeBroadcastChannelRegistry registry,
+        long id,
+        RuntimeAgent owner,
+        string name)
+    {
+        _registry = registry;
+        Id = id;
+        Owner = owner;
+        Name = name;
+    }
+
+    internal long Id { get; }
+
+    internal RuntimeAgent Owner { get; }
+
+    internal string Name { get; }
+
+    internal int Post(ReadOnlySpan<byte> payload)
+        => _registry.Post(Id, Name, payload);
+
+    internal bool TryReceive(out byte[]? payload)
+    {
+        lock (_gate)
+        {
+            if (_messages.Count == 0)
+            {
+                payload = null;
+                return false;
+            }
+
+            payload = _messages.Dequeue();
+            return true;
+        }
+    }
+
+    internal bool Enqueue(ReadOnlySpan<byte> payload)
+    {
+        lock (_gate)
+        {
+            if (_closed)
+            {
+                return false;
+            }
+
+            _messages.Enqueue(payload.ToArray());
+            return true;
+        }
+    }
+
+    internal void CloseFromService()
+    {
+        lock (_gate)
+        {
+            _closed = true;
+            _messages.Clear();
+        }
+    }
+
+    public void Dispose()
+        => _registry.Close(Id);
+}
+
+internal sealed class RuntimeSharedMemoryService : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly RuntimeAgentClusterSharedServices _owner;
+    private readonly List<WeakReference<RuntimeSharedArrayBufferBackingStore>> _stores = [];
+    private long _nextId;
+    private bool _disposed;
+
+    internal RuntimeSharedMemoryService(RuntimeAgentClusterSharedServices owner)
+    {
+        _owner = owner;
+    }
+
+    internal RuntimeSharedArrayBufferBackingStore Create(
+        RuntimeAgent agent,
+        int byteLength)
+        => _owner.Cluster.WhileAgentsActive(
+            agent,
+            second: null,
+            () => CreateCore(byteLength));
+
+    private RuntimeSharedArrayBufferBackingStore CreateCore(int byteLength)
+    {
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            var bytes = byteLength == 0
+                ? System.Array.Empty<byte>()
+                : new byte[byteLength];
+            var store = new RuntimeSharedArrayBufferBackingStore(
+                ++_nextId,
+                _owner,
+                bytes);
+            _stores.Add(new WeakReference<RuntimeSharedArrayBufferBackingStore>(store));
+            if (_stores.Count % 64 == 0)
+            {
+                _stores.RemoveAll(reference => !reference.TryGetTarget(out _));
+            }
+
+            return store;
+        }
+    }
+
+    internal void ReleaseAll()
+    {
+        RuntimeSharedArrayBufferBackingStore[] stores;
+        lock (_gate)
+        {
+            stores = _stores
+                .Select(reference => reference.TryGetTarget(out var store) ? store : null)
+                .Where(store => store != null)
+                .Cast<RuntimeSharedArrayBufferBackingStore>()
+                .ToArray();
+            _stores.Clear();
+        }
+
+        foreach (var store in stores)
+        {
+            store.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+        }
+
+        ReleaseAll();
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(RuntimeSharedMemoryService));
+        }
+    }
+}
+
+internal enum RuntimeAtomicsWaitResult
+{
+    NotEqual,
+    Notified,
+    TimedOut
+}
+
+internal sealed class RuntimeAtomicsSynchronizationDomain : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly RuntimeAgentCluster _cluster;
+    private readonly Dictionary<WaitLocation, List<Waiter>> _waiters = new();
+    private bool _disposed;
+
+    internal RuntimeAtomicsSynchronizationDomain(RuntimeAgentCluster cluster)
+    {
+        _cluster = cluster;
+    }
+
+    internal int WaiterCount
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _waiters.Values.Sum(static waiters => waiters.Count);
+            }
+        }
+    }
+
+    internal RuntimeAtomicsWaitResult Wait(
+        RuntimeAgent agent,
+        RuntimeSharedArrayBufferBackingStore store,
+        int byteOffset,
+        int expectedValue,
+        int timeoutMilliseconds)
+    {
+        Validate(agent, store);
+        var location = new WaitLocation(store.Id, byteOffset);
+        using var waiter = new Waiter(agent);
+
+        var immediateResult = _cluster.WhileAgentsActive(
+            agent,
+            second: null,
+            () =>
+            {
+                lock (_gate)
+                {
+                    ThrowIfDisposed();
+                    if (ReadInt32(store, byteOffset) != expectedValue)
+                    {
+                        return RuntimeAtomicsWaitResult.NotEqual;
+                    }
+
+                    if (!_waiters.TryGetValue(location, out var locationWaiters))
+                    {
+                        locationWaiters = [];
+                        _waiters.Add(location, locationWaiters);
+                    }
+
+                    locationWaiters.Add(waiter);
+                }
+
+                return (RuntimeAtomicsWaitResult?)null;
+            });
+        if (immediateResult.HasValue)
+        {
+            return immediateResult.Value;
+        }
+
+        RuntimeAtomicsWaitResult result;
+        try
+        {
+            var signaled = waiter.Signal.Wait(timeoutMilliseconds, agent.ShutdownToken);
+            result = signaled && !waiter.IsCancelled
+                ? RuntimeAtomicsWaitResult.Notified
+                : RuntimeAtomicsWaitResult.TimedOut;
+        }
+        catch (OperationCanceledException)
+        {
+            result = RuntimeAtomicsWaitResult.TimedOut;
+        }
+        finally
+        {
+            RemoveWaiter(location, waiter);
+        }
+
+        return result;
+    }
+
+    internal int Notify(
+        RuntimeSharedArrayBufferBackingStore store,
+        int byteOffset,
+        int count)
+    {
+        if (count <= 0)
+        {
+            return 0;
+        }
+
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            ValidateStore(store);
+            var location = new WaitLocation(store.Id, byteOffset);
+            if (!_waiters.TryGetValue(location, out var waiters))
+            {
+                return 0;
+            }
+
+            var selected = waiters.Take(count).ToArray();
+            waiters.RemoveRange(0, selected.Length);
+            if (waiters.Count == 0)
+            {
+                _waiters.Remove(location);
+            }
+
+            foreach (var waiter in selected)
+            {
+                waiter.Signal.Set();
+            }
+
+            return selected.Length;
+        }
+    }
+
+    internal void RemoveAgent(RuntimeAgent agent)
+    {
+        lock (_gate)
+        {
+            var removed = new List<Waiter>();
+            foreach (var (location, waiters) in _waiters.ToArray())
+            {
+                removed.AddRange(
+                    waiters.Where(waiter => ReferenceEquals(waiter.Agent, agent)));
+                waiters.RemoveAll(
+                    waiter => ReferenceEquals(waiter.Agent, agent));
+                if (waiters.Count == 0)
+                {
+                    _waiters.Remove(location);
+                }
+            }
+
+            foreach (var waiter in removed)
+            {
+                waiter.Cancel();
+            }
+        }
+    }
+
+    internal void Reset()
+    {
+        lock (_gate)
+        {
+            var waiters = _waiters.Values.SelectMany(static values => values).ToArray();
+            _waiters.Clear();
+            foreach (var waiter in waiters)
+            {
+                waiter.Cancel();
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+        }
+
+        Reset();
+    }
+
+    private void RemoveWaiter(WaitLocation location, Waiter waiter)
+    {
+        lock (_gate)
+        {
+            if (!_waiters.TryGetValue(location, out var waiters))
+            {
+                return;
+            }
+
+            waiters.Remove(waiter);
+            if (waiters.Count == 0)
+            {
+                _waiters.Remove(location);
+            }
+        }
+    }
+
+    private void Validate(
+        RuntimeAgent agent,
+        RuntimeSharedArrayBufferBackingStore store)
+    {
+        ArgumentNullException.ThrowIfNull(agent);
+        if (!ReferenceEquals(agent.Cluster, _cluster))
+        {
+            throw new InvalidOperationException(
+                "Atomics waiters must belong to this agent cluster.");
+        }
+
+        ValidateStore(store);
+    }
+
+    private void ValidateStore(RuntimeSharedArrayBufferBackingStore store)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        if (!ReferenceEquals(store.Owner?.Atomics, this) || store.IsReleased)
+        {
+            throw new InvalidOperationException(
+                "The shared backing store does not belong to this synchronization domain.");
+        }
+    }
+
+    private static int ReadInt32(
+        RuntimeSharedArrayBufferBackingStore store,
+        int byteOffset)
+    {
+        var bytes = store.Bytes;
+        if (byteOffset < 0 || byteOffset > bytes.Length - sizeof(int))
+        {
+            throw new ArgumentOutOfRangeException(nameof(byteOffset));
+        }
+
+        var span = bytes.AsSpan(byteOffset, sizeof(int));
+        return BitConverter.IsLittleEndian
+            ? System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(span)
+            : System.Buffers.Binary.BinaryPrimitives.ReadInt32BigEndian(span);
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(RuntimeAtomicsSynchronizationDomain));
+        }
+    }
+
+    private readonly record struct WaitLocation(long StoreId, int ByteOffset);
+
+    private sealed class Waiter : IDisposable
+    {
+        internal Waiter(RuntimeAgent agent)
+        {
+            Agent = agent;
+        }
+
+        internal RuntimeAgent Agent { get; }
+
+        internal ManualResetEventSlim Signal { get; } = new(false);
+
+        internal bool IsCancelled => Volatile.Read(ref _cancelled) != 0;
+
+        private int _cancelled;
+
+        internal void Cancel()
+        {
+            Volatile.Write(ref _cancelled, 1);
+            Signal.Set();
+        }
+
+        public void Dispose()
+            => Signal.Dispose();
+    }
+}

--- a/src/JavaScriptRuntime/RuntimeAgentSymbolRegistry.cs
+++ b/src/JavaScriptRuntime/RuntimeAgentSymbolRegistry.cs
@@ -1,0 +1,76 @@
+namespace JavaScriptRuntime;
+
+public sealed class RuntimeAgentSymbolRegistry : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, Symbol> _symbols = new(StringComparer.Ordinal);
+    private readonly Dictionary<Symbol, string> _keys = new();
+    private bool _disposed;
+
+    internal RuntimeAgentSymbolRegistry()
+    {
+    }
+
+    internal Symbol GetOrCreate(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            if (_symbols.TryGetValue(key, out var existing))
+            {
+                return existing;
+            }
+
+            var symbol = new Symbol(key);
+            _symbols.Add(key, symbol);
+            _keys.Add(symbol, key);
+            return symbol;
+        }
+    }
+
+    internal string? GetKey(Symbol symbol)
+    {
+        ArgumentNullException.ThrowIfNull(symbol);
+
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            return _keys.GetValueOrDefault(symbol);
+        }
+    }
+
+    internal bool Contains(Symbol symbol)
+    {
+        ArgumentNullException.ThrowIfNull(symbol);
+
+        lock (_gate)
+        {
+            return !_disposed && _keys.ContainsKey(symbol);
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _symbols.Clear();
+            _keys.Clear();
+            _disposed = true;
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(RuntimeAgentSymbolRegistry));
+        }
+    }
+}

--- a/src/JavaScriptRuntime/RuntimeArrayBufferStorage.cs
+++ b/src/JavaScriptRuntime/RuntimeArrayBufferStorage.cs
@@ -1,0 +1,46 @@
+namespace JavaScriptRuntime;
+
+internal class RuntimeArrayBufferStorage
+{
+    private byte[] _bytes;
+
+    internal RuntimeArrayBufferStorage(byte[] bytes)
+    {
+        _bytes = bytes;
+    }
+
+    internal virtual byte[] Bytes
+    {
+        get => Volatile.Read(ref _bytes);
+        set => Volatile.Write(ref _bytes, value);
+    }
+}
+
+internal sealed class RuntimeSharedArrayBufferBackingStore : RuntimeArrayBufferStorage
+{
+    private int _released;
+
+    internal RuntimeSharedArrayBufferBackingStore(
+        long id,
+        RuntimeAgentClusterSharedServices? owner,
+        byte[] bytes)
+        : base(bytes)
+    {
+        Id = id;
+        Owner = owner;
+    }
+
+    internal long Id { get; }
+
+    internal RuntimeAgentClusterSharedServices? Owner { get; }
+
+    internal bool IsReleased => Volatile.Read(ref _released) != 0;
+
+    internal void Release()
+    {
+        if (Interlocked.Exchange(ref _released, 1) == 0)
+        {
+            Bytes = System.Array.Empty<byte>();
+        }
+    }
+}

--- a/src/JavaScriptRuntime/RuntimeOwnership.cs
+++ b/src/JavaScriptRuntime/RuntimeOwnership.cs
@@ -16,6 +16,13 @@ internal sealed class RuntimeAgentCluster : IDisposable
     private RuntimeOwnershipState _state;
     private long _disposalSequence;
 
+    internal RuntimeAgentCluster()
+    {
+        SharedServices = new RuntimeAgentClusterSharedServices(this);
+    }
+
+    internal RuntimeAgentClusterSharedServices SharedServices { get; }
+
     internal bool IsDisposed
     {
         get
@@ -63,13 +70,13 @@ internal sealed class RuntimeAgentCluster : IDisposable
 
             _state = RuntimeOwnershipState.Disposing;
             var agents = _agents.ToArray();
-            _agents.Clear();
 
             for (var index = agents.Length - 1; index >= 0; index--)
             {
                 agents[index].Dispose();
             }
 
+            SharedServices.Dispose();
             DisposalOrder = NextDisposalOrder();
             _state = RuntimeOwnershipState.Disposed;
         }
@@ -78,11 +85,39 @@ internal sealed class RuntimeAgentCluster : IDisposable
     internal long NextDisposalOrder()
         => Interlocked.Increment(ref _disposalSequence);
 
+    internal T WhileAgentsActive<T>(
+        RuntimeAgent first,
+        RuntimeAgent? second,
+        Func<T> action)
+    {
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            if (!ReferenceEquals(first.Cluster, this)
+                || (second != null && !ReferenceEquals(second.Cluster, this)))
+            {
+                throw new InvalidOperationException(
+                    "Agent-cluster services cannot be used by an agent from another cluster.");
+            }
+
+            if (!_agents.Contains(first)
+                || (second != null && !_agents.Contains(second)))
+            {
+                throw new ObjectDisposedException(nameof(RuntimeAgent));
+            }
+
+            return action();
+        }
+    }
+
     internal void Detach(RuntimeAgent agent)
     {
         lock (_gate)
         {
-            _agents.Remove(agent);
+            if (_agents.Remove(agent))
+            {
+                SharedServices.RemoveAgent(agent, _agents.Count == 0);
+            }
         }
     }
 
@@ -105,11 +140,14 @@ internal sealed class RuntimeAgent : IDisposable
     {
         Cluster = cluster;
         Scheduling = new RuntimeAgentSchedulingState();
+        SymbolRegistry = new RuntimeAgentSymbolRegistry();
     }
 
     internal RuntimeAgentCluster Cluster { get; }
 
     internal RuntimeAgentSchedulingState Scheduling { get; }
+
+    internal RuntimeAgentSymbolRegistry SymbolRegistry { get; }
 
     internal CancellationToken ShutdownToken => Scheduling.ShutdownToken;
 
@@ -187,6 +225,7 @@ internal sealed class RuntimeAgent : IDisposable
             }
 
             Scheduling.Dispose();
+            SymbolRegistry.Dispose();
             DisposalOrder = Cluster.NextDisposalOrder();
             _state = RuntimeOwnershipState.Disposed;
         }

--- a/src/JavaScriptRuntime/SharedArrayBuffer.cs
+++ b/src/JavaScriptRuntime/SharedArrayBuffer.cs
@@ -3,24 +3,64 @@ namespace JavaScriptRuntime
     [IntrinsicObject("SharedArrayBuffer")]
     public sealed class SharedArrayBuffer : ArrayBuffer
     {
+        private readonly RuntimeSharedArrayBufferBackingStore _backingStore;
+
         internal static object SharedPrototype
             => RuntimeIntrinsics.Current.SharedArrayBufferPrototype;
 
         public SharedArrayBuffer()
+            : this(CreateBackingStore(null))
         {
-            InitializeIntrinsicSurface();
         }
 
         public SharedArrayBuffer(object? length)
-            : base(length)
+            : this(CreateBackingStore(length))
         {
-            InitializeIntrinsicSurface();
         }
 
         public SharedArrayBuffer(object? length, object? options)
-            : base(length, options, supportsResizing: false)
+            : this(CreateBackingStore(length))
         {
+        }
+
+        private SharedArrayBuffer(RuntimeSharedArrayBufferBackingStore backingStore)
+            : base(backingStore)
+        {
+            _backingStore = backingStore;
             InitializeIntrinsicSurface();
+        }
+
+        internal RuntimeSharedArrayBufferBackingStore BackingStore => _backingStore;
+
+        internal SharedArrayBuffer CreateWrapperForCurrentRealm()
+        {
+            var currentServices = RuntimeExecutionContext.CurrentOrOverride?
+                .Agent.Cluster.SharedServices;
+            if (_backingStore.Owner != null
+                && !ReferenceEquals(_backingStore.Owner, currentServices))
+            {
+                throw new InvalidOperationException(
+                    "SharedArrayBuffer backing stores cannot cross agent clusters.");
+            }
+
+            return new SharedArrayBuffer(_backingStore);
+        }
+
+        private static RuntimeSharedArrayBufferBackingStore CreateBackingStore(object? length)
+        {
+            var byteLength = CoerceByteLength(length);
+            var context = RuntimeExecutionContext.CurrentOrOverride;
+            if (context != null)
+            {
+                return context.Agent.Cluster.SharedServices.SharedMemory.Create(
+                    context.Agent,
+                    byteLength);
+            }
+
+            var bytes = byteLength == 0
+                ? System.Array.Empty<byte>()
+                : new byte[byteLength];
+            return new RuntimeSharedArrayBufferBackingStore(0, null, bytes);
         }
 
         private void InitializeIntrinsicSurface()

--- a/src/JavaScriptRuntime/Symbol.cs
+++ b/src/JavaScriptRuntime/Symbol.cs
@@ -10,9 +10,6 @@ namespace JavaScriptRuntime;
 public sealed class Symbol
 {
     private static long _nextId;
-    private static readonly Dictionary<string, Symbol> _globalRegistry = new(StringComparer.Ordinal);
-    private static readonly Dictionary<Symbol, string> _globalRegistryReverse = new();
-    private static readonly object _registryLock = new();
 
     // Well-known symbols used by core language features.
     // These are singletons so identity comparisons work as expected.
@@ -123,18 +120,7 @@ public sealed class Symbol
     public static object @for(object? key)
     {
         var registryKey = DotNet2JSConversions.ToString(key);
-        lock (_registryLock)
-        {
-            if (_globalRegistry.TryGetValue(registryKey, out var existing))
-            {
-                return existing;
-            }
-
-            var created = new Symbol(registryKey);
-            _globalRegistry[registryKey] = created;
-            _globalRegistryReverse[created] = registryKey;
-            return created;
-        }
+        return GetCurrentRegistry().GetOrCreate(registryKey);
     }
 
     // Symbol.keyFor(sym)
@@ -145,10 +131,7 @@ public sealed class Symbol
             throw new TypeError("Symbol.keyFor requires a symbol");
         }
 
-        lock (_registryLock)
-        {
-            return _globalRegistryReverse.TryGetValue(symbol, out var key) ? key : null;
-        }
+        return GetCurrentRegistry().GetKey(symbol);
     }
 
     // Access well-known symbols via property-read lowering (e.g., Symbol.iterator).
@@ -178,12 +161,13 @@ public sealed class Symbol
         => GetWellKnown(name) != null;
 
     internal static bool IsRegistered(Symbol symbol)
-    {
-        lock (_registryLock)
-        {
-            return _globalRegistryReverse.ContainsKey(symbol);
-        }
-    }
+        => RuntimeExecutionContext.CurrentOrOverride?.Agent.SymbolRegistry.Contains(symbol)
+            ?? false;
+
+    private static RuntimeAgentSymbolRegistry GetCurrentRegistry()
+        => RuntimeExecutionContext.CurrentOrOverride?.Agent.SymbolRegistry
+            ?? throw new InvalidOperationException(
+                "The global symbol registry requires an active JavaScript runtime.");
 
     // Useful for debugging, but keep ToString() JS-like.
     public string DebugId => _debugId;

--- a/tests/Jroc.Tests/RuntimeAgentClusterSharedServicesTests.cs
+++ b/tests/Jroc.Tests/RuntimeAgentClusterSharedServicesTests.cs
@@ -1,0 +1,274 @@
+using JavaScriptRuntime;
+
+namespace Jroc.Tests;
+
+public sealed class RuntimeAgentClusterSharedServicesTests
+{
+    [Fact]
+    public void SymbolRegistryIsSharedByRealmsInOneAgentAndIsolatedBetweenAgents()
+    {
+        var cluster = new RuntimeAgentCluster();
+        var firstAgent = cluster.CreateAgent();
+        var firstRealm = CreateConfiguredRealm(firstAgent);
+        var secondRealm = CreateConfiguredRealm(firstAgent);
+        var otherAgent = cluster.CreateAgent();
+        var otherRealm = CreateConfiguredRealm(otherAgent);
+        var firstContext = RuntimeExecutionContext.GetOrCreate(firstRealm.Services);
+        var secondContext = RuntimeExecutionContext.GetOrCreate(secondRealm.Services);
+        var otherContext = RuntimeExecutionContext.GetOrCreate(otherRealm.Services);
+
+        Symbol first;
+        using (firstContext.EnterAsRoot())
+        {
+            first = Assert.IsType<Symbol>(Symbol.@for("shared"));
+            Assert.Same(first, Symbol.@for("shared"));
+            Assert.Equal("shared", Symbol.keyFor(first));
+        }
+
+        using (secondContext.EnterAsRoot())
+        {
+            Assert.Same(first, Symbol.@for("shared"));
+            Assert.Equal("shared", Symbol.keyFor(first));
+        }
+
+        using (otherContext.EnterAsRoot())
+        {
+            Assert.NotSame(first, Symbol.@for("shared"));
+            Assert.Null(Symbol.keyFor(first));
+        }
+
+        cluster.Dispose();
+    }
+
+    [Fact]
+    public void MessageTransportQueuesOpaqueCopiesAcrossAgentsInOneCluster()
+    {
+        var cluster = new RuntimeAgentCluster();
+        var firstAgent = cluster.CreateAgent();
+        var secondAgent = cluster.CreateAgent();
+        var (first, second) = cluster.SharedServices.Transport.CreateEntangledPair(
+            firstAgent,
+            secondAgent);
+        var payload = new byte[] { 1, 2, 3 };
+
+        Assert.True(first.Post(payload));
+        payload[0] = 9;
+        Assert.True(second.TryReceive(out var received));
+        Assert.Equal([1, 2, 3], received);
+        Assert.False(first.TryReceive(out _));
+
+        secondAgent.Dispose();
+
+        Assert.False(first.Post([4]));
+        cluster.Dispose();
+    }
+
+    [Fact]
+    public void MessageTransportRejectsAnAgentFromAnotherCluster()
+    {
+        var firstCluster = new RuntimeAgentCluster();
+        var secondCluster = new RuntimeAgentCluster();
+        var firstAgent = firstCluster.CreateAgent();
+        var secondAgent = secondCluster.CreateAgent();
+
+        Assert.Throws<InvalidOperationException>(
+            () => firstCluster.SharedServices.Transport.CreateEntangledPair(
+                firstAgent,
+                secondAgent));
+
+        firstCluster.Dispose();
+        secondCluster.Dispose();
+    }
+
+    [Fact]
+    public void BroadcastRegistryFansOutByNameAndUnregistersDisposedAgents()
+    {
+        var cluster = new RuntimeAgentCluster();
+        var firstAgent = cluster.CreateAgent();
+        var secondAgent = cluster.CreateAgent();
+        var first = cluster.SharedServices.Broadcasts.Register(firstAgent, "events");
+        var second = cluster.SharedServices.Broadcasts.Register(secondAgent, "events");
+        var otherName = cluster.SharedServices.Broadcasts.Register(secondAgent, "other");
+
+        Assert.Equal(1, first.Post([1, 2]));
+        Assert.True(second.TryReceive(out var message));
+        Assert.Equal([1, 2], message);
+        Assert.False(first.TryReceive(out _));
+        Assert.False(otherName.TryReceive(out _));
+
+        secondAgent.Dispose();
+
+        Assert.Equal(0, first.Post([3]));
+        cluster.Dispose();
+    }
+
+    [Fact]
+    public void SharedBufferWrappersShareBackingOnlyWithinTheirAgentCluster()
+    {
+        var cluster = new RuntimeAgentCluster();
+        var firstAgent = cluster.CreateAgent();
+        var firstRealm = CreateConfiguredRealm(firstAgent);
+        var secondAgent = cluster.CreateAgent();
+        var secondRealm = CreateConfiguredRealm(secondAgent);
+        var firstContext = RuntimeExecutionContext.GetOrCreate(firstRealm.Services);
+        var secondContext = RuntimeExecutionContext.GetOrCreate(secondRealm.Services);
+        SharedArrayBuffer first;
+
+        using (firstContext.EnterAsRoot())
+        {
+            first = new SharedArrayBuffer(4d);
+            first.RawBytes[0] = 42;
+        }
+
+        using (secondContext.EnterAsRoot())
+        {
+            var second = first.CreateWrapperForCurrentRealm();
+            Assert.NotSame(first, second);
+            Assert.Equal(42, second.RawBytes[0]);
+            Assert.NotSame(
+                PrototypeChain.GetPrototypeOrNull(first),
+                PrototypeChain.GetPrototypeOrNull(second));
+        }
+
+        var otherCluster = new RuntimeAgentCluster();
+        var otherRealm = CreateConfiguredRealm(otherCluster.CreateAgent());
+        var otherContext = RuntimeExecutionContext.GetOrCreate(otherRealm.Services);
+        using (otherContext.EnterAsRoot())
+        {
+            Assert.Throws<InvalidOperationException>(
+                first.CreateWrapperForCurrentRealm);
+        }
+
+        firstAgent.Dispose();
+        Assert.Equal(4d, first.byteLength);
+        secondAgent.Dispose();
+        Assert.Equal(0d, first.byteLength);
+
+        cluster.Dispose();
+        otherCluster.Dispose();
+    }
+
+    [Fact]
+    public void DisposingAnAgentRemovesAndReleasesItsAtomicsWaiters()
+    {
+        var cluster = new RuntimeAgentCluster();
+        var agent = cluster.CreateAgent();
+        var realm = CreateConfiguredRealm(agent);
+        var context = RuntimeExecutionContext.GetOrCreate(realm.Services);
+        RuntimeSharedArrayBufferBackingStore store;
+        using (context.EnterAsRoot())
+        {
+            store = new SharedArrayBuffer(4d).BackingStore;
+        }
+
+        RuntimeAtomicsWaitResult? waitResult = null;
+        Exception? failure = null;
+        var waiterThread = new Thread(() =>
+        {
+            try
+            {
+                using var scope = context.EnterAsRoot();
+                waitResult = cluster.SharedServices.Atomics.Wait(
+                    agent,
+                    store,
+                    0,
+                    expectedValue: 0,
+                    timeoutMilliseconds: System.Threading.Timeout.Infinite);
+            }
+            catch (Exception exception)
+            {
+                failure = exception;
+            }
+        });
+        waiterThread.Start();
+        Assert.True(SpinWait.SpinUntil(
+            () => cluster.SharedServices.Atomics.WaiterCount == 1,
+            TimeSpan.FromSeconds(5)));
+
+        agent.Dispose();
+        waiterThread.Join();
+
+        Assert.Null(failure);
+        Assert.Equal(RuntimeAtomicsWaitResult.TimedOut, waitResult);
+        Assert.Equal(0, cluster.SharedServices.Atomics.WaiterCount);
+        Assert.True(store.IsReleased);
+        cluster.Dispose();
+    }
+
+    [Fact]
+    public void AtomicsDomainNotifiesAcrossAgentsOnlyForTheSharedBackingStoreLocation()
+    {
+        var cluster = new RuntimeAgentCluster();
+        var firstAgent = cluster.CreateAgent();
+        var firstRealm = CreateConfiguredRealm(firstAgent);
+        var secondAgent = cluster.CreateAgent();
+        var context = RuntimeExecutionContext.GetOrCreate(firstRealm.Services);
+        RuntimeSharedArrayBufferBackingStore store;
+        using (context.EnterAsRoot())
+        {
+            store = new SharedArrayBuffer(8d).BackingStore;
+        }
+
+        RuntimeAtomicsWaitResult? waitResult = null;
+        var waiterThread = new Thread(
+            () => waitResult = cluster.SharedServices.Atomics.Wait(
+                firstAgent,
+                store,
+                4,
+                expectedValue: 0,
+                timeoutMilliseconds: System.Threading.Timeout.Infinite));
+        waiterThread.Start();
+        Assert.True(SpinWait.SpinUntil(
+            () => cluster.SharedServices.Atomics.WaiterCount == 1,
+            TimeSpan.FromSeconds(5)));
+
+        Assert.Equal(
+            0,
+            cluster.SharedServices.Atomics.Notify(store, byteOffset: 0, count: 1));
+        Assert.Equal(
+            1,
+            cluster.SharedServices.Atomics.Notify(store, byteOffset: 4, count: 1));
+        waiterThread.Join();
+
+        Assert.Equal(RuntimeAtomicsWaitResult.Notified, waitResult);
+        Assert.Equal(0, cluster.SharedServices.Atomics.WaiterCount);
+        secondAgent.Dispose();
+        cluster.Dispose();
+    }
+
+    [Fact]
+    public void AgentAndClusterSharedServicesAreReservedRealmServices()
+    {
+        var cluster = new RuntimeAgentCluster();
+        var agent = cluster.CreateAgent();
+        var first = agent.CreateRealm();
+        var second = agent.CreateRealm();
+
+        Assert.Same(
+            agent.SymbolRegistry,
+            first.Services.Resolve<RuntimeAgentSymbolRegistry>());
+        Assert.Same(
+            cluster.SharedServices.Transport,
+            second.Services.Resolve<RuntimeMessageTransportService>());
+        Assert.Same(
+            first.Services.Resolve<RuntimeSharedMemoryService>(),
+            second.Services.Resolve<RuntimeSharedMemoryService>());
+        Assert.Throws<InvalidOperationException>(
+            () => first.Services.Remove<RuntimeAtomicsSynchronizationDomain>());
+
+        first.Services.Clear();
+
+        Assert.Same(
+            cluster.SharedServices.Broadcasts,
+            first.Services.Resolve<RuntimeBroadcastChannelRegistry>());
+        cluster.Dispose();
+    }
+
+    private static RuntimeRealm CreateConfiguredRealm(RuntimeAgent agent)
+    {
+        var realm = agent.CreateRealm();
+        realm.Services.RegisterInstance<IPropertyDescriptorStore>(
+            new PropertyDescriptorStore());
+        return realm;
+    }
+}


### PR DESCRIPTION
## Summary

- move the mutable `Symbol.for` / `Symbol.keyFor` registry into `RuntimeAgent`
  so realms in one agent share identity while separate agents remain isolated
- add cluster-owned opaque MessagePort transport, BroadcastChannel routing,
  SharedArrayBuffer backing-store, and Atomics waiter services for future
  `worker_threads` support
- unregister endpoints and waiters when an agent leaves, release shared
  resources when the last agent leaves, and reserve the ownership services in
  realm DI containers
- document the agent/cluster ownership and reference rules

The cluster services store only opaque byte payloads, transport cores, backing
stores, and waiter records. JavaScript wrappers, callbacks, globals,
prototypes, and module state remain realm-owned.

## Validation

- `dotnet build jroc.sln --no-restore --nologo`
- `MSBUILDDISABLENODEREUSE=1 dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-build --no-restore --nologo`
  - 3,330 passed, 1 skipped
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --no-build --no-restore --nologo`
  - 6,312 passed, 58 skipped

Closes #1827
