### PR TITLE
runtime: unify engine and hosted lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime: unify standalone `Engine`, hosted `JsRuntimeInstance`, and future
+  worker bootstrap under an exception-safe `RuntimeLifecycle` (issue #1828).
+  The lifecycle explicitly creates or joins a cluster, creates the agent and
+  realm, enters a root execution frame, pumps work, and tears down in reverse
+  order. Hosted runtimes suppress inherited ambient frames, use agent shutdown
+  as their single cancellation source, and publish startup failures only after
+  partial agent/realm state has been released.
+
 - runtime: make agent and agent-cluster shared services explicit (issue #1827).
   `Symbol.for`/`Symbol.keyFor` identity is now owned by `RuntimeAgent`, while
   opaque MessagePort transport queues, BroadcastChannel routing, shared buffer

--- a/docs/runtime/RuntimeAgentScheduling.md
+++ b/docs/runtime/RuntimeAgentScheduling.md
@@ -48,7 +48,7 @@ Disposing one agent does not cancel, reset, drain, or dispose another agent.
 Concurrent disposal waits for the callback already executing on the owner
 thread, then prevents the next queued callback from starting.
 
-`JsRuntimeInstance` observes the agent shutdown token after runtime
-initialization. Its pre-initialization host queue still has a bootstrap
-cancellation source; issue #1828 will unify that startup path with the common
-agent/realm lifecycle factory.
+`JsRuntimeInstance` is created and torn down through `RuntimeLifecycle` and
+uses the agent shutdown token as its only cancellation source. Startup failure,
+normal disposal, and concurrent host disposal therefore all unregister the
+agent and clear its scheduler through the same reverse-order teardown.

--- a/docs/runtime/RuntimeLifecycle.md
+++ b/docs/runtime/RuntimeLifecycle.md
@@ -1,0 +1,36 @@
+# Runtime lifecycle
+
+`RuntimeLifecycle` is the common bootstrap and teardown path for standalone
+`Engine` execution, hosted `JsRuntimeInstance` modules, and future workers. It
+performs one ordered operation:
+
+1. use a supplied `RuntimeAgentCluster` or create an isolated cluster;
+2. create one agent and realm, then install the standard realm services;
+3. apply explicit host bootstrap inputs before JavaScript is entered;
+4. configure the compiled module assembly and execution metadata;
+5. resolve the agent scheduler and thread-affine event-loop pump;
+6. enter a root `RuntimeExecutionContext`, run the entry point, and pump work;
+7. exit the frame and dispose realm, agent, and owned cluster in reverse order.
+
+Every partial-startup failure follows the same teardown path. When a caller
+supplies a cluster, the lifecycle removes only the agent it created so another
+agent can reuse that cluster. The internal hosted options use this boundary for
+future worker bootstrap. A borrowed test service container retains its existing
+ownership graph, but its agent async context is reset after execution.
+
+Hosted runtimes suppress any `AsyncLocal` runtime frame and invocation state
+inherited from the caller before creating their graph. The state is restored
+only after the hosted lifecycle has exited its own root frame and disposed its
+owned graph. A dedicated CLR thread is therefore an executor choice, not the
+source of runtime identity.
+
+`JsRuntimeInstance` uses the agent shutdown token as its only cancellation
+source after creation. Disposal requests cooperative agent shutdown, wakes its
+queue, lets the script thread exit the root frame, and then disposes the
+lifecycle. Initialization exceptions are published to the host only after the
+agent has been unregistered and partial realm state has been released.
+
+JavaScript wrappers, module state, globals, schedulers, and callbacks remain
+owned by the realm or agent described in
+[Runtime ownership](RuntimeOwnership.md); `RuntimeLifecycle` coordinates those
+owners but does not introduce another state owner.

--- a/docs/runtime/RuntimeOwnership.md
+++ b/docs/runtime/RuntimeOwnership.md
@@ -24,6 +24,11 @@ RuntimeAgentCluster
           -> RuntimeExecutionContext (while entered)
 ```
 
+`RuntimeLifecycle` is the bootstrap scope that creates or joins this graph,
+enters its root execution frame, pumps the event loop, and disposes owned
+children in reverse order. It coordinates ownership without becoming a fourth
+state owner. See [Runtime lifecycle](RuntimeLifecycle.md).
+
 - `RuntimeAgentCluster` owns agents and the deliberately cross-agent transport,
   broadcast, shared-memory, and Atomics coordination services.
 - `RuntimeAgent` owns execution, scheduling, and global-symbol-registry
@@ -103,10 +108,13 @@ cluster resolve the same transport, broadcast, shared-memory, and Atomics
 services. Child DI scopes retain the same owners. After realm disposal, its
 service container and any child scopes reject further use.
 
-The factory currently creates an isolated cluster, agent, realm, and service
-container for each `RuntimeServices.BuildServiceProvider()` call. Each realm
-owns its intrinsic graph, module state, and realm-created value caches; its
-agent owns one scheduling graph.
+Production `Engine` and `JsRuntimeInstance` paths use `RuntimeLifecycle`.
+Standalone execution creates an isolated cluster; hosted and future worker
+paths may supply a cluster explicitly. `RuntimeServices.BuildServiceProvider()`
+remains a low-level test/embedding helper that creates an isolated cluster,
+agent, realm, and service container. Each realm owns its intrinsic graph,
+module state, and realm-created value caches; its agent owns one scheduling
+graph.
 
 ## Intrinsic ownership
 

--- a/src/JavaScriptRuntime/Engine/Engine.cs
+++ b/src/JavaScriptRuntime/Engine/Engine.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using JavaScriptRuntime.Modules.CommonJS;
 using JavaScriptRuntime.Modules.Shared;
 using JavaScriptRuntime.DependencyInjection;
@@ -19,91 +18,28 @@ public class Engine
     {
         ArgumentNullException.ThrowIfNull(scriptEntryPoint);
 
-        try
-        {
-            var serviceProvider = ConfigureRuntime(
-                modulesAssembly: scriptEntryPoint.Method.Module.Assembly,
-                isHostedExecution: false);
-            var runtimeContext = serviceProvider.Resolve<RuntimeExecutionContext>();
-
-            using (runtimeContext.EnterAsRoot())
+        using var lifecycle = RuntimeLifecycle.Create(
+            scriptEntryPoint.Method.Module.Assembly,
+            isHostedExecution: false,
+            existingServices: _serviceProviderOverride.Value);
+        lifecycle.Execute(
+            serviceProvider =>
             {
-                try
+                ConfigureChildProcessIpc(serviceProvider);
+                var moduleExecutor = new ModuleExecutor(serviceProvider);
+
+                var forkEntryModule = System.Environment.GetEnvironmentVariable(
+                    ChildProcessRuntimeOptions.ForkEntryModuleEnvVar);
+                if (!string.IsNullOrWhiteSpace(forkEntryModule))
                 {
-                    RuntimeServices.SetCurrentThis(null);
-                    ConfigureChildProcessIpc(serviceProvider);
-                    var moduleExecutor = new ModuleExecutor(serviceProvider);
-
-                    var forkEntryModule = System.Environment.GetEnvironmentVariable(
-                        ChildProcessRuntimeOptions.ForkEntryModuleEnvVar);
-                    if (!string.IsNullOrWhiteSpace(forkEntryModule))
-                    {
-                        moduleExecutor.Execute(scriptEntryPoint, forkEntryModule);
-                    }
-                    else
-                    {
-                        moduleExecutor.Execute(scriptEntryPoint);
-                    }
-
-                    RunEventLoopUntilIdle(
-                        serviceProvider.Resolve<NodeEventLoopPump>(),
-                        waitForTimers: true);
+                    moduleExecutor.Execute(scriptEntryPoint, forkEntryModule);
                 }
-                finally
+                else
                 {
-                    if (serviceProvider.TryResolve<AsyncContextRuntime>(
-                            out var asyncContext)
-                        && asyncContext != null)
-                    {
-                        asyncContext.Reset();
-                    }
-
-                    RuntimeServices.SetCurrentThis(null);
+                    moduleExecutor.Execute(scriptEntryPoint);
                 }
-            }
-        }
-        finally
-        {
-            _serviceProviderOverride.Value = null;
-        }
-    }
-
-    internal static ServiceContainer ConfigureRuntime(
-        Assembly modulesAssembly,
-        bool isHostedExecution = false,
-        string? compiledAssemblyPath = null)
-    {
-        ArgumentNullException.ThrowIfNull(modulesAssembly);
-
-        // Prevent accidentally hosting multiple runtimes on the same thread.
-        // This catches common integration bugs where a host thread is reused and global state leaks.
-        if (RuntimeExecutionContext.Current != null)
-        {
-            throw new InvalidOperationException(
-                "A JROC runtime execution frame is already active. " +
-                "Exit the current frame before starting another engine.");
-        }
-
-        // Use the test override if present; otherwise construct the default runtime container.
-        var serviceProvider = _serviceProviderOverride.Value ?? RuntimeServices.BuildServiceProvider();
-
-        _ = RuntimeExecutionContext.GetOrCreate(
-            serviceProvider,
-            isHostedExecution,
-            CompiledAssemblyPathResolver.Resolve(
-                modulesAssembly,
-                compiledAssemblyPath,
-                allowAssemblyLocationFallback: !isHostedExecution));
-
-        // Resolve scheduler/event-loop singletons via DI so other services can depend on them.
-        // Note: ServiceContainer manages singleton instances per-container.
-        _ = serviceProvider.Resolve<NodeSchedulerState>();
-        _ = serviceProvider.Resolve<NodeEventLoopPump>();
-
-        // Provide the compiled modules assembly for runtime dependency/module resolution.
-        serviceProvider.Resolve<RuntimeRealm>().ModuleState.ModulesAssembly = modulesAssembly;
-
-        return serviceProvider;
+            },
+            waitForTimers: true);
     }
 
     internal sealed class RuntimeServiceProviderOverride

--- a/src/JavaScriptRuntime/Hosting/JsModuleLoadOptions.cs
+++ b/src/JavaScriptRuntime/Hosting/JsModuleLoadOptions.cs
@@ -5,6 +5,8 @@ namespace Jroc.Runtime;
 
 public sealed class JsModuleLoadOptions
 {
+    internal RuntimeAgentCluster? AgentCluster { get; init; }
+
     /// <summary>
     /// Launchable compiled assembly path used by hosted <c>child_process.fork()</c>.
     /// Hosted runtimes do not infer this automatically; set it explicitly when hosted code may call <c>fork()</c>.

--- a/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
+++ b/src/JavaScriptRuntime/Hosting/JsRuntimeInstance.cs
@@ -4,8 +4,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using JavaScriptRuntime;
 using JavaScriptRuntime.Modules.CommonJS;
-using JavaScriptRuntime.DependencyInjection;
-using JavaScriptRuntime.EngineCore;
 using JavaScriptRuntime.Node;
 
 namespace Jroc.Runtime;
@@ -33,16 +31,11 @@ internal sealed class JsRuntimeInstance : IDisposable
     // Dedicated thread that owns the engine, synchronization context, and event loop.
     private readonly Thread _thread;
 
-    // Cancellation used to stop consuming the queue and unblock waiting operations during disposal.
-    private readonly CancellationTokenSource _shutdown = new();
-
     // Completed once initial module load has either succeeded or failed (exception is propagated).
     // This is awaited synchronously in the ctor to surface module-load errors immediately.
     private readonly TaskCompletionSource _initialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    // Service provider/sync context are thread-affine and created inside ThreadMain.
-    private ServiceContainer? _serviceProvider;
-    private NodeEventLoopPump? _eventLoop;
+    // The runtime agent is created on the script thread before initialization completes.
     private RuntimeAgent? _agent;
 
     // Exports returned by CommonJS module evaluation (require(...) result).
@@ -120,7 +113,7 @@ internal sealed class JsRuntimeInstance : IDisposable
         RegisterWorkItem(item);
         try
         {
-            _queue.Add(item, _shutdown.Token);
+            _queue.Add(item, GetShutdownToken());
         }
         catch (OperationCanceledException)
         {
@@ -165,7 +158,7 @@ internal sealed class JsRuntimeInstance : IDisposable
         RegisterWorkItem(item);
         try
         {
-            _queue.Add(item, _shutdown.Token);
+            _queue.Add(item, GetShutdownToken());
         }
         catch (OperationCanceledException)
         {
@@ -199,16 +192,7 @@ internal sealed class JsRuntimeInstance : IDisposable
 
         _agent?.RequestShutdown();
 
-        // Stop accepting work and wake the consuming enumerable.
-        try
-        {
-            _shutdown.Cancel();
-        }
-        catch (ObjectDisposedException)
-        {
-            // If the runtime thread already terminated, it may have disposed the CTS.
-        }
-
+        // Stop accepting work. Agent shutdown cancellation wakes the consumer.
         try
         {
             _queue.CompleteAdding();
@@ -225,7 +209,13 @@ internal sealed class JsRuntimeInstance : IDisposable
         // Avoid self-join if Dispose is called from within the script thread.
         if (Thread.CurrentThread.ManagedThreadId != _thread.ManagedThreadId)
         {
-            _ = _thread.Join(DisposeJoinTimeout);
+            if (!_thread.Join(DisposeJoinTimeout))
+            {
+                throw new TimeoutException(
+                    "Timed out waiting for the JavaScript runtime thread to stop.");
+            }
+
+            _terminated.Task.GetAwaiter().GetResult();
         }
 
         // This type intentionally has no finalizer (it would be unsafe to block/join on the finalizer thread).
@@ -289,7 +279,7 @@ internal sealed class JsRuntimeInstance : IDisposable
 
         try
         {
-            _queue.Add(item, _shutdown.Token);
+            _queue.Add(item, GetShutdownToken());
             return true;
         }
         catch (Exception exception)
@@ -430,48 +420,51 @@ internal sealed class JsRuntimeInstance : IDisposable
 
     private void ThreadMain(Assembly compiledAssembly, string moduleSpecifier)
     {
+        RuntimeLifecycle? lifecycle = null;
         IDisposable? executionScope = null;
+        Exception? initializationFailure = null;
+        var initializationCancelled = false;
         try
         {
             // Extremely defensive: under normal usage, Dispose cannot be called until after the ctor returns
             // (which waits for initialization). This guard prevents configuring thread-affine runtime state
             // if cancellation/disposal is somehow signaled early.
-            if (Volatile.Read(ref _disposeSignaled) != 0 || _shutdown.IsCancellationRequested)
+            if (Volatile.Read(ref _disposeSignaled) != 0)
             {
                 _initialized.TrySetResult();
                 return;
             }
 
-            // Configure engine services *for this thread*; the sync context/event loop are thread-affine.
-            var serviceProvider = Engine.ConfigureRuntime(
+            lifecycle = RuntimeLifecycle.Create(
                 compiledAssembly,
                 isHostedExecution: true,
-                compiledAssemblyPath: _options?.CompiledAssemblyPath);
-            _serviceProvider = serviceProvider;
-            _agent = serviceProvider.Resolve<RuntimeAgent>();
-            executionScope = serviceProvider
-                .Resolve<RuntimeExecutionContext>()
-                .EnterAsRoot();
+                compiledAssemblyPath: _options?.CompiledAssemblyPath,
+                cluster: _options?.AgentCluster,
+                configureServices: serviceProvider =>
+                {
+                    if (_options?.HostRuntimeIntrinsics != null)
+                    {
+                        serviceProvider.Replace(_options.HostRuntimeIntrinsics);
+                    }
 
-            if (_options?.HostRuntimeIntrinsics != null)
-            {
-                serviceProvider.Replace(_options.HostRuntimeIntrinsics);
-            }
-
-            if (_options?.ChildProcessLauncher != null)
-            {
-                serviceProvider.RegisterInstance<IChildProcessLauncher>(_options.ChildProcessLauncher);
-            }
-
-            _eventLoop = serviceProvider.Resolve<NodeEventLoopPump>();
+                    if (_options?.ChildProcessLauncher != null)
+                    {
+                        serviceProvider.RegisterInstance<IChildProcessLauncher>(
+                            _options.ChildProcessLauncher);
+                    }
+                },
+                suppressInheritedExecutionContext: true);
+            _agent = lifecycle.Agent;
+            executionScope = lifecycle.EnterAsRoot();
+            var eventLoop = lifecycle.EventLoop;
 
             // Load/evaluate the entry module (CommonJS require) and capture its exports.
-            var require = _serviceProvider.Resolve<Require>();
+            var require = lifecycle.Services.Resolve<Require>();
             _exports = require.RequireModule(moduleSpecifier);
 
             // Drain microtasks/queued work produced during module evaluation.
             // Timers are intentionally not awaited during initialization.
-            Engine.RunEventLoopUntilIdle(_eventLoop, waitForTimers: false);
+            Engine.RunEventLoopUntilIdle(eventLoop, waitForTimers: false);
 
             // Signal successful initialization after module evaluation completes.
             _initialized.TrySetResult();
@@ -479,12 +472,12 @@ internal sealed class JsRuntimeInstance : IDisposable
             // Process cross-thread invocations serially, while also pumping the JS event loop
             // (including timers) even when the host is idle. This avoids deadlocks where a
             // Promise resolves via setTimeout/setInterval but no new host invocations arrive.
-            while (!_shutdown.IsCancellationRequested
-                && !_agent.ShutdownToken.IsCancellationRequested)
+            var shutdownToken = lifecycle.Agent.ShutdownToken;
+            while (!shutdownToken.IsCancellationRequested)
             {
-                int waitMs = _eventLoop.GetWaitForWorkOrNextTimerMilliseconds(maxWaitMs: 50);
+                int waitMs = eventLoop.GetWaitForWorkOrNextTimerMilliseconds(maxWaitMs: 50);
 
-                if (_queue.TryTake(out var item, waitMs, _shutdown.Token))
+                if (_queue.TryTake(out var item, waitMs, shutdownToken))
                 {
                     try
                     {
@@ -494,44 +487,94 @@ internal sealed class JsRuntimeInstance : IDisposable
                     {
                         _pendingWorkItems.TryRemove(item, out _);
                     }
-                    Engine.RunEventLoopUntilIdle(_eventLoop, waitForTimers: false);
+                    Engine.RunEventLoopUntilIdle(eventLoop, waitForTimers: false);
                     continue;
                 }
 
                 // Timeout: give the event loop a chance to run due timers/microtasks.
-                Engine.RunEventLoopUntilIdle(_eventLoop, waitForTimers: false);
+                Engine.RunEventLoopUntilIdle(eventLoop, waitForTimers: false);
             }
         }
         catch (OperationCanceledException)
         {
-            // Shutdown path: ensure ctor unblocks even if cancellation occurs during initialization.
-            _initialized.TrySetResult();
+            initializationCancelled = !_initialized.Task.IsCompleted;
         }
         catch (Exception ex)
         {
-            // Propagate initialization or runtime failures to constructor/Invoke callers.
-            _initialized.TrySetException(ex);
+            if (!_initialized.Task.IsCompleted)
+            {
+                initializationFailure = ex;
+            }
         }
         finally
         {
-            FailPendingOperations();
+            Exception? cleanupFailure = null;
 
-            var agent = _agent;
-            executionScope?.Dispose();
-            agent?.Dispose();
+            try
+            {
+                FailPendingOperations();
+            }
+            catch (Exception exception)
+            {
+                cleanupFailure = exception;
+            }
+
+            try
+            {
+                executionScope?.Dispose();
+            }
+            catch (Exception exception)
+            {
+                cleanupFailure ??= exception;
+            }
+
+            try
+            {
+                lifecycle?.Dispose();
+            }
+            catch (Exception exception)
+            {
+                cleanupFailure ??= exception;
+            }
+
             _exports = null;
-            _eventLoop = null;
-            _serviceProvider = null;
             _agent = null;
 
-            // Mark thread termination before disposing shared resources.
-            _terminated.TrySetResult();
+            try
+            {
+                _queue.Dispose();
+            }
+            catch (Exception exception)
+            {
+                cleanupFailure ??= exception;
+            }
+            finally
+            {
+                if (cleanupFailure != null)
+                {
+                    _terminated.TrySetException(cleanupFailure);
+                }
+                else
+                {
+                    _terminated.TrySetResult();
+                }
 
-            // Release managed resources once the owning script thread is done using them.
-            _queue.Dispose();
-            _shutdown.Dispose();
+                var startupFailure = initializationFailure ?? cleanupFailure;
+                if (startupFailure != null && !_initialized.Task.IsCompleted)
+                {
+                    _initialized.TrySetException(startupFailure);
+                }
+                else if (initializationCancelled)
+                {
+                    _initialized.TrySetResult();
+                }
+            }
         }
     }
+
+    private CancellationToken GetShutdownToken()
+        => Volatile.Read(ref _agent)?.ShutdownToken
+            ?? new CancellationToken(canceled: true);
 
     private void EnsureNotDisposed()
     {

--- a/src/JavaScriptRuntime/RuntimeExecutionContext.cs
+++ b/src/JavaScriptRuntime/RuntimeExecutionContext.cs
@@ -101,6 +101,22 @@ internal sealed class RuntimeExecutionContext
     internal IDisposable EnterAsRoot()
         => EnterCore(asRoot: true);
 
+    internal static IDisposable SuppressInheritedState()
+    {
+        var previous = Ambient.Value;
+        var invocationState = RuntimeServices.CaptureAndClearAmbientInvocationState();
+        try
+        {
+            SetAmbient(null);
+            return new AmbientSuppressionScope(previous, invocationState);
+        }
+        catch
+        {
+            RuntimeServices.RestoreAmbientInvocationState(invocationState);
+            throw;
+        }
+    }
+
     internal static void SetLegacyServiceProvider(ServiceContainer? services)
     {
         var current = Ambient.Value;
@@ -346,6 +362,39 @@ internal sealed class RuntimeExecutionContext
                 RuntimeServices.RestoreAmbientInvocationState(_invocationState);
             }
 
+            _disposed = true;
+        }
+    }
+
+    private sealed class AmbientSuppressionScope : IDisposable
+    {
+        private readonly AmbientState? _previous;
+        private readonly object _invocationState;
+        private bool _disposed;
+
+        internal AmbientSuppressionScope(
+            AmbientState? previous,
+            object invocationState)
+        {
+            _previous = previous;
+            _invocationState = invocationState;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (Ambient.Value?.Frame != null)
+            {
+                throw new InvalidOperationException(
+                    "The runtime execution frame must exit before inherited state is restored.");
+            }
+
+            SetAmbient(_previous);
+            RuntimeServices.RestoreAmbientInvocationState(_invocationState);
             _disposed = true;
         }
     }

--- a/src/JavaScriptRuntime/RuntimeLifecycle.cs
+++ b/src/JavaScriptRuntime/RuntimeLifecycle.cs
@@ -1,0 +1,223 @@
+using System.Reflection;
+using JavaScriptRuntime.DependencyInjection;
+using JavaScriptRuntime.EngineCore;
+
+namespace JavaScriptRuntime;
+
+internal sealed class RuntimeLifecycle : IDisposable
+{
+    private readonly IDisposable? _ambientSuppression;
+    private readonly bool _ownsAgent;
+    private readonly bool _ownsCluster;
+    private int _disposed;
+
+    private RuntimeLifecycle(
+        RuntimeAgentCluster cluster,
+        RuntimeAgent agent,
+        RuntimeRealm realm,
+        ServiceContainer services,
+        RuntimeExecutionContext executionContext,
+        NodeEventLoopPump eventLoop,
+        bool ownsAgent,
+        bool ownsCluster,
+        IDisposable? ambientSuppression)
+    {
+        Cluster = cluster;
+        Agent = agent;
+        Realm = realm;
+        Services = services;
+        ExecutionContext = executionContext;
+        EventLoop = eventLoop;
+        _ownsAgent = ownsAgent;
+        _ownsCluster = ownsCluster;
+        _ambientSuppression = ambientSuppression;
+    }
+
+    internal RuntimeAgentCluster Cluster { get; }
+
+    internal RuntimeAgent Agent { get; }
+
+    internal RuntimeRealm Realm { get; }
+
+    internal ServiceContainer Services { get; }
+
+    internal RuntimeExecutionContext ExecutionContext { get; }
+
+    internal NodeEventLoopPump EventLoop { get; }
+
+    internal static RuntimeLifecycle Create(
+        Assembly modulesAssembly,
+        bool isHostedExecution,
+        string? compiledAssemblyPath = null,
+        RuntimeAgentCluster? cluster = null,
+        ServiceContainer? existingServices = null,
+        Action<ServiceContainer>? configureServices = null,
+        bool suppressInheritedExecutionContext = false)
+    {
+        ArgumentNullException.ThrowIfNull(modulesAssembly);
+        if (cluster != null && existingServices != null)
+        {
+            throw new ArgumentException(
+                "An existing service container already determines its runtime agent cluster.");
+        }
+
+        IDisposable? ambientSuppression = null;
+        RuntimeAgentCluster? selectedCluster = null;
+        RuntimeAgent? agent = null;
+        var ownsAgent = false;
+        var ownsCluster = false;
+
+        try
+        {
+            if (suppressInheritedExecutionContext)
+            {
+                ambientSuppression = RuntimeExecutionContext.SuppressInheritedState();
+            }
+
+            if (RuntimeExecutionContext.Current != null)
+            {
+                throw new InvalidOperationException(
+                    "A JROC runtime execution frame is already active. " +
+                    "Exit the current frame before starting another engine.");
+            }
+
+            RuntimeRealm realm;
+            ServiceContainer services;
+            if (existingServices != null)
+            {
+                realm = existingServices.OwningRealm
+                    ?? throw new InvalidOperationException(
+                        "The supplied runtime service container has no owning realm.");
+                if (realm.IsDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(RuntimeRealm));
+                }
+
+                selectedCluster = realm.Agent.Cluster;
+                agent = realm.Agent;
+                services = existingServices;
+            }
+            else
+            {
+                selectedCluster = cluster ?? new RuntimeAgentCluster();
+                ownsCluster = cluster == null;
+                agent = selectedCluster.CreateAgent();
+                ownsAgent = true;
+                realm = agent.CreateRealm();
+                services = realm.Services;
+                RuntimeServices.ConfigureServiceProvider(services);
+            }
+
+            configureServices?.Invoke(services);
+
+            var executionContext = RuntimeExecutionContext.GetOrCreate(
+                services,
+                isHostedExecution,
+                CompiledAssemblyPathResolver.Resolve(
+                    modulesAssembly,
+                    compiledAssemblyPath,
+                    allowAssemblyLocationFallback: !isHostedExecution));
+
+            realm.ModuleState.ModulesAssembly = modulesAssembly;
+            _ = services.Resolve<NodeSchedulerState>();
+            var eventLoop = services.Resolve<NodeEventLoopPump>();
+
+            return new RuntimeLifecycle(
+                selectedCluster,
+                agent,
+                realm,
+                services,
+                executionContext,
+                eventLoop,
+                ownsAgent,
+                ownsCluster,
+                ambientSuppression);
+        }
+        catch
+        {
+            try
+            {
+                if (ownsAgent)
+                {
+                    agent?.Dispose();
+                }
+            }
+            finally
+            {
+                try
+                {
+                    if (ownsCluster)
+                    {
+                        selectedCluster?.Dispose();
+                    }
+                }
+                finally
+                {
+                    ambientSuppression?.Dispose();
+                }
+            }
+
+            throw;
+        }
+    }
+
+    internal IDisposable EnterAsRoot()
+    {
+        ThrowIfDisposed();
+        return ExecutionContext.EnterAsRoot();
+    }
+
+    internal void Execute(
+        Action<ServiceContainer> entryPoint,
+        bool waitForTimers)
+    {
+        ArgumentNullException.ThrowIfNull(entryPoint);
+        ThrowIfDisposed();
+
+        using var scope = EnterAsRoot();
+        entryPoint(Services);
+        Engine.RunEventLoopUntilIdle(EventLoop, waitForTimers);
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            if (_ownsAgent)
+            {
+                Agent.Dispose();
+            }
+            else
+            {
+                Agent.Scheduling.AsyncContext.Reset();
+            }
+        }
+        finally
+        {
+            try
+            {
+                if (_ownsCluster)
+                {
+                    Cluster.Dispose();
+                }
+            }
+            finally
+            {
+                _ambientSuppression?.Dispose();
+            }
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            throw new ObjectDisposedException(nameof(RuntimeLifecycle));
+        }
+    }
+}

--- a/src/JavaScriptRuntime/RuntimeServices.cs
+++ b/src/JavaScriptRuntime/RuntimeServices.cs
@@ -1798,6 +1798,13 @@ public class RuntimeServices
     public static ServiceContainer BuildServiceProvider()
     {
         var container = RuntimeOwnershipFactory.CreateIsolatedRealm().Services;
+        ConfigureServiceProvider(container);
+        return container;
+    }
+
+    internal static void ConfigureServiceProvider(ServiceContainer container)
+    {
+        ArgumentNullException.ThrowIfNull(container);
         container.RegisterInstance(new GlobalThisOptions());
         container.RegisterInstance(HostRuntimeIntrinsicDescriptors.Empty);
         container.RegisterInstance(new ConsoleOutputSinks());
@@ -1807,7 +1814,5 @@ public class RuntimeServices
         container.Register<IEnvironment, DefaultEnvironment>();
         container.Register<Node.IChildProcessLauncher, Node.DefaultChildProcessLauncher>();
         container.Register<Node.DiagnosticsChannelRuntime>();
-
-        return container;
     }
 }

--- a/tests/Jroc.Tests/Hosting/ModuleLoadTests.cs
+++ b/tests/Jroc.Tests/Hosting/ModuleLoadTests.cs
@@ -1001,6 +1001,24 @@ public class ModuleLoadTests
         Assert.Contains("boom", jsError.JsMessage ?? jsError.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void JsRuntimeInstance_WhenStartupFails_UnregistersItsAgentBeforeThrowing()
+    {
+        using var module = CompileAndLoadModuleAssemblyFromResource("boom", "boom.js");
+        var cluster = new RuntimeAgentCluster();
+        var options = new JsModuleLoadOptions
+        {
+            AgentCluster = cluster
+        };
+
+        _ = Assert.ThrowsAny<Exception>(
+            () => new JsRuntimeInstance(module.Assembly, "boom", options));
+
+        Assert.Equal(0, cluster.AgentCount);
+        Assert.False(cluster.IsDisposed);
+        cluster.Dispose();
+    }
+
     public interface IMissingMemberExports : IDisposable
     {
         string DoesNotExist { get; }

--- a/tests/Jroc.Tests/RuntimeLifecycleTests.cs
+++ b/tests/Jroc.Tests/RuntimeLifecycleTests.cs
@@ -1,0 +1,250 @@
+using JavaScriptRuntime;
+using JavaScriptRuntime.DependencyInjection;
+using JavaScriptRuntime.EngineCore;
+
+namespace Jroc.Tests;
+
+public sealed class RuntimeLifecycleTests
+{
+    [Fact]
+    public void ExecuteEntersRootPumpsWorkAndDisposesOwnedGraph()
+    {
+        RuntimeAgentCluster cluster;
+        RuntimeAgent agent;
+        RuntimeRealm realm;
+        var microtaskRan = false;
+
+        using (var lifecycle = CreateLifecycle())
+        {
+            cluster = lifecycle.Cluster;
+            agent = lifecycle.Agent;
+            realm = lifecycle.Realm;
+
+            lifecycle.Execute(
+                services =>
+                {
+                    Assert.Same(
+                        lifecycle.ExecutionContext,
+                        RuntimeExecutionContext.Current);
+                    Assert.Same(realm, RuntimeExecutionContext.Current!.Realm);
+                    services.Resolve<IMicrotaskScheduler>()
+                        .QueueMicrotask(() => microtaskRan = true);
+                },
+                waitForTimers: false);
+
+            Assert.True(microtaskRan);
+            Assert.Null(RuntimeExecutionContext.Current);
+        }
+
+        Assert.True(realm.IsDisposed);
+        Assert.True(agent.IsDisposed);
+        Assert.True(cluster.IsDisposed);
+        Assert.True(realm.DisposalOrder < agent.DisposalOrder);
+        Assert.True(agent.DisposalOrder < cluster.DisposalOrder);
+    }
+
+    [Fact]
+    public void ExplicitClusterCanHostAReplacementAgentAfterLifecycleDisposal()
+    {
+        var cluster = new RuntimeAgentCluster();
+        RuntimeAgent firstAgent;
+
+        using (var lifecycle = CreateLifecycle(cluster: cluster))
+        {
+            firstAgent = lifecycle.Agent;
+            Assert.Same(cluster, lifecycle.Cluster);
+            Assert.Equal(1, cluster.AgentCount);
+        }
+
+        Assert.True(firstAgent.IsDisposed);
+        Assert.False(cluster.IsDisposed);
+        Assert.Equal(0, cluster.AgentCount);
+
+        var replacement = cluster.CreateAgent();
+        Assert.False(replacement.IsDisposed);
+        cluster.Dispose();
+    }
+
+    [Fact]
+    public void ConfigurationFailureUnwindsAgentButNotSuppliedCluster()
+    {
+        var cluster = new RuntimeAgentCluster();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => CreateLifecycle(
+                cluster,
+                _ => throw new InvalidOperationException("bootstrap failed")));
+
+        Assert.Equal("bootstrap failed", exception.Message);
+        Assert.Equal(0, cluster.AgentCount);
+        Assert.False(cluster.IsDisposed);
+        Assert.Null(RuntimeExecutionContext.Current);
+        cluster.Dispose();
+    }
+
+    [Fact]
+    public async Task HostedLifecycleSuppressesAndRestoresInheritedRuntimeState()
+    {
+        var parentServices = RuntimeServices.BuildServiceProvider();
+        var parentContext = RuntimeExecutionContext.GetOrCreate(parentServices);
+        var parentThis = new object();
+
+        using (parentContext.EnterAsRoot())
+        {
+            RuntimeServices.SetCurrentThis(parentThis);
+            Engine._serviceProviderOverride.Value = parentServices;
+
+            await Task.Run(() =>
+            {
+                Assert.Same(parentContext, RuntimeExecutionContext.Current);
+                Assert.Same(parentThis, RuntimeServices.GetCurrentThis());
+
+                using (var lifecycle = CreateLifecycle(
+                    suppressInheritedExecutionContext: true))
+                {
+                    lifecycle.Execute(
+                        _ =>
+                        {
+                            Assert.NotSame(
+                                parentContext,
+                                RuntimeExecutionContext.Current);
+                            Assert.Null(RuntimeServices.GetCurrentThis());
+                            Assert.Null(Engine._serviceProviderOverride.Value);
+                        },
+                        waitForTimers: false);
+                }
+
+                Assert.Same(parentContext, RuntimeExecutionContext.Current);
+                Assert.Same(parentThis, RuntimeServices.GetCurrentThis());
+                Assert.Same(
+                    parentServices,
+                    Engine._serviceProviderOverride.Value);
+            });
+
+            Engine._serviceProviderOverride.Value = null;
+            RuntimeServices.SetCurrentThis(null);
+        }
+
+        parentServices.Resolve<RuntimeAgentCluster>().Dispose();
+    }
+
+    [Fact]
+    public async Task ConcurrentHostedLifecyclesKeepObservableStateIsolated()
+    {
+        using var ready = new Barrier(2);
+        var first = RunIsolatedLifecycle("first", ready);
+        var second = RunIsolatedLifecycle("second", ready);
+
+        var results = await Task.WhenAll(first, second);
+
+        Assert.Equal("first", results[0].Value);
+        Assert.Equal("second", results[1].Value);
+        Assert.NotSame(results[0].Realm, results[1].Realm);
+        Assert.NotSame(results[0].Global, results[1].Global);
+        Assert.NotSame(results[0].Scheduler, results[1].Scheduler);
+        Assert.All(results, result => Assert.True(result.ClusterDisposed));
+        Assert.Null(RuntimeExecutionContext.Current);
+    }
+
+    [Fact]
+    public void BorrowedServiceProviderIsConfiguredButNotDisposed()
+    {
+        var services = RuntimeServices.BuildServiceProvider();
+        var realm = services.OwningRealm!;
+        var agent = realm.Agent;
+
+        using (var lifecycle = RuntimeLifecycle.Create(
+            typeof(RuntimeLifecycleTests).Assembly,
+            isHostedExecution: false,
+            existingServices: services))
+        {
+            lifecycle.Execute(
+                activeServices => Assert.Same(services, activeServices),
+                waitForTimers: false);
+        }
+
+        Assert.False(realm.IsDisposed);
+        Assert.False(agent.IsDisposed);
+        agent.Cluster.Dispose();
+    }
+
+    [Fact]
+    public void RepeatedCreateExecuteDisposeCyclesLeaveNoAmbientState()
+    {
+        for (var index = 0; index < 5; index++)
+        {
+            RuntimeAgentCluster cluster;
+            using (var lifecycle = CreateLifecycle())
+            {
+                cluster = lifecycle.Cluster;
+                lifecycle.Execute(
+                    _ => Assert.NotNull(RuntimeExecutionContext.Current),
+                    waitForTimers: false);
+            }
+
+            Assert.True(cluster.IsDisposed);
+            Assert.Null(RuntimeExecutionContext.Current);
+        }
+    }
+
+    private static RuntimeLifecycle CreateLifecycle(
+        RuntimeAgentCluster? cluster = null,
+        Action<ServiceContainer>? configureServices = null,
+        bool suppressInheritedExecutionContext = false)
+        => RuntimeLifecycle.Create(
+            typeof(RuntimeLifecycleTests).Assembly,
+            isHostedExecution: true,
+            cluster: cluster,
+            configureServices: configureServices,
+            suppressInheritedExecutionContext: suppressInheritedExecutionContext);
+
+    private static Task<IsolationResult> RunIsolatedLifecycle(
+        string value,
+        Barrier ready)
+        => Task.Run(() =>
+        {
+            RuntimeRealm realm;
+            object global;
+            NodeSchedulerState scheduler;
+            RuntimeAgentCluster cluster;
+
+            using (var lifecycle = CreateLifecycle(
+                suppressInheritedExecutionContext: true))
+            {
+                realm = lifecycle.Realm;
+                cluster = lifecycle.Cluster;
+                scheduler = lifecycle.Services.Resolve<NodeSchedulerState>();
+                object? runtimeGlobal = null;
+
+                lifecycle.Execute(
+                    _ =>
+                    {
+                        runtimeGlobal = lifecycle.ExecutionContext.GetOrCreateGlobalObject();
+                        var global = runtimeGlobal;
+                        ObjectRuntime.SetItem(global, "lifecycleValue", value);
+                        Assert.True(ready.SignalAndWait(TimeSpan.FromSeconds(5)));
+                        Assert.Equal(
+                            value,
+                            ObjectRuntime.GetItem(global, "lifecycleValue"));
+                    },
+                    waitForTimers: false);
+                global = runtimeGlobal
+                    ?? throw new InvalidOperationException(
+                        "The lifecycle did not create its global object.");
+            }
+
+            return new IsolationResult(
+                realm,
+                global,
+                scheduler,
+                ObjectRuntime.GetItem(global, "lifecycleValue"),
+                cluster.IsDisposed);
+        });
+
+    private sealed record IsolationResult(
+        RuntimeRealm Realm,
+        object Global,
+        NodeSchedulerState Scheduler,
+        object? Value,
+        bool ClusterDisposed);
+}


### PR DESCRIPTION
## Summary

- introduce an exception-safe `RuntimeLifecycle` shared by standalone and hosted execution
- make cluster selection, agent/realm creation, root execution frames, event-loop pumping, and reverse-order cleanup explicit
- isolate hosted runtimes from inherited ambient state and use agent shutdown as the single cancellation source
- cover ownership, partial startup, concurrent isolation, repeated cycles, and hosted startup cleanup
- document the lifecycle and ownership contract

## Validation

- `dotnet build js2il.sln --no-restore`
- `MSBUILDDISABLENODEREUSE=1 dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-build --no-restore` (3,347 passed, 1 skipped)
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --no-build --no-restore` (6,312 passed, 58 skipped)

Closes #1828
