### PR TITLE
runtime: complete mutable static state audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- runtime: complete the realm migration with an executable mutable-static
+  ownership audit and repeated parallel isolation/unload gates (issue #1829).
+  Generated-type metadata and symbol-key caches are now weak-keyed, while
+  `dns` default order, `fs.constants`, and `path.posix`/`path.win32` are owned
+  by realm-local Node module instances.
+
 - runtime: unify standalone `Engine`, hosted `JsRuntimeInstance`, and future
   worker bootstrap under an exception-safe `RuntimeLifecycle` (issue #1828).
   The lifecycle explicitly creates or joins a cluster, creates the agent and

--- a/docs/runtime/Index.md
+++ b/docs/runtime/Index.md
@@ -19,6 +19,7 @@ These documents describe the JavaScriptRuntime hosting model and its internal ex
 - [Runtime agent scheduling](RuntimeAgentScheduling.md)
 - [Runtime lifecycle](RuntimeLifecycle.md)
 - [Runtime ownership](RuntimeOwnership.md)
+- [Runtime static-state ownership](RuntimeStaticState.md)
 
 ## Performance
 

--- a/docs/runtime/RuntimeOwnership.md
+++ b/docs/runtime/RuntimeOwnership.md
@@ -178,6 +178,8 @@ change observable semantics.
 
 ## Reference rules
 
+- The complete mutable-static ownership matrix and its executable guard are
+  documented in [Runtime static-state ownership](RuntimeStaticState.md).
 - Process-wide code may retain immutable metadata, but not an active realm,
   agent, or cluster.
 - A cluster may reference its active agents.

--- a/docs/runtime/RuntimeStaticState.md
+++ b/docs/runtime/RuntimeStaticState.md
@@ -1,0 +1,129 @@
+# Runtime static-state ownership
+
+This is the approved mutable-static inventory for `src/JavaScriptRuntime`.
+`RuntimeStaticStateAuditTests` reflects over `JavaScriptRuntime.dll` and fails
+when a writable static field or readonly reference candidate is added without
+an ownership decision here and in the executable matrix. Candidates include
+arrays, common mutable collections, lazy/thread/async holders, weak tables,
+encodings, regexes, and non-delegate runtime classes.
+
+JavaScript-observable values belong to a `RuntimeRealm`, `RuntimeAgent`, or
+`RuntimeAgentCluster`. Process state is limited to immutable CLR metadata,
+weak identity metadata, execution-flow carriers, monotonic deoptimization
+hints, resource identity allocators, and context-less compatibility fallbacks.
+
+## Writable static fields
+
+| Field | Owner | Why it may remain static |
+| --- | --- | --- |
+| `Array._defaultPrototypeChainHasIndexedProperties` | CLR thread | Thread-local fast-path observation only |
+| `Array._observedPrototypeIntrinsicsId` | CLR thread | Thread-local fast-path observation only |
+| `Array._observedPrototypeMutationVersion` | CLR thread | Thread-local fast-path observation only |
+| `Array._prototypeMutationVersion` | Process | Monotonic deoptimization version; retains no JavaScript value |
+| `AsyncContextRuntime._activeContextRuntimeCount` | Process | Fast-path activity count; actual async-hook state is agent-owned |
+| `AsyncContextRuntime._enabledHookCount` | Process | Fast-path activity count; actual hooks are agent-owned |
+| `FsCommon._nextFileDescriptor` | Process | Identity allocator for process file resources |
+| `RegExp._prototypeWellKnownSymbolFastPathFlags` | Process | Monotonic deoptimization flags; can only disable an optimization |
+| `RuntimeIntrinsics._initializationDepth` | CLR thread | Reentrant bootstrap state for the calling thread |
+| `RuntimeIntrinsics._nextId` | Process | Metadata identity allocator |
+| `RuntimeIntrinsics._processDefault` | Process | Context-less compatibility graph, never a live realm's graph |
+| `RuntimeServices._constructorArgStack` | CLR thread | Synchronous invocation state |
+| `RuntimeServices._constructorNewTargetStack` | CLR thread | Synchronous invocation state |
+| `RuntimeServices._derivedConstructorThisStack` | CLR thread | Synchronous invocation state |
+| `RuntimeServices._generatedFunctionDirectCallStack` | CLR thread | Synchronous invocation state |
+| `String.substringCache` | CLR thread | Primitive strings only |
+| `String.substringCacheNextIndex` | CLR thread | Index into the thread-local primitive cache |
+| `Symbol._nextId` | Process | Identity allocator; symbol values are not stored by the counter |
+
+Bootstrap-in-progress state must be thread-local. A process-wide counter is not
+an acceptable substitute even when initialization work is lock-serialized:
+another thread must not observe itself as reentrant.
+
+## Mutable static holders
+
+| Field | Owner | Retention rule |
+| --- | --- | --- |
+| `ArgumentsObject.FieldCaches` | Process metadata | `ConditionalWeakTable<Type, ...>`; collectible generated types are weak keys |
+| `Closure._delegateInvokeMetadata` | Process metadata | Weak-keyed delegate metadata |
+| `GlobalThis._fallbackGlobalObject` | CLR thread | Used only without an active runtime frame |
+| `JSON.RawJsonObjects` | Process identity metadata | Raw-JSON values are weak keys |
+| `JsShape._empty` | CLR thread | Context-less empty shape only |
+| `AsyncResourceObject.States` | Process identity metadata | Async resource receivers are weak keys |
+| `ObjectRuntime._encodedSymbolKeys` | Process identity metadata | Encoded key strings are weak keys; symbols live only with their property keys |
+| `ObjectRuntime._integrityStates` | Process identity metadata | Target objects are weak keys |
+| `PropertyDescriptorStore._defaultRuntimeStore` | CLR thread | Context-less descriptor fallback only |
+| `PropertyDescriptorStore._intrinsicInitializationDepth` | CLR thread | Reentrant intrinsic bootstrap state |
+| `RuntimeExecutionContext.Ambient` | Async flow | The sole ambient realm/agent pointer |
+| `RuntimeIntrinsics._blockedThreads` | Process coordination | Transient wait graph; entries are removed when waits end |
+| `RuntimeServices._currentArguments` | Async flow | Invocation state captured/restored by root frames |
+| `RuntimeServices._currentCallArguments` | Async flow | Invocation state captured/restored by root frames |
+| `RuntimeServices._currentCallee` | Async flow | Invocation state captured/restored by root frames |
+| `RuntimeServices._currentLexicalSuperReceiver` | Async flow | Invocation state captured/restored by root frames |
+| `RuntimeServices._currentLexicalSuperScopes` | Async flow | Invocation state captured/restored by root frames |
+| `RuntimeServices._currentNewTarget` | Async flow | Invocation state captured/restored by root frames |
+| `RuntimeServices._currentThis` | Async flow | Invocation state captured/restored by root frames |
+| `JsReturnConverter.ResultConversions` | Process metadata | Weak-keyed constructed generic methods |
+
+A weak-keyed table is approved only when the key has the semantic lifetime of
+the cached value. Ephemeron values may refer back to their keys without keeping
+collectible types or JavaScript objects alive.
+
+## Immutable process state
+
+The remaining readonly statics fall into these audited groups:
+
+- Built-in delegates in `GlobalThis`, `ObjectRuntime`, intrinsic types, and
+  Node adapters are immutable CLR call targets. Realm-visible
+  `JsFunctionObject` wrappers are materialized by `RuntimeIntrinsics`.
+- `Symbol.iterator` through `Symbol.unscopables` are ECMA-262 well-known symbol
+  identities. `Events.ErrorMonitorSymbol` is the immutable
+  `node:events.errorMonitor` module token.
+- `RuntimeServices.EmptyScopes`, `TemporalDeadZoneSentinel`, `Array.Hole`,
+  `Map.NullKeySentinel`, `WeakSet._dummyValue`, and generator sentinels are ABI
+  tokens. `EmptyScopes` is intentionally a one-element array and must never be
+  mutated.
+- Frozen intrinsic, Node module, global-binding, and delegate-type catalogs
+  contain runtime-assembly types or strings only. They cannot contain
+  generated/collectible types.
+- Regexes, encodings, path-independent configuration records, method handles,
+  and primitive lookup arrays are immutable implementation metadata.
+- `GlobalThis`'s default console, process, and global object are compatibility
+  fallbacks used only when no runtime frame exists. A live runtime always
+  resolves the realm-owned service graph.
+
+`Math.random` uses the BCL's process entropy source without retaining a JROC
+static generator. Process-wide identifiers and conservative fast-path flags
+may affect allocation order or performance, but never JavaScript ownership or
+observable state.
+
+## Migrations completed by the final audit
+
+- `dns` default result order, `fs.constants`, and `path.posix`/`path.win32` are
+  now owned by their realm-local Node module instances.
+- Argument field metadata and hosted generic return-conversion methods use
+  weak type keys, so collectible generated assemblies are not retained.
+- Encoded symbol-key metadata uses weak string identity rather than a
+  process-wide strong dictionary.
+- Intrinsic and Node module discovery catalogs and the JavaScript delegate-type
+  catalog are frozen after construction.
+
+## Enforcement
+
+- Any new writable static or readonly reference candidate must update the
+  executable ownership matrix and this document. Frozen collections,
+  delegates, strings, reflection handles, and value types are excluded as
+  immutable metadata categories.
+- Process caches must never strongly retain a realm, agent, cluster,
+  JavaScript object, callback, captured scope, module instance, or collectible
+  generated type.
+- JavaScript-visible module wrappers and values belong to the realm even when
+  their backing CLR behavior is stateless.
+- Ambient state identifies the active owner; it is not an independent owner.
+- Parallel tests must overlap execution. Sequential create/dispose tests do not
+  prove isolation.
+
+The stress gate overlaps four runtimes repeatedly and covers globals,
+intrinsics, module state, agent symbol registries, microtasks, timers, async
+call state, template objects, and Node module wrappers. Separate weak-reference
+gates verify runtime graphs, encoded symbols, and collectible generated types
+are reclaimed after bounded GC cycles.

--- a/src/JavaScriptRuntime/ArgumentsObject.cs
+++ b/src/JavaScriptRuntime/ArgumentsObject.cs
@@ -5,12 +5,13 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace JavaScriptRuntime;
 
 public sealed class ArgumentsObject : JsObject, IExoticJsObject, IDictionary<string, object?>
 {
-    private static readonly ConcurrentDictionary<(Type ScopeType, string Name), FieldInfo?> _fieldCache = new();
+    private static readonly ConditionalWeakTable<Type, ConcurrentDictionary<string, FieldInfo?>> FieldCaches = new();
     private static readonly Func<object[], object?[], object?> _restrictedCalleeAccessor = static (_, __) =>
         throw new TypeError("Cannot access restricted arguments property 'callee'");
 
@@ -327,7 +328,7 @@ public sealed class ArgumentsObject : JsObject, IExoticJsObject, IDictionary<str
             yield return key;
         }
 
-descriptorKeys:
+    descriptorKeys:
         if (_hasLengthProperty)
         {
             yield return "length";
@@ -356,8 +357,7 @@ descriptorKeys:
             return null;
         }
 
-        var field = _fieldCache.GetOrAdd((_scopeInstance.GetType(), parameterName), static key =>
-            key.ScopeType.GetField(key.Name, BindingFlags.Instance | BindingFlags.Public));
+        var field = GetScopeField(_scopeInstance.GetType(), parameterName);
         return field?.GetValue(_scopeInstance);
     }
 
@@ -368,10 +368,21 @@ descriptorKeys:
             return;
         }
 
-        var field = _fieldCache.GetOrAdd((_scopeInstance.GetType(), parameterName), static key =>
-            key.ScopeType.GetField(key.Name, BindingFlags.Instance | BindingFlags.Public));
+        var field = GetScopeField(_scopeInstance.GetType(), parameterName);
         field?.SetValue(_scopeInstance, value);
     }
+
+    private static FieldInfo? GetScopeField(Type scopeType, string name)
+        => FieldCaches
+            .GetValue(
+                scopeType,
+                static _ => new ConcurrentDictionary<string, FieldInfo?>(
+                    StringComparer.Ordinal))
+            .GetOrAdd(
+                name,
+                fieldName => scopeType.GetField(
+                    fieldName,
+                    BindingFlags.Instance | BindingFlags.Public));
 
     internal override bool TryGetOwnPropertyValue(string key, out object? value)
     {

--- a/src/JavaScriptRuntime/Hosting/JsReturnConverter.cs
+++ b/src/JavaScriptRuntime/Hosting/JsReturnConverter.cs
@@ -1,6 +1,6 @@
 using JavaScriptRuntime;
-using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Jroc.Runtime;
@@ -21,8 +21,7 @@ internal static class JsReturnConverter
                      && m.IsGenericMethodDefinition
                      && m.GetParameters().Length == 1);
 
-    private static readonly ConcurrentDictionary<Type, MethodInfo> PromiseToTaskByResultType = new();
-    private static readonly ConcurrentDictionary<Type, MethodInfo> TaskFromResultByResultType = new();
+    private static readonly ConditionalWeakTable<Type, ResultConversionMethods> ResultConversions = new();
 
     internal static object? ConvertReturn(JsRuntimeInstance runtime, object? value, Type returnType)
     {
@@ -44,23 +43,24 @@ internal static class JsReturnConverter
         if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>))
         {
             var resultType = returnType.GetGenericArguments()[0];
+            var conversionMethods = ResultConversions.GetValue(
+                resultType,
+                static type => new ResultConversionMethods(
+                    PromiseToTaskOpenGeneric.MakeGenericMethod(type),
+                    TaskFromResultOpenGeneric.MakeGenericMethod(type)));
 
             if (value is Promise p)
             {
-                var method = PromiseToTaskByResultType.GetOrAdd(
-                    resultType,
-                    t => PromiseToTaskOpenGeneric.MakeGenericMethod(t));
-
-                return method.Invoke(null, new object?[] { runtime, p });
+                return conversionMethods.PromiseToTask.Invoke(
+                    null,
+                    new object?[] { runtime, p });
             }
 
             var converted = ConvertReturn(runtime, value, resultType);
 
-            var fromResult = TaskFromResultByResultType.GetOrAdd(
-                resultType,
-                t => TaskFromResultOpenGeneric.MakeGenericMethod(t));
-
-            return fromResult.Invoke(null, new[] { converted });
+            return conversionMethods.TaskFromResult.Invoke(
+                null,
+                new[] { converted });
         }
 
         if (returnType == typeof(void))
@@ -145,4 +145,8 @@ internal static class JsReturnConverter
 
         return returnType.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IJsConstructor<>));
     }
+
+    private sealed record ResultConversionMethods(
+        MethodInfo PromiseToTask,
+        MethodInfo TaskFromResult);
 }

--- a/src/JavaScriptRuntime/IntrinsicObjectRegistry.cs
+++ b/src/JavaScriptRuntime/IntrinsicObjectRegistry.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -6,47 +7,27 @@ namespace JavaScriptRuntime
 {
     public static class IntrinsicObjectRegistry
     {
-        private static readonly object _sync = new();
-        private static volatile Dictionary<string, IntrinsicObjectInfo>? _byName;
+        private static readonly FrozenDictionary<string, IntrinsicObjectInfo> ByName =
+            Build();
 
         public static Type? Get(string name)
         {
             if (string.IsNullOrWhiteSpace(name)) return null;
-            var map = EnsureMap();
-            return map.TryGetValue(name, out var info) ? info.Type : null;
+            return ByName.TryGetValue(name, out var info) ? info.Type : null;
         }
 
         public static IntrinsicObjectInfo? GetInfo(string name)
         {
             if (string.IsNullOrWhiteSpace(name)) return null;
-            var map = EnsureMap();
-            return map.TryGetValue(name, out var info) ? info : null;
+            return ByName.TryGetValue(name, out var info) ? info : null;
         }
 
         public static IReadOnlyCollection<IntrinsicObjectInfo> GetAll()
         {
-            return EnsureMap().Values.ToArray();
+            return ByName.Values;
         }
 
-        private static Dictionary<string, IntrinsicObjectInfo> EnsureMap()
-        {
-            var map = _byName;
-            if (map == null)
-            {
-                lock (_sync)
-                {
-                    map = _byName;
-                    if (map == null)
-                    {
-                        map = Build();
-                        _byName = map;
-                    }
-                }
-            }
-            return map;
-        }
-
-        private static Dictionary<string, IntrinsicObjectInfo> Build()
+        private static FrozenDictionary<string, IntrinsicObjectInfo> Build()
         {
             var dict = new Dictionary<string, IntrinsicObjectInfo>(StringComparer.Ordinal);
             var asm = typeof(IntrinsicObjectAttribute).Assembly;
@@ -58,7 +39,7 @@ namespace JavaScriptRuntime
                     dict[attr.Name] = new IntrinsicObjectInfo(attr.Name, t, attr.CallKind);
                 }
             }
-            return dict;
+            return dict.ToFrozenDictionary(StringComparer.Ordinal);
         }
     }
 

--- a/src/JavaScriptRuntime/JsFuncDelegates.cs
+++ b/src/JavaScriptRuntime/JsFuncDelegates.cs
@@ -1,12 +1,19 @@
+using System.Collections.Frozen;
+
 namespace JavaScriptRuntime;
 
 internal static class JsFuncDelegates
 {
-    private static HashSet<Type> _registeredDelegateTypes = new();
+    private static readonly FrozenSet<Type> RegisteredDelegateTypes =
+        CreateRegisteredDelegateTypes();
 
-    static JsFuncDelegates()
+    internal static bool IsJsFuncDelegateType(Type type)
+        => RegisteredDelegateTypes.Contains(type);
+
+    private static FrozenSet<Type> CreateRegisteredDelegateTypes()
     {
         var runtimeAssembly = typeof(JsFuncDelegates).Assembly;
+        var registeredDelegateTypes = new HashSet<Type>();
 
         // Register all JsFuncN delegate types
         for (int i = 0; i <= 32; i++)
@@ -14,23 +21,19 @@ internal static class JsFuncDelegates
             var delegateType = runtimeAssembly.GetType($"JavaScriptRuntime.JsFunc{i}");
             if (delegateType != null)
             {
-                _registeredDelegateTypes.Add(delegateType);
+                registeredDelegateTypes.Add(delegateType);
             }
 
             var noScopesDelegateType = runtimeAssembly.GetType($"JavaScriptRuntime.JsFuncNoScopes{i}");
             if (noScopesDelegateType != null)
             {
-                _registeredDelegateTypes.Add(noScopesDelegateType);
+                registeredDelegateTypes.Add(noScopesDelegateType);
             }
         }
 
-        _registeredDelegateTypes.Add(typeof(JsDoubleFunc0));
-        _registeredDelegateTypes.Add(typeof(JsDoubleFuncNoScopes0));
-    }
-
-    internal static bool IsJsFuncDelegateType(Type type)
-    {
-        return _registeredDelegateTypes.Contains(type);
+        registeredDelegateTypes.Add(typeof(JsDoubleFunc0));
+        registeredDelegateTypes.Add(typeof(JsDoubleFuncNoScopes0));
+        return registeredDelegateTypes.ToFrozenSet();
     }
 }
 

--- a/src/JavaScriptRuntime/Math.cs
+++ b/src/JavaScriptRuntime/Math.cs
@@ -9,17 +9,15 @@ namespace JavaScriptRuntime
     [IntrinsicObject("Math")]
     public static class Math
     {
-        private static readonly System.Random _random = new System.Random();
-
-    // 20.2.1 Value Properties of the Math Object
-    public static double E => global::System.Math.E;
-    public static double LN10 => global::System.Math.Log(10.0);
-    public static double LN2 => global::System.Math.Log(2.0);
-    public static double LOG10E => global::System.Math.Log10(global::System.Math.E);
-    public static double LOG2E => global::System.Math.Log(global::System.Math.E, 2.0);
-    public static double PI => global::System.Math.PI;
-    public static double SQRT1_2 => global::System.Math.Sqrt(0.5);
-    public static double SQRT2 => global::System.Math.Sqrt(2.0);
+        // 20.2.1 Value Properties of the Math Object
+        public static double E => global::System.Math.E;
+        public static double LN10 => global::System.Math.Log(10.0);
+        public static double LN2 => global::System.Math.Log(2.0);
+        public static double LOG10E => global::System.Math.Log10(global::System.Math.E);
+        public static double LOG2E => global::System.Math.Log(global::System.Math.E, 2.0);
+        public static double PI => global::System.Math.PI;
+        public static double SQRT1_2 => global::System.Math.Sqrt(0.5);
+        public static double SQRT2 => global::System.Math.Sqrt(2.0);
 
         /// <summary>
         /// Math.ceil(x): returns the smallest integer greater than or equal to x.
@@ -67,13 +65,13 @@ namespace JavaScriptRuntime
             if (d == 0) return d; // preserve +0/-0 when the argument already equals zero
 
             double r = System.Math.Floor(d + 0.5);
-            
+
             // ECMAScript spec: if result is 0 and input was negative, return -0
             if (r == 0.0 && d < 0.0)
             {
                 return -0.0;
             }
-            
+
             return r;
         }
 
@@ -199,7 +197,7 @@ namespace JavaScriptRuntime
         public static double random()
         {
             // 0 <= x < 1
-            return _random.NextDouble();
+            return System.Random.Shared.NextDouble();
         }
 
         public static double cbrt(object? x)

--- a/src/JavaScriptRuntime/Node/Dns.cs
+++ b/src/JavaScriptRuntime/Node/Dns.cs
@@ -7,7 +7,7 @@ namespace JavaScriptRuntime.Node;
 [NodeModule("dns")]
 public sealed partial class Dns
 {
-    private static string _defaultResultOrder = "verbatim";
+    private string _defaultResultOrder = "verbatim";
 
     public object? lookup(object[] args)
     {
@@ -30,7 +30,9 @@ public sealed partial class Dns
                 "The \"callback\" argument must be of type function.");
         }
 
-        var options = args.Length == 3 ? ParseLookupOptions(args[1]) : new LookupOptions();
+        var options = args.Length == 3
+            ? ParseLookupOptions(args[1])
+            : new LookupOptions { Order = GetDefaultResultOrder() };
         var scheduler = GlobalThis.ServiceProvider?.Resolve<NodeSchedulerState>()
             ?? throw new InvalidOperationException(
                 "NodeSchedulerState is not available for dns.lookup.");
@@ -156,18 +158,19 @@ public sealed partial class Dns
         return records;
     }
 
-    private static LookupOptions ParseLookupOptions(object? options)
+    private LookupOptions ParseLookupOptions(object? options)
     {
         if (options is null or JsNull)
         {
-            return new LookupOptions();
+            return new LookupOptions { Order = GetDefaultResultOrder() };
         }
 
         if (options is double or int or long or short)
         {
             return new LookupOptions
             {
-                Family = ParseFamily(options, "family")
+                Family = ParseFamily(options, "family"),
+                Order = GetDefaultResultOrder()
             };
         }
 
@@ -262,7 +265,7 @@ public sealed partial class Dns
     private static int GetFamily(IPAddress address)
         => address.AddressFamily == AddressFamily.InterNetwork ? 4 : 6;
 
-    private static string GetDefaultResultOrder()
+    private string GetDefaultResultOrder()
         => Volatile.Read(ref _defaultResultOrder);
 
     private sealed class LookupOptions
@@ -271,7 +274,7 @@ public sealed partial class Dns
 
         public int Family { get; init; }
 
-        public string Order { get; init; } = GetDefaultResultOrder();
+        public string Order { get; init; } = "verbatim";
     }
 
     private sealed class DnsLookupError(string hostname, Exception innerException)

--- a/src/JavaScriptRuntime/Node/FS.cs
+++ b/src/JavaScriptRuntime/Node/FS.cs
@@ -9,7 +9,7 @@ namespace JavaScriptRuntime.Node
     [NodeModule("fs")]
     public sealed partial class FS
     {
-        private static readonly object _constants = CreateConstants();
+        private readonly object _constants = CreateConstants();
 
         private IIOScheduler? _ioScheduler;
         private object? _promises;

--- a/src/JavaScriptRuntime/Node/NodeModuleRegistry.cs
+++ b/src/JavaScriptRuntime/Node/NodeModuleRegistry.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -8,7 +9,7 @@ namespace JavaScriptRuntime.Node
 {
     public static class NodeModuleRegistry
     {
-        private static readonly Lazy<Dictionary<string, Type>> ModulesByName = new(() =>
+        private static readonly Lazy<FrozenDictionary<string, Type>> ModulesByName = new(() =>
         {
             var asm = typeof(NodeModuleAttribute).Assembly;
             var modules = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
@@ -30,10 +31,10 @@ namespace JavaScriptRuntime.Node
                 }
             }
 
-            return modules;
+            return modules.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         });
 
-        private static readonly Lazy<Dictionary<string, Type>> ContractsByName = new(() =>
+        private static readonly Lazy<FrozenDictionary<string, Type>> ContractsByName = new(() =>
         {
             var contracts = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
             var contractTypes = typeof(NodeModuleInterfaceAttribute).Assembly
@@ -62,7 +63,7 @@ namespace JavaScriptRuntime.Node
                 }
             }
 
-            return contracts;
+            return contracts.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
         });
 
         public static string NormalizeModuleName(string specifier)

--- a/src/JavaScriptRuntime/Node/Path.cs
+++ b/src/JavaScriptRuntime/Node/Path.cs
@@ -8,8 +8,8 @@ namespace JavaScriptRuntime.Node
     [NodeModule("path")]
     public sealed partial class Path
     {
-        private static readonly VariantPath _posix = VariantPath.Posix;
-        private static readonly VariantPath _win32 = VariantPath.Win32;
+        private readonly VariantPath _posix = new(isWin32: false);
+        private readonly VariantPath _win32 = new(isWin32: true);
 
         // Node: path.posix and path.win32 are always present (even on Windows).
         public object posix => _posix;
@@ -300,15 +300,12 @@ namespace JavaScriptRuntime.Node
         // TODO: Consider delegating the host Path implementation to VariantPath to avoid duplication.
         private sealed class VariantPath
         {
-            public static readonly VariantPath Posix = new VariantPath(isWin32: false);
-            public static readonly VariantPath Win32 = new VariantPath(isWin32: true);
-
             private readonly bool _isWin32;
             private readonly char _sep;
             private readonly char _altSep;
             private readonly string _delimiter;
 
-            private VariantPath(bool isWin32)
+            internal VariantPath(bool isWin32)
             {
                 _isWin32 = isWin32;
                 _sep = isWin32 ? '\\' : '/';

--- a/src/JavaScriptRuntime/ObjectRuntime.Operations.cs
+++ b/src/JavaScriptRuntime/ObjectRuntime.Operations.cs
@@ -219,7 +219,7 @@ namespace JavaScriptRuntime
         }
 
         private static readonly ConditionalWeakTable<object, ObjectIntegrityState> _integrityStates = new();
-        private static readonly ConcurrentDictionary<string, Symbol> _encodedSymbolKeys = new(StringComparer.Ordinal);
+        private static readonly ConditionalWeakTable<string, Symbol> _encodedSymbolKeys = new();
 
         private static ObjectIntegrityState GetIntegrityState(object target) => _integrityStates.GetOrCreateValue(target);
 
@@ -230,7 +230,8 @@ namespace JavaScriptRuntime
 
         internal static bool IsEncodedSymbolKey(string? key)
         {
-            return !string.IsNullOrEmpty(key) && _encodedSymbolKeys.ContainsKey(key);
+            return !string.IsNullOrEmpty(key)
+                && _encodedSymbolKeys.TryGetValue(key, out _);
         }
 
         private static bool TryDecodeEncodedSymbolKey(string? key, [NotNullWhen(true)] out Symbol? symbol)
@@ -3544,7 +3545,7 @@ namespace JavaScriptRuntime
                 // We encode Symbol keys to a stable internal string so computed
                 // properties like obj[Symbol.iterator] can round-trip.
                 var encoded = sym.DebugId;
-                _encodedSymbolKeys.TryAdd(encoded, sym);
+                _ = _encodedSymbolKeys.GetValue(encoded, _ => sym);
                 return encoded;
             }
 
@@ -6833,7 +6834,7 @@ namespace JavaScriptRuntime
         public static int CoerceToInt32(object? value)
         {
             if (value is null) return 0;
-            
+
             switch (value)
             {
                 case double d: return (int)d;

--- a/tests/Jroc.Tests/RuntimeStaticStateAuditTests.cs
+++ b/tests/Jroc.Tests/RuntimeStaticStateAuditTests.cs
@@ -1,0 +1,546 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using JavaScriptRuntime;
+using JavaScriptRuntime.EngineCore;
+using JavaScriptRuntime.Modules.CommonJS;
+using JavaScriptRuntime.Node;
+using Jroc.Runtime;
+using AssemblyName = System.Reflection.AssemblyName;
+
+namespace Jroc.Tests;
+
+public sealed class RuntimeStaticStateAuditTests
+{
+    private const int StressRuntimeCount = 4;
+    private const int StressRoundCount = 4;
+
+    private static readonly ApprovedStatic[] ApprovedWritableStatics =
+    [
+        new("JavaScriptRuntime.Array._defaultPrototypeChainHasIndexedProperties", "thread-local deoptimization state"),
+        new("JavaScriptRuntime.Array._observedPrototypeIntrinsicsId", "thread-local deoptimization state"),
+        new("JavaScriptRuntime.Array._observedPrototypeMutationVersion", "thread-local deoptimization state"),
+        new("JavaScriptRuntime.Array._prototypeMutationVersion", "process-wide monotonic deoptimization version"),
+        new("JavaScriptRuntime.Node.AsyncContextRuntime._activeContextRuntimeCount", "process-wide fast-path activity count"),
+        new("JavaScriptRuntime.Node.AsyncContextRuntime._enabledHookCount", "process-wide fast-path activity count"),
+        new("JavaScriptRuntime.Node.FsCommon._nextFileDescriptor", "process-wide resource identity allocator"),
+        new("JavaScriptRuntime.RegExp._prototypeWellKnownSymbolFastPathFlags", "process-wide monotonic deoptimization flags"),
+        new("JavaScriptRuntime.RuntimeIntrinsics._initializationDepth", "thread-local bootstrap state"),
+        new("JavaScriptRuntime.RuntimeIntrinsics._nextId", "process-wide metadata identity allocator"),
+        new("JavaScriptRuntime.RuntimeIntrinsics._processDefault", "context-less process fallback"),
+        new("JavaScriptRuntime.RuntimeServices._constructorArgStack", "thread-local invocation state"),
+        new("JavaScriptRuntime.RuntimeServices._constructorNewTargetStack", "thread-local invocation state"),
+        new("JavaScriptRuntime.RuntimeServices._derivedConstructorThisStack", "thread-local invocation state"),
+        new("JavaScriptRuntime.RuntimeServices._generatedFunctionDirectCallStack", "thread-local invocation state"),
+        new("JavaScriptRuntime.String.substringCache", "thread-local primitive value cache"),
+        new("JavaScriptRuntime.String.substringCacheNextIndex", "thread-local primitive value cache"),
+        new("JavaScriptRuntime.Symbol._nextId", "process-wide primitive identity allocator"),
+    ];
+
+    private static readonly ApprovedStatic[] ApprovedReadonlyReferenceStatics =
+    [
+        new("JavaScriptRuntime.ArgumentsObject.FieldCaches", "weak-keyed CLR metadata"),
+        new("JavaScriptRuntime.Array.Hole", "immutable ABI sentinel"),
+        new("JavaScriptRuntime.Closure._delegateInvokeMetadata", "weak-keyed CLR metadata"),
+        new("JavaScriptRuntime.Date.DateOnlyRegex", "immutable regex metadata"),
+        new("JavaScriptRuntime.Date.LocalDateTimeRegex", "immutable regex metadata"),
+        new("JavaScriptRuntime.DotNet2JSConversions.SmallIntStrings", "immutable primitive lookup"),
+        new("JavaScriptRuntime.Engine._serviceProviderOverride", "ambient override handle"),
+        new("JavaScriptRuntime.EngineCore.NodeEventLoopPump+NoOpFinalizationRegistryHost.Instance", "stateless host singleton"),
+        new("JavaScriptRuntime.GeneratorObject+DynamicGeneratorIterator.NoYield", "immutable ABI sentinel"),
+        new("JavaScriptRuntime.GlobalThis._defaultConsole", "context-less process fallback"),
+        new("JavaScriptRuntime.GlobalThis._defaultProcess", "context-less process fallback"),
+        new("JavaScriptRuntime.GlobalThis._fallbackGlobalObject", "thread-local context-less fallback"),
+        new("JavaScriptRuntime.GlobalThis._strictUtf8", "immutable encoding metadata"),
+        new("JavaScriptRuntime.JSON.RawJsonObjects", "weak-keyed value metadata"),
+        new("JavaScriptRuntime.JsShape._empty", "thread-local empty shape"),
+        new("JavaScriptRuntime.Map.NullKeySentinel", "immutable ABI sentinel"),
+        new("JavaScriptRuntime.Node.AsyncResourceObject.States", "weak-keyed async resource metadata"),
+        new("JavaScriptRuntime.Node.Buffer+Base64PassthroughEncoding.Instance", "stateless encoding singleton"),
+        new("JavaScriptRuntime.Node.Buffer+HexPassthroughEncoding.Instance", "stateless encoding singleton"),
+        new("JavaScriptRuntime.Node.BufferModule.StrictUtf8", "immutable encoding metadata"),
+        new("JavaScriptRuntime.Node.ChildProcess+StdioConfiguration.AsyncDefault", "immutable configuration"),
+        new("JavaScriptRuntime.Node.ChildProcess+StdioConfiguration.ForkDefault", "immutable configuration"),
+        new("JavaScriptRuntime.Node.ChildProcess+StdioConfiguration.IgnoreAll", "immutable configuration"),
+        new("JavaScriptRuntime.Node.ChildProcess+StdioConfiguration.InheritAll", "immutable configuration"),
+        new("JavaScriptRuntime.Node.ChildProcess+StdioConfiguration.SyncDefault", "immutable configuration"),
+        new("JavaScriptRuntime.Node.Events.ErrorMonitorSymbol", "immutable Node module symbol"),
+        new("JavaScriptRuntime.Node.FsEncodingOptions.Utf8NoBom", "immutable encoding metadata"),
+        new("JavaScriptRuntime.Node.NodeModuleRegistry.ContractsByName", "lazy frozen type metadata"),
+        new("JavaScriptRuntime.Node.NodeModuleRegistry.ModulesByName", "lazy frozen type metadata"),
+        new("JavaScriptRuntime.Node.Process._platform", "lazy immutable primitive metadata"),
+        new("JavaScriptRuntime.ObjectRuntime._encodedSymbolKeys", "weak-keyed symbol metadata"),
+        new("JavaScriptRuntime.ObjectRuntime._integrityStates", "weak-keyed object metadata"),
+        new("JavaScriptRuntime.PropertyDescriptorStore._defaultRuntimeStore", "thread-local context-less fallback"),
+        new("JavaScriptRuntime.PropertyDescriptorStore._intrinsicInitializationDepth", "thread-local bootstrap state"),
+        new("JavaScriptRuntime.PropertyDescriptorStore+DescriptorSnapshot.Empty", "immutable snapshot"),
+        new("JavaScriptRuntime.PropertyDescriptorStore+OverrideSnapshot.Empty", "immutable snapshot"),
+        new("JavaScriptRuntime.RuntimeExecutionContext.Ambient", "async-flow execution pointer"),
+        new("JavaScriptRuntime.RuntimeIntrinsics._blockedThreads", "transient bootstrap wait graph"),
+        new("JavaScriptRuntime.RuntimeIntrinsics._processDefaultGate", "process fallback synchronization"),
+        new("JavaScriptRuntime.RuntimeServices.EmptyScopes", "immutable ABI array"),
+        new("JavaScriptRuntime.RuntimeServices.TemporalDeadZoneSentinel", "immutable ABI sentinel"),
+        new("JavaScriptRuntime.RuntimeServices._currentArguments", "async-flow invocation state"),
+        new("JavaScriptRuntime.RuntimeServices._currentCallArguments", "async-flow invocation state"),
+        new("JavaScriptRuntime.RuntimeServices._currentCallee", "async-flow invocation state"),
+        new("JavaScriptRuntime.RuntimeServices._currentLexicalSuperReceiver", "async-flow invocation state"),
+        new("JavaScriptRuntime.RuntimeServices._currentLexicalSuperScopes", "async-flow invocation state"),
+        new("JavaScriptRuntime.RuntimeServices._currentNewTarget", "async-flow invocation state"),
+        new("JavaScriptRuntime.RuntimeServices._currentThis", "async-flow invocation state"),
+        new("JavaScriptRuntime.String.Latin1CharStrings", "immutable primitive lookup"),
+        new("JavaScriptRuntime.Symbol._asyncIterator", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.Symbol._hasInstance", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.Symbol._isConcatSpreadable", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.Symbol._iterator", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.Symbol._match", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.Symbol._matchAll", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.Symbol._replace", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.Symbol._search", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.Symbol._species", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.Symbol._split", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.Symbol._toPrimitive", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.Symbol._toStringTag", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.Symbol._unscopables", "ECMA-262 well-known symbol"),
+        new("JavaScriptRuntime.WeakSet._dummyValue", "immutable ABI sentinel"),
+        new("Jroc.Runtime.JsReturnConverter.ResultConversions", "weak-keyed CLR metadata"),
+    ];
+
+    private static readonly HashSet<Type> MutableReferenceContainerDefinitions =
+    [
+        typeof(Lazy<>),
+        typeof(AsyncLocal<>),
+        typeof(ThreadLocal<>),
+        typeof(ConditionalWeakTable<,>),
+        typeof(ConcurrentDictionary<,>),
+        typeof(Dictionary<,>),
+        typeof(HashSet<>),
+        typeof(List<>),
+        typeof(Queue<>),
+        typeof(Stack<>),
+    ];
+
+    [Fact]
+    public void WritableStaticsMatchTheApprovedOwnershipMatrix()
+    {
+        var actual = GetRuntimeStaticFields()
+            .Where(field => !field.IsLiteral && !field.IsInitOnly)
+            .Select(GetFieldName)
+            .Order(StringComparer.Ordinal);
+        var expected = ApprovedWritableStatics
+            .Select(item => item.Name)
+            .Order(StringComparer.Ordinal);
+
+        Assert.Equal(expected, actual);
+        Assert.All(
+            ApprovedWritableStatics,
+            item => Assert.False(string.IsNullOrWhiteSpace(item.Owner)));
+    }
+
+    [Fact]
+    public void ReadonlyReferenceStaticsMatchTheApprovedOwnershipMatrix()
+    {
+        var actual = GetRuntimeStaticFields()
+            .Where(field => field.IsInitOnly)
+            .Where(field => IsMutableReferenceCandidate(field.FieldType))
+            .Select(GetFieldName)
+            .Order(StringComparer.Ordinal);
+        var expected = ApprovedReadonlyReferenceStatics
+            .Select(item => item.Name)
+            .Order(StringComparer.Ordinal);
+
+        Assert.Equal(expected, actual);
+        Assert.All(
+            ApprovedReadonlyReferenceStatics,
+            item => Assert.False(string.IsNullOrWhiteSpace(item.Owner)));
+    }
+
+    [Fact]
+    public async Task ParallelRuntimeStressKeepsObservableStateIsolated()
+    {
+        for (var round = 0; round < StressRoundCount; round++)
+        {
+            using var ready = new Barrier(StressRuntimeCount);
+            var tasks = Enumerable.Range(0, StressRuntimeCount)
+                .Select(index => Task.Run(
+                    () => RunStressRuntime($"{round}:{index}", index, ready)))
+                .ToArray();
+
+            var results = await Task.WhenAll(tasks);
+
+            Assert.All(results, result =>
+            {
+                Assert.Equal(result.Id, result.GlobalValue);
+                Assert.Equal(result.Id, result.PrototypeValue);
+                Assert.Equal(result.Id, result.ImportMetaValue);
+                Assert.Equal(result.Id, result.RequireValue);
+                Assert.Equal(result.Id, result.MicrotaskThis);
+                Assert.Equal(result.Id, result.FsConstantsValue);
+                Assert.Equal(result.ExpectedDnsOrder, result.DnsOrder);
+                Assert.True(result.TimerRan);
+                Assert.True(result.ClusterDisposed);
+            });
+
+            for (var first = 0; first < results.Length; first++)
+            {
+                for (var second = first + 1; second < results.Length; second++)
+                {
+                    Assert.NotSame(results[first].Global, results[second].Global);
+                    Assert.NotSame(results[first].ObjectPrototype, results[second].ObjectPrototype);
+                    Assert.NotSame(results[first].ImportMeta, results[second].ImportMeta);
+                    Assert.NotSame(results[first].Template, results[second].Template);
+                    Assert.NotSame(results[first].RegisteredSymbol, results[second].RegisteredSymbol);
+                    Assert.NotSame(results[first].Scheduler, results[second].Scheduler);
+                    Assert.NotSame(results[first].AsyncContext, results[second].AsyncContext);
+                    Assert.NotSame(results[first].Dns, results[second].Dns);
+                    Assert.NotSame(results[first].FsConstants, results[second].FsConstants);
+                    Assert.NotSame(results[first].PathPosix, results[second].PathPosix);
+                    Assert.NotSame(results[first].PathWin32, results[second].PathWin32);
+                }
+            }
+        }
+
+        Assert.Null(RuntimeExecutionContext.Current);
+    }
+
+    [Fact]
+    public void DisposedRuntimeGraphsBecomeCollectible()
+    {
+        var references = CreateDisposedRuntimeGraphReferences();
+
+        CollectUntilDead(references);
+
+        Assert.All(references, reference => Assert.False(reference.IsAlive));
+    }
+
+    [Fact]
+    public void StaticMetadataCachesDoNotRetainCollectibleTypes()
+    {
+        var references = PopulateStaticMetadataCachesWithCollectibleType();
+
+        CollectUntilDead(references);
+
+        Assert.All(references, reference => Assert.False(reference.IsAlive));
+    }
+
+    [Fact]
+    public void EncodedSymbolMetadataDoesNotRetainUnusedSymbols()
+    {
+        var references = CreateEncodedSymbolReferences();
+
+        CollectUntilDead(references);
+
+        Assert.All(references, reference => Assert.False(reference.IsAlive));
+    }
+
+    private static StressResult RunStressRuntime(
+        string id,
+        int index,
+        Barrier ready)
+    {
+        StressResult result;
+        RuntimeAgentCluster cluster;
+
+        using (var lifecycle = RuntimeLifecycle.Create(
+            typeof(RuntimeStaticStateAuditTests).Assembly,
+            isHostedExecution: true,
+            suppressInheritedExecutionContext: true))
+        {
+            cluster = lifecycle.Cluster;
+            object? global = null;
+            object? objectPrototype = null;
+            object? importMeta = null;
+            object? template = null;
+            Symbol? registeredSymbol = null;
+            NodeSchedulerState? scheduler = null;
+            AsyncContextRuntime? asyncContext = null;
+            Dns? dns = null;
+            object? fsConstants = null;
+            object? pathPosix = null;
+            object? pathWin32 = null;
+            object? globalValue = null;
+            object? prototypeValue = null;
+            object? importMetaValue = null;
+            object? requireValue = null;
+            object? fsConstantsValue = null;
+            object? microtaskThis = null;
+            var timerRan = false;
+            var expectedDnsOrder = index % 2 == 0
+                ? "ipv4first"
+                : "ipv6first";
+            string? dnsOrder = null;
+
+            lifecycle.Execute(
+                services =>
+                {
+                    global = GlobalThis.globalThis;
+                    objectPrototype = GlobalThis.ObjectPrototypeValue;
+                    ObjectRuntime.SetProperty(global, "realmStress", id);
+                    ObjectRuntime.SetProperty(objectPrototype, "realmStress", id);
+
+                    importMeta = RuntimeServices.GetImportMeta("shared.js");
+                    ObjectRuntime.SetProperty(importMeta, "realmStress", id);
+                    RequireDelegate require = _ => id;
+                    RuntimeServices.RegisterModuleRequire("shared.js", require);
+
+                    template = RuntimeServices.CreateTemplateObject(
+                        "shared.js:1:1",
+                        [id],
+                        [id]);
+                    registeredSymbol = Assert.IsType<Symbol>(
+                        Symbol.@for("shared-runtime-symbol"));
+
+                    var requireService = services.Resolve<Require>();
+                    dns = Assert.IsType<Dns>(
+                        requireService.RequireModule("node:dns"));
+                    Assert.Same(
+                        dns,
+                        requireService.RequireModule("dns"));
+                    dns.setDefaultResultOrder(expectedDnsOrder);
+                    fsConstants = Assert.IsType<FS>(
+                        requireService.RequireModule("node:fs")).constants;
+                    ObjectRuntime.SetProperty(
+                        fsConstants,
+                        "realmStress",
+                        id);
+                    var path = Assert.IsType<JavaScriptRuntime.Node.Path>(
+                        requireService.RequireModule("node:path"));
+                    pathPosix = path.posix;
+                    pathWin32 = path.win32;
+
+                    scheduler = services.Resolve<NodeSchedulerState>();
+                    asyncContext = services.Resolve<AsyncContextRuntime>();
+                    RuntimeServices.SetCurrentThis(id);
+                    services.Resolve<IMicrotaskScheduler>()
+                        .QueueMicrotask(
+                            () => microtaskThis = RuntimeServices.GetCurrentThis());
+                    _ = services.Resolve<IScheduler>().Schedule(
+                        () => timerRan = true,
+                        TimeSpan.Zero);
+
+                    Assert.True(
+                        ready.SignalAndWait(TimeSpan.FromSeconds(10)));
+
+                    globalValue = ObjectRuntime.GetProperty(
+                        global,
+                        "realmStress");
+                    prototypeValue = ObjectRuntime.GetProperty(
+                        objectPrototype,
+                        "realmStress");
+                    importMetaValue = ObjectRuntime.GetProperty(
+                        importMeta,
+                        "realmStress");
+                    requireValue = RuntimeServices
+                        .GetRequireForModule("shared.js")!("ignored");
+                    fsConstantsValue = ObjectRuntime.GetProperty(
+                        fsConstants,
+                        "realmStress");
+                    dnsOrder = dns.getDefaultResultOrder();
+                },
+                waitForTimers: true);
+
+            result = new StressResult(
+                id,
+                global!,
+                objectPrototype!,
+                importMeta!,
+                template!,
+                registeredSymbol!,
+                scheduler!,
+                asyncContext!,
+                dns!,
+                fsConstants!,
+                pathPosix!,
+                pathWin32!,
+                globalValue,
+                prototypeValue,
+                importMetaValue,
+                requireValue,
+                fsConstantsValue,
+                microtaskThis,
+                timerRan,
+                expectedDnsOrder,
+                dnsOrder,
+                ClusterDisposed: false);
+        }
+
+        return result with { ClusterDisposed = cluster.IsDisposed };
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference[] CreateDisposedRuntimeGraphReferences()
+    {
+        WeakReference[] references;
+
+        using (var lifecycle = RuntimeLifecycle.Create(
+            typeof(RuntimeStaticStateAuditTests).Assembly,
+            isHostedExecution: true,
+            suppressInheritedExecutionContext: true))
+        {
+            object? global = null;
+            object? prototype = null;
+            object? template = null;
+            object? nodeModule = null;
+
+            lifecycle.Execute(
+                services =>
+                {
+                    global = GlobalThis.globalThis;
+                    prototype = GlobalThis.ObjectPrototypeValue;
+                    template = RuntimeServices.CreateTemplateObject(
+                        "collectible",
+                        ["value"],
+                        ["value"]);
+                    nodeModule = services.Resolve<Require>()
+                        .RequireModule("node:dns");
+                },
+                waitForTimers: false);
+
+            references =
+            [
+                new WeakReference(lifecycle.Cluster),
+                new WeakReference(lifecycle.Agent),
+                new WeakReference(lifecycle.Realm),
+                new WeakReference(global),
+                new WeakReference(prototype),
+                new WeakReference(template),
+                new WeakReference(nodeModule),
+            ];
+        }
+
+        return references;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference[] PopulateStaticMetadataCachesWithCollectibleType()
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName($"CollectibleStaticMetadata_{Guid.NewGuid():N}"),
+            AssemblyBuilderAccess.RunAndCollect);
+        var module = assembly.DefineDynamicModule("main");
+        var typeBuilder = module.DefineType("Generated.Scope");
+        _ = typeBuilder.DefineField(
+            "value",
+            typeof(object),
+            FieldAttributes.Public);
+        var collectibleType = typeBuilder.CreateType()!;
+        var scope = Activator.CreateInstance(collectibleType)!;
+        collectibleType.GetField("value")!.SetValue(scope, 1d);
+        var arguments = new ArgumentsObject(
+            [1d],
+            scope,
+            ["value"],
+            calleeValue: null);
+
+        Assert.Equal(1d, arguments["0"]);
+        arguments["0"] = 2d;
+        Assert.Equal(2d, collectibleType.GetField("value")!.GetValue(scope));
+        Assert.False(JsFuncDelegates.IsJsFuncDelegateType(collectibleType));
+
+        var runtime = (JsRuntimeInstance)RuntimeHelpers.GetUninitializedObject(
+            typeof(JsRuntimeInstance));
+        var taskType = typeof(Task<>).MakeGenericType(collectibleType);
+        _ = JsReturnConverter.ConvertReturn(runtime, null, taskType);
+
+        return
+        [
+            new WeakReference(scope),
+            new WeakReference(collectibleType),
+            new WeakReference(assembly),
+        ];
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference[] CreateEncodedSymbolReferences()
+    {
+        var symbol = new Symbol("collectible");
+        var encodedKey = ObjectRuntime.ToPropertyKeyString(symbol);
+
+        return
+        [
+            new WeakReference(symbol),
+            new WeakReference(encodedKey),
+        ];
+    }
+
+    private static void CollectUntilDead(IEnumerable<WeakReference> references)
+    {
+        var materialized = references.ToArray();
+        for (var attempt = 0;
+            attempt < 12 && materialized.Any(reference => reference.IsAlive);
+            attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+    }
+
+    private static IEnumerable<FieldInfo> GetRuntimeStaticFields()
+        => typeof(RuntimeServices).Assembly
+            .GetTypes()
+            .Where(type => type.FullName?.Contains(
+                '<',
+                StringComparison.Ordinal) != true)
+            .Where(type => !type.IsDefined(
+                typeof(CompilerGeneratedAttribute),
+                inherit: false))
+            .SelectMany(type => type.GetFields(
+                BindingFlags.Static
+                | BindingFlags.Public
+                | BindingFlags.NonPublic
+                | BindingFlags.DeclaredOnly))
+            .Where(field => !field.IsDefined(
+                typeof(CompilerGeneratedAttribute),
+                inherit: false));
+
+    private static string GetFieldName(FieldInfo field)
+        => $"{field.DeclaringType!.FullName}.{field.Name}";
+
+    private static bool IsMutableReferenceCandidate(Type fieldType)
+    {
+        var genericDefinition = fieldType.IsGenericType
+            ? fieldType.GetGenericTypeDefinition()
+            : null;
+
+        return fieldType.IsArray
+            || fieldType == typeof(object)
+            || fieldType == typeof(Random)
+            || fieldType == typeof(Regex)
+            || typeof(Encoding).IsAssignableFrom(fieldType)
+            || (genericDefinition != null
+                && MutableReferenceContainerDefinitions.Contains(
+                    genericDefinition))
+            || (fieldType.Assembly == typeof(RuntimeServices).Assembly
+                && fieldType.IsClass
+                && !typeof(Delegate).IsAssignableFrom(fieldType));
+    }
+
+    private sealed record ApprovedStatic(string Name, string Owner);
+
+    private sealed record StressResult(
+        string Id,
+        object Global,
+        object ObjectPrototype,
+        object ImportMeta,
+        object Template,
+        Symbol RegisteredSymbol,
+        NodeSchedulerState Scheduler,
+        AsyncContextRuntime AsyncContext,
+        Dns Dns,
+        object FsConstants,
+        object PathPosix,
+        object PathWin32,
+        object? GlobalValue,
+        object? PrototypeValue,
+        object? ImportMetaValue,
+        object? RequireValue,
+        object? FsConstantsValue,
+        object? MicrotaskThis,
+        bool TimerRan,
+        string ExpectedDnsOrder,
+        string? DnsOrder,
+        bool ClusterDisposed);
+}


### PR DESCRIPTION
## Summary

- add an executable ownership matrix for every writable runtime static and every readonly reference candidate
- migrate generated-type metadata and encoded symbol caches to weak-key ephemeron tables
- move `dns` default order, `fs.constants`, and `path.posix`/`path.win32` into realm-local Node module instances
- freeze process-wide discovery/delegate catalogs and remove the retained `Math.random` generator
- add repeated four-runtime isolation stress plus runtime-graph, symbol, and collectible-type reclamation gates
- document the final static-state rules and approved ownership exceptions

## Validation

- `dotnet build jroc.sln --no-restore` (zero warnings/errors)
- `MSBUILDDISABLENODEREUSE=1 dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore` (3,353 passed, 1 skipped)
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --no-restore` (6,312 passed, 58 skipped)
- changed-file whitespace verification with `dotnet format`

Closes #1829
