### PR TITLE
perf(string): migrate built-ins to explicit-receiver ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
   preserves custom `@@replace` dispatch ordering, and invokes functional
   replacements with the required match arguments. Empty global-RegExp matches
   retain the correct `lastIndex` for `matchAll` iteration.
+- perf(runtime): migrate `String.prototype` and String iterator built-ins to
+  the explicit-receiver ABI (issue #1889). Fixed arities zero through five no
+  longer publish ambient invocation state or allocate argument arrays,
+  `concat` retains a receiver-aware variadic path, trim aliases share their
+  canonical function objects, and the legacy `substr` surface is now exposed.
 - perf(runtime): add an internal explicit-receiver built-in ABI for fixed
   arities zero through five and a variadic fallback (issue #1888).
   Receiver-aware adapters now bypass ambient invocation state and invoke

--- a/src/JavaScriptRuntime/String.cs
+++ b/src/JavaScriptRuntime/String.cs
@@ -57,43 +57,44 @@ namespace JavaScriptRuntime
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
 
-            DefinePrototypeMethod(prototype, "at", (Func<object[], object?[]?, object?>)PrototypeAt, 1);
-            DefinePrototypeMethod(prototype, "charAt", (Func<object[], object?[]?, object?>)PrototypeCharAt, 1);
-            DefinePrototypeMethod(prototype, "charCodeAt", (Func<object[], object?[]?, object?>)PrototypeCharCodeAt, 1);
-            DefinePrototypeMethod(prototype, "codePointAt", (Func<object[], object?[]?, object?>)PrototypeCodePointAt, 1);
-            DefinePrototypeMethod(prototype, "concat", (Func<object[], object?[]?, object?>)PrototypeConcat, 1);
-            DefinePrototypeMethod(prototype, "endsWith", (Func<object[], object?[]?, object?>)PrototypeEndsWith, 1);
-            DefinePrototypeMethod(prototype, "includes", (Func<object[], object?[]?, object?>)PrototypeIncludes, 1);
-            DefinePrototypeMethod(prototype, "indexOf", (Func<object[], object?[]?, object?>)PrototypeIndexOf, 1);
-            DefinePrototypeMethod(prototype, "isWellFormed", (Func<object[], object?[]?, object?>)PrototypeIsWellFormed, 0);
-            DefinePrototypeMethod(prototype, "lastIndexOf", (Func<object[], object?[]?, object?>)PrototypeLastIndexOf, 1);
-            DefinePrototypeMethod(prototype, "localeCompare", (Func<object[], object?[]?, object?>)PrototypeLocaleCompare, 1);
-            DefinePrototypeMethod(prototype, "match", (Func<object[], object?[]?, object?>)PrototypeMatch, 1);
-            DefinePrototypeMethod(prototype, "matchAll", (Func<object[], object?[]?, object?>)PrototypeMatchAll, 1);
-            DefinePrototypeMethod(prototype, "normalize", (Func<object[], object?[]?, object?>)PrototypeNormalize, 0);
-            DefinePrototypeMethod(prototype, "padEnd", (Func<object[], object?[]?, object?>)PrototypePadEnd, 1);
-            DefinePrototypeMethod(prototype, "padStart", (Func<object[], object?[]?, object?>)PrototypePadStart, 1);
-            DefinePrototypeMethod(prototype, "repeat", (Func<object[], object?[]?, object?>)PrototypeRepeat, 1);
-            DefinePrototypeMethod(prototype, "replace", (Func<object[], object?[]?, object?>)PrototypeReplace, 2);
-            DefinePrototypeMethod(prototype, "replaceAll", (Func<object[], object?[]?, object?>)PrototypeReplaceAll, 2);
-            DefinePrototypeMethod(prototype, "search", (Func<object[], object?[]?, object?>)PrototypeSearch, 1);
-            DefinePrototypeMethod(prototype, "slice", (Func<object[], object?[]?, object?>)PrototypeSlice, 2);
-            DefinePrototypeMethod(prototype, "split", (Func<object[], object?[]?, object?>)PrototypeSplit, 2);
-            DefinePrototypeMethod(prototype, "startsWith", (Func<object[], object?[]?, object?>)PrototypeStartsWith, 1);
-            DefinePrototypeMethod(prototype, "substring", (Func<object[], object?[]?, object?>)PrototypeSubstring, 2);
-            DefinePrototypeMethod(prototype, "toLowerCase", (Func<object[], object?[]?, object?>)PrototypeToLowerCase, 0);
-            DefinePrototypeMethod(prototype, "toLocaleLowerCase", (Func<object[], object?[]?, object?>)PrototypeToLocaleLowerCase, 0);
-            DefinePrototypeMethod(prototype, "toLocaleUpperCase", (Func<object[], object?[]?, object?>)PrototypeToLocaleUpperCase, 0);
-            DefinePrototypeMethod(prototype, "toString", (Func<object[], object?[]?, object?>)PrototypeToString, 0);
-            DefinePrototypeMethod(prototype, "toUpperCase", (Func<object[], object?[]?, object?>)PrototypeToUpperCase, 0);
-            DefinePrototypeMethod(prototype, "toWellFormed", (Func<object[], object?[]?, object?>)PrototypeToWellFormed, 0);
-            DefinePrototypeMethod(prototype, "trim", (Func<object[], object?[]?, object?>)PrototypeTrim, 0);
-            DefinePrototypeMethod(prototype, "trimEnd", (Func<object[], object?[]?, object?>)PrototypeTrimEnd, 0);
-            DefinePrototypeMethod(prototype, "trimLeft", (Func<object[], object?[]?, object?>)((scopes, args) => PrototypeTrimStart(scopes, args)), 0);
-            DefinePrototypeMethod(prototype, "trimRight", (Func<object[], object?[]?, object?>)((scopes, args) => PrototypeTrimEnd(scopes, args)), 0);
-            DefinePrototypeMethod(prototype, "trimStart", (Func<object[], object?[]?, object?>)PrototypeTrimStart, 0);
-            DefinePrototypeMethod(prototype, "valueOf", (Func<object[], object?[]?, object?>)PrototypeValueOf, 0);
-            DefinePrototypeMethod(prototype, IteratorSymbolPropertyKey, (Func<object[], object?[]?, object?>)PrototypeIterator, 0, "[Symbol.iterator]");
+            DefinePrototypeMethod(prototype, "at", (BuiltinFunction1)PrototypeAt, 1);
+            DefinePrototypeMethod(prototype, "charAt", (BuiltinFunction1)PrototypeCharAt, 1);
+            DefinePrototypeMethod(prototype, "charCodeAt", (BuiltinFunction1)PrototypeCharCodeAt, 1);
+            DefinePrototypeMethod(prototype, "codePointAt", (BuiltinFunction1)PrototypeCodePointAt, 1);
+            DefinePrototypeMethod(prototype, "concat", (BuiltinFunctionVariadic)PrototypeConcat, 1);
+            DefinePrototypeMethod(prototype, "endsWith", (BuiltinFunction2)PrototypeEndsWith, 1);
+            DefinePrototypeMethod(prototype, "includes", (BuiltinFunction2)PrototypeIncludes, 1);
+            DefinePrototypeMethod(prototype, "indexOf", (BuiltinFunction2)PrototypeIndexOf, 1);
+            DefinePrototypeMethod(prototype, "isWellFormed", (BuiltinFunction0)PrototypeIsWellFormed, 0);
+            DefinePrototypeMethod(prototype, "lastIndexOf", (BuiltinFunction2)PrototypeLastIndexOf, 1);
+            DefinePrototypeMethod(prototype, "localeCompare", (BuiltinFunction3)PrototypeLocaleCompare, 1);
+            DefinePrototypeMethod(prototype, "match", (BuiltinFunction1)PrototypeMatch, 1);
+            DefinePrototypeMethod(prototype, "matchAll", (BuiltinFunction1)PrototypeMatchAll, 1);
+            DefinePrototypeMethod(prototype, "normalize", (BuiltinFunction1)PrototypeNormalize, 0);
+            DefinePrototypeMethod(prototype, "padEnd", (BuiltinFunction2)PrototypePadEnd, 1);
+            DefinePrototypeMethod(prototype, "padStart", (BuiltinFunction2)PrototypePadStart, 1);
+            DefinePrototypeMethod(prototype, "repeat", (BuiltinFunction1)PrototypeRepeat, 1);
+            DefinePrototypeMethod(prototype, "replace", (BuiltinFunction2)PrototypeReplace, 2);
+            DefinePrototypeMethod(prototype, "replaceAll", (BuiltinFunction2)PrototypeReplaceAll, 2);
+            DefinePrototypeMethod(prototype, "search", (BuiltinFunction1)PrototypeSearch, 1);
+            DefinePrototypeMethod(prototype, "slice", (BuiltinFunction2)PrototypeSlice, 2);
+            DefinePrototypeMethod(prototype, "split", (BuiltinFunction2)PrototypeSplit, 2);
+            DefinePrototypeMethod(prototype, "startsWith", (BuiltinFunction2)PrototypeStartsWith, 1);
+            DefinePrototypeMethod(prototype, "substr", (BuiltinFunction2)PrototypeSubstr, 2);
+            DefinePrototypeMethod(prototype, "substring", (BuiltinFunction2)PrototypeSubstring, 2);
+            DefinePrototypeMethod(prototype, "toLowerCase", (BuiltinFunction0)PrototypeToLowerCase, 0);
+            DefinePrototypeMethod(prototype, "toLocaleLowerCase", (BuiltinFunction0)PrototypeToLocaleLowerCase, 0);
+            DefinePrototypeMethod(prototype, "toLocaleUpperCase", (BuiltinFunction0)PrototypeToLocaleUpperCase, 0);
+            DefinePrototypeMethod(prototype, "toString", (BuiltinFunction0)PrototypeToString, 0);
+            DefinePrototypeMethod(prototype, "toUpperCase", (BuiltinFunction0)PrototypeToUpperCase, 0);
+            DefinePrototypeMethod(prototype, "toWellFormed", (BuiltinFunction0)PrototypeToWellFormed, 0);
+            DefinePrototypeMethod(prototype, "trim", (BuiltinFunction0)PrototypeTrim, 0);
+            DefinePrototypeMethod(prototype, "trimEnd", (BuiltinFunction0)PrototypeTrimEnd, 0);
+            DefinePrototypeMethod(prototype, "trimStart", (BuiltinFunction0)PrototypeTrimStart, 0);
+            DefinePrototypeAlias(prototype, "trimLeft", "trimStart");
+            DefinePrototypeAlias(prototype, "trimRight", "trimEnd");
+            DefinePrototypeMethod(prototype, "valueOf", (BuiltinFunction0)PrototypeValueOf, 0);
+            DefinePrototypeMethod(prototype, IteratorSymbolPropertyKey, (BuiltinFunction0)PrototypeIterator, 0, "[Symbol.iterator]");
             PropertyDescriptorStore.DefineOrUpdate(prototype, StringDataPropertyName, new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Data,
@@ -117,8 +118,8 @@ namespace JavaScriptRuntime
         {
             using var _ = PropertyDescriptorStore.BeginIntrinsicInitialization();
 
-            DefinePrototypeMethod(prototype, "next", (Func<object[], object?[]?, object?>)StringIteratorPrototypeNext, 0);
-            DefinePrototypeMethod(prototype, IteratorSymbolPropertyKey, (Func<object[], object?[]?, object?>)StringIteratorPrototypeIterator, 0, "[Symbol.iterator]");
+            DefinePrototypeMethod(prototype, "next", (BuiltinFunction0)StringIteratorPrototypeNext, 0);
+            DefinePrototypeMethod(prototype, IteratorSymbolPropertyKey, (BuiltinFunction0)StringIteratorPrototypeIterator, 0, "[Symbol.iterator]");
             PropertyDescriptorStore.DefineOrUpdate(prototype, ToStringTagSymbolPropertyKey, new JsPropertyDescriptor
             {
                 Kind = JsPropertyDescriptorKind.Data,
@@ -142,7 +143,10 @@ namespace JavaScriptRuntime
                 JavaScriptRuntime.Function.InitializeFunctionInstance(
                     builtinFunction,
                     length,
-                    functionName);
+                    functionName,
+                    requiresInvocationContext:
+                        !BuiltinFunctionDelegates.IsReceiverAware(
+                            builtinFunction.Target));
                 PropertyDescriptorStore.DefineOrUpdate(builtinFunction, "prototype", new JsPropertyDescriptor
                 {
                     Kind = JsPropertyDescriptorKind.Data,
@@ -160,6 +164,23 @@ namespace JavaScriptRuntime
                 Configurable = true,
                 Writable = true,
                 Value = value
+            });
+        }
+
+        private static void DefinePrototypeAlias(object target, string alias, string canonicalName)
+        {
+            if (!PropertyDescriptorStore.TryGetOwn(target, canonicalName, out var canonicalDescriptor))
+            {
+                throw new InvalidOperationException($"String.prototype.{canonicalName} is not initialized.");
+            }
+
+            PropertyDescriptorStore.DefineOrUpdate(target, alias, new JsPropertyDescriptor
+            {
+                Kind = JsPropertyDescriptorKind.Data,
+                Enumerable = false,
+                Configurable = true,
+                Writable = true,
+                Value = canonicalDescriptor.Value
             });
         }
 
@@ -593,148 +614,135 @@ namespace JavaScriptRuntime
             return builder.ToString();
         }
 
-        private static object? PrototypeAt(object[] scopes, object?[]? args)
-            => At(ThisStringValue(RuntimeServices.GetCurrentThis()), GetArg(args, 0));
+        private static object? PrototypeAt(object? thisArgument, object? index)
+            => At(ThisStringValue(thisArgument), index);
 
-        private static object? PrototypeCharAt(object[] scopes, object?[]? args)
+        private static object? PrototypeCharAt(object? thisArgument, object? index)
+            => CharAt(ThisStringValue(thisArgument), index);
+
+        private static object? PrototypeCharCodeAt(object? thisArgument, object? index)
+            => CharCodeAt(ThisStringValue(thisArgument), index);
+
+        private static object? PrototypeCodePointAt(object? thisArgument, object? index)
+            => CodePointAt(ThisStringValue(thisArgument), index);
+
+        private static object? PrototypeConcat(object? thisArgument, in JsCallArguments arguments)
         {
-            var input = ThisStringValue(RuntimeServices.GetCurrentThis());
-            return args == null || args.Length == 0 ? CharAt(input) : CharAt(input, args[0]);
+            var builder = new StringBuilder(ThisStringValue(thisArgument));
+            for (var index = 0; index < arguments.Count; index++)
+            {
+                var argument = arguments.GetArgument(index);
+                if (argument is Symbol)
+                {
+                    throw new TypeError("Cannot convert a Symbol value to a string");
+                }
+
+                builder.Append(DotNet2JSConversions.ToString(argument));
+            }
+
+            return builder.ToString();
         }
 
-        private static object? PrototypeCharCodeAt(object[] scopes, object?[]? args)
-        {
-            var input = ThisStringValue(RuntimeServices.GetCurrentThis());
-            return args == null || args.Length == 0 ? CharCodeAt(input) : CharCodeAt(input, args[0]);
-        }
+        private static object? PrototypeEndsWith(object? thisArgument, object? searchString, object? endPosition)
+            => EndsWith(ThisStringValue(thisArgument), searchString, endPosition);
 
-        private static object? PrototypeCodePointAt(object[] scopes, object?[]? args)
-            => CodePointAt(ThisStringValue(RuntimeServices.GetCurrentThis()), GetArg(args, 0));
+        private static object? PrototypeIncludes(object? thisArgument, object? searchString, object? position)
+            => IncludesDynamic(ThisStringValue(thisArgument), searchString, position);
 
-        private static object? PrototypeConcat(object[] scopes, object?[]? args)
-            => Concat(ThisStringValue(RuntimeServices.GetCurrentThis()), args ?? System.Array.Empty<object?>());
+        private static object? PrototypeIndexOf(object? thisArgument, object? searchString, object? position)
+            => IndexOfDynamic(ThisStringValue(thisArgument), searchString, position);
 
-        private static object? PrototypeEndsWith(object[] scopes, object?[]? args)
-        {
-            var input = ThisStringValue(RuntimeServices.GetCurrentThis());
-            return EndsWith(input, GetArg(args, 0), GetArg(args, 1));
-        }
+        private static object? PrototypeIsWellFormed(object? thisArgument)
+            => IsWellFormed(ThisStringValue(thisArgument));
 
-        private static object? PrototypeIncludes(object[] scopes, object?[]? args)
-        {
-            var input = ThisStringValue(RuntimeServices.GetCurrentThis());
-            return IncludesDynamic(input, GetArg(args, 0), GetArg(args, 1));
-        }
+        private static object? PrototypeIterator(object? thisArgument)
+            => CreateIterator(ThisStringValue(thisArgument));
 
-        private static object? PrototypeIndexOf(object[] scopes, object?[]? args)
-        {
-            var input = ThisStringValue(RuntimeServices.GetCurrentThis());
-            return IndexOfDynamic(input, GetArg(args, 0), GetArg(args, 1));
-        }
+        private static object? PrototypeLastIndexOf(object? thisArgument, object? searchString, object? position)
+            => LastIndexOfDynamic(ThisStringValue(thisArgument), searchString, position);
 
-        private static object? PrototypeIsWellFormed(object[] scopes, object?[]? args)
-            => IsWellFormed(ThisStringValue(RuntimeServices.GetCurrentThis()));
+        private static object? PrototypeLocaleCompare(
+            object? thisArgument,
+            object? compareString,
+            object? locales,
+            object? options)
+            => LocaleCompare(
+                ThisStringValue(thisArgument),
+                DotNet2JSConversions.ToString(compareString),
+                locales,
+                options);
 
-        private static object? PrototypeIterator(object[] scopes, object?[]? args)
-            => CreateIterator(ThisStringValue(RuntimeServices.GetCurrentThis()));
+        private static object? PrototypeMatch(object? thisArgument, object? regexp)
+            => Match(ThisStringValue(thisArgument), regexp);
 
-        private static object? PrototypeLastIndexOf(object[] scopes, object?[]? args)
-        {
-            var input = ThisStringValue(RuntimeServices.GetCurrentThis());
-            return LastIndexOfDynamic(input, GetArg(args, 0), GetArg(args, 1));
-        }
+        private static object? PrototypeMatchAll(object? thisArgument, object? regexp)
+            => MatchAll(ThisStringValue(thisArgument), regexp);
 
-        private static object? PrototypeLocaleCompare(object[] scopes, object?[]? args)
-        {
-            var input = ThisStringValue(RuntimeServices.GetCurrentThis());
-            var other = DotNet2JSConversions.ToString(GetArg(args, 0));
-            return LocaleCompare(input, other, GetArg(args, 1), GetArg(args, 2));
-        }
+        private static object? PrototypeNormalize(object? thisArgument, object? form)
+            => Normalize(ThisStringValue(thisArgument), form);
 
-        private static object? PrototypeMatch(object[] scopes, object?[]? args)
-            => Match(ThisStringValue(RuntimeServices.GetCurrentThis()), GetArg(args, 0));
+        private static object? PrototypePadEnd(object? thisArgument, object? maxLength, object? fillString)
+            => PadEnd(ThisStringValue(thisArgument), maxLength, fillString);
 
-        private static object? PrototypeMatchAll(object[] scopes, object?[]? args)
-            => MatchAll(ThisStringValue(RuntimeServices.GetCurrentThis()), GetArg(args, 0));
+        private static object? PrototypePadStart(object? thisArgument, object? maxLength, object? fillString)
+            => PadStart(ThisStringValue(thisArgument), maxLength, fillString);
 
-        private static object? PrototypeNormalize(object[] scopes, object?[]? args)
-            => Normalize(ThisStringValue(RuntimeServices.GetCurrentThis()), GetArg(args, 0));
+        private static object? PrototypeRepeat(object? thisArgument, object? count)
+            => Repeat(ThisStringValue(thisArgument), count);
 
-        private static object? PrototypePadEnd(object[] scopes, object?[]? args)
-            => PadEnd(ThisStringValue(RuntimeServices.GetCurrentThis()), GetArg(args, 0), GetArg(args, 1));
+        private static object? PrototypeReplace(object? thisArgument, object? searchValue, object? replaceValue)
+            => Replace(ThisStringValue(thisArgument), searchValue, replaceValue);
 
-        private static object? PrototypePadStart(object[] scopes, object?[]? args)
-            => PadStart(ThisStringValue(RuntimeServices.GetCurrentThis()), GetArg(args, 0), GetArg(args, 1));
+        private static object? PrototypeReplaceAll(object? thisArgument, object? searchValue, object? replaceValue)
+            => ReplaceAll(thisArgument, searchValue, replaceValue);
 
-        private static object? PrototypeRepeat(object[] scopes, object?[]? args)
-            => Repeat(ThisStringValue(RuntimeServices.GetCurrentThis()), GetArg(args, 0));
+        private static object? PrototypeSearch(object? thisArgument, object? regexp)
+            => Search(ThisStringValue(thisArgument), regexp);
 
-        private static object? PrototypeReplace(object[] scopes, object?[]? args)
-            => Replace(ThisStringValue(RuntimeServices.GetCurrentThis()), GetArg(args, 0), GetArg(args, 1));
+        private static object? PrototypeSlice(object? thisArgument, object? start, object? end)
+            => Slice(ThisStringValue(thisArgument), start, end);
 
-        private static object? PrototypeReplaceAll(object[] scopes, object?[]? args)
-            => ReplaceAll(RuntimeServices.GetCurrentThis(), GetArg(args, 0), GetArg(args, 1));
+        private static object? PrototypeSplit(object? thisArgument, object? separator, object? limit)
+            => Split(ThisStringValue(thisArgument), separator, limit);
 
-        private static object? PrototypeSearch(object[] scopes, object?[]? args)
-            => Search(ThisStringValue(RuntimeServices.GetCurrentThis()), GetArg(args, 0));
+        private static object? PrototypeStartsWith(object? thisArgument, object? searchString, object? position)
+            => StartsWith(ThisStringValue(thisArgument), searchString, position);
 
-        private static object? PrototypeSlice(object[] scopes, object?[]? args)
-        {
-            var input = ThisStringValue(RuntimeServices.GetCurrentThis());
-            return args == null || args.Length < 2
-                ? Slice(input, GetArg(args, 0))
-                : Slice(input, GetArg(args, 0), args[1]);
-        }
+        private static object? PrototypeSubstr(object? thisArgument, object? start, object? length)
+            => Substr(ThisStringValue(thisArgument), start, length);
 
-        private static object? PrototypeSplit(object[] scopes, object?[]? args)
-        {
-            var input = ThisStringValue(RuntimeServices.GetCurrentThis());
-            return Split(input, GetArg(args, 0), GetArg(args, 1));
-        }
+        private static object? PrototypeSubstring(object? thisArgument, object? start, object? end)
+            => Substring(ThisStringValue(thisArgument), start, end);
 
-        private static object? PrototypeStartsWith(object[] scopes, object?[]? args)
-        {
-            var input = ThisStringValue(RuntimeServices.GetCurrentThis());
-            return StartsWith(input, GetArg(args, 0), GetArg(args, 1));
-        }
+        private static object? PrototypeToLowerCase(object? thisArgument)
+            => ToLowerCase(ThisStringValue(thisArgument));
 
-        private static object? PrototypeSubstring(object[] scopes, object?[]? args)
-        {
-            var input = ThisStringValue(RuntimeServices.GetCurrentThis());
-            return args == null || args.Length < 2
-                ? Substring(input, GetArg(args, 0))
-                : Substring(input, GetArg(args, 0), args[1]);
-        }
+        private static object? PrototypeToLocaleLowerCase(object? thisArgument)
+            => ToLocaleLowerCase(ThisStringValue(thisArgument));
 
-        private static object? PrototypeToLowerCase(object[] scopes, object?[]? args)
-            => ToLowerCase(ThisStringValue(RuntimeServices.GetCurrentThis()));
+        private static object? PrototypeToLocaleUpperCase(object? thisArgument)
+            => ToLocaleUpperCase(ThisStringValue(thisArgument));
 
-        private static object? PrototypeToLocaleLowerCase(object[] scopes, object?[]? args)
-            => ToLocaleLowerCase(ThisStringValue(RuntimeServices.GetCurrentThis()));
+        private static object? PrototypeToString(object? thisArgument)
+            => ThisStringValue(thisArgument);
 
-        private static object? PrototypeToLocaleUpperCase(object[] scopes, object?[]? args)
-            => ToLocaleUpperCase(ThisStringValue(RuntimeServices.GetCurrentThis()));
+        private static object? PrototypeToUpperCase(object? thisArgument)
+            => ToUpperCase(ThisStringValue(thisArgument));
 
-        private static object? PrototypeToString(object[] scopes, object?[]? args)
-            => ThisStringValue(RuntimeServices.GetCurrentThis());
+        private static object? PrototypeToWellFormed(object? thisArgument)
+            => ToWellFormed(ThisStringValue(thisArgument));
 
-        private static object? PrototypeToUpperCase(object[] scopes, object?[]? args)
-            => ToUpperCase(ThisStringValue(RuntimeServices.GetCurrentThis()));
+        private static object? PrototypeTrim(object? thisArgument)
+            => Trim(ThisStringValue(thisArgument));
 
-        private static object? PrototypeToWellFormed(object[] scopes, object?[]? args)
-            => ToWellFormed(ThisStringValue(RuntimeServices.GetCurrentThis()));
+        private static object? PrototypeTrimEnd(object? thisArgument)
+            => TrimEnd(ThisStringValue(thisArgument));
 
-        private static object? PrototypeTrim(object[] scopes, object?[]? args)
-            => Trim(ThisStringValue(RuntimeServices.GetCurrentThis()));
+        private static object? PrototypeTrimStart(object? thisArgument)
+            => TrimStart(ThisStringValue(thisArgument));
 
-        private static object? PrototypeTrimEnd(object[] scopes, object?[]? args)
-            => TrimEnd(ThisStringValue(RuntimeServices.GetCurrentThis()));
-
-        private static object? PrototypeTrimStart(object[] scopes, object?[]? args)
-            => TrimStart(ThisStringValue(RuntimeServices.GetCurrentThis()));
-
-        private static object? PrototypeValueOf(object[] scopes, object?[]? args)
-            => ThisStringValue(RuntimeServices.GetCurrentThis());
+        private static object? PrototypeValueOf(object? thisArgument)
+            => ThisStringValue(thisArgument);
 
         private static object? ConstructorFromCharCode(object[] scopes, object?[]? args)
             => FromCharCode(args);
@@ -751,12 +759,12 @@ namespace JavaScriptRuntime
             return Raw(template, substitutions);
         }
 
-        private static object? StringIteratorPrototypeIterator(object[] scopes, object?[]? args)
-            => RuntimeServices.GetCurrentThis();
+        private static object? StringIteratorPrototypeIterator(object? thisArgument)
+            => thisArgument;
 
-        private static object? StringIteratorPrototypeNext(object[] scopes, object?[]? args)
+        private static object? StringIteratorPrototypeNext(object? thisArgument)
         {
-            var iterator = RuntimeServices.GetCurrentThis() as PublicStringIterator
+            var iterator = thisArgument as PublicStringIterator
                 ?? throw new TypeError("String Iterator.prototype.next called on incompatible receiver");
             return iterator.next();
         }

--- a/tests/Jroc.Tests/String/BuiltinAdapterRuntimeTests.cs
+++ b/tests/Jroc.Tests/String/BuiltinAdapterRuntimeTests.cs
@@ -1,0 +1,173 @@
+using JavaScriptRuntime;
+using JavaScriptRuntime.DependencyInjection;
+
+namespace Jroc.Tests.String;
+
+public sealed class BuiltinAdapterRuntimeTests
+{
+    private static readonly string[] PrototypeMethodNames =
+    [
+        "at",
+        "charAt",
+        "charCodeAt",
+        "codePointAt",
+        "concat",
+        "endsWith",
+        "includes",
+        "indexOf",
+        "isWellFormed",
+        "lastIndexOf",
+        "localeCompare",
+        "match",
+        "matchAll",
+        "normalize",
+        "padEnd",
+        "padStart",
+        "repeat",
+        "replace",
+        "replaceAll",
+        "search",
+        "slice",
+        "split",
+        "startsWith",
+        "substr",
+        "substring",
+        "toLowerCase",
+        "toLocaleLowerCase",
+        "toLocaleUpperCase",
+        "toString",
+        "toUpperCase",
+        "toWellFormed",
+        "trim",
+        "trimEnd",
+        "trimLeft",
+        "trimRight",
+        "trimStart",
+        "valueOf",
+        Symbol.iterator.DebugId
+    ];
+
+    [Fact]
+    public void StringPrototypeMethodsUseReceiverAwareAdapters()
+    {
+        WithRealm(() =>
+        {
+            foreach (var methodName in PrototypeMethodNames)
+            {
+                var adapter = Assert.IsType<BuiltinDelegateFunctionAdapter>(
+                    ObjectRuntime.GetItem(JavaScriptRuntime.String.Prototype, methodName));
+
+                Assert.True(BuiltinFunctionDelegates.IsReceiverAware(adapter.Target), methodName);
+                Assert.False(adapter.RequiresInvocationContext, methodName);
+            }
+
+            var concat = Assert.IsType<BuiltinDelegateFunctionAdapter>(
+                ObjectRuntime.GetItem(JavaScriptRuntime.String.Prototype, "concat"));
+            Assert.IsType<BuiltinFunctionVariadic>(concat.Target);
+
+            var iteratorNext = Assert.IsType<BuiltinDelegateFunctionAdapter>(
+                ObjectRuntime.GetItem(JavaScriptRuntime.String.StringIteratorPrototype, "next"));
+            var iteratorSelf = Assert.IsType<BuiltinDelegateFunctionAdapter>(
+                ObjectRuntime.GetItem(
+                    JavaScriptRuntime.String.StringIteratorPrototype,
+                    Symbol.iterator.DebugId));
+            Assert.False(iteratorNext.RequiresInvocationContext);
+            Assert.False(iteratorSelf.RequiresInvocationContext);
+        });
+    }
+
+    [Fact]
+    public void StringPrototypeAliasesShareTheirCanonicalAdapters()
+    {
+        WithRealm(() =>
+        {
+            Assert.Same(
+                ObjectRuntime.GetItem(JavaScriptRuntime.String.Prototype, "trimStart"),
+                ObjectRuntime.GetItem(JavaScriptRuntime.String.Prototype, "trimLeft"));
+            Assert.Same(
+                ObjectRuntime.GetItem(JavaScriptRuntime.String.Prototype, "trimEnd"),
+                ObjectRuntime.GetItem(JavaScriptRuntime.String.Prototype, "trimRight"));
+        });
+    }
+
+    [Fact]
+    public void StringPrototypeCommonAritiesAllocateNoInvocationState()
+    {
+        WithRealm(() =>
+        {
+            const string receiver = "abc";
+            object argument = 1d;
+            var trim = Assert.IsType<BuiltinDelegateFunctionAdapter>(
+                ObjectRuntime.GetItem(JavaScriptRuntime.String.Prototype, "trim"));
+
+            for (var index = 0; index < 1_000; index++)
+            {
+                InvokeTrim(index % 6);
+            }
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            object? result = null;
+            for (var index = 0; index < 10_000; index++)
+            {
+                for (var arity = 0; arity <= 5; arity++)
+                {
+                    result = InvokeTrim(arity);
+                }
+            }
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.Same(receiver, result);
+            Assert.Equal(0, allocated);
+
+            object? InvokeTrim(int arity)
+                => arity switch
+                {
+                    0 => CallableOperations.Call0(trim, receiver),
+                    1 => CallableOperations.Call1(trim, receiver, argument),
+                    2 => CallableOperations.Call2(trim, receiver, argument, argument),
+                    3 => CallableOperations.Call3(trim, receiver, argument, argument, argument),
+                    4 => CallableOperations.Call4(trim, receiver, argument, argument, argument, argument),
+                    5 => CallableOperations.Call5(trim, receiver, argument, argument, argument, argument, argument),
+                    _ => throw new ArgumentOutOfRangeException(nameof(arity))
+                };
+        });
+    }
+
+    [Fact]
+    public void StringPrototypeAdapterCanBeCalledFromAnotherRealm()
+    {
+        var firstRealmSlice = WithRealm(
+            () => ObjectRuntime.GetItem(JavaScriptRuntime.String.Prototype, "slice")!);
+
+        var result = WithRealm(() =>
+        {
+            var secondRealmSlice =
+                ObjectRuntime.GetItem(JavaScriptRuntime.String.Prototype, "slice");
+            Assert.NotSame(firstRealmSlice, secondRealmSlice);
+
+            return CallableOperations.Call2(
+                firstRealmSlice,
+                "abcdef",
+                1d,
+                4d);
+        });
+
+        Assert.Equal("bcd", result);
+    }
+
+    private static T WithRealm<T>(Func<T> body)
+    {
+        var context = RuntimeExecutionContext.GetOrCreate(
+            RuntimeServices.BuildServiceProvider());
+        using var scope = context.EnterAsRoot();
+        return body();
+    }
+
+    private static void WithRealm(Action body)
+        => WithRealm(
+            () =>
+            {
+                body();
+                return true;
+            });
+}

--- a/tests/Jroc.Tests/String/ExecutionTests.cs
+++ b/tests/Jroc.Tests/String/ExecutionTests.cs
@@ -222,6 +222,12 @@ namespace Jroc.Tests.String
         }
 
         [Fact]
+        public Task String_ExplicitReceiverAbi()
+        {
+            return ExecutionTest(nameof(String_ExplicitReceiverAbi));
+        }
+
+        [Fact]
         public Task String_Repeat_Basic()
         {
             return ExecutionTest(nameof(String_Repeat_Basic));

--- a/tests/Jroc.Tests/String/GeneratorTests.cs
+++ b/tests/Jroc.Tests/String/GeneratorTests.cs
@@ -244,6 +244,13 @@ namespace Jroc.Tests.String
         }
 
         [Fact]
+        public Task String_ExplicitReceiverAbi()
+        {
+            var testName = nameof(String_ExplicitReceiverAbi);
+            return GenerateTest(testName);
+        }
+
+        [Fact]
         public Task String_Repeat_Basic()
         {
             var testName = nameof(String_Repeat_Basic);

--- a/tests/Jroc.Tests/String/JavaScript/String_ExplicitReceiverAbi.js
+++ b/tests/Jroc.Tests/String/JavaScript/String_ExplicitReceiverAbi.js
@@ -1,0 +1,23 @@
+"use strict";
+
+console.log(String.prototype.slice.call("abcdef", 1, 4));
+console.log(String.prototype.toUpperCase.call(new String("mixed")));
+console.log(String.prototype.startsWith.call(12345, "23"));
+console.log(String.prototype.endsWith.apply("abcdef", ["de", 5]));
+console.log(String.prototype.concat.call("a", "b", "c", "d", "e", "f", "g"));
+console.log("abcdef".substr(-3, 2));
+console.log(String.prototype.trimLeft === String.prototype.trimStart);
+console.log(String.prototype.trimRight === String.prototype.trimEnd);
+
+try {
+    String.prototype.trim.call(null);
+} catch (error) {
+    console.log(error instanceof TypeError);
+}
+
+var originalSlice = String.prototype.slice;
+String.prototype.slice = function () {
+    return "overridden";
+};
+console.log("abcdef".slice(1, 4));
+String.prototype.slice = originalSlice;

--- a/tests/Jroc.Tests/String/Snapshots/ExecutionTests.String_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/ExecutionTests.String_ExplicitReceiverAbi.verified.txt
@@ -1,0 +1,10 @@
+﻿bcd
+MIXED
+false
+true
+abcdefg
+de
+true
+true
+true
+overridden

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ExplicitReceiverAbi.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_ExplicitReceiverAbi.verified.txt
@@ -1,0 +1,633 @@
+﻿// IL code: String_ExplicitReceiverAbi
+.class private auto ansi '<Module>'
+{
+} // end of class <Module>
+
+.class private auto ansi beforefieldinit Modules.String_ExplicitReceiverAbi
+	extends [System.Runtime]System.Object
+{
+	// Nested Types
+	.class nested public auto ansi abstract sealed beforefieldinit FunctionExpression_L19C25
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Scope
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Scope::.ctor
+
+		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject::ConstructCore
+
+		} // end of class FunctionObject
+
+
+		// Methods
+		.method public hidebysig static 
+			object __js_call__ (
+				object newTarget
+			) cil managed 
+		{
+			.custom instance void [JavaScriptRuntime]Jroc.Runtime.JsCallableScopeAbiAttribute::.ctor(valuetype [JavaScriptRuntime]Jroc.Runtime.CallableScopeAbiKind) = (
+				01 00 00 00 00 00 00 00
+			)
+			// Header size: 1
+			// Code size: 6 (0x6)
+			.maxstack 8
+
+			IL_0000: ldstr "overridden"
+			IL_0005: ret
+		} // end of method FunctionExpression_L19C25::__js_call__
+
+	} // end of class FunctionExpression_L19C25
+
+	.class nested public auto ansi beforefieldinit Scope
+		extends [System.Runtime]System.Object
+	{
+		// Nested Types
+		.class nested public auto ansi beforefieldinit Block_L12C4
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L12C4::.ctor
+
+		} // end of class Block_L12C4
+
+		.class nested public auto ansi beforefieldinit Block_L14C16
+			extends [System.Runtime]System.Object
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Header size: 1
+				// Code size: 8 (0x8)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+				IL_0006: nop
+				IL_0007: ret
+			} // end of method Block_L14C16::.ctor
+
+		} // end of class Block_L14C16
+
+
+		// Methods
+		.method public hidebysig specialname rtspecialname 
+			instance void .ctor () cil managed 
+		{
+			// Header size: 1
+			// Code size: 8 (0x8)
+			.maxstack 8
+
+			IL_0000: ldarg.0
+			IL_0001: call instance void [System.Runtime]System.Object::.ctor()
+			IL_0006: nop
+			IL_0007: ret
+		} // end of method Scope::.ctor
+
+	} // end of class Scope
+
+
+	// Methods
+	.method public hidebysig static 
+		void __js_module_init__ (
+			object exports,
+			class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate require,
+			object module,
+			string __filename,
+			string __dirname
+		) cil managed 
+	{
+		// Header size: 12
+		// Code size: 1221 (0x4c5)
+		.maxstack 8
+		.locals init (
+			[0] class Modules.String_ExplicitReceiverAbi/Scope,
+			[1] class [System.Runtime]System.Exception,
+			[2] object,
+			[3] object,
+			[4] object,
+			[5] object,
+			[6] class [JavaScriptRuntime]JavaScriptRuntime.Console,
+			[7] object,
+			[8] object,
+			[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
+			[10] float64,
+			[11] object,
+			[12] bool,
+			[13] object,
+			[14] object[],
+			[15] class Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25/FunctionObject
+		)
+
+		IL_0000: newobj instance void Modules.String_ExplicitReceiverAbi/Scope::.ctor()
+		IL_0005: stloc.0
+		IL_0006: nop
+		IL_0007: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_000c: stloc.s 6
+		IL_000e: ldstr "String"
+		IL_0013: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0018: ldstr "prototype"
+		IL_001d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0022: stloc.s 7
+		IL_0024: ldloc.s 7
+		IL_0026: ldstr "slice"
+		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0030: stloc.s 7
+		IL_0032: ldloc.s 7
+		IL_0034: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0039: ldstr "call"
+		IL_003e: ldstr "abcdef"
+		IL_0043: ldc.r8 1
+		IL_004c: box [System.Runtime]System.Double
+		IL_0051: ldc.r8 4
+		IL_005a: box [System.Runtime]System.Double
+		IL_005f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember3(object, string, object, object, object)
+		IL_0064: stloc.s 7
+		IL_0066: ldloc.s 6
+		IL_0068: ldloc.s 7
+		IL_006a: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_006f: pop
+		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0075: stloc.s 6
+		IL_0077: ldstr "String"
+		IL_007c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0081: ldstr "prototype"
+		IL_0086: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_008b: stloc.s 7
+		IL_008d: ldloc.s 7
+		IL_008f: ldstr "toUpperCase"
+		IL_0094: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0099: stloc.s 7
+		IL_009b: ldloc.s 7
+		IL_009d: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_00a2: stloc.s 7
+		IL_00a4: ldstr "String"
+		IL_00a9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ae: stloc.s 8
+		IL_00b0: ldloc.s 8
+		IL_00b2: dup
+		IL_00b3: ldstr "mixed"
+		IL_00b8: call object [JavaScriptRuntime]JavaScriptRuntime.CallableOperations::Construct1(object, object, object)
+		IL_00bd: stloc.s 8
+		IL_00bf: ldloc.s 7
+		IL_00c1: ldstr "call"
+		IL_00c6: ldloc.s 8
+		IL_00c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+		IL_00cd: stloc.s 8
+		IL_00cf: ldloc.s 6
+		IL_00d1: ldloc.s 8
+		IL_00d3: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_00d8: pop
+		IL_00d9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_00de: stloc.s 6
+		IL_00e0: ldstr "String"
+		IL_00e5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_00ea: ldstr "prototype"
+		IL_00ef: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_00f4: stloc.s 8
+		IL_00f6: ldloc.s 8
+		IL_00f8: ldstr "startsWith"
+		IL_00fd: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0102: stloc.s 8
+		IL_0104: ldloc.s 8
+		IL_0106: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_010b: ldstr "call"
+		IL_0110: ldc.r8 12345
+		IL_0119: box [System.Runtime]System.Double
+		IL_011e: ldstr "23"
+		IL_0123: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0128: stloc.s 8
+		IL_012a: ldloc.s 6
+		IL_012c: ldloc.s 8
+		IL_012e: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0133: pop
+		IL_0134: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0139: stloc.s 6
+		IL_013b: ldstr "String"
+		IL_0140: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0145: ldstr "prototype"
+		IL_014a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_014f: stloc.s 8
+		IL_0151: ldloc.s 8
+		IL_0153: ldstr "endsWith"
+		IL_0158: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_015d: stloc.s 8
+		IL_015f: ldloc.s 8
+		IL_0161: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_0166: ldc.i4.2
+		IL_0167: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Array::.ctor(int32)
+		IL_016c: dup
+		IL_016d: ldstr "de"
+		IL_0172: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::Add(object)
+		IL_0177: dup
+		IL_0178: ldc.r8 5
+		IL_0181: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Array::AddNumber(float64)
+		IL_0186: stloc.s 9
+		IL_0188: ldstr "apply"
+		IL_018d: ldstr "abcdef"
+		IL_0192: ldloc.s 9
+		IL_0194: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0199: stloc.s 8
+		IL_019b: ldloc.s 6
+		IL_019d: ldloc.s 8
+		IL_019f: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_01a4: pop
+		IL_01a5: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_01aa: stloc.s 6
+		IL_01ac: ldstr "String"
+		IL_01b1: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_01b6: ldstr "prototype"
+		IL_01bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01c0: stloc.s 8
+		IL_01c2: ldloc.s 8
+		IL_01c4: ldstr "concat"
+		IL_01c9: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_01ce: stloc.s 8
+		IL_01d0: ldloc.s 8
+		IL_01d2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+		IL_01d7: ldstr "call"
+		IL_01dc: ldc.i4.7
+		IL_01dd: newarr [System.Runtime]System.Object
+		IL_01e2: dup
+		IL_01e3: ldc.i4.0
+		IL_01e4: ldstr "a"
+		IL_01e9: stelem.ref
+		IL_01ea: dup
+		IL_01eb: ldc.i4.1
+		IL_01ec: ldstr "b"
+		IL_01f1: stelem.ref
+		IL_01f2: dup
+		IL_01f3: ldc.i4.2
+		IL_01f4: ldstr "c"
+		IL_01f9: stelem.ref
+		IL_01fa: dup
+		IL_01fb: ldc.i4.3
+		IL_01fc: ldstr "d"
+		IL_0201: stelem.ref
+		IL_0202: dup
+		IL_0203: ldc.i4.4
+		IL_0204: ldstr "e"
+		IL_0209: stelem.ref
+		IL_020a: dup
+		IL_020b: ldc.i4.5
+		IL_020c: ldstr "f"
+		IL_0211: stelem.ref
+		IL_0212: dup
+		IL_0213: ldc.i4.6
+		IL_0214: ldstr "g"
+		IL_0219: stelem.ref
+		IL_021a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember(object, string, object[])
+		IL_021f: stloc.s 8
+		IL_0221: ldloc.s 6
+		IL_0223: ldloc.s 8
+		IL_0225: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_022a: pop
+		IL_022b: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0230: stloc.s 6
+		IL_0232: ldc.r8 3
+		IL_023b: neg
+		IL_023c: stloc.s 10
+		IL_023e: ldloc.s 10
+		IL_0240: box [System.Runtime]System.Double
+		IL_0245: stloc.s 11
+		IL_0247: ldstr "abcdef"
+		IL_024c: ldstr "substr"
+		IL_0251: ldloc.s 11
+		IL_0253: ldc.r8 2
+		IL_025c: box [System.Runtime]System.Double
+		IL_0261: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_0266: stloc.s 8
+		IL_0268: ldloc.s 6
+		IL_026a: ldloc.s 8
+		IL_026c: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_0271: pop
+		IL_0272: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0277: stloc.s 6
+		IL_0279: ldstr "String"
+		IL_027e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0283: ldstr "prototype"
+		IL_0288: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_028d: stloc.s 8
+		IL_028f: ldloc.s 8
+		IL_0291: ldstr "trimLeft"
+		IL_0296: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_029b: stloc.s 8
+		IL_029d: ldstr "String"
+		IL_02a2: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02a7: ldstr "prototype"
+		IL_02ac: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02b1: stloc.s 7
+		IL_02b3: ldloc.s 7
+		IL_02b5: ldstr "trimStart"
+		IL_02ba: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02bf: stloc.s 7
+		IL_02c1: ldloc.s 8
+		IL_02c3: ldloc.s 7
+		IL_02c5: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_02ca: stloc.s 12
+		IL_02cc: ldloc.s 12
+		IL_02ce: box [System.Runtime]System.Boolean
+		IL_02d3: stloc.s 13
+		IL_02d5: ldloc.s 6
+		IL_02d7: ldloc.s 13
+		IL_02d9: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_02de: pop
+		IL_02df: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_02e4: stloc.s 6
+		IL_02e6: ldstr "String"
+		IL_02eb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_02f0: ldstr "prototype"
+		IL_02f5: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_02fa: stloc.s 7
+		IL_02fc: ldloc.s 7
+		IL_02fe: ldstr "trimRight"
+		IL_0303: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0308: stloc.s 7
+		IL_030a: ldstr "String"
+		IL_030f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0314: ldstr "prototype"
+		IL_0319: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_031e: stloc.s 8
+		IL_0320: ldloc.s 8
+		IL_0322: ldstr "trimEnd"
+		IL_0327: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_032c: stloc.s 8
+		IL_032e: ldloc.s 7
+		IL_0330: ldloc.s 8
+		IL_0332: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::StrictEqual(object, object)
+		IL_0337: stloc.s 12
+		IL_0339: ldloc.s 12
+		IL_033b: box [System.Runtime]System.Boolean
+		IL_0340: stloc.s 13
+		IL_0342: ldloc.s 6
+		IL_0344: ldloc.s 13
+		IL_0346: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_034b: pop
+		.try
+		{
+			IL_034c: nop
+			IL_034d: ldstr "String"
+			IL_0352: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_0357: ldstr "prototype"
+			IL_035c: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_0361: stloc.s 8
+			IL_0363: ldloc.s 8
+			IL_0365: ldstr "trim"
+			IL_036a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+			IL_036f: stloc.s 8
+			IL_0371: ldloc.s 8
+			IL_0373: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::RequireObjectCoercible(object)
+			IL_0378: ldstr "call"
+			IL_037d: ldc.i4.0
+			IL_037e: box [JavaScriptRuntime]JavaScriptRuntime.JsNull
+			IL_0383: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember1(object, string, object)
+			IL_0388: pop
+			IL_0389: leave IL_03f2
+		} // end .try
+		catch [System.Runtime]System.Exception
+		{
+			IL_038e: stloc.1
+			IL_038f: ldloc.1
+			IL_0390: isinst [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException
+			IL_0395: dup
+			IL_0396: brtrue IL_03ab
+
+			IL_039b: pop
+			IL_039c: ldloc.1
+			IL_039d: isinst [JavaScriptRuntime]JavaScriptRuntime.Error
+			IL_03a2: dup
+			IL_03a3: brtrue IL_03b6
+
+			IL_03a8: pop
+			IL_03a9: rethrow
+
+			IL_03ab: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.JsThrownValueException::get_Value()
+			IL_03b0: stloc.2
+			IL_03b1: br IL_03b7
+
+			IL_03b6: stloc.2
+
+			IL_03b7: ldloc.2
+			IL_03b8: stloc.3
+			IL_03b9: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+			IL_03be: stloc.s 6
+			IL_03c0: ldloc.3
+			IL_03c1: stloc.s 8
+			IL_03c3: ldstr "TypeError"
+			IL_03c8: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+			IL_03cd: stloc.s 7
+			IL_03cf: ldloc.s 8
+			IL_03d1: ldloc.s 7
+			IL_03d3: call bool [JavaScriptRuntime]JavaScriptRuntime.Operators::InstanceOf(object, object)
+			IL_03d8: stloc.s 12
+			IL_03da: ldloc.s 12
+			IL_03dc: box [System.Runtime]System.Boolean
+			IL_03e1: stloc.s 13
+			IL_03e3: ldloc.s 6
+			IL_03e5: ldloc.s 13
+			IL_03e7: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+			IL_03ec: pop
+			IL_03ed: leave IL_03f2
+		} // end handler
+
+		IL_03f2: ldstr "String"
+		IL_03f7: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_03fc: ldstr "prototype"
+		IL_0401: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0406: stloc.s 7
+		IL_0408: ldloc.s 7
+		IL_040a: ldstr "slice"
+		IL_040f: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_0414: stloc.s 4
+		IL_0416: ldstr "String"
+		IL_041b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_0420: ldstr "prototype"
+		IL_0425: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_042a: stloc.s 7
+		IL_042c: ldc.i4.1
+		IL_042d: newarr [System.Runtime]System.Object
+		IL_0432: dup
+		IL_0433: ldc.i4.0
+		IL_0434: ldloc.0
+		IL_0435: stelem.ref
+		IL_0436: stloc.s 14
+		IL_0438: newobj instance void Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25/FunctionObject::.ctor()
+		IL_043d: ldc.i4.0
+		IL_043e: conv.r8
+		IL_043f: ldstr ""
+		IL_0444: ldc.i4.0
+		IL_0445: ldc.i4.1
+		IL_0446: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_ExplicitReceiverAbi/FunctionExpression_L19C25/FunctionObject>(!!0, float64, string, bool, bool)
+		IL_044b: stloc.s 15
+		IL_044d: ldloc.s 7
+		IL_044f: ldstr "slice"
+		IL_0454: ldloc.s 15
+		IL_0456: ldc.i4.1
+		IL_0457: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_045c: pop
+		IL_045d: call class [JavaScriptRuntime]JavaScriptRuntime.Console [JavaScriptRuntime]JavaScriptRuntime.GlobalThis::get_console()
+		IL_0462: stloc.s 6
+		IL_0464: ldstr "abcdef"
+		IL_0469: ldstr "slice"
+		IL_046e: ldc.r8 1
+		IL_0477: box [System.Runtime]System.Double
+		IL_047c: ldc.r8 4
+		IL_0485: box [System.Runtime]System.Double
+		IL_048a: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::CallMember2(object, string, object, object)
+		IL_048f: stloc.s 7
+		IL_0491: ldloc.s 6
+		IL_0493: ldloc.s 7
+		IL_0495: callvirt instance object [JavaScriptRuntime]JavaScriptRuntime.Console::log(object)
+		IL_049a: pop
+		IL_049b: ldstr "String"
+		IL_04a0: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
+		IL_04a5: ldstr "prototype"
+		IL_04aa: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetItem(object, string)
+		IL_04af: stloc.s 7
+		IL_04b1: ldloc.s 7
+		IL_04b3: ldstr "slice"
+		IL_04b8: ldloc.s 4
+		IL_04ba: ldc.i4.1
+		IL_04bb: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::SetItem(object, string, object, bool)
+		IL_04c0: pop
+		IL_04c1: ldnull
+		IL_04c2: stloc.s 5
+		IL_04c4: ret
+	} // end of method String_ExplicitReceiverAbi::__js_module_init__
+
+} // end of class Modules.String_ExplicitReceiverAbi
+
+.class private auto ansi beforefieldinit Program
+	extends [System.Runtime]System.Object
+{
+	// Methods
+	.method public static 
+		void Main () cil managed 
+	{
+		// Header size: 1
+		// Code size: 23 (0x17)
+		.maxstack 8
+		.entrypoint
+
+		IL_0000: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::.ctor()
+		IL_0005: ldnull
+		IL_0006: ldftn void Modules.String_ExplicitReceiverAbi::__js_module_init__(object, class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.RequireDelegate, object, string, string)
+		IL_000c: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate::.ctor(object, native int)
+		IL_0011: callvirt instance void [JavaScriptRuntime]JavaScriptRuntime.Engine::Execute(class [JavaScriptRuntime]JavaScriptRuntime.Modules.CommonJS.ModuleMainDelegate)
+		IL_0016: ret
+	} // end of method Program::Main
+
+} // end of class Program
+


### PR DESCRIPTION
## Summary

- migrate all `String.prototype` and String iterator built-ins to the explicit-receiver ABI
- keep `concat` variadic without materializing an argument array
- make `trimLeft`/`trimRight` share the canonical trim adapter identities
- expose the existing legacy `substr` implementation so the required Dromaeo scenario runs
- add receiver, alias, override, cross-realm, and zero-allocation runtime coverage

## Validation

- `dotnet test tests/Jroc.Tests/Jroc.Tests.csproj --no-restore --filter "FullyQualifiedName~Jroc.Tests.String"`
  - 90 passed
- `dotnet test tests/Jroc.Test262.Tests/Jroc.Test262.Tests.csproj --no-restore --filter "FullyQualifiedName~Jroc.Test262.Tests.built_ins.String.prototype"`
  - 573 passed, 1 existing skip
- `dotnet build src/JavaScriptRuntime/JavaScriptRuntime.csproj --no-restore`

## Benchmark

Command:

```text
node scripts/runPhasedBenchmarkScenario.js dromaeo-object-string
```

| Build | Mean | Allocated |
| --- | ---: | ---: |
| Legacy argument-array ABI | 359.23 ms | 197.13 MB/op |
| Explicit-receiver ABI | 84.88 ms | 70.68 MB/op |
| Change | -76.4% | -64.1% |

The unmodified pre-change branch cannot execute this benchmark because
`String.prototype.substr` was not registered. For an isolated comparison, the
legacy baseline used only a temporary registration of the existing `Substr`
helper through the old `Func<object[], object?[]?, object?>` adapter; no other
baseline code was changed.

The remaining gap from the historical ~55 MB/op baseline is outside this ABI
migration: dynamic `String.prototype` property resolution is intentionally
preserved after #1894, and guarded lookup specialization remains separate
follow-up work.

Closes #1889
