### PR TITLE
docs: add documentation navigation indexes

### DIFF
--- a/docs/ECMA262/1/Index.md
+++ b/docs/ECMA262/1/Index.md
@@ -1,0 +1,9 @@
+# Section 1: Scope
+
+This folder contains JROC coverage documentation for Section 1: Scope. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 1: Scope](Section1.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/10/Index.md
+++ b/docs/ECMA262/10/Index.md
@@ -1,0 +1,17 @@
+# Section 10: Ordinary and Exotic Objects Behaviours
+
+This folder contains JROC coverage documentation for Section 10: Ordinary and Exotic Objects Behaviours. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 10: Ordinary and Exotic Objects Behaviours](Section10.md)
+
+## Subsections
+
+- [Section 10.1: Ordinary Object Internal Methods and Internal Slots](Section10_1.md)
+- [Section 10.2: ECMAScript Function Objects](Section10_2.md)
+- [Section 10.3: Built-in Function Objects](Section10_3.md)
+- [Section 10.4: Built-in Exotic Object Internal Methods and Slots](Section10_4.md)
+- [Section 10.5: Proxy Object Internal Methods and Internal Slots](Section10_5.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/11/Index.md
+++ b/docs/ECMA262/11/Index.md
@@ -1,0 +1,14 @@
+# Section 11: ECMAScript Language: Source Text
+
+This folder contains JROC coverage documentation for Section 11: ECMAScript Language: Source Text. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 11: ECMAScript Language: Source Text](Section11.md)
+
+## Subsections
+
+- [Section 11.1: Source Text](Section11_1.md)
+- [Section 11.2: Types of Source Code](Section11_2.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/12/Index.md
+++ b/docs/ECMA262/12/Index.md
@@ -1,0 +1,22 @@
+# Section 12: ECMAScript Language: Lexical Grammar
+
+This folder contains JROC coverage documentation for Section 12: ECMAScript Language: Lexical Grammar. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 12: ECMAScript Language: Lexical Grammar](Section12.md)
+
+## Subsections
+
+- [Section 12.1: Unicode Format-Control Characters](Section12_1.md)
+- [Section 12.2: White Space](Section12_2.md)
+- [Section 12.3: Line Terminators](Section12_3.md)
+- [Section 12.4: Comments](Section12_4.md)
+- [Section 12.5: Hashbang Comments](Section12_5.md)
+- [Section 12.6: Tokens](Section12_6.md)
+- [Section 12.7: Names and Keywords](Section12_7.md)
+- [Section 12.8: Punctuators](Section12_8.md)
+- [Section 12.9: Literals](Section12_9.md)
+- [Section 12.10: Automatic Semicolon Insertion](Section12_10.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/13/Index.md
+++ b/docs/ECMA262/13/Index.md
@@ -1,0 +1,28 @@
+# Section 13: ECMAScript Language: Expressions
+
+This folder contains JROC coverage documentation for Section 13: ECMAScript Language: Expressions. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 13: ECMAScript Language: Expressions](Section13.md)
+
+## Subsections
+
+- [Section 13.1: Identifiers](Section13_1.md)
+- [Section 13.2: Primary Expression](Section13_2.md)
+- [Section 13.3: Left-Hand-Side Expressions](Section13_3.md)
+- [Section 13.4: Update Expressions](Section13_4.md)
+- [Section 13.5: Unary Operators](Section13_5.md)
+- [Section 13.6: Exponentiation Operator](Section13_6.md)
+- [Section 13.7: Multiplicative Operators](Section13_7.md)
+- [Section 13.8: Additive Operators](Section13_8.md)
+- [Section 13.9: Bitwise Shift Operators](Section13_9.md)
+- [Section 13.10: Relational Operators](Section13_10.md)
+- [Section 13.11: Equality Operators](Section13_11.md)
+- [Section 13.12: Binary Bitwise Operators](Section13_12.md)
+- [Section 13.13: Binary Logical Operators](Section13_13.md)
+- [Section 13.14: Conditional Operator ( ? : )](Section13_14.md)
+- [Section 13.15: Assignment Operators](Section13_15.md)
+- [Section 13.16: Comma Operator ( , )](Section13_16.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/14/Index.md
+++ b/docs/ECMA262/14/Index.md
@@ -1,0 +1,28 @@
+# Section 14: ECMAScript Language: Statements and Declarations
+
+This folder contains JROC coverage documentation for Section 14: ECMAScript Language: Statements and Declarations. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 14: ECMAScript Language: Statements and Declarations](Section14.md)
+
+## Subsections
+
+- [Section 14.1: Statement Semantics](Section14_1.md)
+- [Section 14.2: Block](Section14_2.md)
+- [Section 14.3: Declarations and the Variable Statement](Section14_3.md)
+- [Section 14.4: Empty Statement](Section14_4.md)
+- [Section 14.5: Expression Statement](Section14_5.md)
+- [Section 14.6: The if Statement](Section14_6.md)
+- [Section 14.7: Iteration Statements](Section14_7.md)
+- [Section 14.8: The continue Statement](Section14_8.md)
+- [Section 14.9: The break Statement](Section14_9.md)
+- [Section 14.10: The return Statement](Section14_10.md)
+- [Section 14.11: The with Statement](Section14_11.md)
+- [Section 14.12: The switch Statement](Section14_12.md)
+- [Section 14.13: Labelled Statements](Section14_13.md)
+- [Section 14.14: The throw Statement](Section14_14.md)
+- [Section 14.15: The try Statement](Section14_15.md)
+- [Section 14.16: The debugger Statement](Section14_16.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/15/Index.md
+++ b/docs/ECMA262/15/Index.md
@@ -1,0 +1,22 @@
+# Section 15: ECMAScript Language: Functions and Classes
+
+This folder contains JROC coverage documentation for Section 15: ECMAScript Language: Functions and Classes. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 15: ECMAScript Language: Functions and Classes](Section15.md)
+
+## Subsections
+
+- [Section 15.1: Parameter Lists](Section15_1.md)
+- [Section 15.2: Function Definitions](Section15_2.md)
+- [Section 15.3: Arrow Function Definitions](Section15_3.md)
+- [Section 15.4: Method Definitions](Section15_4.md)
+- [Section 15.5: Generator Function Definitions](Section15_5.md)
+- [Section 15.6: Async Generator Function Definitions](Section15_6.md)
+- [Section 15.7: Class Definitions](Section15_7.md)
+- [Section 15.8: Async Function Definitions](Section15_8.md)
+- [Section 15.9: Async Arrow Function Definitions](Section15_9.md)
+- [Section 15.10: Tail Position Calls](Section15_10.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/16/Index.md
+++ b/docs/ECMA262/16/Index.md
@@ -1,0 +1,14 @@
+# Section 16: ECMAScript Language: Scripts and Modules
+
+This folder contains JROC coverage documentation for Section 16: ECMAScript Language: Scripts and Modules. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 16: ECMAScript Language: Scripts and Modules](Section16.md)
+
+## Subsections
+
+- [Section 16.1: Scripts](Section16_1.md)
+- [Section 16.2: Modules](Section16_2.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/17/Index.md
+++ b/docs/ECMA262/17/Index.md
@@ -1,0 +1,13 @@
+# Section 17: Error Handling and Language Extensions
+
+This folder contains JROC coverage documentation for Section 17: Error Handling and Language Extensions. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 17: Error Handling and Language Extensions](Section17.md)
+
+## Subsections
+
+- [Section 17.1: Forbidden Extensions](Section17_1.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/18/Index.md
+++ b/docs/ECMA262/18/Index.md
@@ -1,0 +1,9 @@
+# Section 18: ECMAScript Standard Built-in Objects
+
+This folder contains JROC coverage documentation for Section 18: ECMAScript Standard Built-in Objects. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 18: ECMAScript Standard Built-in Objects](Section18.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/19/Index.md
+++ b/docs/ECMA262/19/Index.md
@@ -1,0 +1,16 @@
+# Section 19: The Global Object
+
+This folder contains JROC coverage documentation for Section 19: The Global Object. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 19: The Global Object](Section19.md)
+
+## Subsections
+
+- [Section 19.1: Value Properties of the Global Object](Section19_1.md)
+- [Section 19.2: Function Properties of the Global Object](Section19_2.md)
+- [Section 19.3: Constructor Properties of the Global Object](Section19_3.md)
+- [Section 19.4: Other Properties of the Global Object](Section19_4.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/2/Index.md
+++ b/docs/ECMA262/2/Index.md
@@ -1,0 +1,15 @@
+# Section 2: Conformance
+
+This folder contains JROC coverage documentation for Section 2: Conformance. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 2: Conformance](Section2.md)
+
+## Subsections
+
+- [Section 2.1: Example Normative Optional Clause Heading](Section2_1.md)
+- [Section 2.2: Example Legacy Clause Heading](Section2_2.md)
+- [Section 2.3: Example Legacy Normative Optional Clause Heading](Section2_3.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/20/Index.md
+++ b/docs/ECMA262/20/Index.md
@@ -1,0 +1,17 @@
+# Section 20: Fundamental Objects
+
+This folder contains JROC coverage documentation for Section 20: Fundamental Objects. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 20: Fundamental Objects](Section20.md)
+
+## Subsections
+
+- [Section 20.1: Object Objects](Section20_1.md)
+- [Section 20.2: Function Objects](Section20_2.md)
+- [Section 20.3: Boolean Objects](Section20_3.md)
+- [Section 20.4: Symbol Objects](Section20_4.md)
+- [Section 20.5: Error Objects](Section20_5.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/21/Index.md
+++ b/docs/ECMA262/21/Index.md
@@ -1,0 +1,16 @@
+# Section 21: Numbers and Dates
+
+This folder contains JROC coverage documentation for Section 21: Numbers and Dates. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 21: Numbers and Dates](Section21.md)
+
+## Subsections
+
+- [Section 21.1: Number Objects](Section21_1.md)
+- [Section 21.2: BigInt Objects](Section21_2.md)
+- [Section 21.3: The Math Object](Section21_3.md)
+- [Section 21.4: Date Objects](Section21_4.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/22/Index.md
+++ b/docs/ECMA262/22/Index.md
@@ -1,0 +1,14 @@
+# Section 22: Text Processing
+
+This folder contains JROC coverage documentation for Section 22: Text Processing. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 22: Text Processing](Section22.md)
+
+## Subsections
+
+- [Section 22.1: String Objects](Section22_1.md)
+- [Section 22.2: RegExp (Regular Expression) Objects](Section22_2.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/23/Index.md
+++ b/docs/ECMA262/23/Index.md
@@ -1,0 +1,15 @@
+# Section 23: Indexed Collections
+
+This folder contains JROC coverage documentation for Section 23: Indexed Collections. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 23: Indexed Collections](Section23.md)
+
+## Subsections
+
+- [Section 23.1: Array Objects](Section23_1.md)
+- [Section 23.2: TypedArray Objects](Section23_2.md)
+- [Section 23.3: Uint8Array Objects](Section23_3.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/24/Index.md
+++ b/docs/ECMA262/24/Index.md
@@ -1,0 +1,17 @@
+# Section 24: Keyed Collections
+
+This folder contains JROC coverage documentation for Section 24: Keyed Collections. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 24: Keyed Collections](Section24.md)
+
+## Subsections
+
+- [Section 24.1: Map Objects](Section24_1.md)
+- [Section 24.2: Set Objects](Section24_2.md)
+- [Section 24.3: WeakMap Objects](Section24_3.md)
+- [Section 24.4: WeakSet Objects](Section24_4.md)
+- [Section 24.5: Abstract Operations for Keyed Collections](Section24_5.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/25/Index.md
+++ b/docs/ECMA262/25/Index.md
@@ -1,0 +1,17 @@
+# Section 25: Structured Data
+
+This folder contains JROC coverage documentation for Section 25: Structured Data. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 25: Structured Data](Section25.md)
+
+## Subsections
+
+- [Section 25.1: ArrayBuffer Objects](Section25_1.md)
+- [Section 25.2: SharedArrayBuffer Objects](Section25_2.md)
+- [Section 25.3: DataView Objects](Section25_3.md)
+- [Section 25.4: The Atomics Object](Section25_4.md)
+- [Section 25.5: The JSON Object](Section25_5.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/26/Index.md
+++ b/docs/ECMA262/26/Index.md
@@ -1,0 +1,14 @@
+# Section 26: Managing Memory
+
+This folder contains JROC coverage documentation for Section 26: Managing Memory. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 26: Managing Memory](Section26.md)
+
+## Subsections
+
+- [Section 26.1: WeakRef Objects](Section26_1.md)
+- [Section 26.2: FinalizationRegistry Objects](Section26_2.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/27/Index.md
+++ b/docs/ECMA262/27/Index.md
@@ -1,0 +1,19 @@
+# Section 27: Control Abstraction Objects
+
+This folder contains JROC coverage documentation for Section 27: Control Abstraction Objects. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 27: Control Abstraction Objects](Section27.md)
+
+## Subsections
+
+- [Section 27.1: Iteration](Section27_1.md)
+- [Section 27.2: Promise Objects](Section27_2.md)
+- [Section 27.3: GeneratorFunction Objects](Section27_3.md)
+- [Section 27.4: AsyncGeneratorFunction Objects](Section27_4.md)
+- [Section 27.5: Generator Objects](Section27_5.md)
+- [Section 27.6: AsyncGenerator Objects](Section27_6.md)
+- [Section 27.7: AsyncFunction Objects](Section27_7.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/28/Index.md
+++ b/docs/ECMA262/28/Index.md
@@ -1,0 +1,15 @@
+# Section 28: Reflection
+
+This folder contains JROC coverage documentation for Section 28: Reflection. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 28: Reflection](Section28.md)
+
+## Subsections
+
+- [Section 28.1: The Reflect Object](Section28_1.md)
+- [Section 28.2: Proxy Objects](Section28_2.md)
+- [Section 28.3: Module Namespace Objects](Section28_3.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/29/Index.md
+++ b/docs/ECMA262/29/Index.md
@@ -1,0 +1,23 @@
+# Section 29: Memory Model
+
+This folder contains JROC coverage documentation for Section 29: Memory Model. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 29: Memory Model](Section29.md)
+
+## Subsections
+
+- [Section 29.1: Memory Model Fundamentals](Section29_1.md)
+- [Section 29.2: Agent Events Records](Section29_2.md)
+- [Section 29.3: Chosen Value Records](Section29_3.md)
+- [Section 29.4: Candidate Executions](Section29_4.md)
+- [Section 29.5: Abstract Operations for the Memory Model](Section29_5.md)
+- [Section 29.6: Relations of Candidate Executions](Section29_6.md)
+- [Section 29.7: Properties of Valid Executions](Section29_7.md)
+- [Section 29.8: Races](Section29_8.md)
+- [Section 29.9: Data Races](Section29_9.md)
+- [Section 29.10: Data Race Freedom](Section29_10.md)
+- [Section 29.11: Shared Memory Guidelines](Section29_11.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/3/Index.md
+++ b/docs/ECMA262/3/Index.md
@@ -1,0 +1,9 @@
+# Section 3: Normative References
+
+This folder contains JROC coverage documentation for Section 3: Normative References. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 3: Normative References](Section3.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/4/Index.md
+++ b/docs/ECMA262/4/Index.md
@@ -1,0 +1,17 @@
+# Section 4: Overview
+
+This folder contains JROC coverage documentation for Section 4: Overview. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 4: Overview](Section4.md)
+
+## Subsections
+
+- [Section 4.1: Web Scripting](Section4_1.md)
+- [Section 4.2: Hosts and Implementations](Section4_2.md)
+- [Section 4.3: ECMAScript Overview](Section4_3.md)
+- [Section 4.4: Terms and Definitions](Section4_4.md)
+- [Section 4.5: Organization of This Specification](Section4_5.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/5/Index.md
+++ b/docs/ECMA262/5/Index.md
@@ -1,0 +1,14 @@
+# Section 5: Notational Conventions
+
+This folder contains JROC coverage documentation for Section 5: Notational Conventions. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 5: Notational Conventions](Section5.md)
+
+## Subsections
+
+- [Section 5.1: Syntactic and Lexical Grammars](Section5_1.md)
+- [Section 5.2: Algorithm Conventions](Section5_2.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/6/Index.md
+++ b/docs/ECMA262/6/Index.md
@@ -1,0 +1,14 @@
+# Section 6: ECMAScript Data Types and Values
+
+This folder contains JROC coverage documentation for Section 6: ECMAScript Data Types and Values. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 6: ECMAScript Data Types and Values](Section6.md)
+
+## Subsections
+
+- [Section 6.1: ECMAScript Language Types](Section6_1.md)
+- [Section 6.2: ECMAScript Specification Types](Section6_2.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/7/Index.md
+++ b/docs/ECMA262/7/Index.md
@@ -1,0 +1,16 @@
+# Section 7: Abstract Operations
+
+This folder contains JROC coverage documentation for Section 7: Abstract Operations. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 7: Abstract Operations](Section7.md)
+
+## Subsections
+
+- [Section 7.1: Type Conversion](Section7_1.md)
+- [Section 7.2: Testing and Comparison Operations](Section7_2.md)
+- [Section 7.3: Operations on Objects](Section7_3.md)
+- [Section 7.4: Operations on Iterator Objects](Section7_4.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/8/Index.md
+++ b/docs/ECMA262/8/Index.md
@@ -1,0 +1,18 @@
+# Section 8: Syntax-Directed Operations
+
+This folder contains JROC coverage documentation for Section 8: Syntax-Directed Operations. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 8: Syntax-Directed Operations](Section8.md)
+
+## Subsections
+
+- [Section 8.1: Runtime Semantics: Evaluation](Section8_1.md)
+- [Section 8.2: Scope Analysis](Section8_2.md)
+- [Section 8.3: Labels](Section8_3.md)
+- [Section 8.4: Function Name Inference](Section8_4.md)
+- [Section 8.5: Contains](Section8_5.md)
+- [Section 8.6: Miscellaneous](Section8_6.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/9/Index.md
+++ b/docs/ECMA262/9/Index.md
@@ -1,0 +1,25 @@
+# Section 9: Executable Code and Execution Contexts
+
+This folder contains JROC coverage documentation for Section 9: Executable Code and Execution Contexts. Start with the top-level section document, then use the subsection pages for clause-level status and notes.
+
+## Section document
+
+- [Section 9: Executable Code and Execution Contexts](Section9.md)
+
+## Subsections
+
+- [Section 9.1: Environment Records](Section9_1.md)
+- [Section 9.2: PrivateEnvironment Records](Section9_2.md)
+- [Section 9.3: Realms](Section9_3.md)
+- [Section 9.4: Execution Contexts](Section9_4.md)
+- [Section 9.5: Jobs and Host Operations to Enqueue Jobs](Section9_5.md)
+- [Section 9.6: Agents](Section9_6.md)
+- [Section 9.7: Agent Clusters](Section9_7.md)
+- [Section 9.8: Forward Progress](Section9_8.md)
+- [Section 9.9: Processing Model of WeakRef and FinalizationRegistry Targets](Section9_9.md)
+- [Section 9.10: ClearKeptObjects ( )](Section9_10.md)
+- [Section 9.11: AddToKeptObjects ( value )](Section9_11.md)
+- [Section 9.12: CleanupFinalizationRegistry ( finalizationRegistry )](Section9_12.md)
+- [Section 9.13: CanBeHeldWeakly ( v )](Section9_13.md)
+
+Where a JSON file accompanies a coverage Markdown page, it is the structured source used to maintain the coverage documentation.

--- a/docs/ECMA262/Index.md
+++ b/docs/ECMA262/Index.md
@@ -18,6 +18,7 @@ Important:
 Notes:
 - `Partially Supported` is deprecated legacy wording and is treated as `Supported with Limitations`.
 - Prototype-chain design/strategy: see [PrototypeChainSupport.md](../compiler/PrototypeChainSupport.md).
+- Coverage maintenance workflow: see the [ECMA-262 documentation guide](readme.md).
 
 > Last generated (UTC): 2026-07-25T20:59:24Z
 
@@ -31,33 +32,32 @@ Notes:
 
 | Section | Title | Status | Spec | Document |
 |---:|---|---|---|---|
-| 1 | Scope | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-scope) | [Section1.md](1/Section1.md) |
-| 2 | Conformance | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance) | [Section2.md](2/Section2.md) |
-| 3 | Normative References | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-normative-references) | [Section3.md](3/Section3.md) |
-| 4 | Overview | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-overview) | [Section4.md](4/Section4.md) |
-| 5 | Notational Conventions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-notational-conventions) | [Section5.md](5/Section5.md) |
-| 6 | ECMAScript Data Types and Values | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values) | [Section6.md](6/Section6.md) |
-| 7 | Abstract Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations) | [Section7.md](7/Section7.md) |
-| 8 | Syntax-Directed Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations) | [Section8.md](8/Section8.md) |
-| 9 | Executable Code and Execution Contexts | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-executable-code-and-execution-contexts) | [Section9.md](9/Section9.md) |
-| 10 | Ordinary and Exotic Objects Behaviours | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-and-exotic-objects-behaviours) | [Section10.md](10/Section10.md) |
-| 11 | ECMAScript Language: Source Text | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-source-code) | [Section11.md](11/Section11.md) |
-| 12 | ECMAScript Language: Lexical Grammar | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar) | [Section12.md](12/Section12.md) |
-| 13 | ECMAScript Language: Expressions | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-expressions) | [Section13.md](13/Section13.md) |
-| 14 | ECMAScript Language: Statements and Declarations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-statements-and-declarations) | [Section14.md](14/Section14.md) |
-| 15 | ECMAScript Language: Functions and Classes | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-functions-and-classes) | [Section15.md](15/Section15.md) |
-| 16 | ECMAScript Language: Scripts and Modules | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-scripts-and-modules) | [Section16.md](16/Section16.md) |
-| 17 | Error Handling and Language Extensions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-error-handling-and-language-extensions) | [Section17.md](17/Section17.md) |
-| 18 | ECMAScript Standard Built-in Objects | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects) | [Section18.md](18/Section18.md) |
-| 19 | The Global Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-global-object) | [Section19.md](19/Section19.md) |
-| 20 | Fundamental Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-fundamental-objects) | [Section20.md](20/Section20.md) |
-| 21 | Numbers and Dates | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-numbers-and-dates) | [Section21.md](21/Section21.md) |
-| 22 | Text Processing | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-text-processing) | [Section22.md](22/Section22.md) |
-| 23 | Indexed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-indexed-collections) | [Section23.md](23/Section23.md) |
-| 24 | Keyed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-keyed-collections) | [Section24.md](24/Section24.md) |
-| 25 | Structured Data | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-structured-data) | [Section25.md](25/Section25.md) |
-| 26 | Managing Memory | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-managing-memory) | [Section26.md](26/Section26.md) |
-| 27 | Control Abstraction Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-control-abstraction-objects) | [Section27.md](27/Section27.md) |
-| 28 | Reflection | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-reflection) | [Section28.md](28/Section28.md) |
-| 29 | Memory Model | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-memory-model) | [Section29.md](29/Section29.md) |
-
+| 1 | Scope | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-scope) | [Section 1 index](1/Index.md) |
+| 2 | Conformance | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-conformance) | [Section 2 index](2/Index.md) |
+| 3 | Normative References | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-normative-references) | [Section 3 index](3/Index.md) |
+| 4 | Overview | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-overview) | [Section 4 index](4/Index.md) |
+| 5 | Notational Conventions | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-notational-conventions) | [Section 5 index](5/Index.md) |
+| 6 | ECMAScript Data Types and Values | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values) | [Section 6 index](6/Index.md) |
+| 7 | Abstract Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-abstract-operations) | [Section 7 index](7/Index.md) |
+| 8 | Syntax-Directed Operations | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-syntax-directed-operations) | [Section 8 index](8/Index.md) |
+| 9 | Executable Code and Execution Contexts | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-executable-code-and-execution-contexts) | [Section 9 index](9/Index.md) |
+| 10 | Ordinary and Exotic Objects Behaviours | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ordinary-and-exotic-objects-behaviours) | [Section 10 index](10/Index.md) |
+| 11 | ECMAScript Language: Source Text | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-source-code) | [Section 11 index](11/Index.md) |
+| 12 | ECMAScript Language: Lexical Grammar | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar) | [Section 12 index](12/Index.md) |
+| 13 | ECMAScript Language: Expressions | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-expressions) | [Section 13 index](13/Index.md) |
+| 14 | ECMAScript Language: Statements and Declarations | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-statements-and-declarations) | [Section 14 index](14/Index.md) |
+| 15 | ECMAScript Language: Functions and Classes | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-functions-and-classes) | [Section 15 index](15/Index.md) |
+| 16 | ECMAScript Language: Scripts and Modules | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-language-scripts-and-modules) | [Section 16 index](16/Index.md) |
+| 17 | Error Handling and Language Extensions | Untracked | [tc39.es](https://tc39.es/ecma262/#sec-error-handling-and-language-extensions) | [Section 17 index](17/Index.md) |
+| 18 | ECMAScript Standard Built-in Objects | N/A (informational) | [tc39.es](https://tc39.es/ecma262/#sec-ecmascript-standard-built-in-objects) | [Section 18 index](18/Index.md) |
+| 19 | The Global Object | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-global-object) | [Section 19 index](19/Index.md) |
+| 20 | Fundamental Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-fundamental-objects) | [Section 20 index](20/Index.md) |
+| 21 | Numbers and Dates | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-numbers-and-dates) | [Section 21 index](21/Index.md) |
+| 22 | Text Processing | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-text-processing) | [Section 22 index](22/Index.md) |
+| 23 | Indexed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-indexed-collections) | [Section 23 index](23/Index.md) |
+| 24 | Keyed Collections | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-keyed-collections) | [Section 24 index](24/Index.md) |
+| 25 | Structured Data | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-structured-data) | [Section 25 index](25/Index.md) |
+| 26 | Managing Memory | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-managing-memory) | [Section 26 index](26/Index.md) |
+| 27 | Control Abstraction Objects | Supported with Limitations | [tc39.es](https://tc39.es/ecma262/#sec-control-abstraction-objects) | [Section 27 index](27/Index.md) |
+| 28 | Reflection | Incomplete | [tc39.es](https://tc39.es/ecma262/#sec-reflection) | [Section 28 index](28/Index.md) |
+| 29 | Memory Model | Not Yet Supported | [tc39.es](https://tc39.es/ecma262/#sec-memory-model) | [Section 29 index](29/Index.md) |

--- a/docs/Index.md
+++ b/docs/Index.md
@@ -1,0 +1,24 @@
+# JROC documentation
+
+This documentation covers using JROC, its compiler and runtime design, JavaScript and Node.js compatibility, development planning, and historical project records. Start with the package guides for installation and hosting, then follow the area indexes for focused reference material.
+
+## Package and project guides
+
+- [Project README](../README.md) — project overview, installation, and command-line usage.
+- [jroc NuGet package guide](NuGet.README.md) — using the compiler package.
+- [Jroc.Core NuGet package guide](Jroc.Core.NuGet.README.md) — programmatic compilation APIs.
+- [Jroc.Runtime NuGet package guide](Jroc.Runtime.NuGet.README.md) — runtime hosting APIs.
+- [Jroc.SDK NuGet package guide](Jroc.SDK.NuGet.README.md) — MSBuild-integrated compilation and hosting.
+
+## Documentation areas
+
+- [Architecture decision records](adr/Index.md) — recorded decisions on compiler and test262 architecture.
+- [Archive](archive/Index.md) — superseded roadmaps, status references, and release-history material.
+- [Compiler](compiler/Index.md) — compilation pipeline, lowering, callable, module, and type-system designs.
+- [Diagrams](diagrams/Index.md) — source diagrams for compiler and runtime concepts.
+- [ECMA-262 coverage](ECMA262/Index.md) — clause-by-clause ECMAScript support tracking.
+- [Node.js support](nodejs/Index.md) — Node.js module and global compatibility coverage.
+- [Planning](planning/Index.md) — future project direction.
+- [Runtime](runtime/Index.md) — runtime lifecycle, object model, hosting, and scheduling designs.
+- [SDK](sdk/Index.md) — .NET SDK tutorials, API references, and package validation.
+- [Tracking issues](tracking-issues/Index.md) — prioritized compatibility backlogs and issue triage.

--- a/docs/adr/Index.md
+++ b/docs/adr/Index.md
@@ -1,0 +1,15 @@
+# Architecture decision records
+
+These records explain architectural choices that guide JROC's compiler, runtime, resumable callable ABI, prototype representation, and test262 workflow. Read them in numerical order when tracing the evolution of a decision.
+
+## Decisions
+
+- [ADR 0001: DI Container Choice (Runtime vs Compiler)](0001-di-runtime-vs-compiler.md)
+- [ADR 0002: Resumable Callable State Storage (Scope-Attached vs Separate State Object)](0002-resumable-state-scope-vs-stateobject.md)
+- [ADR 0003: Class Method Scopes ABI for Resumable Callables](0003-class-method-scopes-abi-for-resumable-callables.md)
+- [ADR 0004: Prototype Chain Representation](0004-prototype-chain-representation.md)
+- [ADR 0005: test262 Intake and Sync Model](0005-test262-intake-and-sync-model.md)
+- [ADR 0006: test262 Result Classification and Baseline Artifact](0006-test262-result-classification-and-baseline.md)
+- [ADR 0007: test262 CI Suites and Reporting Workflow](0007-test262-ci-suites-and-reporting-workflow.md)
+- [ADR 0008: test262 Docs and Backlog Linkage](0008-test262-docs-and-backlog-linkage.md)
+- [ADR 0009: test262 Post-MVP Expansion Plan](0009-test262-post-mvp-expansion-plan.md)

--- a/docs/archive/Index.md
+++ b/docs/archive/Index.md
@@ -1,0 +1,19 @@
+# Documentation archive
+
+This archive preserves superseded planning, feature-status, migration, and Node.js support references that are useful for historical context but are not the primary source for current project guidance.
+
+## Subdirectories
+
+- [Changelog archive](changelog/Index.md) — older release-line changelogs.
+
+## Historical compatibility and roadmap references
+
+- [ECMA-262 feature implementation documentation index](ECMA262_README.md)
+- [ECMA-262 feature priority executive summary](ECMA262FeaturePriority.md)
+- [ECMA-262 feature status quick reference](ECMA262FeatureStatus.md)
+- [Feature implementation roadmap](FeatureImplementationRoadmap.md)
+
+## Historical implementation notes
+
+- [Lowering pipeline migration punch list](LoweringPipeline_Migration_PunchList.md)
+- [Node module support punch list](NodeModuleSupport_PunchList.md)

--- a/docs/compiler/Index.md
+++ b/docs/compiler/Index.md
@@ -1,0 +1,38 @@
+# Compiler design
+
+These design documents describe the JROC compiler pipeline, including callable planning, lowering, IL emission, JavaScript semantics, module resolution, debug information, and optimization work. They are implementation references rather than end-user guides.
+
+## Compilation architecture and callable model
+
+- [Callable architecture baselines](CallableArchitectureBaselines.md)
+- [Captured variables and the scopes ABI](CapturedVariables_ScopesABI.md)
+- [Generated arrow function objects](GeneratedArrowFunctionObjects.md)
+- [Generated function-object types](GeneratedFunctionObjectTypes.md)
+- [Stable function-valued binding calls](StableFunctionBindingCalls.md)
+- [Two-phase compilation pipeline](TwoPhaseCompilationPipeline.md)
+
+## Lowering, code generation, and optimization
+
+- [Async/await lowering specification](AsyncAwait_LoweringSpec.md)
+- [Async/await three-way comparison](AsyncAwait_ThreeWay_Comparison.md)
+- [Instruction chaining](InstructionChaining.md)
+- [LIR rematerialization](LIRRematerialization.md)
+- [LIR stack scheduler](LIRStackScheduler.md)
+- [Portable PDB emission plan](PdbEmission_Plan.md)
+- [Synchronous generator lowering specification](SynchronousGenerators_LoweringSpec.md)
+
+## JavaScript semantics and object model
+
+- [JavaScript `eval` support design](EvalSupportDesign.md)
+- [JavaScript to .NET type mapping](JavaScriptToDotNetTypeMapping.md)
+- [Object literal type inference](ObjectLiteralTypeInference.md)
+- [Prototype chain support strategy](PrototypeChainSupport.md)
+- [Prototype support design](Prototypes_SupportDesign.md)
+
+## Modules, invocation, and asynchronous execution
+
+- [Event loop and scheduling](EventLoopAndScheduling.md)
+- [Late-bound invocation and DLR investigation](LateBoundInvocation_DLR_Investigation.md)
+- [npm package imports](NpmPackageImports.md)
+- [Pending IO count for `fs/promises.readFile`](PendingIOCount_ReadFileAsync_Design.md)
+- [Scopes, classes, and async/generator state](Scopes_Classes_AsyncGenerator_Design.md)

--- a/docs/diagrams/Index.md
+++ b/docs/diagrams/Index.md
@@ -1,0 +1,7 @@
+# Diagrams
+
+This folder contains source diagrams used to communicate JROC architecture and relationships. Render the Mermaid source with a compatible Markdown or Mermaid viewer when a visual diagram is needed.
+
+## Diagram sources
+
+- [JROC classes diagram](jroc-classes.mmd)

--- a/docs/planning/Index.md
+++ b/docs/planning/Index.md
@@ -1,0 +1,7 @@
+# Planning
+
+This folder contains forward-looking project planning material. The futures document collects potential directions and work that may inform later implementation priorities.
+
+## Planning documents
+
+- [Futures](FUTURES.md)

--- a/docs/runtime/Index.md
+++ b/docs/runtime/Index.md
@@ -1,0 +1,25 @@
+# Runtime design
+
+These documents describe the JavaScriptRuntime hosting model and its internal execution, object, lifecycle, ownership, realm, scheduling, and performance behavior. Use the SDK documentation for supported consumer-facing hosting workflows.
+
+## Hosting and invocation
+
+- [Hosting compiled JavaScript as a .NET library](DotNetLibraryHosting.md)
+- [JsFunctionObject invocation ABI](JsFunctionObjectInvocationAbi.md)
+
+## Object model and execution state
+
+- [Runtime object representation](OrdinaryObjectRepresentation.md)
+- [Runtime execution frames](RuntimeExecutionFrames.md)
+- [Runtime module state](RuntimeModuleState.md)
+- [Realm-created value caches](RuntimeRealmValueCaches.md)
+
+## Lifecycle and scheduling
+
+- [Runtime agent scheduling](RuntimeAgentScheduling.md)
+- [Runtime lifecycle](RuntimeLifecycle.md)
+- [Runtime ownership](RuntimeOwnership.md)
+
+## Performance
+
+- [RegExp and string hot-path performance optimizations](RegExpStringPerformanceOptimizations.md)

--- a/docs/sdk/Index.md
+++ b/docs/sdk/Index.md
@@ -83,7 +83,7 @@ dynamic exports = module.Exports;
 Console.WriteLine((double)exports.add(1, 2));
 ```
 
-## Tutorials
+## [Tutorials](tutorials/Index.md)
 
 - [Getting started](tutorials/GettingStarted.md)
 - [MSBuild build task](tutorials/MSBuildBuildTask.md)
@@ -95,7 +95,7 @@ Console.WriteLine((double)exports.add(1, 2));
 - [Diagnostics + exceptions](tutorials/DiagnosticsAndExceptions.md)
 - [Module ids + discovery](tutorials/ModuleIdsAndDiscovery.md)
 
-## API reference
+## [API reference](api/Index.md)
 
 - [`JrocCompile` MSBuild task](api/JrocCompile.md)
 - [In-memory compiler APIs](api/InMemoryCompiler.md)

--- a/docs/sdk/api/Index.md
+++ b/docs/sdk/api/Index.md
@@ -1,0 +1,15 @@
+# SDK API reference
+
+This reference describes the public .NET APIs used to compile JavaScript, host compiled modules, invoke exports, configure MSBuild compilation, and interpret interop and exception behavior.
+
+## Compilation and build integration
+
+- [In-memory compiler API](InMemoryCompiler.md)
+- [`JrocCompile` MSBuild task](JrocCompile.md)
+
+## Module hosting and invocation
+
+- [JsEngine](JsEngine.md)
+- [Handles and constructors](Handles.md)
+- [Hosting exceptions](Exceptions.md)
+- [JavaScript and CLR type mapping](TypeMapping.md)

--- a/docs/sdk/tutorials/Index.md
+++ b/docs/sdk/tutorials/Index.md
@@ -1,0 +1,21 @@
+# SDK tutorials
+
+These tutorials walk .NET developers through compiling JavaScript with JROC, integrating compilation with MSBuild, hosting exports, handling asynchronous work, and diagnosing runtime behavior.
+
+## Getting started and compilation
+
+- [Getting started](GettingStarted.md)
+- [MSBuild build task](MSBuildBuildTask.md)
+- [In-memory compile-and-run](InMemoryCompileAndRun.md)
+
+## Hosting modules
+
+- [Typed hosting](TypedHosting.md)
+- [Dynamic hosting](DynamicHosting.md)
+- [Module IDs and discovery](ModuleIdsAndDiscovery.md)
+
+## Runtime operation
+
+- [Async exports and event loop](AsyncAndEventLoop.md)
+- [Lifetime and disposal](LifetimeAndDisposal.md)
+- [Diagnostics and exceptions](DiagnosticsAndExceptions.md)

--- a/docs/tracking-issues/Index.md
+++ b/docs/tracking-issues/Index.md
@@ -1,0 +1,15 @@
+# Tracking issues
+
+This folder organizes JROC compatibility and implementation work into triage references, prioritized backlogs, and focused delivery plans. Use it to understand open feature gaps and how issues are evaluated.
+
+## Triage and overview
+
+- [Tracking issues and triage overview](README.md)
+- [Issue triage snapshot](IssueTriage.md)
+- [Triage scoreboard](TriageScoreboard.md)
+
+## Compatibility backlogs and plans
+
+- [ECMA-262 top missing features backlog](ECMA262TopMissingBacklog.md)
+- [Node gap popularity backlog](NodeGapPopularityBacklog.md)
+- [Phase 1 rest/spread foundation tracking issues](Phase1-TrackingIssues.md)


### PR DESCRIPTION
## Summary

- add a root documentation index covering package guides and each documentation area
- add navigation indexes to every documentation subfolder that lacked one
- connect ECMA-262 section and SDK child indexes from their existing parent indexes

## Validation

- verified all 43 documentation directories contain `Index.md`
- verified every parent index links each immediate child index
- verified all relative links in changed indexes resolve
- verified every Markdown and Mermaid document is linked from its folder index
