### PR TITLE
chore(scripts): share JROC self-compilation

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -28,60 +28,15 @@
 const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
+const { maybeRunCompiledWithJroc } = require('./selfCompileWithJroc');
 
-function maybeRunCompiledWithJroc() {
-  if (process.env.JROC_RELEASE_BOOTSTRAPPED === '1') {
-    return;
-  }
-  if (process.env.JROC_RELEASE_NODE_ONLY === '1' || process.argv.includes('--node-only')) {
-    return;
-  }
-
-  const argv0 = path.basename((process.argv[0] || '').toLowerCase());
-  const runningViaNode = argv0 === 'node' || argv0 === 'node.exe';
-  if (!runningViaNode) {
-    return;
-  }
-
-  const scriptPath = __filename;
-  const outDir = path.join(__dirname, 'out', 'release');
-  const dllPath = path.join(outDir, 'release.dll');
-
-  try {
-    fs.rmSync(outDir, { recursive: true, force: true });
-  } catch {
-    // ignore cleanup errors before compile
-  }
-  fs.mkdirSync(outDir, { recursive: true });
-
-  const compile = cp.spawnSync('jroc', [scriptPath, outDir], {
-    stdio: 'inherit',
-    cwd: path.resolve(__dirname, '..'),
-  });
-  if (compile.error) {
-    throw compile.error;
-  }
-  if (compile.status !== 0) {
-    process.exit(compile.status ?? 1);
-  }
-
-  if (!fs.existsSync(dllPath)) {
-    throw new Error(`Compiled release assembly not found: ${dllPath}`);
-  }
-
-  const forwardedArgs = process.argv.slice(2);
-  const runCompiled = cp.spawnSync('dotnet', [dllPath, ...forwardedArgs], {
-    stdio: 'inherit',
-    cwd: path.resolve(__dirname, '..'),
-    env: { ...process.env, JROC_RELEASE_BOOTSTRAPPED: '1' },
-  });
-  if (runCompiled.error) {
-    throw runCompiled.error;
-  }
-  process.exit(runCompiled.status ?? 1);
-}
-
-maybeRunCompiledWithJroc();
+maybeRunCompiledWithJroc({
+  scriptPath: __filename,
+  outputDirectory: path.join(__dirname, 'out', 'release'),
+  assemblyName: 'release',
+  bootstrapEnvironmentVariable: 'JROC_RELEASE_BOOTSTRAPPED',
+  nodeOnlyEnvironmentVariable: 'JROC_RELEASE_NODE_ONLY',
+});
 
 function isRepoRoot(dir) {
   return (

--- a/scripts/selfCompileWithJroc.js
+++ b/scripts/selfCompileWithJroc.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const cp = require("node:child_process");
+
+function maybeRunCompiledWithJroc({
+  scriptPath,
+  outputDirectory,
+  assemblyName,
+  bootstrapEnvironmentVariable,
+  nodeOnlyEnvironmentVariable,
+}) {
+  if (!scriptPath || !outputDirectory || !assemblyName) {
+    throw new Error("Self-compilation requires a script path, output directory, and assembly name.");
+  }
+
+  if (process.env[bootstrapEnvironmentVariable] === "1") {
+    return;
+  }
+
+  if (process.env[nodeOnlyEnvironmentVariable] === "1" || process.argv.includes("--node-only")) {
+    return;
+  }
+
+  const argv0 = path.basename((process.argv[0] || "").toLowerCase());
+  const runningViaNode = argv0 === "node" || argv0 === "node.exe";
+  if (!runningViaNode) {
+    return;
+  }
+
+  fs.rmSync(outputDirectory, { recursive: true, force: true });
+  fs.mkdirSync(outputDirectory, { recursive: true });
+
+  const repositoryRoot = path.resolve(__dirname, "..");
+  const compile = cp.spawnSync("jroc", [scriptPath, outputDirectory], {
+    stdio: "inherit",
+    cwd: repositoryRoot,
+  });
+  if (compile.error) {
+    throw compile.error;
+  }
+  if (compile.status !== 0) {
+    process.exit(compile.status ?? 1);
+  }
+
+  const dllPath = path.join(outputDirectory, `${assemblyName}.dll`);
+  if (!fs.existsSync(dllPath)) {
+    throw new Error(`Compiled assembly not found: ${dllPath}`);
+  }
+
+  const runCompiled = cp.spawnSync("dotnet", [dllPath, ...process.argv.slice(2)], {
+    stdio: "inherit",
+    cwd: repositoryRoot,
+    env: { ...process.env, [bootstrapEnvironmentVariable]: "1" },
+  });
+  if (runCompiled.error) {
+    throw runCompiled.error;
+  }
+
+  process.exit(runCompiled.status ?? 1);
+}
+
+module.exports = { maybeRunCompiledWithJroc };

--- a/scripts/summarizePrCiFailures.js
+++ b/scripts/summarizePrCiFailures.js
@@ -2,6 +2,16 @@
 "use strict";
 
 const cp = require("node:child_process");
+const path = require("node:path");
+const { maybeRunCompiledWithJroc } = require("./selfCompileWithJroc");
+
+maybeRunCompiledWithJroc({
+  scriptPath: __filename,
+  outputDirectory: path.join(__dirname, "out", "summarizePrCiFailures"),
+  assemblyName: "summarizePrCiFailures",
+  bootstrapEnvironmentVariable: "JROC_SUMMARIZE_PR_CI_FAILURES_BOOTSTRAPPED",
+  nodeOnlyEnvironmentVariable: "JROC_SUMMARIZE_PR_CI_FAILURES_NODE_ONLY",
+});
 
 function parseArgs(argv) {
   const args = {
@@ -23,6 +33,8 @@ function parseArgs(argv) {
         break;
       case "--no-logs":
         args.includeLogs = false;
+        break;
+      case "--node-only":
         break;
       case "--help":
       case "-h":
@@ -49,6 +61,7 @@ Options:
   --pr, -p <number>      Pull request number (positional form also supported)
   --repo <owner/name>    Explicit repository override
   --no-logs              Do not fetch failed job logs for failed test names
+  --node-only            Skip JROC self-compilation
   --help, -h             Show help
 `);
 }


### PR DESCRIPTION
## Summary
- Extract JROC self-compilation into a reusable script helper.
- Preserve `release.js` behavior and its existing escape hatches.
- Self-compile `summarizePrCiFailures.js` by default, with `--node-only` for the Node fallback.

## Validation
- `node scripts/release.js --help --node-only`
- `node scripts/summarizePrCiFailures.js --help --node-only`
- `node scripts/release.js --help`
- `node scripts/summarizePrCiFailures.js --help`
- `node scripts/summarizePrCiFailures.js 1905 --no-logs`
- `node --check scripts/selfCompileWithJroc.js && node --check scripts/release.js && node --check scripts/summarizePrCiFailures.js`
